### PR TITLE
Add missing api.CSSFontFeatureValuesRule.valueText feature

### DIFF
--- a/api/CSSFontFeatureValuesRule.json
+++ b/api/CSSFontFeatureValuesRule.json
@@ -63,6 +63,38 @@
             "deprecated": false
           }
         }
+      },
+      "valueText": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/CSSFontPaletteValuesRule.json
+++ b/api/CSSFontPaletteValuesRule.json
@@ -1,0 +1,239 @@
+{
+  "api": {
+    "CSSFontPaletteValuesRule": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "101"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "101"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": "15.3> ≤15.5"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "basePalette": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "101"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "101"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "fontFamily": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "101"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "101"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "name": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "101"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "101"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "overrideColors": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "101"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "101"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/CSSImportRule.json
+++ b/api/CSSImportRule.json
@@ -79,6 +79,53 @@
           }
         }
       },
+      "layerName": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": "97"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "media": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSImportRule/media",

--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -303,6 +303,56 @@
           }
         }
       },
+      "insertRule": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "45"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "5",
+              "version_removed": "21"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSKeyframesRule/name",

--- a/api/CSSLayerBlockRule.json
+++ b/api/CSSLayerBlockRule.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "CSSLayerBlockRule": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "99"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "99"
+          },
+          "firefox": {
+            "version_added": "97"
+          },
+          "firefox_android": {
+            "version_added": "≤102"
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": "15.3> ≤15.5"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "name": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": "97"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/CSSLayerStatementRule.json
+++ b/api/CSSLayerStatementRule.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "CSSLayerStatementRule": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "99"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "99"
+          },
+          "firefox": {
+            "version_added": "97"
+          },
+          "firefox_android": {
+            "version_added": "≤102"
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": "15.3> ≤15.5"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "nameList": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": "97"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/CSSMathClamp.json
+++ b/api/CSSMathClamp.json
@@ -1,0 +1,239 @@
+{
+  "api": {
+    "CSSMathClamp": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "100"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "100"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "CSSMathClamp": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lower": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "upper": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "value": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/CSSMozDocumentRule.json
+++ b/api/CSSMozDocumentRule.json
@@ -1,0 +1,51 @@
+{
+  "api": {
+    "CSSMozDocumentRule": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "≤3"
+          },
+          "firefox_android": {
+            "version_added": "≤102"
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/CSSStyleDeclaration.json
+++ b/api/CSSStyleDeclaration.json
@@ -207,6 +207,55 @@
           }
         }
       },
+      "getPropertyShorthand": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "29"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getPropertyValue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration/getPropertyValue",
@@ -239,6 +288,55 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isPropertyImplicit": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "29"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/DOMConfiguration.json
+++ b/api/DOMConfiguration.json
@@ -1,0 +1,52 @@
+{
+  "api": {
+    "DOMConfiguration": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "≤3",
+            "version_removed": "6"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/DOMException.json
+++ b/api/DOMException.json
@@ -126,6 +126,100 @@
           }
         }
       },
+      "data": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "filename": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "message": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMException/message",
@@ -204,6 +298,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "result": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/DOMImplementation.json
+++ b/api/DOMImplementation.json
@@ -160,6 +160,54 @@
           }
         }
       },
+      "getFeature": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "hasFeature": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMImplementation/hasFeature",

--- a/api/DOMSettableTokenList.json
+++ b/api/DOMSettableTokenList.json
@@ -1,0 +1,106 @@
+{
+  "api": {
+    "DOMSettableTokenList": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤15",
+            "version_removed": "50"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "≤13",
+            "version_removed": "17"
+          },
+          "firefox": {
+            "version_added": "4",
+            "version_removed": "47"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "≤12.1",
+            "version_removed": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "≤6",
+            "version_removed": "9.1> ≤10.1"
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "value": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "44",
+              "version_removed": "50"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "17"
+            },
+            "firefox": {
+              "version_added": "4",
+              "version_removed": "47"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -660,6 +660,53 @@
           }
         }
       },
+      "toString": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "3> ≤3.6"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "trim_whitespace": {
         "__compat": {
           "description": "Trims whitespace",

--- a/api/DataCue.json
+++ b/api/DataCue.json
@@ -69,6 +69,54 @@
           }
         }
       },
+      "data": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "type": {
         "__compat": {
           "spec_url": "https://wicg.github.io/datacue/#dom-datacue-type",

--- a/api/DataTransferItemList.json
+++ b/api/DataTransferItemList.json
@@ -119,6 +119,54 @@
           }
         }
       },
+      "item": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "11.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DataTransferItemList/length",

--- a/api/DedicatedWorkerGlobalScope.json
+++ b/api/DedicatedWorkerGlobalScope.json
@@ -369,6 +369,53 @@
             "deprecated": false
           }
         }
+      },
+      "rtctransform_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/DeviceLightEvent.json
+++ b/api/DeviceLightEvent.json
@@ -53,6 +53,55 @@
           "deprecated": false
         }
       },
+      "DeviceLightEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": "15",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "value": {
         "__compat": {
           "support": {

--- a/api/DeviceMotionEvent.json
+++ b/api/DeviceMotionEvent.json
@@ -150,6 +150,55 @@
           }
         }
       },
+      "initDeviceMotionEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": "≤6"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "interval": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/DeviceMotionEvent/interval",

--- a/api/DeviceOrientationEvent.json
+++ b/api/DeviceOrientationEvent.json
@@ -242,6 +242,56 @@
           }
         }
       },
+      "initDeviceOrientationEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "59"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": "≤6"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "requestPermission": {
         "__compat": {
           "spec_url": "https://w3c.github.io/deviceorientation/#dom-deviceorientationevent-requestpermission",

--- a/api/DevicePosture.json
+++ b/api/DevicePosture.json
@@ -1,0 +1,145 @@
+{
+  "api": {
+    "DevicePosture": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "≤17.0"
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "change_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "type": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/DeviceProximityEvent.json
+++ b/api/DeviceProximityEvent.json
@@ -46,6 +46,54 @@
           "deprecated": true
         }
       },
+      "DeviceProximityEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "15",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "max": {
         "__compat": {
           "support": {

--- a/api/Directory.json
+++ b/api/Directory.json
@@ -1,0 +1,239 @@
+{
+  "api": {
+    "Directory": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "42"
+          },
+          "firefox_android": {
+            "version_added": "≤102"
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "getFiles": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getFilesAndDirectories": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "42"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "name": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "42"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "path": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "42"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/Document.json
+++ b/api/Document.json
@@ -165,6 +165,53 @@
           }
         }
       },
+      "abort_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "activeElement": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/activeElement",
@@ -537,6 +584,194 @@
           }
         }
       },
+      "animationcancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "54"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "12"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "79"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationiteration_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "79"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "79"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "append": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/append",
@@ -613,6 +848,288 @@
           }
         }
       },
+      "auxclick_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforecopy_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforecut_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforeinput_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "87"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforematch_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforepaste_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "beforescriptexecute_event": {
         "__compat": {
           "description": "<code>beforescriptexecute</code> event",
@@ -643,6 +1160,53 @@
           "status": {
             "experimental": false,
             "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "beforexrselect_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "90"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -719,6 +1283,53 @@
           }
         }
       },
+      "blur_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "body": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/body",
@@ -759,6 +1370,147 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "cancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "14.1> ≤15.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "canplay_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "canplaythrough_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -912,6 +1664,53 @@
           }
         }
       },
+      "change_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "characterSet": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/characterSet",
@@ -1042,6 +1841,53 @@
                 "version_added": "1"
               }
             ]
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "charset": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "44"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -1186,6 +2032,53 @@
           }
         }
       },
+      "click_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "close": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/close",
@@ -1258,6 +2151,53 @@
           }
         }
       },
+      "close_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "14.1> ≤15.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "compatMode": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/compatMode",
@@ -1290,6 +2230,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "contains": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "16"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -1350,6 +2337,147 @@
           }
         }
       },
+      "contextlost_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "contextmenu_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "contextrestored_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "cookie": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/cookie",
@@ -1383,6 +2511,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "copy_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -2254,6 +3429,53 @@
           }
         }
       },
+      "cuechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "68"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "currentScript": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/currentScript",
@@ -2282,6 +3504,100 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "cut_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dblclick_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -2606,6 +3922,477 @@
           }
         }
       },
+      "domConfig": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "6"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "drag_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragenter_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragexit_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragleave_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragover_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "drop_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "durationchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "elementFromPoint": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/elementFromPoint",
@@ -2775,6 +4562,53 @@
           }
         }
       },
+      "emptied_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "enableStyleSheetsForSet": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/enableStyleSheetsForSet",
@@ -2805,6 +4639,100 @@
             "experimental": false,
             "standard_track": false,
             "deprecated": true
+          }
+        }
+      },
+      "ended_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "error_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -3507,6 +5435,53 @@
           }
         }
       },
+      "focus_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "fonts": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/fonts",
@@ -3533,6 +5508,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "formdata_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "72"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "14.1> ≤15.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -4133,6 +6155,54 @@
           }
         }
       },
+      "getBoxObjectFor": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "3> ≤3.6"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getBoxQuads": {
         "__compat": {
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-geometryutils-getboxquads",
@@ -4168,6 +6238,55 @@
           },
           "status": {
             "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getCSSCanvasContext": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "48"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -4375,6 +6494,104 @@
           }
         }
       },
+      "getItems": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "16",
+              "version_removed": "49"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getOverrideStyle": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "43"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getSelection": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/getSelection",
@@ -4408,6 +6625,53 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "gotpointercapture_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
             }
           },
           "status": {
@@ -4776,6 +7040,288 @@
           }
         }
       },
+      "input_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "inputEncoding": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "invalid_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "keydown_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "keypress_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "keyup_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "lastElementChild": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/lastElementChild",
@@ -4997,6 +7543,241 @@
           }
         }
       },
+      "load_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadeddata_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadedmetadata_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "location": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/location",
@@ -5079,6 +7860,664 @@
           }
         }
       },
+      "mousedown_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseenter_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "30"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "10"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseleave_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "30"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "10"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mousemove_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseout_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseover_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseup_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mousewheel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozCancelFullScreen": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozFullScreen": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozfullscreenchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozFullScreenElement": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozFullScreenEnabled": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "10"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozfullscreenerror_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "10"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "mozSetImageElement": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/mozSetImageElement",
@@ -5142,6 +8581,54 @@
           "status": {
             "experimental": false,
             "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "msElementsFromPoint": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -5291,6 +8778,100 @@
           }
         }
       },
+      "paste_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pause_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "pictureInPictureElement": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/pictureInPictureElement",
@@ -5355,6 +8936,100 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "play_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "playing_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -5445,6 +9120,241 @@
           }
         }
       },
+      "pointercancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerdown_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerenter_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerleave_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerlockchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "36"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "50"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "pointerLockElement": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/pointerLockElement",
@@ -5482,6 +9392,288 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerlockerror_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "36"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "50"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointermove_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerout_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerover_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerrawupdate_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerup_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -5551,6 +9743,147 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "prerendering": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "prerenderingchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "progress_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -5898,6 +10231,53 @@
           }
         }
       },
+      "ratechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "readyState": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/readyState",
@@ -6081,6 +10461,54 @@
           }
         }
       },
+      "rejectionhandled_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "11",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "releaseCapture": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/releaseCapture",
@@ -6186,6 +10614,54 @@
           }
         }
       },
+      "renameNode": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "6"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "replaceChildren": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/replaceChildren",
@@ -6265,6 +10741,100 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "reset_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "resize_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "33> ≤35"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "38"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -6497,6 +11067,53 @@
           }
         }
       },
+      "search_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "securitypolicyviolation_event": {
         "__compat": {
           "description": "<code>securitypolicyviolation</code> event",
@@ -6524,6 +11141,147 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "seeked_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "seeking_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "select_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -6609,6 +11367,244 @@
           }
         }
       },
+      "selectstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "show_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32",
+              "version_removed": "61"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "9",
+              "version_removed": "85"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "slotchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": "93"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "stalled_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "strictErrorChecking": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "6"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "styleSheets": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/styleSheets",
@@ -6682,6 +11678,100 @@
           }
         }
       },
+      "submit_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "suspend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "timeline": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/timeline",
@@ -6708,6 +11798,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "timeupdate_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -6748,6 +11885,524 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "toggle_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "36"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchcancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchforcechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchmove_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitioncancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "87"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "87"
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "12"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "79"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionrun_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "87"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "87"
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "12"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "87"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "12"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "unhandledrejection_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "11",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -7094,6 +12749,100 @@
           }
         }
       },
+      "volumechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "waiting_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "wasDiscarded": {
         "__compat": {
           "spec_url": "https://wicg.github.io/page-lifecycle/#dom-document-wasdiscarded",
@@ -7122,6 +12871,1144 @@
           },
           "status": {
             "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitanimationend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "81"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "81"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitanimationiteration_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "81"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "81"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitanimationstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "81"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "81"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitCancelFullScreen": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitCurrentFullScreenElement": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitExitFullscreen": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "20"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitExitPointerLock": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "22",
+              "version_removed": "38"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitfullscreenchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitFullscreenElement": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "20"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitFullscreenEnabled": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "20"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitfullscreenerror_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "18"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitFullScreenKeyboardInputAllowed": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "41"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitHidden": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitIsFullScreen": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforcechanged_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforcedown_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforceup_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforcewillbegin_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitpointerlockchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "22",
+              "version_removed": "38"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitPointerLockElement": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "22",
+              "version_removed": "38"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitpointerlockerror_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "22",
+              "version_removed": "38"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkittransitionend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "81"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "81"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitVisibilityState": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "wheel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "31"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "17"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/DragEvent.json
+++ b/api/DragEvent.json
@@ -126,6 +126,55 @@
             "deprecated": false
           }
         }
+      },
+      "initDragEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": "≤3.6"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/Element.json
+++ b/api/Element.json
@@ -2231,6 +2231,53 @@
           }
         }
       },
+      "attributeStyleMap": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "auxclick_event": {
         "__compat": {
           "description": "<code>auxclick</code> event",
@@ -2302,6 +2349,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforeload_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -4216,6 +4310,55 @@
           }
         }
       },
+      "getDestinationInsertionPoints": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "33> ≤35",
+              "version_removed": "88"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "79",
+              "version_removed": "88"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getElementsByClassName": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/getElementsByClassName",
@@ -5636,6 +5779,149 @@
           }
         }
       },
+      "mozfullscreenchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "9",
+              "version_removed": "20"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozfullscreenerror_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "10",
+              "version_removed": "20"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozRequestFullScreen": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "14"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "msContentZoom_event": {
         "__compat": {
           "description": "<code>msContentZoom</code> event",
@@ -5669,6 +5955,54 @@
           "status": {
             "experimental": false,
             "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "msMatchesSelector": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -6615,6 +6949,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "releaseCapture": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -8034,6 +8415,54 @@
           }
         }
       },
+      "search_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6",
+              "version_removed": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "securitypolicyviolation_event": {
         "__compat": {
           "description": "<code>securitypolicyviolation</code> event",
@@ -8071,6 +8500,56 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": true
+          }
+        }
+      },
+      "selectstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "71"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -8971,6 +9450,387 @@
           }
         }
       },
+      "webkitanimationend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitanimationiteration_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitanimationstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitCreateShadowRoot": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "25",
+              "version_removed": "36"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitcurrentplaybacktargetiswirelesschanged_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitfullscreenchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitfullscreenerror_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "18"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitMatchesSelector": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "44"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "webkitmouseforcechanged_event": {
         "__compat": {
           "description": "<code>webkitmouseforcechanged</code> event",
@@ -9111,6 +9971,338 @@
           "status": {
             "experimental": false,
             "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitneedkey_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitplaybacktargetavailabilitychanged_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitpresentationmodechanged_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitRequestFullscreen": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "20"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitRequestFullScreen": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitRequestPointerLock": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "22",
+              "version_removed": "38"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkittransitionend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -476,6 +476,53 @@
           }
         }
       },
+      "ariaInvalid": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "ariaKeyShortcuts": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaKeyShortcuts",
@@ -1479,6 +1526,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "role": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "103"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "103"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/EnterPictureInPictureEvent.json
+++ b/api/EnterPictureInPictureEvent.json
@@ -1,0 +1,151 @@
+{
+  "api": {
+    "EnterPictureInPictureEvent": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "70",
+            "version_removed": "85"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "79",
+            "version_removed": "85"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "13.1"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "EnterPictureInPictureEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "70",
+              "version_removed": "85"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "79",
+              "version_removed": "85"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pictureInPictureWindow": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "70",
+              "version_removed": "85"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "79",
+              "version_removed": "85"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/Entity.json
+++ b/api/Entity.json
@@ -1,0 +1,199 @@
+{
+  "api": {
+    "Entity": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤15",
+            "version_removed": "33> ≤35"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "≤3",
+            "version_removed": "7"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "≤12.1",
+            "version_removed": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "≤6",
+            "version_removed": "9.1> ≤10.1"
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "notationName": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8",
+              "version_removed": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "publicId": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8",
+              "version_removed": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "systemId": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8",
+              "version_removed": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/EntityReference.json
+++ b/api/EntityReference.json
@@ -1,0 +1,55 @@
+{
+  "api": {
+    "EntityReference": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤15",
+            "version_removed": "29"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "≤3",
+            "version_removed": "7"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "≤12.1",
+            "version_removed": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "≤6",
+            "version_removed": "9.1> ≤10.1"
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/Event.json
+++ b/api/Event.json
@@ -538,6 +538,54 @@
           }
         }
       },
+      "getPreventDefault": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "3> ≤3.6",
+              "version_removed": "59"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "initEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Event/initEvent",
@@ -683,6 +731,149 @@
           "status": {
             "experimental": false,
             "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "path": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "33> ≤35"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "preventBubble": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "24"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "preventCapture": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "24"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/EventCounts.json
+++ b/api/EventCounts.json
@@ -254,6 +254,53 @@
             "deprecated": false
           }
         }
+      },
+      "@@iterator": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "85"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "85"
+            },
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/EventSource.json
+++ b/api/EventSource.json
@@ -134,6 +134,55 @@
           }
         }
       },
+      "URL": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "43"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "worker_support": {
         "__compat": {
           "description": "Available in workers",

--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -432,6 +432,53 @@
             "deprecated": false
           }
         }
+      },
+      "targetClientId": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "11.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/FileError.json
+++ b/api/FileError.json
@@ -1,0 +1,55 @@
+{
+  "api": {
+    "FileError": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤15",
+            "version_removed": "54"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "3> ≤3.6",
+            "version_removed": "13"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "≤12.1",
+            "version_removed": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "≤6",
+            "version_removed": "13.1> ≤14.1"
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/FileException.json
+++ b/api/FileException.json
@@ -1,0 +1,52 @@
+{
+  "api": {
+    "FileException": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "≤3",
+            "version_removed": "14"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/FontData.json
+++ b/api/FontData.json
@@ -1,0 +1,286 @@
+{
+  "api": {
+    "FontData": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "103"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "103"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "blob": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "103"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "103"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "family": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "103"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "103"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "fullName": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "103"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "103"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "postscriptName": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "103"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "103"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "style": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "103"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "103"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/GPUBuffer.json
+++ b/api/GPUBuffer.json
@@ -1,0 +1,239 @@
+{
+  "api": {
+    "GPUBuffer": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "15.3> ≤15.5"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "destroy": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getMappedRange": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mapAsync": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "unmap": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/GPUBufferUsage.json
+++ b/api/GPUBufferUsage.json
@@ -1,0 +1,51 @@
+{
+  "api": {
+    "GPUBufferUsage": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "15.3> ≤15.5"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/GPUColorWrite.json
+++ b/api/GPUColorWrite.json
@@ -1,0 +1,51 @@
+{
+  "api": {
+    "GPUColorWrite": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "15.3> ≤15.5"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/GPUCommandEncoder.json
+++ b/api/GPUCommandEncoder.json
@@ -1,0 +1,615 @@
+{
+  "api": {
+    "GPUCommandEncoder": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "15.3> ≤15.5"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "beginComputePass": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beginRenderPass": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "copyBufferToBuffer": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "copyBufferToTexture": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "copyTextureToBuffer": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "copyTextureToTexture": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "finish": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "insertDebugMarker": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "popDebugGroup": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pushDebugGroup": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "resolveQuerySet": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "writeTimestamp": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/GPUComputePassEncoder.json
+++ b/api/GPUComputePassEncoder.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "GPUComputePassEncoder": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "15.3> ≤15.5"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "setPipeline": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/GPUMapMode.json
+++ b/api/GPUMapMode.json
@@ -1,0 +1,51 @@
+{
+  "api": {
+    "GPUMapMode": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "15.3> ≤15.5"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/GPUQueue.json
+++ b/api/GPUQueue.json
@@ -1,0 +1,286 @@
+{
+  "api": {
+    "GPUQueue": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "15.3> ≤15.5"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "copyExternalImageToTexture": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "onSubmittedWorkDone": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "submit": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "writeBuffer": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "writeTexture": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/GPURenderPassEncoder.json
+++ b/api/GPURenderPassEncoder.json
@@ -1,0 +1,380 @@
+{
+  "api": {
+    "GPURenderPassEncoder": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "15.3> ≤15.5"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "beginOcclusionQuery": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "endOcclusionQuery": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "executeBundles": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "setBlendConstant": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "setScissorRect": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "setStencilReference": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "setViewport": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/GPUShaderStage.json
+++ b/api/GPUShaderStage.json
@@ -1,0 +1,51 @@
+{
+  "api": {
+    "GPUShaderStage": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "15.3> ≤15.5"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/GPUTextureUsage.json
+++ b/api/GPUTextureUsage.json
@@ -1,0 +1,51 @@
+{
+  "api": {
+    "GPUTextureUsage": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "15.3> ≤15.5"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/GamepadButtonEvent.json
+++ b/api/GamepadButtonEvent.json
@@ -1,0 +1,52 @@
+{
+  "api": {
+    "GamepadButtonEvent": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "22",
+            "version_removed": "24"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/GeolocationCoordinates.json
+++ b/api/GeolocationCoordinates.json
@@ -305,6 +305,53 @@
           }
         }
       },
+      "floorLevel": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "heading": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GeolocationCoordinates/heading",

--- a/api/GestureEvent.json
+++ b/api/GestureEvent.json
@@ -34,6 +34,194 @@
           "deprecated": false
         }
       },
+      "altKey": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "clientX": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "clientY": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ctrlKey": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "initGestureEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GestureEvent/initGestureEvent",
@@ -65,6 +253,53 @@
           "status": {
             "experimental": false,
             "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "metaKey": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -135,6 +370,194 @@
           "status": {
             "experimental": false,
             "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "screenX": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "screenY": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "shiftKey": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "target": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -41,6 +41,53 @@
           "deprecated": false
         }
       },
+      "attributionSourceId": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "charset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/charset",
@@ -339,6 +386,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "hrefTranslate": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/HTMLAppletElement.json
+++ b/api/HTMLAppletElement.json
@@ -1,0 +1,617 @@
+{
+  "api": {
+    "HTMLAppletElement": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤15",
+            "version_removed": "47"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "≤13",
+            "version_removed": "17"
+          },
+          "firefox": {
+            "version_added": "≤3",
+            "version_removed": "56"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "≤12.1",
+            "version_removed": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "≤6",
+            "version_removed": "13.1> ≤14.1"
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "align": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "46",
+              "version_removed": "47"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "17"
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "56"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "alt": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "46",
+              "version_removed": "47"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "17"
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "56"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "archive": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "46",
+              "version_removed": "47"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "17"
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "56"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "code": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "46",
+              "version_removed": "47"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "17"
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "56"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "codeBase": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "46",
+              "version_removed": "47"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "17"
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "56"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "height": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "46",
+              "version_removed": "47"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "17"
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "56"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "hspace": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "46",
+              "version_removed": "47"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "17"
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "56"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "name": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "46",
+              "version_removed": "47"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "17"
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "56"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "object": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "46",
+              "version_removed": "47"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "17"
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "56"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vspace": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "46",
+              "version_removed": "47"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "17"
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "56"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "width": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "46",
+              "version_removed": "47"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "17"
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "56"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/HTMLBaseFontElement.json
+++ b/api/HTMLBaseFontElement.json
@@ -1,0 +1,208 @@
+{
+  "api": {
+    "HTMLBaseFontElement": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤15",
+            "version_removed": "28"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "≤13",
+            "version_removed": "79"
+          },
+          "firefox": {
+            "version_added": "≤3",
+            "version_removed": "4"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "≤6",
+            "version_removed": "9.1> ≤10.1"
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "color": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "28"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "4"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6",
+              "version_removed": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "face": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "28"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "4"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6",
+              "version_removed": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "size": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "28"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "4"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6",
+              "version_removed": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/HTMLBodyElement.json
+++ b/api/HTMLBodyElement.json
@@ -41,6 +41,53 @@
           "deprecated": false
         }
       },
+      "afterprint_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "63"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "aLink": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLBodyElement/aLink",
@@ -125,6 +172,100 @@
           }
         }
       },
+      "beforeprint_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "63"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforeunload_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "bgColor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLBodyElement/bgColor",
@@ -164,6 +305,431 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": true
+          }
+        }
+      },
+      "blur_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "error_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "focus_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "focusin_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "focusout_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "gamepadconnected_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "gamepaddisconnected_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "hashchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "3> ≤3.6"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "languagechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "37"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "32"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -209,6 +775,664 @@
           }
         }
       },
+      "load_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "message_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "messageerror_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "57"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "offline_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "online_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "orientationchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pagehide_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pageshow_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "popstate_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "rejectionhandled_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "49"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "69"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "resize_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "scroll_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "selectionchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "71"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "9≤92"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "storage_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "text": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLBodyElement/text",
@@ -251,6 +1475,100 @@
           }
         }
       },
+      "unhandledrejection_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "49"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "69"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "unload_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "vLink": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLBodyElement/vLink",
@@ -290,6 +1608,194 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": true
+          }
+        }
+      },
+      "webkitmouseforcechanged_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforcedown_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforceup_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforcewillbegin_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -43,6 +43,53 @@
           "deprecated": false
         }
       },
+      "autofocus": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "checkValidity": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-checkvalidity-dev",

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -830,6 +830,54 @@
           }
         }
       },
+      "mozGetAsFile": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "4",
+              "version_removed": "74"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "mozOpaque": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/mozOpaque",
@@ -860,6 +908,101 @@
             "experimental": false,
             "standard_track": false,
             "deprecated": true
+          }
+        }
+      },
+      "mozPrintCallback": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "18"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "msToBlob": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -41,6 +41,100 @@
           "deprecated": false
         }
       },
+      "HTMLElement": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "abort_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "accessKey": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/accessKey",
@@ -108,6 +202,194 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationcancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "54"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "12"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "79"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationiteration_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "79"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "79"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -318,6 +600,147 @@
           }
         }
       },
+      "auxclick_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforecopy_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforecut_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "beforeinput_event": {
         "__compat": {
           "description": "<code>beforeinput</code> event",
@@ -401,6 +824,100 @@
           }
         }
       },
+      "beforepaste_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforexrselect_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "blur": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/blur",
@@ -435,6 +952,194 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "blur_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "cancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "14.1> ≤15.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "canplay_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "canplaythrough_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -544,6 +1249,100 @@
           }
         }
       },
+      "click_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "close_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "14.1> ≤15.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "contentEditable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/contentEditable",
@@ -578,6 +1377,53 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "contextlost_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -632,6 +1478,241 @@
           }
         }
       },
+      "contextmenu_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "contextrestored_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "copy_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "cuechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "68"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "cut_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "dataset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/dataset",
@@ -667,6 +1748,53 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dblclick_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
             }
           },
           "status": {
@@ -1109,6 +2237,195 @@
           }
         }
       },
+      "dropzone": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "durationchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "emptied_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ended_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "enterKeyHint": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/enterKeyHint",
@@ -1148,6 +2465,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "error_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -1271,6 +2635,147 @@
               "standard_track": true,
               "deprecated": false
             }
+          }
+        }
+      },
+      "focus_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "formdata_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "72"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "14.1> ≤15.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "gotpointercapture_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -1511,6 +3016,53 @@
           }
         }
       },
+      "invalid_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "isContentEditable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/isContentEditable",
@@ -1553,6 +3105,441 @@
           }
         }
       },
+      "itemId": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "16",
+              "version_removed": "49"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "itemProp": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "16",
+              "version_removed": "49"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "itemRef": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "16",
+              "version_removed": "49"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "itemScope": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "16",
+              "version_removed": "49"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "itemType": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "16",
+              "version_removed": "49"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "itemValue": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "16",
+              "version_removed": "49"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "keydown_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "keypress_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "keyup_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "lang": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/lang",
@@ -1587,6 +3574,759 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "load_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadeddata_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadedmetadata_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lostpointercapture_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mousedown_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseenter_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "30"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "10"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseleave_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "30"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "10"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mousemove_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseout_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseover_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseup_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mousewheel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozfullscreenchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozfullscreenerror_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "10"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -1883,6 +4623,1374 @@
           }
         }
       },
+      "paste_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pause_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "play_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "playing_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointercancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerdown_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerenter_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerleave_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointermove_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerout_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerover_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerrawupdate_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerup_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "progress_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "properties": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "16",
+              "version_removed": "49"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ratechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "rejectionhandled_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "11",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "reset_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "resize_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "33> ≤35"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "38"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "scroll_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "search_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "securitypolicyviolation_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": "93"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "seeked_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "seeking_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "select_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "selectionchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "71"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "9≤92"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "selectstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "show_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32",
+              "version_removed": "61"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "9",
+              "version_removed": "85"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "slotchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": "93"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "spellcheck": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/spellcheck",
@@ -1927,6 +6035,53 @@
           }
         }
       },
+      "stalled_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "style": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/style",
@@ -1961,6 +6116,100 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "submit_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "suspend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -2018,6 +6267,53 @@
           }
         }
       },
+      "timeupdate_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "title": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/title",
@@ -2060,6 +6356,476 @@
           }
         }
       },
+      "toggle_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "36"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchcancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchforcechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchmove_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitioncancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "87"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "87"
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "12"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "79"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionrun_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "87"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "87"
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "12"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "87"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "12"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "translate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/translate",
@@ -2086,6 +6852,761 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "unhandledrejection_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "11",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "virtualKeyboardPolicy": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "94"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "94"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "volumechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "waiting_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitanimationend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "81"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "81"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitanimationiteration_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "81"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "81"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitanimationstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "81"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "81"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitdropzone": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "58"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitfullscreenchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitfullscreenerror_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "18"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforcechanged_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforcedown_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforceup_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforcewillbegin_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkittransitionend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "81"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "81"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "wheel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "31"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "17"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -125,6 +125,53 @@
           }
         }
       },
+      "autocapitalize": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "autocomplete": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFormElement/autocomplete",
@@ -538,6 +585,100 @@
           }
         }
       },
+      "rel": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "relList": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "reportValidity": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFormElement/reportValidity",
@@ -566,6 +707,54 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "requestAutocomplete": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "31",
+              "version_removed": "52"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/HTMLFrameElement.json
+++ b/api/HTMLFrameElement.json
@@ -166,6 +166,155 @@
           }
         }
       },
+      "getSVGDocument": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "48"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "height": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "38"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "location": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "36"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "longDesc": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFrameElement/longDesc",
@@ -457,6 +606,56 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": true
+          }
+        }
+      },
+      "width": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "38"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/HTMLFrameSetElement.json
+++ b/api/HTMLFrameSetElement.json
@@ -41,6 +41,147 @@
           "deprecated": true
         }
       },
+      "afterprint_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "63"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforeprint_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "63"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforeunload_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "cols": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#dom-frameset-cols",
@@ -82,6 +223,617 @@
           }
         }
       },
+      "gamepadconnected_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "gamepaddisconnected_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "hashchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "languagechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "37"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "32"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "message_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "messageerror_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "57"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "offline_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "online_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "orientationchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pagehide_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pageshow_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "popstate_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "rejectionhandled_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "49"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "69"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "rows": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#dom-frameset-rows",
@@ -120,6 +872,147 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": true
+          }
+        }
+      },
+      "storage_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "45"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "unhandledrejection_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "49"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "69"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "unload_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       }

--- a/api/HTMLHtmlElement.json
+++ b/api/HTMLHtmlElement.json
@@ -39,6 +39,55 @@
           "deprecated": false
         }
       },
+      "manifest": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "37"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "version": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLHtmlElement/version",

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -394,6 +394,102 @@
           }
         }
       },
+      "error_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "fetchpriority": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "101",
+              "version_removed": "102"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "101",
+              "version_removed": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "fetchPriority": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLImageElement/fetchPriority",

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -158,6 +158,53 @@
           }
         }
       },
+      "autocapitalize": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "autocomplete": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement/autocomplete",
@@ -190,6 +237,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "autofocus": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -1211,6 +1305,149 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozGetFileNameArray": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "3> ≤3.6",
+              "version_removed": "22"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozIsTextField": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozSetFileNameArray": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "3> ≤3.6",
+              "version_removed": "22"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -2447,6 +2684,54 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "textLength": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
             }
           },
           "status": {

--- a/api/HTMLIsIndexElement.json
+++ b/api/HTMLIsIndexElement.json
@@ -1,0 +1,154 @@
+{
+  "api": {
+    "HTMLIsIndexElement": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤15",
+            "version_removed": "19"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "≤3",
+            "version_removed": "4"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "≤12.1",
+            "version_removed": "15"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "form": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "19"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "4"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "prompt": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "19"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "4"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -201,6 +201,55 @@
           }
         }
       },
+      "fetchpriority": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "101",
+              "version_removed": "102"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "101",
+              "version_removed": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "fetchPriority": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/fetchPriority",
@@ -452,6 +501,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "nonce": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "75"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -1294,6 +1294,104 @@
           }
         }
       },
+      "getVideoPlaybackQuality": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "42"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "initialTime": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "16",
+              "version_removed": "32"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "9",
+              "version_removed": "23"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6",
+              "version_removed": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "load": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/load",
@@ -1628,6 +1726,53 @@
           }
         }
       },
+      "mozCaptureStream": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "15"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "mozCaptureStreamUntilEnded": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozCaptureStreamUntilEnded",
@@ -1658,6 +1803,54 @@
             "experimental": false,
             "standard_track": false,
             "deprecated": true
+          }
+        }
+      },
+      "mozChannels": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "4",
+              "version_removed": "28"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -1694,6 +1887,54 @@
           }
         }
       },
+      "mozFrameBufferLength": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "4",
+              "version_removed": "28"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "mozGetMetadata": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/mozGetMetadata",
@@ -1724,6 +1965,149 @@
             "experimental": false,
             "standard_track": false,
             "deprecated": true
+          }
+        }
+      },
+      "mozLoadFrom": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "3> ≤3.6",
+              "version_removed": "24"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozPreservesPitch": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "20"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozSampleRate": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "4",
+              "version_removed": "28"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -3340,6 +3724,435 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitAudioDecodedByteCount": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitClosedCaptionsVisible": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "32"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitCurrentPlaybackTargetIsWireless": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitHasClosedCaptions": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "32"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitKeys": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitPreservesPitch": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "32"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitSetMediaKeys": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitShowPlaybackTargetPicker": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitVideoDecodedByteCount": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/HTMLMenuItemElement.json
+++ b/api/HTMLMenuItemElement.json
@@ -139,6 +139,54 @@
           }
         }
       },
+      "defaultChecked": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "8",
+              "version_removed": "85"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "disabled": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMenuItemElement/disabled",

--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -873,6 +873,54 @@
           }
         }
       },
+      "typeMustMatch": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "27",
+              "version_removed": "68"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "useMap": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/useMap",

--- a/api/HTMLPreElement.json
+++ b/api/HTMLPreElement.json
@@ -82,6 +82,55 @@
             "deprecated": true
           }
         }
+      },
+      "wrap": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "38"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/HTMLPropertiesCollection.json
+++ b/api/HTMLPropertiesCollection.json
@@ -1,0 +1,148 @@
+{
+  "api": {
+    "HTMLPropertiesCollection": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "16",
+            "version_removed": "49"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "namedItem": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "16",
+              "version_removed": "49"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "names": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "16",
+              "version_removed": "49"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -237,6 +237,55 @@
           }
         }
       },
+      "fetchpriority": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "101",
+              "version_removed": "102"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "101",
+              "version_removed": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "fetchPriority": {
         "__compat": {
           "spec_url": "https://wicg.github.io/priority-hints/#script",
@@ -378,6 +427,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "nonce": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "75"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -171,6 +171,100 @@
           }
         }
       },
+      "autofocus": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "blur": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "checkValidity": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/checkValidity",
@@ -249,6 +343,53 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "focus": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/HTMLStyleElement.json
+++ b/api/HTMLStyleElement.json
@@ -119,6 +119,53 @@
           }
         }
       },
+      "nonce": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "61"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "75"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "scoped": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLStyleElement/scoped",

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -112,6 +112,53 @@
           }
         }
       },
+      "autofocus": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "checkValidity": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-checkvalidity-dev",

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -833,6 +833,570 @@
           }
         }
       },
+      "webkitDecodedFrameCount": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitDisplayingFullscreen": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitDroppedFrameCount": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitEnterFullscreen": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitEnterFullScreen": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitExitFullscreen": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitExitFullScreen": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitPresentationMode": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitSetPresentationMode": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitSupportsFullscreen": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitSupportsPresentationMode": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitWirelessVideoPlaybackDisabled": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/width",

--- a/api/HashChangeEvent.json
+++ b/api/HashChangeEvent.json
@@ -77,6 +77,55 @@
           }
         }
       },
+      "initHashChangeEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "47"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤6"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "newURL": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HashChangeEvent/newURL",

--- a/api/Headers.json
+++ b/api/Headers.json
@@ -306,6 +306,55 @@
           }
         }
       },
+      "getAll": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "42",
+              "version_removed": "60"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "39",
+              "version_removed": "52"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "has": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/has",

--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -99,6 +99,53 @@
           }
         }
       },
+      "abort_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "11"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "close": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/close",
@@ -177,6 +224,55 @@
           }
         }
       },
+      "createMutableFile": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "33",
+              "version_removed": "103"
+            },
+            "firefox_android": {
+              "version_added": "≤102",
+              "version_removed": "103"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "createObjectStore": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBDatabase/createObjectStore",
@@ -245,6 +341,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "error_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/IDBDatabaseException.json
+++ b/api/IDBDatabaseException.json
@@ -1,0 +1,53 @@
+{
+  "api": {
+    "IDBDatabaseException": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "24",
+            "version_removed": "25"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "4",
+            "version_removed": "14"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/IDBVersionChangeEvent.json
+++ b/api/IDBVersionChangeEvent.json
@@ -128,6 +128,100 @@
           }
         }
       },
+      "dataLoss": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "29"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dataLossMessage": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "newVersion": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBVersionChangeEvent/newVersion",
@@ -196,6 +290,54 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "version": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "17",
+              "version_removed": "26"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/IDBVersionChangeRequest.json
+++ b/api/IDBVersionChangeRequest.json
@@ -1,0 +1,52 @@
+{
+  "api": {
+    "IDBVersionChangeRequest": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "4",
+            "version_removed": "10"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/ImageBitmapRenderingContext.json
+++ b/api/ImageBitmapRenderingContext.json
@@ -106,6 +106,53 @@
             "deprecated": false
           }
         }
+      },
+      "transferImageBitmap": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "46"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -110,6 +110,53 @@
           }
         }
       },
+      "delay": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "disconnect": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserver/disconnect",
@@ -321,6 +368,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "trackVisibility": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/IntersectionObserverEntry.json
+++ b/api/IntersectionObserverEntry.json
@@ -215,6 +215,53 @@
           }
         }
       },
+      "isVisible": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "rootBounds": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserverEntry/rootBounds",

--- a/api/KeyEvent.json
+++ b/api/KeyEvent.json
@@ -1,0 +1,51 @@
+{
+  "api": {
+    "KeyEvent": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "≤3"
+          },
+          "firefox_android": {
+            "version_added": "≤102"
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -78,6 +78,55 @@
           }
         }
       },
+      "altGraphKey": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "38"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "altKey": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyboardEvent/altKey",
@@ -743,6 +792,54 @@
           }
         }
       },
+      "initKeyEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "93"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "isComposing": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyboardEvent/isComposing",
@@ -997,6 +1094,55 @@
           }
         }
       },
+      "keyLocation": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "50"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "location": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/KeyboardEvent/location",
@@ -1144,6 +1290,53 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "which": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
             }
           },
           "status": {

--- a/api/KeyboardLayoutMap.json
+++ b/api/KeyboardLayoutMap.json
@@ -265,6 +265,53 @@
             "deprecated": false
           }
         }
+      },
+      "@@iterator": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/LaunchParams.json
+++ b/api/LaunchParams.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "LaunchParams": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "102"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "102"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "files": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/LaunchQueue.json
+++ b/api/LaunchQueue.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "LaunchQueue": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "102"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "102"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "setConsumer": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/LocalMediaStream.json
+++ b/api/LocalMediaStream.json
@@ -1,0 +1,100 @@
+{
+  "api": {
+    "LocalMediaStream": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "19",
+            "version_removed": "64"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "stop": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "19",
+              "version_removed": "64"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/MIDIInputMap.json
+++ b/api/MIDIInputMap.json
@@ -368,6 +368,53 @@
             "deprecated": false
           }
         }
+      },
+      "@@iterator": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/MIDIOutputMap.json
+++ b/api/MIDIOutputMap.json
@@ -368,6 +368,53 @@
             "deprecated": false
           }
         }
+      },
+      "@@iterator": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/MSGestureEvent.json
+++ b/api/MSGestureEvent.json
@@ -1,0 +1,580 @@
+{
+  "api": {
+    "MSGestureEvent": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "≤13",
+            "version_removed": "79"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "expansion": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "gestureObject": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "initGestureEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "rotation": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "scale": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "translationX": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "translationY": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "velocityAngular": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "velocityExpansion": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "velocityX": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "velocityY": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/MathMLElement.json
+++ b/api/MathMLElement.json
@@ -34,6 +34,523 @@
           "deprecated": false
         }
       },
+      "abort_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationcancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationiteration_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "autofocus": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "auxclick_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforecopy_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforecut_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforeinput_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "87"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforepaste_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "blur": {
         "__compat": {
           "support": {
@@ -58,6 +575,523 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "blur_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "cancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "14.1> ≤15.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "canplay_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "canplaythrough_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "change_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "click_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "close_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "14.1> ≤15.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "contextmenu_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "copy_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "cuechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "cut_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -98,6 +1132,617 @@
           }
         }
       },
+      "dblclick_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "drag_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragenter_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragexit_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragleave_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragover_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "drop_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "durationchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "emptied_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ended_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "error_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "focus": {
         "__compat": {
           "support": {
@@ -122,6 +1767,2499 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "focus_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "formdata_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "72"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "14.1> ≤15.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "gotpointercapture_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "input_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "invalid_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "keydown_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "keypress_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "keyup_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "load_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadeddata_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadedmetadata_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lostpointercapture_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mousedown_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseenter_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseleave_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mousemove_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseout_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseover_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseup_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mousewheel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozfullscreenchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozfullscreenerror_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "nonce": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "paste_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pause_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "play_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "playing_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointercancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerdown_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerenter_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerleave_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointermove_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerout_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerover_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerup_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "progress_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ratechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "rejectionhandled_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "reset_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "resize_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "scroll_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "search_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "securitypolicyviolation_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "93"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "seeked_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "seeking_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "select_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "selectionchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "9≤92"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "selectstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "show_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71",
+              "version_removed": "85"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "slotchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "93"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "stalled_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -163,6 +4301,100 @@
           }
         }
       },
+      "submit_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "suspend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "tabIndex": {
         "__compat": {
           "support": {
@@ -187,6 +4419,1182 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "timeupdate_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "toggle_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchcancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchforcechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchmove_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitioncancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionrun_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "unhandledrejection_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "volumechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "waiting_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitanimationend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitanimationiteration_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitanimationstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitfullscreenchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitfullscreenerror_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforcechanged_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforcedown_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforceup_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforcewillbegin_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkittransitionend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "wheel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "71"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/MediaController.json
+++ b/api/MediaController.json
@@ -1,0 +1,766 @@
+{
+  "api": {
+    "MediaController": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "17",
+            "version_removed": "36"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15",
+            "version_removed": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "≤6"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "MediaController": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "17",
+              "version_removed": "36"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "buffered": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "currentTime": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "defaultPlaybackRate": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "duration": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "muted": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pause": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "17",
+              "version_removed": "36"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "paused": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "play": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "17",
+              "version_removed": "36"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "playbackRate": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "playbackState": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "played": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "seekable": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "unpause": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "25",
+              "version_removed": "36"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "volume": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -401,6 +401,53 @@
             "deprecated": false
           }
         }
+      },
+      "setCaptureHandleConfig": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/MediaList.json
+++ b/api/MediaList.json
@@ -238,6 +238,53 @@
             "deprecated": false
           }
         }
+      },
+      "toString": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -249,6 +249,54 @@
           }
         }
       },
+      "ignoreMutedMedia": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "49",
+              "version_removed": "57"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "isTypeSupported": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/isTypeSupported",

--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -645,6 +645,54 @@
           }
         }
       },
+      "sourceclosed_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "50",
+              "version_removed": "87"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "sourceended_event": {
         "__compat": {
           "description": "<code>sourceended</code> event",

--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -610,6 +610,54 @@
             "deprecated": false
           }
         }
+      },
+      "stop": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "33> ≤38",
+              "version_removed": "64"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -71,6 +71,53 @@
           }
         }
       },
+      "capturehandlechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": null
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "clone": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrack/clone",
@@ -242,6 +289,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getCaptureHandle": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": null
+            }
           },
           "status": {
             "experimental": false,

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -381,6 +381,53 @@
             "deprecated": false
           }
         }
+      },
+      "userActivation": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "72"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -329,6 +329,53 @@
           }
         }
       },
+      "fromElement": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getModifierState": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MouseEvent/getModifierState",
@@ -437,6 +484,53 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": true
+          }
+        }
+      },
+      "initNSMouseEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "3> ≤3.6"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -694,6 +788,100 @@
               }
             ],
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozInputSource": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "4"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozPressure": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "3> ≤3.6"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -1073,6 +1261,147 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "toElement": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitForce": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "which": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
             }
           },
           "status": {

--- a/api/NDEFReader.json
+++ b/api/NDEFReader.json
@@ -107,6 +107,53 @@
           }
         }
       },
+      "makeReadOnly": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "reading_event": {
         "__compat": {
           "description": "<code>reading</code> event",

--- a/api/NameList.json
+++ b/api/NameList.json
@@ -1,0 +1,292 @@
+{
+  "api": {
+    "NameList": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "≤3",
+            "version_removed": "10"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "contains": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "10"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "containsNS": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "10"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getName": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "10"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getNamespaceURI": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "10"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "length": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "10"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/NavigateEvent.json
+++ b/api/NavigateEvent.json
@@ -1,0 +1,474 @@
+{
+  "api": {
+    "NavigateEvent": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "102"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "102"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "NavigateEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "destination": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "downloadRequest": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "formData": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "hashChange": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "info": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "navigationType": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "signal": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "userInitiated": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -303,6 +303,54 @@
           }
         }
       },
+      "battery": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "16",
+              "version_removed": "50"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "bluetooth": {
         "__compat": {
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-navigator-bluetooth",
@@ -830,6 +878,53 @@
           }
         }
       },
+      "devicePosture": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "doNotTrack": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/doNotTrack",
@@ -1026,6 +1121,54 @@
           }
         }
       },
+      "getDisplayMedia": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "14> ≤16",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getGamepads": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/getGamepads",
@@ -1164,6 +1307,55 @@
           },
           "status": {
             "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getStorageUpdates": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "49"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -1937,6 +2129,101 @@
           }
         }
       },
+      "mozBattery": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "11",
+              "version_removed": "16"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozGetUserMedia": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "17"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "mozIsLocallyAvailable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/mozIsLocallyAvailable",
@@ -2379,6 +2666,55 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": true
+          }
+        }
+      },
+      "registerContentHandler": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -4313,6 +4649,53 @@
           }
         }
       },
+      "userActivation": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "72"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "userAgent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/userAgent",
@@ -4678,6 +5061,147 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitGetUserMedia": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "21"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitPersistentStorage": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "27"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitTemporaryStorage": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "27"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Node.json
+++ b/api/Node.json
@@ -332,6 +332,55 @@
           }
         }
       },
+      "getFeature": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "7"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getRootNode": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/getRootNode",
@@ -358,6 +407,54 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getUserData": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "23"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -747,6 +844,58 @@
           }
         }
       },
+      "localName": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "46"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "17"
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "48"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6",
+              "version_removed": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "lookupNamespaceURI": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/lookupNamespaceURI",
@@ -823,6 +972,58 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "namespaceURI": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "46"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "17"
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "48"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6",
+              "version_removed": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -1161,6 +1362,57 @@
           }
         }
       },
+      "prefix": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "33> ≤35"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "48"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6",
+              "version_removed": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "previousSibling": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Node/previousSibling",
@@ -1315,6 +1567,54 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "setUserData": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "23"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/NodeIterator.json
+++ b/api/NodeIterator.json
@@ -84,6 +84,58 @@
           }
         }
       },
+      "expandEntityReferences": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "41"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": "≤12",
+              "version_removed": "21"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6",
+              "version_removed": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "filter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NodeIterator/filter",

--- a/api/NodeList.json
+++ b/api/NodeList.json
@@ -258,6 +258,54 @@
             "deprecated": false
           }
         }
+      },
+      "@@iterator": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "27",
+              "version_removed": "36"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/Notation.json
+++ b/api/Notation.json
@@ -1,0 +1,153 @@
+{
+  "api": {
+    "Notation": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤15",
+            "version_removed": "39"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "≤3",
+            "version_removed": "7"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "≤12.1",
+            "version_removed": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "≤6",
+            "version_removed": "8> ≤9.1"
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "publicId": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "7"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8",
+              "version_removed": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "systemId": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "7"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8",
+              "version_removed": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -540,6 +540,54 @@
           }
         }
       },
+      "display_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "20",
+              "version_removed": "33"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "error_event": {
         "__compat": {
           "description": "<code>error</code> event",
@@ -574,6 +622,53 @@
               "version_added": false
             },
             "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "get": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "27"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -924,6 +1019,54 @@
           },
           "status": {
             "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "show": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "20",
+              "version_removed": "33"
+            },
+            "chrome_android": {
+              "version_added": null
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": null
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": null
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/OES_draw_buffers_indexed.json
+++ b/api/OES_draw_buffers_indexed.json
@@ -1,0 +1,380 @@
+{
+  "api": {
+    "OES_draw_buffers_indexed": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "100"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "100"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "blendEquationiOES": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "blendEquationSeparateiOES": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "blendFunciOES": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "blendFuncSeparateiOES": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "colorMaskiOES": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "disableiOES": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "enableiOES": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -84,6 +84,100 @@
           }
         }
       },
+      "contextlost_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "contextrestored_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "convertToBlob": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OffscreenCanvas/convertToBlob",

--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -296,6 +296,53 @@
           }
         }
       },
+      "createConicGradient": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "createImageData": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-createimagedata-dev",
@@ -725,6 +772,147 @@
           }
         }
       },
+      "fontKerning": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "fontStretch": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "fontVariantCaps": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getImageData": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-getimagedata-dev",
@@ -956,6 +1144,53 @@
           }
         }
       },
+      "isContextLost": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "isPointInPath": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-ispointinpath-dev",
@@ -1014,6 +1249,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "letterSpacing": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -1385,6 +1667,53 @@
           }
         }
       },
+      "reset": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "resetTransform": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-resettransform-dev",
@@ -1476,6 +1805,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "roundRect": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -1946,6 +2322,53 @@
           }
         }
       },
+      "textRendering": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "transform": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-transform-dev",
@@ -2004,6 +2427,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "wordSpacing": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/OscillatorNode.json
+++ b/api/OscillatorNode.json
@@ -152,6 +152,106 @@
           }
         }
       },
+      "noteOff": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "21",
+              "version_removed": "41"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6",
+              "version_removed": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "noteOn": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "21",
+              "version_removed": "41"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6",
+              "version_removed": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "setPeriodicWave": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OscillatorNode/setPeriodicWave",

--- a/api/OverconstrainedErrorEvent.json
+++ b/api/OverconstrainedErrorEvent.json
@@ -35,6 +35,53 @@
           "deprecated": true
         }
       },
+      "OverconstrainedErrorEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "error": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OverconstrainedErrorEvent/error",

--- a/api/OverflowEvent.json
+++ b/api/OverflowEvent.json
@@ -1,0 +1,198 @@
+{
+  "api": {
+    "OverflowEvent": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤15",
+            "version_removed": "43"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "≤13",
+            "version_removed": "17"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15",
+            "version_removed": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "≤6"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "horizontalOverflow": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "17"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "orient": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "17"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "verticalOverflow": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "17"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/Path2D.json
+++ b/api/Path2D.json
@@ -421,6 +421,53 @@
             "deprecated": false
           }
         }
+      },
+      "roundRect": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/PaymentAddress.json
+++ b/api/PaymentAddress.json
@@ -204,6 +204,56 @@
           }
         }
       },
+      "languageCode": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "60",
+              "version_removed": "74"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "14> ≤16",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "11.1",
+              "version_removed": "12.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "organization": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentAddress/organization",

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -203,6 +203,53 @@
           }
         }
       },
+      "hasEnrolledInstrument": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "74"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "id": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/id",

--- a/api/PaymentRequestEvent.json
+++ b/api/PaymentRequestEvent.json
@@ -107,6 +107,100 @@
           }
         }
       },
+      "changeShippingAddress": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "80"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "changeShippingOption": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "80"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "instrumentKey": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestEvent/instrumentKey",
@@ -251,6 +345,53 @@
           }
         }
       },
+      "paymentOptions": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "80"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "paymentRequestId": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequestEvent/paymentRequestId",
@@ -355,6 +496,53 @@
           },
           "status": {
             "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "shippingOptions": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "80"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/PerformanceEventTiming.json
+++ b/api/PerformanceEventTiming.json
@@ -67,6 +67,53 @@
           }
         }
       },
+      "interactionId": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "96"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "96"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "processingEnd": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceEventTiming/processingEnd",

--- a/api/PerformanceNavigationTiming.json
+++ b/api/PerformanceNavigationTiming.json
@@ -38,6 +38,53 @@
           "deprecated": false
         }
       },
+      "activationStart": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "domComplete": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceNavigationTiming/domComplete",

--- a/api/ProcessingInstruction.json
+++ b/api/ProcessingInstruction.json
@@ -39,6 +39,53 @@
           "deprecated": false
         }
       },
+      "data": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "sheet": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ProcessingInstruction/sheet",

--- a/api/ProgressEvent.json
+++ b/api/ProgressEvent.json
@@ -88,6 +88,57 @@
           }
         }
       },
+      "initProgressEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "17"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": "3> ≤3.6",
+              "version_removed": "24"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "lengthComputable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ProgressEvent/lengthComputable",

--- a/api/PropertyNodeList.json
+++ b/api/PropertyNodeList.json
@@ -1,0 +1,100 @@
+{
+  "api": {
+    "PropertyNodeList": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "16",
+            "version_removed": "49"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "getValues": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "16",
+              "version_removed": "49"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -50,6 +50,53 @@
           "deprecated": false
         }
       },
+      "authenticatorAttachment": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "98"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "98"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getClientExtensionResults": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/getClientExtensionResults",

--- a/api/PushSubscriptionChangeEvent.json
+++ b/api/PushSubscriptionChangeEvent.json
@@ -40,6 +40,54 @@
           "deprecated": false
         }
       },
+      "PushSubscriptionChangeEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "17",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "newSubscription": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushSubscriptionChangeEvent/newSubscription",

--- a/api/RGBColor.json
+++ b/api/RGBColor.json
@@ -1,0 +1,198 @@
+{
+  "api": {
+    "RGBColor": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤15",
+            "version_removed": "40"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "≤3",
+            "version_removed": "62"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "≤12.1",
+            "version_removed": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "≤6"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "blue": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "20",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "green": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "20",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "red": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "20",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -916,6 +916,54 @@
           }
         }
       },
+      "stream": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "17> ≤22",
+              "version_removed": "50"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "transferable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Glossary/Transferable_objects",

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -614,6 +614,53 @@
           }
         }
       },
+      "addtrack_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "34"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "addTransceiver": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/addTransceiver",

--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -389,6 +389,53 @@
           }
         }
       },
+      "playoutDelayHint": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "79"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "rtcpTransport": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpReceiver/rtcpTransport",
@@ -452,6 +499,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transform": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/RTCRtpScriptTransform.json
+++ b/api/RTCRtpScriptTransform.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "RTCRtpScriptTransform": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "15.3> ≤15.5"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "RTCRtpScriptTransform": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/RTCRtpScriptTransformer.json
+++ b/api/RTCRtpScriptTransformer.json
@@ -1,0 +1,286 @@
+{
+  "api": {
+    "RTCRtpScriptTransformer": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "15.3> ≤15.5"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "generateKeyFrame": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "options": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "readable": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "sendKeyFrameRequest": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "writable": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -395,6 +395,53 @@
           }
         }
       },
+      "transform": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "transport": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpSender/transport",

--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -256,6 +256,53 @@
             "deprecated": false
           }
         }
+      },
+      "@@iterator": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "58"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/RTCTransformEvent.json
+++ b/api/RTCTransformEvent.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "RTCTransformEvent": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "15.3> ≤15.5"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "transformer": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/Range.json
+++ b/api/Range.json
@@ -642,6 +642,53 @@
           }
         }
       },
+      "expand": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "extractContents": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Range/extractContents",

--- a/api/Rect.json
+++ b/api/Rect.json
@@ -1,0 +1,246 @@
+{
+  "api": {
+    "Rect": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤15",
+            "version_removed": "40"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "≤3",
+            "version_removed": "62"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15",
+            "version_removed": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "≤6"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "bottom": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "20",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "left": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "20",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "right": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "20",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "top": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "20",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/Request.json
+++ b/api/Request.json
@@ -584,6 +584,55 @@
           }
         }
       },
+      "context": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "44",
+              "version_removed": "46"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "3> ≤39",
+              "version_removed": "42"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "credentials": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request/credentials",

--- a/api/SQLTransaction.json
+++ b/api/SQLTransaction.json
@@ -1,0 +1,100 @@
+{
+  "api": {
+    "SQLTransaction": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "≤12.1",
+            "version_removed": "15"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "9.1> ≤10.1"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "executeSql": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/SVGAltGlyphElement.json
+++ b/api/SVGAltGlyphElement.json
@@ -125,6 +125,56 @@
             "deprecated": true
           }
         }
+      },
+      "href": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "4",
+              "version_removed": "49"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/SVGAnimationElement.json
+++ b/api/SVGAnimationElement.json
@@ -41,6 +41,53 @@
           "deprecated": false
         }
       },
+      "begin_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "33> ≤35"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "93"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "beginElement": {
         "__compat": {
           "support": {
@@ -162,6 +209,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "end_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "33> ≤35"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "93"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -404,6 +498,53 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "repeat_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "33> ≤35"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "93"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
             }
           },
           "status": {

--- a/api/SVGCursorElement.json
+++ b/api/SVGCursorElement.json
@@ -38,6 +38,251 @@
           "standard_track": true,
           "deprecated": true
         }
+      },
+      "href": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "57"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "requiredExtensions": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "57"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "systemLanguage": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "57"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "x": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "57"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "y": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "57"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/SVGDiscardElement.json
+++ b/api/SVGDiscardElement.json
@@ -1,0 +1,53 @@
+{
+  "api": {
+    "SVGDiscardElement": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "33> ≤35",
+            "version_removed": "81"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "79",
+            "version_removed": "81"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -43,6 +43,241 @@
           "deprecated": false
         }
       },
+      "abort_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationcancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "54"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "12"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "79"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationiteration_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "79"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "79"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "attributeStyleMap": {
         "__compat": {
           "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-elementcssinlinestyle-attributestylemap",
@@ -109,6 +344,335 @@
           }
         }
       },
+      "auxclick_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforecopy_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforecut_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforeinput_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "87"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforematch_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforepaste_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforexrselect_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "blur": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-blur-dev",
@@ -139,6 +703,241 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "blur_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "cancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "14.1> ≤15.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "canplay_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "canplaythrough_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "change_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
             }
           },
           "status": {
@@ -191,6 +990,382 @@
           }
         }
       },
+      "click_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "close_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "14.1> ≤15.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "contextlost_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "contextmenu_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "contextrestored_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "copy_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "cuechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "68"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "cut_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "dataset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGElement/dataset",
@@ -225,6 +1400,570 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dblclick_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "drag_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragenter_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragexit_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragleave_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragover_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "drop_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "durationchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "emptied_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ended_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -351,6 +2090,382 @@
           }
         }
       },
+      "focus_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "formdata_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "72"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "14.1> ≤15.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "gotpointercapture_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "input_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "invalid_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "keydown_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "keypress_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "keyup_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "load_event": {
         "__compat": {
           "description": "<code>load</code> event",
@@ -389,6 +2504,712 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadeddata_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadedmetadata_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lostpointercapture_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mousedown_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseenter_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "30"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "10"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseleave_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "30"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "10"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mousemove_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseout_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseover_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseup_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mousewheel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozfullscreenchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozfullscreenerror_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "10"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
             }
           },
           "status": {
@@ -704,6 +3525,1372 @@
           }
         }
       },
+      "paste_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pause_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "play_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "playing_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointercancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerdown_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerenter_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerleave_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointermove_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerout_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerover_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerrawupdate_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerup_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "59"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "progress_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ratechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "rejectionhandled_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "11",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "reset_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "resize_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "33> ≤35"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "38"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "scroll_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "search_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "securitypolicyviolation_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": "93"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "seeked_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "seeking_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "select_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "selectionchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "71"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "9≤92"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "selectstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "show_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32",
+              "version_removed": "61"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "9",
+              "version_removed": "85"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "slotchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": "93"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "stalled_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "style": {
         "__compat": {
           "spec_url": "https://drafts.csswg.org/cssom/#dom-elementcssinlinestyle-style",
@@ -737,6 +4924,100 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "submit_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "suspend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -780,6 +5061,571 @@
           }
         }
       },
+      "timeupdate_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "toggle_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "36"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchcancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchforcechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchmove_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitioncancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "87"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "87"
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "12"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "79"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionrun_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "87"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "87"
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "12"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "87"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "12"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "unhandledrejection_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "11",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "viewportElement": {
         "__compat": {
           "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGElement__viewportElement",
@@ -814,6 +5660,617 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "volumechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "waiting_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitanimationend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "81"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "81"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitanimationiteration_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "81"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "81"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitanimationstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "81"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "81"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitfullscreenchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitfullscreenerror_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "18"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforcechanged_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforcedown_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforceup_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforcewillbegin_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkittransitionend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "81"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "81"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "wheel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "31"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "17"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
             }
           },
           "status": {

--- a/api/SVGGlyphRefElement.json
+++ b/api/SVGGlyphRefElement.json
@@ -181,6 +181,55 @@
           }
         }
       },
+      "href": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "40"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "x": {
         "__compat": {
           "support": {

--- a/api/SVGGraphicsElement.json
+++ b/api/SVGGraphicsElement.json
@@ -101,6 +101,53 @@
           "deprecated": false
         }
       },
+      "autofocus": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "79"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "78"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getBBox": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGraphicsElement/getBBox",

--- a/api/SVGMatrix.json
+++ b/api/SVGMatrix.json
@@ -42,6 +42,805 @@
           "standard_track": true,
           "deprecated": true
         }
+      },
+      "a": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "b": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "c": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "d": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "e": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "f": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "flipX": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "flipY": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "inverse": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "multiply": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "rotate": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "rotateFromVector": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "scale": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "scaleNonUniform": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "skewX": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "skewY": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "translate": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -1221,6 +1221,54 @@
           }
         }
       },
+      "rejectionhandled_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "11",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "screenPixelToMillimeterX": {
         "__compat": {
           "support": {
@@ -1403,6 +1451,103 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": true
+          }
+        }
+      },
+      "unhandledrejection_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "11",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "unload_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -1624,6 +1769,58 @@
           }
         }
       },
+      "viewport": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "55"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "18"
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "21"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6",
+              "version_removed": "13.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "width": {
         "__compat": {
           "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__width",
@@ -1744,6 +1941,53 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "zoomAndPan": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
             }
           },
           "status": {

--- a/api/SVGStylable.json
+++ b/api/SVGStylable.json
@@ -1,0 +1,52 @@
+{
+  "api": {
+    "SVGStylable": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "≤3",
+            "version_removed": "20"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/SVGTests.json
+++ b/api/SVGTests.json
@@ -1,0 +1,52 @@
+{
+  "api": {
+    "SVGTests": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "12",
+            "version_removed": "21"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/SVGTransformable.json
+++ b/api/SVGTransformable.json
@@ -1,0 +1,52 @@
+{
+  "api": {
+    "SVGTransformable": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "≤3",
+            "version_removed": "21"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/SVGURIReference.json
+++ b/api/SVGURIReference.json
@@ -1,0 +1,52 @@
+{
+  "api": {
+    "SVGURIReference": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "≤3",
+            "version_removed": "22"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/SVGUseElement.json
+++ b/api/SVGUseElement.json
@@ -43,6 +43,57 @@
           "deprecated": false
         }
       },
+      "animatedInstanceRoot": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "37"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6",
+              "version_removed": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "height": {
         "__compat": {
           "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGUseElement__height",
@@ -118,6 +169,57 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "3"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "instanceRoot": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "37"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6",
+              "version_removed": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
             }
           },
           "status": {

--- a/api/SVGViewElement.json
+++ b/api/SVGViewElement.json
@@ -169,6 +169,53 @@
             "deprecated": true
           }
         }
+      },
+      "zoomAndPan": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "15"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/SVGViewSpec.json
+++ b/api/SVGViewSpec.json
@@ -1,0 +1,102 @@
+{
+  "api": {
+    "SVGViewSpec": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "21",
+            "version_removed": "56"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "≤3",
+            "version_removed": "21"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15",
+            "version_removed": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "6> ≤8"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "zoomAndPan": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43",
+              "version_removed": "56"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/SVGZoomAndPan.json
+++ b/api/SVGZoomAndPan.json
@@ -1,0 +1,54 @@
+{
+  "api": {
+    "SVGZoomAndPan": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "21",
+            "version_removed": "29"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "≤13",
+            "version_removed": "17"
+          },
+          "firefox": {
+            "version_added": null
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "≤12.1",
+            "version_removed": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/Screen.json
+++ b/api/Screen.json
@@ -187,6 +187,53 @@
           }
         }
       },
+      "change_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "colorDepth": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen/colorDepth",
@@ -263,6 +310,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isExtended": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -420,6 +514,386 @@
             "experimental": false,
             "standard_track": false,
             "deprecated": true
+          }
+        }
+      },
+      "mozLockOrientation": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "14"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozOrientation": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "14"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozorientationchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "14"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozUnlockOrientation": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "14"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "msLockOrientation": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "msOrientation": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "msorientationchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "msUnlockOrientation": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/ScreenDetailed.json
+++ b/api/ScreenDetailed.json
@@ -1,0 +1,427 @@
+{
+  "api": {
+    "ScreenDetailed": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "100"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "100"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "availLeft": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "availTop": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "devicePixelRatio": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isInternal": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isPrimary": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "label": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "left": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "top": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/ScreenDetails.json
+++ b/api/ScreenDetails.json
@@ -1,0 +1,239 @@
+{
+  "api": {
+    "ScreenDetails": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "100"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "100"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "currentScreen": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "currentscreenchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "screens": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "screenschange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/Selection.json
+++ b/api/Selection.json
@@ -161,6 +161,147 @@
           }
         }
       },
+      "baseNode": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "baseOffset": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "caretBidiLevel": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "collapse": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Selection/collapse",
@@ -592,6 +733,100 @@
               "standard_track": true,
               "deprecated": false
             }
+          }
+        }
+      },
+      "extentNode": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "extentOffset": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "14"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/Serial.json
+++ b/api/Serial.json
@@ -35,6 +35,100 @@
           "deprecated": false
         }
       },
+      "connect_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "89"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "89"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "disconnect_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "89"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "89"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getPorts": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Serial/getPorts",

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -258,6 +258,53 @@
           }
         }
       },
+      "caches": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "40"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "44"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "11.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "canmakepayment_event": {
         "__compat": {
           "description": "<code>canmakepayment</code> event",

--- a/api/ServiceWorkerMessageEvent.json
+++ b/api/ServiceWorkerMessageEvent.json
@@ -1,0 +1,347 @@
+{
+  "api": {
+    "ServiceWorkerMessageEvent": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "45",
+            "version_removed": "57"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "44",
+            "version_removed": "55"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "ServiceWorkerMessageEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "45",
+              "version_removed": "57"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "44",
+              "version_removed": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "data": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "45",
+              "version_removed": "57"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "44",
+              "version_removed": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lastEventId": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "45",
+              "version_removed": "57"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "44",
+              "version_removed": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "origin": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "45",
+              "version_removed": "57"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "44",
+              "version_removed": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ports": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "45",
+              "version_removed": "57"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "44",
+              "version_removed": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "source": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "45",
+              "version_removed": "57"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "44",
+              "version_removed": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -451,6 +451,53 @@
           }
         }
       },
+      "mozFullScreenElement": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "63"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "pictureInPictureElement": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/pictureInPictureElement",
@@ -548,6 +595,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "slotchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": "93"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/SourceBufferList.json
+++ b/api/SourceBufferList.json
@@ -133,6 +133,54 @@
           }
         }
       },
+      "item": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBufferList/length",

--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -512,6 +512,54 @@
           }
         }
       },
+      "serviceURI": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "44",
+              "version_removed": "49"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "soundend_event": {
         "__compat": {
           "description": "<code>soundend</code> event",

--- a/api/Text.json
+++ b/api/Text.json
@@ -156,6 +156,155 @@
           }
         }
       },
+      "getDestinationInsertionPoints": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "33> ≤35",
+              "version_removed": "88"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "79",
+              "version_removed": "88"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isElementContentWhitespace": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "3> ≤3.6",
+              "version_removed": "10"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "replaceWholeText": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "41"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "3> ≤3.6",
+              "version_removed": "10"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6",
+              "version_removed": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "splitText": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Text/splitText",

--- a/api/TextEvent.json
+++ b/api/TextEvent.json
@@ -1,0 +1,145 @@
+{
+  "api": {
+    "TextEvent": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤15"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "≤13"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "≤12.1"
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": "≤6"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": "≤17.0"
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "data": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "initTextEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -131,6 +131,53 @@
           }
         }
       },
+      "addRegion": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "cuechange_event": {
         "__compat": {
           "description": "<code>cuechange</code> event",
@@ -467,6 +514,53 @@
           }
         }
       },
+      "regions": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "removeCue": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrack/removeCue",
@@ -501,6 +595,53 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "removeRegion": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/TextTrackCue.json
+++ b/api/TextTrackCue.json
@@ -175,6 +175,53 @@
           }
         }
       },
+      "getCueAsHTML": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "31"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "id": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackCue/id",

--- a/api/TextTrackCueList.json
+++ b/api/TextTrackCueList.json
@@ -79,6 +79,56 @@
           }
         }
       },
+      "item": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "23",
+              "version_removed": "48"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackCueList/length",

--- a/api/TextTrackList.json
+++ b/api/TextTrackList.json
@@ -165,6 +165,56 @@
           }
         }
       },
+      "item": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "23",
+              "version_removed": "48"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TextTrackList/length",

--- a/api/Touch.json
+++ b/api/Touch.json
@@ -781,6 +781,198 @@
             "deprecated": false
           }
         }
+      },
+      "webkitForce": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43",
+              "version_removed": "47"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitRadiusX": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43",
+              "version_removed": "47"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitRadiusY": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43",
+              "version_removed": "47"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitRotationAngle": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43",
+              "version_removed": "47"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/TreeWalker.json
+++ b/api/TreeWalker.json
@@ -87,6 +87,58 @@
           }
         }
       },
+      "expandEntityReferences": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "41"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": "≤12",
+              "version_removed": "21"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6",
+              "version_removed": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "filter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TreeWalker/filter",

--- a/api/UIEvent.json
+++ b/api/UIEvent.json
@@ -82,6 +82,53 @@
           }
         }
       },
+      "cancelBubble": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "detail": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/UIEvent/detail",
@@ -165,6 +212,346 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": true
+          }
+        }
+      },
+      "isChar": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "55"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "layerX": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "45"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "layerY": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "45"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pageX": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "45"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "69"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pageY": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "45"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "69"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "rangeOffset": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "rangeParent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/UserActivation.json
+++ b/api/UserActivation.json
@@ -1,0 +1,145 @@
+{
+  "api": {
+    "UserActivation": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "72"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "79"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "≤17.0"
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "hasBeenActive": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "72"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "isActive": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "72"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/UserDataHandler.json
+++ b/api/UserDataHandler.json
@@ -1,0 +1,100 @@
+{
+  "api": {
+    "UserDataHandler": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "≤3",
+            "version_removed": "26"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "handle": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤25",
+              "version_removed": "26"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/UserMessageHandler.json
+++ b/api/UserMessageHandler.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "UserMessageHandler": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "6> ≤8"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "postMessage": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/UserMessageHandlersNamespace.json
+++ b/api/UserMessageHandlersNamespace.json
@@ -1,0 +1,51 @@
+{
+  "api": {
+    "UserMessageHandlersNamespace": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "6> ≤8"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/UserProximityEvent.json
+++ b/api/UserProximityEvent.json
@@ -46,6 +46,54 @@
           "deprecated": true
         }
       },
+      "UserProximityEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "15",
+              "version_removed": "62"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "near": {
         "__compat": {
           "support": {

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -298,6 +298,54 @@
             "deprecated": true
           }
         }
+      },
+      "sizeZ": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "55",
+              "version_removed": "97"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/VTTCue.json
+++ b/api/VTTCue.json
@@ -342,6 +342,54 @@
           }
         }
       },
+      "regionId": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "size": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTCue/size",

--- a/api/VTTRegion.json
+++ b/api/VTTRegion.json
@@ -238,6 +238,53 @@
           }
         }
       },
+      "track": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "viewportAnchorX": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VTTRegion/viewportAnchorX",

--- a/api/VideoTrackList.json
+++ b/api/VideoTrackList.json
@@ -259,6 +259,54 @@
           }
         }
       },
+      "item": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoTrackList/length",

--- a/api/WebAssembly.json
+++ b/api/WebAssembly.json
@@ -1,0 +1,286 @@
+{
+  "api": {
+    "WebAssembly": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "57"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "14> ≤16"
+          },
+          "firefox": {
+            "version_added": "52"
+          },
+          "firefox_android": {
+            "version_added": "≤102"
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": "11"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": "≤17.0"
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "compile": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "14> ≤16"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "compileStreaming": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "14> ≤16"
+            },
+            "firefox": {
+              "version_added": "58"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "14.1> ≤15.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "instantiate": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "14> ≤16"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "instantiateStreaming": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "60"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "14> ≤16"
+            },
+            "firefox": {
+              "version_added": "58"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "14.1> ≤15.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "validate": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "14> ≤16"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/WebGL2ComputeRenderingContext.json
+++ b/api/WebGL2ComputeRenderingContext.json
@@ -1,0 +1,52 @@
+{
+  "api": {
+    "WebGL2ComputeRenderingContext": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "69",
+            "version_removed": "70"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -5635,6 +5635,53 @@
           }
         }
       },
+      "lineWidth": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "14.1> ≤15.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "linkProgram": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/linkProgram",

--- a/api/WebKitAnimationEvent.json
+++ b/api/WebKitAnimationEvent.json
@@ -1,0 +1,296 @@
+{
+  "api": {
+    "WebKitAnimationEvent": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤15",
+            "version_removed": "71"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "≤15",
+            "version_removed": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "≤6"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "WebKitAnimationEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "16",
+              "version_removed": "71"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationName": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "71"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "elapsedTime": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "71"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "initWebKitAnimationEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "18"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pseudoElement": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "68",
+              "version_removed": "71"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/WebKitCSSMatrix.json
+++ b/api/WebKitCSSMatrix.json
@@ -52,6 +52,53 @@
           "standard_track": true,
           "deprecated": false
         }
+      },
+      "WebKitCSSMatrix": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/WebKitMediaKeyError.json
+++ b/api/WebKitMediaKeyError.json
@@ -1,0 +1,51 @@
+{
+  "api": {
+    "WebKitMediaKeyError": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "6> ≤8"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/WebKitMediaKeyMessageEvent.json
+++ b/api/WebKitMediaKeyMessageEvent.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "WebKitMediaKeyMessageEvent": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "6> ≤8"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "WebKitMediaKeyMessageEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/WebKitMediaKeyNeededEvent.json
+++ b/api/WebKitMediaKeyNeededEvent.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "WebKitMediaKeyNeededEvent": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "9.1> ≤10.1"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "WebKitMediaKeyNeededEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/WebKitMediaKeySession.json
+++ b/api/WebKitMediaKeySession.json
@@ -1,0 +1,51 @@
+{
+  "api": {
+    "WebKitMediaKeySession": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "6> ≤8"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/WebKitMediaKeys.json
+++ b/api/WebKitMediaKeys.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "WebKitMediaKeys": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "6> ≤8"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "WebKitMediaKeys": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/WebKitMutationObserver.json
+++ b/api/WebKitMutationObserver.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "WebKitMutationObserver": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "18"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "79"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15"
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": "≤6"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": "≤17.0"
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "WebKitMutationObserver": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "18"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/WebKitNamespace.json
+++ b/api/WebKitNamespace.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "WebKitNamespace": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "6> ≤8"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "messageHandlers": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/WebKitPlaybackTargetAvailabilityEvent.json
+++ b/api/WebKitPlaybackTargetAvailabilityEvent.json
@@ -1,0 +1,145 @@
+{
+  "api": {
+    "WebKitPlaybackTargetAvailabilityEvent": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "8> ≤9.1"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "WebKitPlaybackTargetAvailabilityEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "availability": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/WebKitPoint.json
+++ b/api/WebKitPoint.json
@@ -39,6 +39,56 @@
           "deprecated": true
         }
       },
+      "WebKitPoint": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "39"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "x": {
         "__compat": {
           "support": {

--- a/api/WebKitTransitionEvent.json
+++ b/api/WebKitTransitionEvent.json
@@ -1,0 +1,297 @@
+{
+  "api": {
+    "WebKitTransitionEvent": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤15",
+            "version_removed": "71"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "≤15",
+            "version_removed": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "≤6"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "WebKitTransitionEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "16",
+              "version_removed": "71"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "elapsedTime": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "71"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "initWebKitTransitionEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "18"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "propertyName": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "71"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pseudoElement": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "26",
+              "version_removed": "71"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -50,6 +50,55 @@
           "deprecated": false
         }
       },
+      "URL": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "43"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "WebSocket": {
         "__compat": {
           "description": "<code>WebSocket()</code> constructor",

--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -1,0 +1,474 @@
+{
+  "api": {
+    "WebTransport": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "97"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "97"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "WebTransport": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "close": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "closed": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createBidirectionalStream": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "createUnidirectionalStream": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "datagrams": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "incomingBidirectionalStreams": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "incomingUnidirectionalStreams": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ready": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/WebTransportBidirectionalStream.json
+++ b/api/WebTransportBidirectionalStream.json
@@ -1,0 +1,145 @@
+{
+  "api": {
+    "WebTransportBidirectionalStream": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "97"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "97"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "readable": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "writable": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/WebTransportDatagramDuplexStream.json
+++ b/api/WebTransportDatagramDuplexStream.json
@@ -1,0 +1,380 @@
+{
+  "api": {
+    "WebTransportDatagramDuplexStream": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "97"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "97"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "incomingHighWaterMark": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "incomingMaxAge": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "maxDatagramSize": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "outgoingHighWaterMark": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "outgoingMaxAge": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "readable": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "writable": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/WebTransportError.json
+++ b/api/WebTransportError.json
@@ -1,0 +1,192 @@
+{
+  "api": {
+    "WebTransportError": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "97"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "97"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "WebTransportError": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "source": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "streamErrorCode": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -227,6 +227,103 @@
           }
         }
       },
+      "initWebKitWheelEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "38"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "initWheelEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "pinch_to_zoom_support": {
         "__compat": {
           "description": "Pinch-to-zoom maps to <code>WheelEvent</code> + <code>ctrl</code> key.",
@@ -254,6 +351,55 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitDirectionInvertedFromDevice": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "16",
+              "version_removed": "38"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Window.json
+++ b/api/Window.json
@@ -87,6 +87,100 @@
           }
         }
       },
+      "abort_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "absolutedeviceorientation_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "46"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "afterprint_event": {
         "__compat": {
           "description": "<code>afterprint</code> event",
@@ -173,6 +267,194 @@
           }
         }
       },
+      "animationcancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "54"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "12"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationiteration_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "animationstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "appinstalled_event": {
         "__compat": {
           "description": "<code>appinstalled</code> event",
@@ -206,6 +488,149 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "applicationCache": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": null
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "86"
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "auxclick_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforeinput_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "87"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -259,6 +684,53 @@
               }
             ],
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "beforematch_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -478,6 +950,53 @@
           }
         }
       },
+      "beforexrselect_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "90"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "blur": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/blur",
@@ -573,6 +1092,53 @@
           }
         }
       },
+      "cancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "14.1> ≤15.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "cancelAnimationFrame": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/cancelAnimationFrame",
@@ -657,6 +1223,100 @@
           }
         }
       },
+      "canplay_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "canplaythrough_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "captureEvents": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#dom-window-captureevents",
@@ -696,6 +1356,53 @@
           }
         }
       },
+      "change_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "clearImmediate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/clearImmediate",
@@ -730,6 +1437,100 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "click_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "clientInformation": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9≤92"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -783,6 +1584,53 @@
           }
         }
       },
+      "close_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "14.1> ≤15.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "closed": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/closed",
@@ -815,6 +1663,54 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "compassneedscalibration_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -872,6 +1768,147 @@
           }
         }
       },
+      "contextlost_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "contextmenu_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "contextrestored_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "99"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "cookieStore": {
         "__compat": {
           "spec_url": "https://wicg.github.io/cookie-store/#dom-window-cookiestore",
@@ -907,6 +1944,53 @@
           }
         }
       },
+      "cuechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "68"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "customElements": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/customElements",
@@ -933,6 +2017,148 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dblclick_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "defaultstatus": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "defaultStatus": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "23"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -1257,6 +2483,382 @@
           }
         }
       },
+      "drag_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragenter_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragexit_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragleave_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragover_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dragstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "drop_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "dump": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/dump",
@@ -1304,6 +2906,147 @@
           "status": {
             "experimental": false,
             "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "durationchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "emptied_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ended_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -1581,6 +3324,53 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "formdata_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "72"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "14.1> ≤15.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
             }
           },
           "status": {
@@ -1991,6 +3781,150 @@
           }
         }
       },
+      "getDigitalGoodsService": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getMatchedCSSRules": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "64"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getScreenDetails": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "100"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getSelection": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/getSelection",
@@ -2023,6 +3957,101 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "globalStorage": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "13"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "gotpointercapture_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -2126,6 +4155,55 @@
           }
         }
       },
+      "home": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "32"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "innerHeight": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/innerHeight",
@@ -2220,6 +4298,241 @@
           }
         }
       },
+      "input_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "invalid_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "keydown_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "keypress_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "keyup_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "languagechange_event": {
         "__compat": {
           "description": "<code>languagechange</code> event",
@@ -2254,6 +4567,53 @@
               "version_added": "4.0"
             },
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "launchQueue": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "102"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -2341,6 +4701,194 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadeddata_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadedmetadata_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -2489,6 +5037,53 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lostpointercapture_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -2666,6 +5261,382 @@
           }
         }
       },
+      "mousedown_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseenter_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "30"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "10"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseleave_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "30"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "10"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mousemove_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseout_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseover_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mouseup_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mousewheel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "moveBy": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/moveBy",
@@ -2746,6 +5717,148 @@
           }
         }
       },
+      "mozAnimationStartTime": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "4",
+              "version_removed": "42"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozfullscreenchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozfullscreenerror_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "10"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "mozInnerScreenX": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/mozInnerScreenX",
@@ -2812,6 +5925,54 @@
           }
         }
       },
+      "mozPaintCount": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "4",
+              "version_removed": "72"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/name",
@@ -2845,6 +6006,54 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "navigate": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1",
+              "version_removed": "15"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -3008,6 +6217,53 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "offscreenBuffering": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
             }
           },
           "status": {
@@ -3213,6 +6469,53 @@
               "standard_track": false,
               "deprecated": true
             }
+          }
+        }
+      },
+      "openDatabase": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -3710,6 +7013,53 @@
           }
         }
       },
+      "pause_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "personalbar": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/personalbar",
@@ -3744,6 +7094,571 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pkcs11": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "29"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "play_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "playing_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointercancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerdown_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerenter_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerleave_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointermove_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerout_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerover_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerrawupdate_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "77"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pointerup_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "55"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": null
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -3946,6 +7861,53 @@
           }
         }
       },
+      "progress_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "prompt": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/prompt",
@@ -3985,6 +7947,100 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "queryLocalFonts": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "103"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "103"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ratechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -4230,6 +8286,53 @@
           }
         }
       },
+      "reset_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "resize_event": {
         "__compat": {
           "description": "<code>resize</code> event",
@@ -4399,6 +8502,54 @@
           "status": {
             "experimental": true,
             "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "routeEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "25"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -4742,6 +8893,53 @@
               "standard_track": true,
               "deprecated": false
             }
+          }
+        }
+      },
+      "scroll_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },
@@ -5423,6 +9621,335 @@
           }
         }
       },
+      "search_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "securitypolicyviolation_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": "93"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "15.3> ≤15.5"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "seeked_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "seeking_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "select_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "selectionchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "71"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "9≤92"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "selectstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "71"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "17"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "self": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/self",
@@ -5585,6 +10112,55 @@
           }
         }
       },
+      "show_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "32",
+              "version_removed": "61"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "9",
+              "version_removed": "85"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "showDirectoryPicker": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/web/api/window/showdirectorypicker",
@@ -5737,6 +10313,54 @@
           }
         }
       },
+      "sidebar": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "102"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "sizeToContent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/sizeToContent",
@@ -5773,6 +10397,53 @@
           }
         }
       },
+      "slotchange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "97"
+            },
+            "firefox": {
+              "version_added": "93"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "speechSynthesis": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/speechSynthesis",
@@ -5805,6 +10476,53 @@
             "webview_android": {
               "version_added": false,
               "notes": "See <a href='https://crbug.com/487255'>bug 487255</a>."
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "stalled_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
             }
           },
           "status": {
@@ -6016,6 +10734,194 @@
           }
         }
       },
+      "submit_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "suspend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "timeupdate_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "toggle_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "36"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "49"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "toolbar": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/toolbar",
@@ -6091,6 +10997,429 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchcancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchforcechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchmove_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "touchstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitioncancel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "87"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "87"
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "12"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "26"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionrun_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "87"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "87"
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "12"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "transitionstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "87"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": null
+            },
+            "firefox": {
+              "version_added": "53"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "12"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -6323,6 +11652,53 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "volumechange_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -6809,6 +12185,290 @@
           }
         }
       },
+      "waiting_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitanimationend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitanimationiteration_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitanimationstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitCancelAnimationFrame": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "18"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitCancelRequestAnimationFrame": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "57"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "webkitConvertPointFromNodeToPage": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/webkitConvertPointFromNodeToPage",
@@ -6890,6 +12550,525 @@
             "experimental": false,
             "standard_track": false,
             "deprecated": true
+          }
+        }
+      },
+      "webkitIndexedDB": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "57"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforcechanged_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforcedown_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforceup_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitmouseforcewillbegin_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "8> ≤9.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitRequestAnimationFrame": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitRequestFileSystem": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitResolveLocalFileSystemURL": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitStorageInfo": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkittransitionend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "wheel_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "31"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "17"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -44,6 +44,54 @@
           "deprecated": false
         }
       },
+      "close_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "3> ≤3.6",
+              "version_removed": "51"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "dump": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/dump",
@@ -118,6 +166,53 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "fonts": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "14.1> ≤15.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
           },
           "status": {
             "experimental": false,
@@ -418,6 +513,53 @@
           }
         }
       },
+      "rejectionhandled_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "49"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "69"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "12.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "securitypolicyviolation_event": {
         "__compat": {
           "description": "<code>securitypolicyviolation</code> event",
@@ -492,6 +634,241 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "unhandledrejection_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "49"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": "69"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "12.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitRequestFileSystem": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitRequestFileSystemSync": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitResolveLocalFileSystemSyncURL": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitResolveLocalFileSystemURL": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -619,6 +619,54 @@
           }
         }
       },
+      "productSub": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "serial": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerNavigator/serial",
@@ -717,6 +765,54 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "taintEnabled": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "28",
+              "version_removed": "40"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -836,6 +932,102 @@
           },
           "status": {
             "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vendor": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "vendorSub": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "≤13",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -517,6 +517,100 @@
           }
         }
       },
+      "mozAnon": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "16"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "mozSystem": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "16"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "open": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/open",

--- a/api/XMLHttpRequestEventTarget.json
+++ b/api/XMLHttpRequestEventTarget.json
@@ -38,6 +38,335 @@
           "standard_track": true,
           "deprecated": false
         }
+      },
+      "abort_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "3> ≤3.6"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "error_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "load_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadend_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "18"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "5"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "loadstart_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "3> ≤3.6"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "progress_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "≤3"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "≤6"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "timeout_event": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "29"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤13"
+            },
+            "firefox": {
+              "version_added": "12"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": null
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "6> ≤8"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/XMLHttpRequestProgressEvent.json
+++ b/api/XMLHttpRequestProgressEvent.json
@@ -1,0 +1,149 @@
+{
+  "api": {
+    "XMLHttpRequestProgressEvent": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤15",
+            "version_removed": "50"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15",
+            "version_removed": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "≤6"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "position": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43",
+              "version_removed": "50"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "totalSize": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43",
+              "version_removed": "50"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "9.1> ≤10.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/XMLSerializer.json
+++ b/api/XMLSerializer.json
@@ -83,6 +83,54 @@
           }
         }
       },
+      "serializeToStream": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "≤3",
+              "version_removed": "20"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "serializeToString": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLSerializer/serializeToString",

--- a/api/XRAnchorSet.json
+++ b/api/XRAnchorSet.json
@@ -238,6 +238,53 @@
             "deprecated": false
           }
         }
+      },
+      "@@iterator": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "85"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "85"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/XRFrame.json
+++ b/api/XRFrame.json
@@ -73,6 +73,100 @@
           }
         }
       },
+      "fillJointRadii": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "fillPoses": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getDepthInformation": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRFrame/getDepthInformation",
@@ -176,6 +270,53 @@
           },
           "status": {
             "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getJointPose": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/XRHand.json
+++ b/api/XRHand.json
@@ -1,0 +1,380 @@
+{
+  "api": {
+    "XRHand": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "93"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "entries": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "forEach": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "get": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "keys": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "size": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "values": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "@@iterator": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/XRInputSource.json
+++ b/api/XRInputSource.json
@@ -113,6 +113,53 @@
           }
         }
       },
+      "hand": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "handedness": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRInputSource/handedness",

--- a/api/XRJointPose.json
+++ b/api/XRJointPose.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "XRJointPose": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "93"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "radius": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/XRJointSpace.json
+++ b/api/XRJointSpace.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "XRJointSpace": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "93"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "jointName": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "93"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/XRSystem.json
+++ b/api/XRSystem.json
@@ -158,6 +158,53 @@
             "deprecated": false
           }
         }
+      },
+      "supportsSession": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "83"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/mozRTCIceCandidate.json
+++ b/api/mozRTCIceCandidate.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "mozRTCIceCandidate": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "18"
+          },
+          "firefox_android": {
+            "version_added": "≤102"
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "mozRTCIceCandidate": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "18"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/mozRTCPeerConnection.json
+++ b/api/mozRTCPeerConnection.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "mozRTCPeerConnection": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "18"
+          },
+          "firefox_android": {
+            "version_added": "≤102"
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "mozRTCPeerConnection": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "17> ≤22"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/mozRTCSessionDescription.json
+++ b/api/mozRTCSessionDescription.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "mozRTCSessionDescription": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "18"
+          },
+          "firefox_android": {
+            "version_added": "≤102"
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "mozRTCSessionDescription": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "18"
+            },
+            "firefox_android": {
+              "version_added": "≤102"
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/webkitAudioContext.json
+++ b/api/webkitAudioContext.json
@@ -1,0 +1,152 @@
+{
+  "api": {
+    "webkitAudioContext": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤15",
+            "version_removed": "57"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15",
+            "version_removed": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "≤6",
+            "version_removed": "13.1> ≤14.1"
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "activeSourceCount": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "webkitAudioContext": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤15",
+              "version_removed": "57"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "≤6",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/webkitAudioPannerNode.json
+++ b/api/webkitAudioPannerNode.json
@@ -1,0 +1,54 @@
+{
+  "api": {
+    "webkitAudioPannerNode": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤15",
+            "version_removed": "36"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15",
+            "version_removed": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "≤6",
+            "version_removed": "13.1> ≤14.1"
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/webkitMediaStream.json
+++ b/api/webkitMediaStream.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "webkitMediaStream": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "21"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "79"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "≤17.0"
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "webkitMediaStream": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "21"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/webkitOfflineAudioContext.json
+++ b/api/webkitOfflineAudioContext.json
@@ -1,0 +1,104 @@
+{
+  "api": {
+    "webkitOfflineAudioContext": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "25",
+            "version_removed": "57"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15",
+            "version_removed": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "6> ≤8",
+            "version_removed": "13.1> ≤14.1"
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "webkitOfflineAudioContext": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "25",
+              "version_removed": "57"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "≤15",
+              "version_removed": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "6> ≤8",
+              "version_removed": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/webkitRTCPeerConnection.json
+++ b/api/webkitRTCPeerConnection.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "webkitRTCPeerConnection": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "23"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "14> ≤16"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": "15> ≤89"
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "≤17.0"
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "webkitRTCPeerConnection": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "23"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "≤16"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": "15> ≤89"
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/webkitSpeechGrammar.json
+++ b/api/webkitSpeechGrammar.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "webkitSpeechGrammar": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "25"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "79"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "≤17.0"
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "webkitSpeechGrammar": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "25"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/webkitSpeechGrammarList.json
+++ b/api/webkitSpeechGrammarList.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "webkitSpeechGrammarList": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "25"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "79"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "≤17.0"
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "webkitSpeechGrammarList": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "25"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/webkitSpeechRecognition.json
+++ b/api/webkitSpeechRecognition.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "webkitSpeechRecognition": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "25"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "79"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": "13.1> ≤14.1"
+          },
+          "safari_ios": {
+            "version_added": "≤15.5"
+          },
+          "samsunginternet_android": {
+            "version_added": "≤17.0"
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "webkitSpeechRecognition": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "25"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": "13.1> ≤14.1"
+            },
+            "safari_ios": {
+              "version_added": "≤15.5"
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/webkitSpeechRecognitionError.json
+++ b/api/webkitSpeechRecognitionError.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "webkitSpeechRecognitionError": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "25"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "79"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "≤17.0"
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "webkitSpeechRecognitionError": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "25"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/webkitSpeechRecognitionEvent.json
+++ b/api/webkitSpeechRecognitionEvent.json
@@ -1,0 +1,98 @@
+{
+  "api": {
+    "webkitSpeechRecognitionEvent": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "25"
+          },
+          "chrome_android": {
+            "version_added": "≤103"
+          },
+          "edge": {
+            "version_added": "79"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": null
+          },
+          "opera": {
+            "version_added": false
+          },
+          "opera_android": {
+            "version_added": "≤70"
+          },
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": "≤17.0"
+          },
+          "webview_android": {
+            "version_added": "≤103"
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "webkitSpeechRecognitionEvent": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "25"
+            },
+            "chrome_android": {
+              "version_added": "≤103"
+            },
+            "edge": {
+              "version_added": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": null
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": "≤70"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": "≤17.0"
+            },
+            "webview_android": {
+              "version_added": "≤103"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `valueText` member of the CSSFontFeatureValuesRule API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CSSFontFeatureValuesRule/valueText

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
