### PR TITLE
Add missing api.CSSImportRule.layerName feature

### DIFF
--- a/api/CSSImportRule.json
+++ b/api/CSSImportRule.json
@@ -81,6 +81,7 @@
       },
       "layerName": {
         "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-cascade-5/#dom-cssimportrule-layername",
           "support": {
             "chrome": {
               "version_added": "99"

--- a/api/CSSImportRule.json
+++ b/api/CSSImportRule.json
@@ -79,6 +79,38 @@
           }
         }
       },
+      "layerName": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "97"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "media": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSImportRule/media",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `layerName` member of the CSSImportRule API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CSSImportRule/layerName

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
