### PR TITLE
Add missing CSSLayerBlockRule API

### DIFF
--- a/api/CSSLayerBlockRule.json
+++ b/api/CSSLayerBlockRule.json
@@ -2,6 +2,7 @@
   "api": {
     "CSSLayerBlockRule": {
       "__compat": {
+        "spec_url": "https://drafts.csswg.org/css-cascade-5/#csslayerblockrule",
         "support": {
           "chrome": {
             "version_added": "99"
@@ -33,6 +34,7 @@
       },
       "name": {
         "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-cascade-5/#dom-csslayerblockrule-name",
           "support": {
             "chrome": {
               "version_added": "99"

--- a/api/CSSLayerBlockRule.json
+++ b/api/CSSLayerBlockRule.json
@@ -1,0 +1,68 @@
+{
+  "api": {
+    "CSSLayerBlockRule": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "99"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": "97"
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": "15.4"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "name": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "97"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `CSSLayerBlockRule` API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CSSLayerBlockRule

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
