### PR TITLE
Add missing CSSLayerStatementRule API

### DIFF
--- a/api/CSSLayerStatementRule.json
+++ b/api/CSSLayerStatementRule.json
@@ -2,6 +2,7 @@
   "api": {
     "CSSLayerStatementRule": {
       "__compat": {
+        "spec_url": "https://drafts.csswg.org/css-cascade-5/#csslayerstatementrule",
         "support": {
           "chrome": {
             "version_added": "99"
@@ -33,6 +34,7 @@
       },
       "nameList": {
         "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-cascade-5/#dom-csslayerstatementrule-namelist",
           "support": {
             "chrome": {
               "version_added": "99"

--- a/api/CSSLayerStatementRule.json
+++ b/api/CSSLayerStatementRule.json
@@ -1,0 +1,68 @@
+{
+  "api": {
+    "CSSLayerStatementRule": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "99"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": "97"
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": "15.4"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "nameList": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "97"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `CSSLayerStatementRule` API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CSSLayerStatementRule

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
