### PR TITLE
Add missing CSSMathClamp API

### DIFF
--- a/api/CSSMathClamp.json
+++ b/api/CSSMathClamp.json
@@ -93,7 +93,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/CSSMathClamp.json
+++ b/api/CSSMathClamp.json
@@ -60,7 +60,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/CSSMathClamp.json
+++ b/api/CSSMathClamp.json
@@ -27,7 +27,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }

--- a/api/CSSMathClamp.json
+++ b/api/CSSMathClamp.json
@@ -1,0 +1,165 @@
+{
+  "api": {
+    "CSSMathClamp": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "100"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "CSSMathClamp": {
+        "__compat": {
+          "description": "<code>CSSMathClamp()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lower": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "upper": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "value": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/CSSMathClamp.json
+++ b/api/CSSMathClamp.json
@@ -159,7 +159,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/CSSMathClamp.json
+++ b/api/CSSMathClamp.json
@@ -2,6 +2,7 @@
   "api": {
     "CSSMathClamp": {
       "__compat": {
+        "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#cssmathclamp",
         "support": {
           "chrome": {
             "version_added": "100"
@@ -34,6 +35,7 @@
       "CSSMathClamp": {
         "__compat": {
           "description": "<code>CSSMathClamp()</code> constructor",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-cssmathclamp-cssmathclamp",
           "support": {
             "chrome": {
               "version_added": "100"
@@ -66,6 +68,7 @@
       },
       "lower": {
         "__compat": {
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-cssmathclamp-lower",
           "support": {
             "chrome": {
               "version_added": "100"
@@ -98,6 +101,7 @@
       },
       "upper": {
         "__compat": {
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-cssmathclamp-upper",
           "support": {
             "chrome": {
               "version_added": "100"
@@ -130,6 +134,7 @@
       },
       "value": {
         "__compat": {
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-cssmathclamp-value",
           "support": {
             "chrome": {
               "version_added": "100"

--- a/api/CSSMathClamp.json
+++ b/api/CSSMathClamp.json
@@ -126,7 +126,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `CSSMathClamp` API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CSSMathClamp

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
