### PR TITLE
Add missing Directory API

### DIFF
--- a/api/Directory.json
+++ b/api/Directory.json
@@ -2,6 +2,7 @@
   "api": {
     "Directory": {
       "__compat": {
+        "spec_url": "https://wicg.github.io/directory-upload/proposal.html#dom-directory",
         "support": {
           "chrome": {
             "version_added": false
@@ -33,6 +34,7 @@
       },
       "getFiles": {
         "__compat": {
+          "spec_url": "https://wicg.github.io/directory-upload/proposal.html#dom-directory-getfiles",
           "support": {
             "chrome": {
               "version_added": false
@@ -65,6 +67,7 @@
       },
       "getFilesAndDirectories": {
         "__compat": {
+          "spec_url": "https://wicg.github.io/directory-upload/proposal.html#dom-directory-getfilesanddirectories",
           "support": {
             "chrome": {
               "version_added": false
@@ -97,6 +100,7 @@
       },
       "name": {
         "__compat": {
+          "spec_url": "https://wicg.github.io/directory-upload/proposal.html#dom-directory-name",
           "support": {
             "chrome": {
               "version_added": false
@@ -129,6 +133,7 @@
       },
       "path": {
         "__compat": {
+          "spec_url": "https://wicg.github.io/directory-upload/proposal.html#dom-directory-path",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/Directory.json
+++ b/api/Directory.json
@@ -1,0 +1,164 @@
+{
+  "api": {
+    "Directory": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": "42"
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "getFiles": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "48"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getFilesAndDirectories": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "42"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "name": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "42"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "path": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "42"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/linter/test-spec-urls.ts
+++ b/test/linter/test-spec-urls.ts
@@ -50,6 +50,8 @@ const specsExceptions = [
 
   // Remove if https://github.com/w3c/browser-specs/pull/667#issuecomment-1200089758 is resolved
   'https://w3c.github.io/device-memory',
+
+  'https://wicg.github.io/directory-upload/proposal.html',
 ];
 
 const allowedSpecURLs = [


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `Directory` API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Directory

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
