### PR TITLE
Add missing features for ElementInternals API

### DIFF
--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -476,6 +476,38 @@
           }
         }
       },
+      "ariaInvalid": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "ariaKeyShortcuts": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaKeyShortcuts",
@@ -1465,6 +1497,38 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "98"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "role": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "103"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -503,7 +503,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -1547,7 +1547,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -478,6 +478,7 @@
       },
       "ariaInvalid": {
         "__compat": {
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariainvalid",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -1521,6 +1522,7 @@
       },
       "role": {
         "__compat": {
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-role",
           "support": {
             "chrome": {
               "version_added": "103"


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing features of the ElementInternals API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.0).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ElementInternals

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
