### PR TITLE
Safari 15 fixed the bug where :link and :visited matching on <link> elements

### DIFF
--- a/css/selectors/link.json
+++ b/css/selectors/link.json
@@ -70,8 +70,7 @@
               },
               "opera_android": "mirror",
               "safari": {
-                "version_added": "15",
-                "notes": "Safari used to match <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/227847'>Bug: 227847</a>."
+                "version_added": "15"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/selectors/link.json
+++ b/css/selectors/link.json
@@ -70,8 +70,8 @@
               },
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "notes": "Safari currently matches <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/220740'>Bug: 220740</a>."
+                "version_added": "15",
+                "notes": "Safari used to match <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/227847'>Bug: 227847</a>."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/selectors/visited.json
+++ b/css/selectors/visited.json
@@ -66,8 +66,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "notes": "Safari currently matches <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/220740'>Bug: 220740</a>."
+                "version_added": "15",
+                "notes": "Safari used to match <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/227847'>Bug: 227847</a>."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/selectors/visited.json
+++ b/css/selectors/visited.json
@@ -66,8 +66,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "15",
-                "notes": "Safari used to match <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/227847'>Bug: 227847</a>."
+                "version_added": "15"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION

Safari 15 fixed the bug where :link and :visited matching on `<link>` elements, see https://bugs.webkit.org/show_bug.cgi?id=227847

