### PR TITLE
Update spec URL for css.properties.contain.inline-size

### DIFF
--- a/css/properties/contain.json
+++ b/css/properties/contain.json
@@ -37,7 +37,7 @@
         "inline-size": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain#inline-size",
-            "spec_url": "https://www.w3.org/TR/css-contain-3/#valdef-contain-inline-size",
+            "spec_url": "https://drafts.csswg.org/css-contain-3/#valdef-contain-inline-size",
             "support": {
               "chrome": {
                 "version_added": "105"


### PR DESCRIPTION
This should be the drafts.csswg.org URL rather than the www.w3.org/TR one.