### PR TITLE
Add CSS2.1 link to spec-url for float and clear

### DIFF
--- a/css/properties/clear.json
+++ b/css/properties/clear.json
@@ -4,7 +4,10 @@
       "clear": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/clear",
-          "spec_url": "https://drafts.csswg.org/css-logical/#float-clear",
+          "spec_url": [
+            "https://drafts.csswg.org/css2/#propdef-clear",
+            "https://drafts.csswg.org/css-logical/#float-clear"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/css/properties/float.json
+++ b/css/properties/float.json
@@ -4,7 +4,10 @@
       "float": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/float",
-          "spec_url": "https://drafts.csswg.org/css-logical/#float-clear",
+          "spec_url": [
+            "https://drafts.csswg.org/css2/#propdef-float",
+            "https://drafts.csswg.org/css-logical/#float-clear"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
In mdn/content#19768, the reporter noticed that the latest spec links for the CSS properties `float` and `clear` don't _replace_ the CSS 2.1 spec but merely _extend_ it.

This is unusual, and we should link to both specs for these two properties. (This is rare, I didn't find another case, though I didn't perform an extensive search.)

This PR fixes mdn/content#19768.