### PR TITLE
improve Navigator.vibrate notes

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4535,7 +4535,7 @@
               {
                 "version_added": "79",
                 "partial_implementation": true,
-                "notes": "Vibration is disabled. If the window is visible, then <code>navigator.vibrate()</code> returns <code>true</code>, but no vibration takes place (regardless of hardware support). See <a href='https://bugzil.la/1591113'>bug 1591113</a>."
+                "notes": "Vibration is disabled. If the window is visible, then <code>navigator.vibrate()</code> returns <code>true</code>, but no vibration takes place (regardless of hardware support). Original intent was to disable it for cross-origin frames only (<a href='https://bugzil.la/1591113'>bug 1591113</a>), but was not re-enabled over abuse concerns (<a href='https://bugzil.la/1653318'>bug 1653318</a>)."
               },
               {
                 "version_added": "16",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4535,7 +4535,7 @@
               {
                 "version_added": "79",
                 "partial_implementation": true,
-                "notes": "Vibration is disabled. If the window is visible, then <code>navigator.vibrate()</code> returns <code>true</code>, but no vibration takes place (regardless of hardware support). Original intent was to disable it for cross-origin frames only (<a href='https://bugzil.la/1591113'>bug 1591113</a>), but was not re-enabled over abuse concerns (<a href='https://bugzil.la/1653318'>bug 1653318</a>)."
+                "notes": "Vibration is disabled. If the window is visible, then <code>navigator.vibrate()</code> returns <code>true</code>, but no vibration takes place (regardless of hardware support). Originally, the intent was to disable it for cross-origin frames only (<a href='https://bugzil.la/1591113'>bug 1591113</a>), but the feature was not re-enabled due to abuse concerns (<a href='https://bugzil.la/1653318'>bug 1653318</a>)."
               },
               {
                 "version_added": "16",


### PR DESCRIPTION
The notes for `Navigator.vibrate` on Firefox Android explain that the API was completely disabled, but point to a bug where it was only to be disabled for third-party frames. This can be a bit confusing, so I expand the explanation and point to the following [regression bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1653318).

I'm not sure this is the right place to expand on the reason for the change, but thought about suggesting it in case you see fit.