### PR TITLE
Remove irrelevant flags from Safari for CSS scroll-behavior property

### DIFF
--- a/css/properties/scroll-behavior.json
+++ b/css/properties/scroll-behavior.json
@@ -21,35 +21,10 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": [
-              {
-                "version_added": "15.4"
-              },
-              {
-                "version_added": "14",
-                "version_removed": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "CSSOM View Smooth Scrolling"
-                  }
-                ]
-              }
-            ],
-            "safari_ios": [
-              {
-                "version_added": "15.4"
-              },
-              {
-                "version_added": "14",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "CSSOM View Smooth Scrolling"
-                  }
-                ]
-              }
-            ],
+            "safari": {
+              "version_added": "15.4"
+            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
This PR removes the irrelevant flag data for the `scroll-behavior` CSS property from Safari.  This, in turn, fixes https://github.com/mdn/browser-compat-data/issues/17517.