### PR TITLE
Support for animation-composition in FF104

### DIFF
--- a/css/properties/animation-composition.json
+++ b/css/properties/animation-composition.json
@@ -1,0 +1,47 @@
+{
+  "css": {
+    "properties": {
+      "animation-timeline": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-timeline",
+          "spec_url": "https://drafts.csswg.org/css-animations-2/#animation-timeline",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.scroll-linked-animations.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/animation-composition.json
+++ b/css/properties/animation-composition.json
@@ -37,7 +37,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/css/properties/animation-composition.json
+++ b/css/properties/animation-composition.json
@@ -1,10 +1,10 @@
 {
   "css": {
     "properties": {
-      "animation-timeline": {
+      "animation-composition": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-timeline",
-          "spec_url": "https://drafts.csswg.org/css-animations-2/#animation-timeline",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-composition",
+          "spec_url": "https://drafts.csswg.org/css-animations-2/#animation-composition",
           "support": {
             "chrome": {
               "version_added": false
@@ -12,11 +12,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "97",
+              "version_added": "104",
               "flags": [
                 {
                   "type": "preference",
-                  "name": "layout.css.scroll-linked-animations.enabled",
+                  "name": "layout.css.animation-composition.enabled",
                   "value_to_set": "true"
                 }
               ]
@@ -37,7 +37,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
- In FF104, support for `animation-composition` has been added behind a preference. (see https://bugzilla.mozilla.org/show_bug.cgi?id=1293490#c11)

- `animation-composition` is also supported in Safari (but not shipped?) (see https://bugs.webkit.org/show_bug.cgi?id=232086). So I've retained `"version_added": false` for Safari.

- Not supported in Chrome yet. (see https://bugs.chromium.org/p/chromium/issues/detail?id=1342699&q=animation-composition&can=2)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Doc issue tracker: https://github.com/mdn/content/issues/18771
Content page: WIP

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
