### PR TITLE
Document the Oculus/Quest browser

### DIFF
--- a/schemas/browsers-schema.md
+++ b/schemas/browsers-schema.md
@@ -97,6 +97,7 @@ The following table indicates initial versions for browsers in BCD. These are th
 | Firefox Android  | 4               | Stable versioning started at 4. Earlier non-Android mobile versions are ignored.                                                                                         |
 | IE               | 1               |                                                                                                                                                                          |
 | Node.js          | 0.10.0          | This project selected 0.10.0 as the first release primarily because the 0.10-series releases was the first to have LTS status applied. See issue #6861.                  |
+| Meta Quest       | 5.0             | The first version documented on the Oculus Developer website.                                                                                                            |
 | Opera            | 2               | Stable versioning started at 2. Opera 1 was demoed at a conference, but never publicly released.                                                                         |
 | Opera Android    | 10.1            | Stable versioning started at 10.1.                                                                                                                                       |
 | Safari           | 1               |                                                                                                                                                                          |

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -183,6 +183,7 @@ The currently accepted browser identifiers should be declared in alphabetical or
 - `firefox_android`, Firefox for Android, sometimes nicknamed Fennec
 - `ie`, Microsoft Internet Explorer (discontinued)
 - `nodejs` Node.js JavaScript runtime built on Chrome's V8 JavaScript engine
+- `oculus`, Meta Quest Browser (formerly Oculus Quest), based on Google Chrome (on Android)
 - `opera`, the Opera browser (desktop), based on Blink since Opera 15
 - `opera_android`, the Opera browser (Android version)
 - `safari`, Safari on macOS


### PR DESCRIPTION
#### Summary

Support was recently added for the browser from Meta Platforms Inc [1];
extend the relevant documentation to include it.

[1] 6a4991bc6dd5fc4a47eb2d1331437cf6d8833b36

#### Test results and supporting details

Because this change concerns documentation only, it includes no automated tests.

#### Related issues

gh-15923
