### PR TITLE
Adds linear() function to easing-function table

### DIFF
--- a/css/types/easing-function.json
+++ b/css/types/easing-function.json
@@ -43,6 +43,43 @@
             "deprecated": false
           }
         },
+        "cubic-bezier": {
+          "__compat": {
+            "description": "<code>cubic-bezier()</code> with ordinate ∉ [0,1]",
+            "support": {
+              "chrome": {
+                "version_added": "16"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "4"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "10"
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": "12.1"
+              },
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "6"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "linear-function": {
           "__compat": {
             "description": "<code>linear()</code>",
@@ -78,43 +115,6 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "cubic-bezier": {
-          "__compat": {
-            "description": "<code>cubic-bezier()</code> with ordinate ∉ [0,1]",
-            "support": {
-              "chrome": {
-                "version_added": "16"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "4"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "10"
-              },
-              "oculus": "mirror",
-              "opera": {
-                "version_added": "12.1"
-              },
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "6"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/types/easing-function.json
+++ b/css/types/easing-function.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>&lt;easing-function&gt;</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/easing-function",
-          "spec_url": "https://drafts.csswg.org/css-easing-2/#easing-functions",
+          "spec_url": "https://drafts.csswg.org/css-easing/#easing-functions",
           "support": {
             "chrome": {
               "version_added": "4"

--- a/css/types/easing-function.json
+++ b/css/types/easing-function.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>&lt;easing-function&gt;</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/easing-function",
-          "spec_url": "https://drafts.csswg.org/css-easing/#easing-functions",
+          "spec_url": "https://drafts.csswg.org/css-easing-2/#easing-functions",
           "support": {
             "chrome": {
               "version_added": "4"
@@ -41,6 +41,46 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "linear-function": {
+          "__compat": {
+            "description": "<code>linear()</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "104",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.linear-easing-function.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         },
         "cubic-bezier": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
- `linear()` function is supported in FF104 behind the preference `layout.css.linear-easing-function.enabled`. (https://bugzilla.mozilla.org/show_bug.cgi?id=1764126)
- This PR also updates the spec url.

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
- It seems that this is not yet implemented in Chrome and Safari from the following issues: 
  - https://bugs.chromium.org/p/chromium/issues/detail?id=1345090&q=easing&can=2
  - https://bugs.webkit.org/show_bug.cgi?id=240061

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
- Doc issue tracker: https://github.com/mdn/content/issues/19709

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
