### PR TITLE
Add XRPose.{angular,linear}Velocity

### DIFF
--- a/api/XRPose.json
+++ b/api/XRPose.json
@@ -37,6 +37,45 @@
           "deprecated": false
         }
       },
+      "angularVelocity": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRPose/angularVelocity",
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrpose-angularvelocity",
+          "support": {
+            "chrome": {
+              "version_added": false,
+              "impl_url": "https://crbug.com/1202213"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": {
+              "version_added": "15.0"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "emulatedPosition": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRPose/emulatedPosition",
@@ -64,6 +103,45 @@
             "samsunginternet_android": {
               "version_added": "11.2"
             },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "linearVelocity": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRPose/linearVelocity",
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrpose-linearvelocity",
+          "support": {
+            "chrome": {
+              "version_added": false,
+              "impl_url": "https://crbug.com/1202213"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": {
+              "version_added": "15.0"
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
             }


### PR DESCRIPTION
Previous PR: https://github.com/mdn/browser-compat-data/pull/11813

Given BCD now supports oculus, these aren't all-false features anymore. Oculus 15.0 ships them.

I don't understand why impl_url fails a test. Edit: I've sent https://github.com/mdn/browser-compat-data/pull/17530