### PR TITLE
No support with impl_url should be allowed

### DIFF
--- a/test/linter/test-versions.ts
+++ b/test/linter/test-versions.ts
@@ -227,7 +227,7 @@ const checkVersions = (
         if (statement.version_added === false) {
           if (
             Object.keys(statement).some(
-              (k) => !['version_added', 'notes'].includes(k),
+              (k) => !['version_added', 'notes', 'impl_url'].includes(k),
             )
           ) {
             logger.error(


### PR DESCRIPTION
See https://github.com/mdn/browser-compat-data/pull/17528 for a test case. I think we should allow `impl_url` with `version_added: false`.