### PR TITLE
WebExtension tweaks for Safari and Manifest V3

### DIFF
--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -862,14 +862,30 @@
               },
               "firefox_android": "mirror",
               "opera": "mirror",
-              "safari": {
-                "notes": "In Safari 14, this event is fired in response to a message from an extension's containing app. In Safari 15.4 and later, this event is also fired in response to a message from webpages.",
-                "version_added": "14"
-              },
-              "safari_ios": {
-                "notes": "In Safari 15, this event is fired in response to a message from an extension's containing app. In Safari 15.4 and later, this event is also fired in response to a message from webpages.",
-                "version_added": "15"
-              }
+              "safari": [
+                {
+                  "version_added": "15.4",
+                  "partial_implementation": true,
+                  "notes": "Since Safari 15.4, this event is also fired in response to a message from webpages allowed in <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/externally_connectable'><code>externally_connectable</code></a>."
+                },
+                {
+                  "version_added": "14",
+                  "partial_implementation": true,
+                  "notes": "This event is only fired in response to a message from an extension's containing app, not webpages nor other extensions."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "15.4",
+                  "partial_implementation": true,
+                  "notes": "Since Safari 15.4, this event is also fired in response to a message from webpages allowed in <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/externally_connectable'><code>externally_connectable</code></a>."
+                },
+                {
+                  "version_added": "15",
+                  "partial_implementation": true,
+                  "notes": "This event is only fired in response to a message from an extension's containing app, not webpages nor other extensions."
+                }
+              ]
             }
           },
           "return_promise": {

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -462,12 +462,9 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false,
-                "notes": "Available in Safari Technology Preview 142."
+                "version_added": "16"
               },
-              "safari_ios": {
-                "version_added": false
-              }
+              "safari_ios": "mirror"
             }
           }
         },

--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -7,7 +7,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting/InjectionTarget",
             "support": {
               "chrome": {
-                "version_added": "88"
+                "version_added": "88",
+                "notes": "Available for use in Manifest V3 or later."
               },
               "edge": "mirror",
               "firefox": {
@@ -16,7 +17,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": "15.4"
+                "version_added": "15.4",
+                "notes": "Available for use in Manifest V2 or later."
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1336,14 +1336,14 @@
               "safari": {
                 "notes": [
                   "The default file format is 'jpeg'.",
-                  "<code>&lt;all_urls&gt;</code> permission is not required to call this."
+                  "<code>&lt;all_urls&gt;</code> permission is optional."
                 ],
                 "version_added": "14"
               },
               "safari_ios": {
                 "notes": [
                   "The default file format is 'jpeg'.",
-                  "<code>&lt;all_urls&gt;</code> permission is not required to call this."
+                  "<code>&lt;all_urls&gt;</code> permission is optional."
                 ],
                 "version_added": "15"
               }

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1855,32 +1855,32 @@
                 "version_added": true,
                 "notes": [
                   "Extensions can't inject scripts into their own pages using this API.",
-                  "Not available for use in Manifest V3."
+                  "Available for use in Manifest V2 only."
                 ]
               },
               "edge": {
                 "version_added": "14",
-                "notes": "Not available for use in Manifest V3."
+                "notes": "Available for use in Manifest V2 only."
               },
               "firefox": {
                 "version_added": "43",
                 "notes": [
                   "Before version 50, Firefox would pass a single result value into its callback rather than an array, unless 'allFrames' had been set.",
-                  "Not available for use in Manifest V3."
+                  "Available for use in Manifest V2 only."
                 ]
               },
               "firefox_android": {
                 "version_added": "54",
-                "notes": "Not available for use in Manifest V3."
+                "notes": "Available for use in Manifest V2 only."
               },
               "opera": "mirror",
               "safari": {
                 "version_added": "14",
-                "notes": "Not available for use in Manifest V3."
+                "notes": "Available for use in Manifest V2 only."
               },
               "safari_ios": {
                 "version_added": "15",
-                "notes": "Not available for use in Manifest V3."
+                "notes": "Available for use in Manifest V2 only."
               }
             }
           },
@@ -2227,28 +2227,28 @@
             "support": {
               "chrome": {
                 "version_added": true,
-                "notes": "Not available for use in Manifest V3."
+                "notes": "Available for use in Manifest V2 only."
               },
               "edge": {
                 "version_added": "14",
-                "notes": "Not available for use in Manifest V3."
+                "notes": "Available for use in Manifest V2 only."
               },
               "firefox": {
                 "version_added": "47",
-                "notes": "Not available for use in Manifest V3."
+                "notes": "Available for use in Manifest V2 only."
               },
               "firefox_android": {
                 "version_added": "54",
-                "notes": "Not available for use in Manifest V3."
+                "notes": "Available for use in Manifest V2 only."
               },
               "opera": "mirror",
               "safari": {
                 "version_added": "14",
-                "notes": "Not available for use in Manifest V3."
+                "notes": "Available for use in Manifest V2 only."
               },
               "safari_ios": {
                 "version_added": "15",
-                "notes": "Not available for use in Manifest V3."
+                "notes": "Available for use in Manifest V2 only."
               }
             }
           },
@@ -3544,25 +3544,25 @@
             "support": {
               "chrome": {
                 "version_added": "87",
-                "notes": "Not available for use in Manifest V3."
+                "notes": "Available for use in Manifest V2 only."
               },
               "edge": "mirror",
               "firefox": {
                 "version_added": "49",
-                "notes": "Not available for use in Manifest V3."
+                "notes": "Available for use in Manifest V2 only."
               },
               "firefox_android": {
                 "version_added": "54",
-                "notes": "Not available for use in Manifest V3."
+                "notes": "Available for use in Manifest V2 only."
               },
               "opera": "mirror",
               "safari": {
                 "version_added": "14",
-                "notes": "Not available for use in Manifest V3."
+                "notes": "Available for use in Manifest V2 only."
               },
               "safari_ios": {
                 "version_added": "15",
-                "notes": "Not available for use in Manifest V3."
+                "notes": "Available for use in Manifest V2 only."
               }
             }
           }

--- a/webextensions/manifest/author.json
+++ b/webextensions/manifest/author.json
@@ -10,7 +10,7 @@
             },
             "edge": {
               "version_added": "14",
-              "notes": "This key is mandatory in Microsoft Edge."
+              "notes": "This property is required."
             },
             "firefox": {
               "version_added": "52"

--- a/webextensions/manifest/background.json
+++ b/webextensions/manifest/background.json
@@ -59,7 +59,7 @@
               },
               "edge": {
                 "version_added": "14",
-                "notes": "The <code>persistent</code> property is mandatory."
+                "notes": "This property is required."
               },
               "firefox": {
                 "version_added": "48",

--- a/webextensions/manifest/background.json
+++ b/webextensions/manifest/background.json
@@ -28,7 +28,8 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Available for use in Manifest V2 only."
               },
               "edge": {
                 "version_added": "14"
@@ -53,11 +54,12 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Available for use in Manifest V2 only."
               },
               "edge": {
                 "version_added": "14",
-                "notes": "The 'persistent' property is mandatory."
+                "notes": "The <code>persistent</code> property is mandatory."
               },
               "firefox": {
                 "version_added": "48",

--- a/webextensions/manifest/background.json
+++ b/webextensions/manifest/background.json
@@ -39,10 +39,12 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "Available for use in Manifest V2 or later."
               },
               "safari_ios": {
-                "version_added": "15"
+                "version_added": "15",
+                "notes": "Available for use in Manifest V2 or later."
               }
             }
           }
@@ -66,14 +68,29 @@
               },
               "firefox_android": "mirror",
               "opera": "mirror",
-              "safari": {
-                "notes": "Before 14.1, only persistent pages are supported.",
-                "version_added": "14"
-              },
-              "safari_ios": {
-                "notes": "Only non-persistent pages are supported. Requires <code>persistent: false</code>.",
-                "version_added": "15"
-              }
+              "safari": [
+                {
+                  "version_added": "14.1",
+                  "notes": "Since Safari 15.4, ignored if <code>service_worker</code> is used."
+                },
+                {
+                  "version_added": "14",
+                  "partial_implementation": true,
+                  "notes": "Only persistent pages are supported."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "notes": "Only non-persistent pages are supported. Requires <code>persistent: false</code> or <code>service_worker</code>.",
+                  "partial_implementation": true,
+                  "version_added": "15.4"
+                },
+                {
+                  "notes": "Only non-persistent pages are supported. Requires <code>persistent: false</code>.",
+                  "partial_implementation": true,
+                  "version_added": "15"
+                }
+              ]
             }
           }
         },
@@ -81,7 +98,8 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "notes": "Available for use in Manifest V2 only."
               },
               "edge": {
                 "version_added": "14"
@@ -93,11 +111,34 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "Available for use in Manifest V2 or later."
               },
               "safari_ios": {
-                "version_added": "15"
+                "version_added": "15",
+                "notes": "Available for use in Manifest V2 or later."
               }
+            }
+          }
+        },
+        "service_worker": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "88",
+                "notes": "Available for use in Manifest V2 or later."
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": "15.4",
+                "notes": "Available for use in Manifest V2 or later."
+              },
+              "safari_ios": "mirror"
             }
           }
         }

--- a/webextensions/manifest/browser_specific_settings.json
+++ b/webextensions/manifest/browser_specific_settings.json
@@ -12,16 +12,10 @@
               "version_added": "15",
               "version_removed": "79"
             },
-            "firefox": [
-              {
-                "version_added": "48"
-              },
-              {
-                "version_added": "42",
-                "alternative_name": "applications",
-                "notes": "Mandatory before Firefox 48."
-              }
-            ],
+            "firefox": {
+              "version_added": "42",
+              "notes": "Before Firefox 48, this property was required."
+            },
             "firefox_android": "mirror",
             "opera": "mirror",
             "safari": {

--- a/webextensions/manifest/chrome_url_overrides.json
+++ b/webextensions/manifest/chrome_url_overrides.json
@@ -20,10 +20,17 @@
             "opera": {
               "version_added": false
             },
-            "safari": {
-              "version_added": "14.1"
-            },
+            "safari": [
+              {
+                "version_added": "14.1"
+              },
+              {
+                "alternative_name": "browser_url_overrides",
+                "version_added": "15"
+              }
+            ],
             "safari_ios": {
+              "alternative_name": "browser_url_overrides",
               "version_added": "15"
             }
           }

--- a/webextensions/manifest/content_security_policy.json
+++ b/webextensions/manifest/content_security_policy.json
@@ -34,10 +34,7 @@
             "support": {
               "chrome": {
                 "version_added": "88",
-                "notes": [
-                  "Available in Canary builds.",
-                  "Available to Manifest V3 only."
-                ]
+                "notes": "Available for use in Manifest V3 or later."
               },
               "edge": "mirror",
               "firefox": {
@@ -53,11 +50,11 @@
               "firefox_android": "mirror",
               "opera": {
                 "version_added": "74",
-                "notes": "Available to Manifest V3 only."
+                "notes": "Available for use in Manifest V3 or later."
               },
               "safari": {
                 "version_added": "15.4",
-                "notes": "Available to Manifest V3 only."
+                "notes": "Available for use in Manifest V3 or later."
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/manifest/externally_connectable.json
+++ b/webextensions/manifest/externally_connectable.json
@@ -21,7 +21,7 @@
             "opera": "mirror",
             "safari": {
               "version_added": "15.4",
-              "notes": "Safari only supports the <code>matches</code> attribute."
+              "notes": "Safari only supports the <code>matches</code> property."
             },
             "safari_ios": "mirror"
           }

--- a/webextensions/manifest/host_permissions.json
+++ b/webextensions/manifest/host_permissions.json
@@ -7,18 +7,18 @@
           "support": {
             "chrome": {
               "version_added": "88",
-              "notes": "Available for use in Manifest V3 only."
+              "notes": "Available for use in Manifest V3 or later."
             },
             "edge": "mirror",
             "firefox": {
               "version_added": "101",
-              "notes": "Available for use in Manifest V3 only."
+              "notes": "Available for use in Manifest V3 or later."
             },
             "firefox_android": "mirror",
             "opera": "mirror",
             "safari": {
               "version_added": "15.4",
-              "notes": "Available for use in Manifest V3 only."
+              "notes": "Available for use in Manifest V3 or later."
             },
             "safari_ios": "mirror"
           }

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -891,14 +891,28 @@
               "opera": {
                 "version_added": false
               },
-              "safari": {
-                "notes": "Before Safari 16, this permission granted a 10 MB storage quota. Since Safari 16, the storage quota is unlimited.",
-                "version_added": "14"
-              },
-              "safari_ios": {
-                "notes": "Does not grant an unlimited storage quota. Grants a 10 MB storage quota, instead of the standard 5 MB.",
-                "version_added": "15"
-              }
+              "safari": [
+                {
+                  "version_added": "16",
+                  "notes": "Since Safari 16, the storage quota is unlimited."
+                },
+                {
+                  "version_added": "14",
+                  "partial_implementation": true,
+                  "notes": "Does not grant an unlimited storage quota. Grants a 10 MB storage quota, instead of the standard 5 MB."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "16",
+                  "notes": "Since Safari 16, the storage quota is unlimited."
+                },
+                {
+                  "version_added": "15",
+                  "partial_implementation": true,
+                  "notes": "Does not grant an unlimited storage quota. Grants a 10 MB storage quota, instead of the standard 5 MB."
+                }
+              ]
             }
           }
         },

--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -62,8 +62,8 @@
                   "version_added": "55",
                   "version_removed": "70",
                   "notes": [
-                    "Before version 59, the RGB array form was not supported for this property.",
-                    "Before version 63, this property was mandatory.",
+                    "Before Firefox 59, the RGB array form was not supported for this property.",
+                    "Before Firefox 63, this property was required.",
                     "Use <code>frame</code> instead."
                   ]
                 },
@@ -633,8 +633,8 @@
                   "version_added": "55",
                   "version_removed": "70",
                   "notes": [
-                    "Before version 59, the RGB array form was not supported for this property.",
-                    "Before version 63, this property was mandatory.",
+                    "Before Firefox 59, the RGB array form was not supported for this property.",
+                    "Before Firefox 63, this property was required.",
                     "Use <code>tab_background_text</code> instead."
                   ]
                 },
@@ -990,7 +990,7 @@
               },
               "firefox": {
                 "version_added": "55",
-                "notes": "Mandatory before Firefox 60"
+                "notes": "Before Firefox 60, this property was required."
               },
               "firefox_android": {
                 "version_added": true


### PR DESCRIPTION
* Add better version specific notes for Safari support.
* Add Safari 16 version support for `runtime.getFrameId` and drop STP reference.
* Add more consistent manifest version availability notes.
    * Features that are dropped in V3 noted as "Manifest V2 only".
    * Features that are added in V3 noted as "Manifest V3 or later" to avoid prematurely limiting to V3 when future versions are supported.
    * Features that are dropped in V3 by some browsers but are supported in full in others still noted as "Manifest V2 or later".
* More consistent use of required/optional instead of mandatory.