### PR TITLE
Correct URL for XRHitTestResult.getPose

### DIFF
--- a/api/XRHitTestResult.json
+++ b/api/XRHitTestResult.json
@@ -73,7 +73,7 @@
       },
       "getPose": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRHitTestResult/createPose",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRHitTestResult/getPose",
           "spec_url": "https://immersive-web.github.io/hit-test/#dom-xrhittestresult-getpose",
           "support": {
             "chrome": {


### PR DESCRIPTION
#### Summary

The URL for this API has been incorrect since its introduction on
2021-08-22 [1]. The mistake does not indicate an omission because there
is no API named `createPose` in the WebXR Hit Test proposal [2].

[1] 6edc6818d361109958490a4052ece8b462987144
[2] https://immersive-web.github.io/hit-test/

#### Test results and supporting details

n/a

#### Related issues

n/a