### PR TITLE
Corrects some incorrect Safari versions for details in webRequest.onResponseStarted.

### DIFF
--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -4384,11 +4384,9 @@
                   },
                   "opera": "mirror",
                   "safari": {
-                    "version_added": "14"
-                  },
-                  "safari_ios": {
                     "version_added": false
-                  }
+                  },
+                  "safari_ios": "mirror"
                 }
               }
             },
@@ -4668,11 +4666,9 @@
                   },
                   "opera": "mirror",
                   "safari": {
-                    "version_added": "14"
-                  },
-                  "safari_ios": {
                     "version_added": false
-                  }
+                  },
+                  "safari_ios": "mirror"
                 }
               }
             },


### PR DESCRIPTION
The data was correct for most of the properties already. Only `ip` and `type` had a version when it should be `false`.

This fixes #16625.