### PR TITLE
Add timestamp to __meta (and document __meta key)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ Apart from the explicitly documented objects below, feature-level support data m
 
 The package contains the following top-level objects:
 
+### `__meta`
+
+An object containing the following package metadata:
+
+- `version` - the package version
+- `timestamp` - the timestamp of when the package version was built
+
 ### [`api`](api)
 
 Data for [Web API](https://developer.mozilla.org/en-US/docs/Web/API) features.

--- a/scripts/release/build.ts
+++ b/scripts/release/build.ts
@@ -29,7 +29,10 @@ const verbatimFiles = ['LICENSE', 'README.md'];
  *
  * @returns {any} Metadata to embed into BCD
  */
-export const generateMeta = (): any => ({ version: packageJson.version });
+export const generateMeta = (): any => ({
+  version: packageJson.version,
+  timestamp: new Date(),
+});
 
 /**
  * Apply mirroring to all statements


### PR DESCRIPTION
This PR adds a build timestamp to the `__meta` object per request.  Additionally, this PR adds documentation regarding the `__meta` object.