### PR TITLE
Mark Safari as supporting return_promise in Safari 15.4.

### DIFF
--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -839,7 +839,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "15.4"
                 },
                 "safari_ios": "mirror"
               }
@@ -899,7 +899,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "15.4"
                 },
                 "safari_ios": "mirror"
               }


### PR DESCRIPTION
This was supported when we shipped Manifest V3 support in 15.4.