### PR TITLE
Remove incorrect note about Firefox popstate event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3770,8 +3770,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4",
-              "notes": "Firefox fires a <code>popstate</code> event on page load."
+              "version_added": "4"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
Fixes https://github.com/mdn/browser-compat-data/issues/17544.

As far as I can see this note is incorrect: https://stackoverflow.com/questions/6421769/popstate-on-pages-load-in-chrome and it is contradicted in the page.