### PR TITLE
Mark JavaScript 'Function.caller' deprecated

### DIFF
--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -371,7 +371,7 @@
             "status": {
               "experimental": false,
               "standard_track": false,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
### Summary
The `Function.caller` has been deprecated for a long time.

### Supporting details

- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features#function
- Current spec doesn't have it https://262.ecma-international.org/13.0/#sec-properties-of-the-function-prototype-object
- https://github.com/claudepache/es-legacy-function-reflection#purpose