### PR TITLE
Chromium 105 changes to Navigation API

### DIFF
--- a/api/NavigateEvent.json
+++ b/api/NavigateEvent.json
@@ -1,6 +1,6 @@
 {
   "api": {
-    "NavigationEvent": {
+    "NavigateEvent": {
       "__compat": {
         "spec_url": "https://wicg.github.io/navigation-api/#navigate-event-class",
         "support": {
@@ -34,9 +34,9 @@
           "deprecated": false
         }
       },
-      "NavigationEvent": {
+      "NavigateEvent": {
         "__compat": {
-          "description": "<code>NavigationEvent()</code> constructor",
+          "description": "<code>NavigateEvent()</code> constructor",
           "spec_url": "https://wicg.github.io/navigation-api/#dom-navigateevent-navigateevent",
           "support": {
             "chrome": {

--- a/api/NavigationEvent.json
+++ b/api/NavigationEvent.json
@@ -280,6 +280,41 @@
           }
         }
       },
+      "intercept": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigateevent-intercept",
+          "support": {
+            "chrome": {
+              "version_added": "105"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "navigationType": {
         "__compat": {
           "spec_url": "https://wicg.github.io/navigation-api/#dom-navigateevent-navigationtype",
@@ -321,6 +356,41 @@
           "support": {
             "chrome": {
               "version_added": "102"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
+      "scroll": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigateevent-scroll",
+          "support": {
+            "chrome": {
+              "version_added": "105"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -414,9 +484,9 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
<!-- ✍️ In a sentence or two, describe your changes. -->
- Chrome 105 deprecated two methods (`restoreScroll` and `transitionWhile`) and introduced two replacement methods (`intercept` and `scroll`).
- Specification and Chromium call the main event `NavigateEvent` not `NavigationEvent`

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
Official detailed blog post about this change:
https://developer.chrome.com/blog/navigateevent-intercept/
Relevant part of specification: https://wicg.github.io/navigation-api/#navigateevent
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Opened console on Chrome 105 Beta and ensured that `NavigateEvent.prototype.intercept` and `NavigateEvent.prototype.scroll` exist

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
