### PR TITLE
FF104 CSS Font Loading API supports workers

### DIFF
--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -82,7 +82,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "104",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.font-loading-api.workers.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -77,7 +77,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "104",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.font-loading-api.workers.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/FontFaceSetLoadEvent.json
+++ b/api/FontFaceSetLoadEvent.json
@@ -72,6 +72,48 @@
           }
         }
       },
+      "worker_support": {
+        "__compat": {
+          "description": "Available in workers",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "104",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.font-loading-api.workers.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "fontfaces": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FontFaceSetLoadEvent/fontfaces",

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -126,6 +126,47 @@
           }
         }
       },
+      "fonts": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/fonts",
+          "spec_url": "https://drafts.csswg.org/css-font-loading/#FontFaceSet-interface",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "104",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.font-loading-api.workers.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "importScripts": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/importScripts",


### PR DESCRIPTION
FF104 adds support for workers to CSS Font Loading API in https://bugzilla.mozilla.org/show_bug.cgi?id=1072107 behind pref layout.css.font-loading-api.workers.enabled

Other docs work can be tracked in https://github.com/mdn/content/issues/18769

FYI @queengooborg 


