### PR TITLE
Update TypeScript defs for __meta block

### DIFF
--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -91,7 +91,8 @@ const generateCompatDataTypes = (): string => {
       };`,
   );
 
-  const metaType = 'export interface MetaBlock {\n  version: string;\n}';
+  const metaType =
+    'export interface MetaBlock {\n  version: string;\n  timestamp: string;\n}';
 
   return `${metaType}\n\nexport interface CompatData {\n${props.join(
     '\n\n',


### PR DESCRIPTION
This PR updates the TypeScript defs for the `__meta` block to include the new `timestamp` property that was recently added.
