### PR TITLE
Add subfeature to CustomElementRegistry API for disabledFeatures static prop

### DIFF
--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -99,6 +99,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "disabledFeatures_static_property": {
+          "__compat": {
+            "description": "Supports <code>disabledFeatures</code> static property",
+            "support": {
+              "chrome": {
+                "version_added": "77"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "92"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "get": {


### PR DESCRIPTION
This PR supersedes #12130 by adding a subfeature rather than notes to the CustomElementRegistry API regarding support for the `disabledFeatures` static property.