### PR TITLE
Remove WeakMap.clear()

### DIFF
--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -241,55 +241,6 @@
             }
           }
         },
-        "clear": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/clear",
-            "support": {
-              "chrome": {
-                "version_added": "36",
-                "version_removed": "43"
-              },
-              "chrome_android": "mirror",
-              "deno": {
-                "version_added": false
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "20",
-                "version_removed": "46"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "11"
-              },
-              "nodejs": {
-                "version_added": "0.12.0",
-                "version_removed": "4.0.0"
-              },
-              "oculus": "mirror",
-              "opera": {
-                "version_added": "25",
-                "version_removed": "30"
-              },
-              "opera_android": {
-                "version_added": "25",
-                "version_removed": "30"
-              },
-              "safari": {
-                "version_added": "8",
-                "version_removed": "9"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
-        },
         "delete": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/delete",


### PR DESCRIPTION
In #20042 we removed the associated content. This is long gone from the web.