### PR TITLE
ci: use setup-node NPM cache

### DIFF
--- a/.github/workflows/add-push-artifacts.yml
+++ b/.github/workflows/add-push-artifacts.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 16.x
+          cache: npm
       - run: npm ci
       - run: npx ts-node ./scripts/enumerate-features.ts features.json
       - run: npx ts-node ./scripts/diff-features.ts --no-github --format=json > features.diff.json

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 16
+          cache: npm
       - run: npm ci
       - run: npm test
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           node-version: 18
           registry-url: 'https://registry.npmjs.org/'
+          cache: npm
       - run: npm ci
       - run: npm test
       - run: npm run build


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

actions/setup-node now wraps actions/cache to allow caching of node_modules between builds

#### Test results and supporting details
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
