### PR TITLE
Apply only specific labels to Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,12 @@ updates:
       interval: daily
       time: "11:00"
     open-pull-requests-limit: 10
+    labels:
+      - "infra :building_construction:"
+      - "dependencies :chains:"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "infra :building_construction:"


### PR DESCRIPTION
This PR assures we're only setting the specific labels we want to for Dependabot PRs, preventing the creation of `javascript` and `github_actions` labels.