### PR TITLE
CSS: Mark `@document` deprecated

### DIFF
--- a/css/at-rules/document.json
+++ b/css/at-rules/document.json
@@ -39,9 +39,9 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         },
         "regexp": {
@@ -72,9 +72,9 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": false,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }


### PR DESCRIPTION
### Summary

[Initially](https://www.w3.org/TR/2012/WD-css3-conditional-20120911/#at-document) in Level 3, @document was [postponed](https://www.w3.org/TR/2012/WD-css3-conditional-20121213/#changes) to Level 4, but then subsequently removed.

### Supporting details

- was removed in https://github.com/w3c/csswg-drafts/pull/3777
- https://developer.mozilla.org/en-US/docs/Web/CSS/@document#specifications