### PR TITLE
Consider `outline` not following border-radius a partial implementation

### DIFF
--- a/css/properties/outline.json
+++ b/css/properties/outline.json
@@ -12,6 +12,7 @@
               },
               {
                 "version_added": "1",
+                "version_removed": "94",
                 "partial_implementation": true,
                 "notes": "Before Chrome 94, <code>outline</code> does not follow the shape of <code>border-radius</code>."
               }
@@ -23,6 +24,7 @@
               },
               {
                 "version_added": "12",
+                "version_removed": "94",
                 "partial_implementation": true,
                 "notes": "Before Edge 94, <code>outline</code> does not follow the shape of <code>border-radius</code>."
               }
@@ -33,6 +35,7 @@
               },
               {
                 "version_added": "1.5",
+                "version_removed": "88",
                 "partial_implementation": true,
                 "notes": "Before Firefox 88, <code>outline</code> does not follow the shape of <code>border-radius</code>."
               },
@@ -53,6 +56,7 @@
               },
               {
                 "version_added": "7",
+                "version_removed": "80",
                 "partial_implementation": true,
                 "notes": "Before Opera 80, <code>outline</code> does not follow the shape of <code>border-radius</code>."
               }
@@ -75,6 +79,7 @@
               },
               {
                 "version_added": "1",
+                "version_removed": "94",
                 "partial_implementation": true,
                 "notes": "Before Chrome 94, <code>outline</code> does not follow the shape of <code>border-radius</code>."
               }

--- a/css/properties/outline.json
+++ b/css/properties/outline.json
@@ -6,18 +6,34 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/outline",
           "spec_url": "https://drafts.csswg.org/css-ui/#outline",
           "support": {
-            "chrome": {
-              "version_added": "1",
-              "notes": "Before Chrome 94, <code>outline</code> does not follow the shape of <code>border-radius</code>."
-            },
+            "chrome": [
+              {
+                "version_added": "94"
+              },
+              {
+                "version_added": "1",
+                "partial_implementation": true,
+                "notes": "Before Chrome 94, <code>outline</code> does not follow the shape of <code>border-radius</code>."
+              }
+            ],
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "12",
-              "notes": "Before Edge 94, <code>outline</code> does not follow the shape of <code>border-radius</code>."
-            },
+            "edge": [
+              {
+                "version_added": "94"
+              },
+              {
+                "version_added": "12",
+                "partial_implementation": true,
+                "notes": "Before Edge 94, <code>outline</code> does not follow the shape of <code>border-radius</code>."
+              }
+            ],
             "firefox": [
               {
+                "version_added": "88"
+              },
+              {
                 "version_added": "1.5",
+                "partial_implementation": true,
                 "notes": "Before Firefox 88, <code>outline</code> does not follow the shape of <code>border-radius</code>."
               },
               {
@@ -31,25 +47,38 @@
               "version_added": "8"
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "7",
-              "notes": "Before Opera 80, <code>outline</code> does not follow the shape of <code>border-radius</code>."
-            },
+            "opera": [
+              {
+                "version_added": "80"
+              },
+              {
+                "version_added": "7",
+                "partial_implementation": true,
+                "notes": "Before Opera 80, <code>outline</code> does not follow the shape of <code>border-radius</code>."
+              }
+            ],
             "opera_android": {
               "version_added": "10.1"
             },
             "safari": {
               "version_added": "1.2",
-              "notes": "<code>outline</code> does not follow the shape of <code>border-radius</code>. See <a href='https://webkit.org/b/231433'>bug 231433</a>."
+              "partial_implementation": true,
+              "notes": "<code>outline</code> does not follow the shape of <code>border-radius</code>. See <a href='https://webkit.org/b/20807'>bug 20807</a>."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "1.0"
             },
-            "webview_android": {
-              "version_added": "1",
-              "notes": "Before Chrome 94, <code>outline</code> does not follow the shape of <code>border-radius</code>."
-            }
+            "webview_android": [
+              {
+                "version_added": "94"
+              },
+              {
+                "version_added": "1",
+                "partial_implementation": true,
+                "notes": "Before Chrome 94, <code>outline</code> does not follow the shape of <code>border-radius</code>."
+              }
+            ]
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
#### Summary
This information is currently in the data, but as a note. It's not tagged to specific versions, either, which means when scanning, for instance, the browser compatibility table on MDN, the Safari column looks the same as browsers which have implemented this. Now that the [spec says this should be done](https://www.w3.org/TR/css-ui-3/#ref-for-border-edge), I think it's reasonable to consider it a partial implementation if it isn't done.

<img width="307" alt="image" src="https://user-images.githubusercontent.com/9437625/187239865-f2aec6e1-0381-4c03-867f-161bfc33c8ec.png">

<img width="348" alt="image" src="https://user-images.githubusercontent.com/9437625/187240669-ae1348e5-240b-4044-af9c-d73d702bc66d.png">


#### Test results and supporting details
The WebKit bug in the note got marked as a duplicate of [this bug](https://bugs.webkit.org/show_bug.cgi?id=20807), so I updated the link.

Also note that on the browsers that have fixed it, I didn't put a `version_removed` property on the partial implementations, only a newer support statement. That seems to be valid, and I'm not totally clear on the semantics of having it vs. not having it, so let me know if I should add it.

#### Related issues
Related to mdn/browser-compat-data#12760, Fyrd/caniuse#6099
