### PR TITLE
HTTP: Mark 'Pragma' header deprecated

### DIFF
--- a/http/headers/Pragma.json
+++ b/http/headers/Pragma.json
@@ -33,7 +33,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
### Summary
It has been deprecated.

### Test results and supporting details
- https://github.com/httpwg/http-core/pull/174
- https://github.com/httpwg/http-core/pull/1048
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Pragma