### PR TITLE
SVG: Mark 'attributes.presentation.clip' deprecated

### DIFF
--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -106,7 +106,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
### Summary
It was deprecated in favor of `clip-path`.

### Test results and supporting details
- https://github.com/w3c/svgwg/pull/480
- https://drafts.fxtf.org/css-masking/#clip-property
- https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/clip#usage_notes

