### PR TITLE
SVG: Mark 'elements.viewTarget' deprecated

### DIFF
--- a/svg/elements/view.json
+++ b/svg/elements/view.json
@@ -132,7 +132,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
### Summary
It has been deprecated.

### Supporting details
- https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewTarget
- https://github.com/w3c/svgwg/blob/39e11cb0d8191ce89053b40561ec6ad00ecc04c4/master/changes.html#L1000
- https://github.com/w3c/svgwg/blob/39e11cb0d8191ce89053b40561ec6ad00ecc04c4/master/linking.html#L1127
- 