### PR TITLE
Chrome 98 HTMLCanvasElement support for contextlost /restored events

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -77,6 +77,76 @@
           }
         }
       },
+      "contextlost_event": {
+        "__compat": {
+          "description": "<code>contextlost</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/webglcontextlost_event",
+          "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-contextlost",
+          "support": {
+            "chrome": {
+              "version_added": "98"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "contextrestored_event": {
+        "__compat": {
+          "description": "<code>contextrestored</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/contextrestored_event",
+          "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-contextrestored",
+          "support": {
+            "chrome": {
+              "version_added": "98"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getContext": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/getContext",
@@ -1303,76 +1373,6 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "contextlost_event": {
-        "__compat": {
-          "description": "<code>contextlost</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/webglcontextlost_event",
-          "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-contextlost",
-          "support": {
-            "chrome": {
-              "version_added": "98"
-            },
-            "chrome_android": "mirror",
-            "edge":  "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "contextrestored_event": {
-        "__compat": {
-          "description": "<code>contextrestored</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/contextrestored_event",
-          "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-contextrestored",
-          "support": {
-            "chrome": {
-              "version_added": "98"
-            },
-            "chrome_android": "mirror",
-            "edge":  "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -1308,6 +1308,76 @@
           }
         }
       },
+      "contextlost_event": {
+        "__compat": {
+          "description": "<code>contextlost</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/webglcontextlost_event",
+          "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-contextlost",
+          "support": {
+            "chrome": {
+              "version_added": "98"
+            },
+            "chrome_android": "mirror",
+            "edge":  "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "contextrestored_event": {
+        "__compat": {
+          "description": "<code>contextrestored</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/contextrestored_event",
+          "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-contextrestored",
+          "support": {
+            "chrome": {
+              "version_added": "98"
+            },
+            "chrome_android": "mirror",
+            "edge":  "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/width",


### PR DESCRIPTION
This adds BCD entries for the new contextlost and contextrestored events in HTMLCanvasElement.

The associated docs are added in https://github.com/mdn/content/pull/19859.

I tested on browserstack to verify that these went in for Chrome 98, and that they are not present in FF.