### PR TITLE
CanvasRenderingContext2D.reset - add missing MDN links

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1587,6 +1587,7 @@
       },
       "isContextLost": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/isContextLost",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-iscontextlost",
           "support": {
             "chrome": {
@@ -2244,6 +2245,7 @@
       },
       "reset": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/reset",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-reset",
           "support": {
             "chrome": {


### PR DESCRIPTION
Added MDN links for `CanvasRenderingContext2D.isContextLost()` and `reset()` created in https://github.com/mdn/content/pull/19859