### PR TITLE
Fix order of function calls in release script

### DIFF
--- a/scripts/release/index.ts
+++ b/scripts/release/index.ts
@@ -94,8 +94,8 @@ const commitAndPR = async (
     console.log(
       chalk`{yellow Please {bold modify RELEASE_NOTES.md} and fill out the {bold Notable changes} section. I'll wait for you.}`,
     );
-    await keypress();
     console.log(chalk`{yellow Press any key to continue.}`);
+    await keypress();
     console.log('');
   }
 


### PR DESCRIPTION
This PR fixes the order of function calls in the release script to ensure that "Press any key to continue" appears before we wait for a keypress.
