### PR TITLE
Update all HTTP Core spec URLs

### DIFF
--- a/http/headers/Accept-Encoding.json
+++ b/http/headers/Accept-Encoding.json
@@ -4,7 +4,7 @@
       "Accept-Encoding": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-Encoding",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#header.accept-encoding",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.accept-encoding",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Accept-Language.json
+++ b/http/headers/Accept-Language.json
@@ -4,7 +4,7 @@
       "Accept-Language": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-Language",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#header.accept-language",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.accept-language",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Accept-Ranges.json
+++ b/http/headers/Accept-Ranges.json
@@ -4,7 +4,7 @@
       "Accept-Ranges": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-Ranges",
-          "spec_url": "https://httpwg.org/specs/rfc7233.html#header.accept-ranges",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.accept-ranges",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Accept.json
+++ b/http/headers/Accept.json
@@ -4,7 +4,7 @@
       "Accept": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#header.accept",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.accept",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Age.json
+++ b/http/headers/Age.json
@@ -4,7 +4,7 @@
       "Age": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Age",
-          "spec_url": "https://httpwg.org/specs/rfc7234.html#header.age",
+          "spec_url": "https://httpwg.org/specs/rfc9111.html#field.age",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Authorization.json
+++ b/http/headers/Authorization.json
@@ -4,7 +4,7 @@
       "Authorization": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Authorization",
-          "spec_url": "https://httpwg.org/specs/rfc7235.html#header.authorization",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.authorization",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Cache-Control.json
+++ b/http/headers/Cache-Control.json
@@ -5,7 +5,7 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control",
           "spec_url": [
-            "https://httpwg.org/specs/rfc7234.html#header.cache-control",
+            "https://httpwg.org/specs/rfc9111.html#field.cache-control",
             "https://httpwg.org/specs/rfc8246.html#the-immutable-cache-control-extension"
           ],
           "support": {

--- a/http/headers/Connection.json
+++ b/http/headers/Connection.json
@@ -4,7 +4,7 @@
       "Connection": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Connection",
-          "spec_url": "https://httpwg.org/specs/rfc7230.html#header.connection",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.connection",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Content-Encoding.json
+++ b/http/headers/Content-Encoding.json
@@ -4,7 +4,7 @@
       "Content-Encoding": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Encoding",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#header.content-encoding",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.content-encoding",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Content-Language.json
+++ b/http/headers/Content-Language.json
@@ -4,7 +4,7 @@
       "Content-Language": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Language",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#header.content-language",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.content-language",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Content-Length.json
+++ b/http/headers/Content-Length.json
@@ -4,7 +4,7 @@
       "Content-Length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Length",
-          "spec_url": "https://httpwg.org/specs/rfc7230.html#header.content-length",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.content-length",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Content-Location.json
+++ b/http/headers/Content-Location.json
@@ -4,7 +4,7 @@
       "Content-Location": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Location",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#header.content-location",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.content-location",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Content-Range.json
+++ b/http/headers/Content-Range.json
@@ -4,7 +4,7 @@
       "Content-Range": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Range",
-          "spec_url": "https://httpwg.org/specs/rfc7233.html#header.content-range",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.content-range",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Content-Type.json
+++ b/http/headers/Content-Type.json
@@ -5,8 +5,8 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Type",
           "spec_url": [
-            "https://httpwg.org/specs/rfc7233.html#status.206",
-            "https://httpwg.org/specs/rfc7231.html#header.content-type"
+            "https://httpwg.org/specs/rfc9110.html#status.206",
+            "https://httpwg.org/specs/rfc9110.html#field.content-type"
           ],
           "support": {
             "chrome": {

--- a/http/headers/Date.json
+++ b/http/headers/Date.json
@@ -4,7 +4,7 @@
       "Date": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Date",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#header.date",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.date",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/ETag.json
+++ b/http/headers/ETag.json
@@ -4,7 +4,7 @@
       "ETag": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/ETag",
-          "spec_url": "https://httpwg.org/specs/rfc7232.html#header.etag",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.etag",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Expect.json
+++ b/http/headers/Expect.json
@@ -4,7 +4,7 @@
       "Expect": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Expect",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#header.expect",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.expect",
           "support": {
             "chrome": {
               "version_added": null

--- a/http/headers/Expires.json
+++ b/http/headers/Expires.json
@@ -4,7 +4,7 @@
       "Expires": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Expires",
-          "spec_url": "https://httpwg.org/specs/rfc7234.html#header.expires",
+          "spec_url": "https://httpwg.org/specs/rfc9111.html#field.expires",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/From.json
+++ b/http/headers/From.json
@@ -4,7 +4,7 @@
       "From": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/From",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#header.from",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.from",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Host.json
+++ b/http/headers/Host.json
@@ -4,7 +4,7 @@
       "Host": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Host",
-          "spec_url": "https://httpwg.org/specs/rfc7230.html#header.host",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.host",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/If-Match.json
+++ b/http/headers/If-Match.json
@@ -4,7 +4,7 @@
       "If-Match": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-Match",
-          "spec_url": "https://httpwg.org/specs/rfc7232.html#header.if-match",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.if-match",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/If-Modified-Since.json
+++ b/http/headers/If-Modified-Since.json
@@ -4,7 +4,7 @@
       "If-Modified-Since": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-Modified-Since",
-          "spec_url": "https://httpwg.org/specs/rfc7232.html#header.if-modified-since",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.if-modified-since",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/If-None-Match.json
+++ b/http/headers/If-None-Match.json
@@ -4,7 +4,7 @@
       "If-None-Match": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-None-Match",
-          "spec_url": "https://httpwg.org/specs/rfc7232.html#header.if-none-match",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.if-none-match",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/If-Range.json
+++ b/http/headers/If-Range.json
@@ -4,7 +4,7 @@
       "If-Range": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-Range",
-          "spec_url": "https://httpwg.org/specs/rfc7233.html#header.if-range",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.if-range",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/If-Unmodified-Since.json
+++ b/http/headers/If-Unmodified-Since.json
@@ -4,7 +4,7 @@
       "If-Unmodified-Since": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/If-Unmodified-Since",
-          "spec_url": "https://httpwg.org/specs/rfc7232.html#header.if-unmodified-since",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.if-unmodified-since",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Keep-Alive.json
+++ b/http/headers/Keep-Alive.json
@@ -4,7 +4,7 @@
       "Keep-Alive": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Keep-Alive",
-          "spec_url": "https://httpwg.org/specs/rfc7230.html#compatibility.with.http.1.0.persistent.connections",
+          "spec_url": "https://httpwg.org/specs/rfc9112.html#compatibility.with.http.1.0.persistent.connections",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Last-Modified.json
+++ b/http/headers/Last-Modified.json
@@ -4,7 +4,7 @@
       "Last-Modified": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Last-Modified",
-          "spec_url": "https://httpwg.org/specs/rfc7232.html#header.last-modified",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.last-modified",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Location.json
+++ b/http/headers/Location.json
@@ -4,7 +4,7 @@
       "Location": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Location",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#header.location",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.location",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Pragma.json
+++ b/http/headers/Pragma.json
@@ -4,7 +4,7 @@
       "Pragma": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Pragma",
-          "spec_url": "https://httpwg.org/specs/rfc7234.html#header.pragma",
+          "spec_url": "https://httpwg.org/specs/rfc9111.html#field.pragma",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Proxy-Authenticate.json
+++ b/http/headers/Proxy-Authenticate.json
@@ -4,7 +4,7 @@
       "Proxy-Authenticate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Proxy-Authenticate",
-          "spec_url": "https://httpwg.org/specs/rfc7235.html#header.proxy-authenticate",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.proxy-authenticate",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Range.json
+++ b/http/headers/Range.json
@@ -4,7 +4,7 @@
       "Range": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Range",
-          "spec_url": "https://httpwg.org/specs/rfc7233.html#header.range",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.range",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Referer.json
+++ b/http/headers/Referer.json
@@ -4,7 +4,7 @@
       "Referer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Referer",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#header.referer",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.referer",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Retry-After.json
+++ b/http/headers/Retry-After.json
@@ -4,7 +4,7 @@
       "Retry-After": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Retry-After",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#header.retry-after",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.retry-after",
           "support": {
             "chrome": {
               "version_added": null

--- a/http/headers/Server.json
+++ b/http/headers/Server.json
@@ -4,7 +4,7 @@
       "Server": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Server",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#header.server",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.server",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/TE.json
+++ b/http/headers/TE.json
@@ -4,7 +4,7 @@
       "TE": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/TE",
-          "spec_url": "https://httpwg.org/specs/rfc7230.html#header.te",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.te",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Trailer.json
+++ b/http/headers/Trailer.json
@@ -5,8 +5,8 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Trailer",
           "spec_url": [
-            "https://httpwg.org/specs/rfc7230.html#header.trailer",
-            "https://httpwg.org/specs/rfc7230.html#chunked.trailer.part"
+            "https://httpwg.org/specs/rfc9110.html#field.trailer",
+            "https://httpwg.org/specs/rfc9112.html#chunked.trailer.section"
           ],
           "support": {
             "chrome": {

--- a/http/headers/Transfer-Encoding.json
+++ b/http/headers/Transfer-Encoding.json
@@ -4,7 +4,7 @@
       "Transfer-Encoding": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Transfer-Encoding",
-          "spec_url": "https://httpwg.org/specs/rfc7230.html#header.transfer-encoding",
+          "spec_url": "https://httpwg.org/specs/rfc9112.html#field.transfer-encoding",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Upgrade.json
+++ b/http/headers/Upgrade.json
@@ -5,9 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Upgrade",
           "spec_url": [
-            "https://httpwg.org/specs/rfc7230.html#header.upgrade",
-            "https://httpwg.org/specs/rfc7231.html#status.426",
-            "https://httpwg.org/specs/rfc7540.html#informational-responses"
+            "https://httpwg.org/specs/rfc9110.html#field.upgrade",
+            "https://httpwg.org/specs/rfc9110.html#status.426",
+            "https://httpwg.org/specs/rfc9113.html#informational-responses"
           ],
           "support": {
             "chrome": {

--- a/http/headers/User-Agent.json
+++ b/http/headers/User-Agent.json
@@ -4,7 +4,7 @@
       "User-Agent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/User-Agent",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#header.user-agent",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.user-agent",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Vary.json
+++ b/http/headers/Vary.json
@@ -4,7 +4,7 @@
       "Vary": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Vary",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#header.vary",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.vary",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/Via.json
+++ b/http/headers/Via.json
@@ -4,7 +4,7 @@
       "Via": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Via",
-          "spec_url": "https://httpwg.org/specs/rfc7230.html#header.via",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.via",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/headers/WWW-Authenticate.json
+++ b/http/headers/WWW-Authenticate.json
@@ -4,7 +4,7 @@
       "WWW-Authenticate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/WWW-Authenticate",
-          "spec_url": "https://httpwg.org/specs/rfc7235.html#header.www-authenticate",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#field.www-authenticate",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/http/headers/Warning.json
+++ b/http/headers/Warning.json
@@ -4,7 +4,7 @@
       "Warning": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Warning",
-          "spec_url": "https://httpwg.org/specs/rfc7234.html#header.warning",
+          "spec_url": "https://httpwg.org/specs/rfc9111.html#field.warning",
           "support": {
             "chrome": {
               "version_added": true

--- a/http/methods.json
+++ b/http/methods.json
@@ -4,7 +4,7 @@
       "CONNECT": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/CONNECT",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#CONNECT",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#CONNECT",
           "support": {
             "chrome": {
               "version_added": true
@@ -40,7 +40,7 @@
       "DELETE": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/DELETE",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#DELETE",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#DELETE",
           "support": {
             "chrome": {
               "version_added": true
@@ -76,7 +76,7 @@
       "GET": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/GET",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#GET",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#GET",
           "support": {
             "chrome": {
               "version_added": true
@@ -112,7 +112,7 @@
       "HEAD": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/HEAD",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#HEAD",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#HEAD",
           "support": {
             "chrome": {
               "version_added": true
@@ -148,7 +148,7 @@
       "OPTIONS": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/OPTIONS",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#OPTIONS",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#OPTIONS",
           "support": {
             "chrome": {
               "version_added": true
@@ -184,7 +184,7 @@
       "POST": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/POST",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#POST",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#POST",
           "support": {
             "chrome": {
               "version_added": true
@@ -220,7 +220,7 @@
       "PUT": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/PUT",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#PUT",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#PUT",
           "support": {
             "chrome": {
               "version_added": true
@@ -256,7 +256,7 @@
       "TRACE": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Methods/TRACE",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#TRACE",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#TRACE",
           "support": {
             "chrome": {
               "version_added": null

--- a/http/status.json
+++ b/http/status.json
@@ -4,7 +4,7 @@
       "100": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/100",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#status.100",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.100",
           "support": {
             "chrome": {
               "version_added": true
@@ -73,7 +73,7 @@
       "200": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/200",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#status.200",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.200",
           "support": {
             "chrome": {
               "version_added": true
@@ -109,7 +109,7 @@
       "201": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/201",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#status.201",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.201",
           "support": {
             "chrome": {
               "version_added": true
@@ -145,7 +145,7 @@
       "204": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/204",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#status.204",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.204",
           "support": {
             "chrome": {
               "version_added": true
@@ -181,7 +181,7 @@
       "206": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/206",
-          "spec_url": "https://httpwg.org/specs/rfc7233.html#status.206",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.206",
           "support": {
             "chrome": {
               "version_added": true
@@ -217,7 +217,7 @@
       "301": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/301",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#status.301",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.301",
           "support": {
             "chrome": {
               "version_added": true
@@ -253,7 +253,7 @@
       "302": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/302",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#status.302",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.302",
           "support": {
             "chrome": {
               "version_added": true
@@ -289,7 +289,7 @@
       "303": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/303",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#status.303",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.303",
           "support": {
             "chrome": {
               "version_added": true
@@ -325,7 +325,7 @@
       "304": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/304",
-          "spec_url": "https://httpwg.org/specs/rfc7232.html#status.304",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.304",
           "support": {
             "chrome": {
               "version_added": true
@@ -361,7 +361,7 @@
       "307": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/307",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#status.307",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.307",
           "support": {
             "chrome": {
               "version_added": true
@@ -397,7 +397,7 @@
       "308": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/308",
-          "spec_url": "https://httpwg.org/specs/rfc7538.html#status.308",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.308",
           "support": {
             "chrome": {
               "version_added": "36"
@@ -436,7 +436,7 @@
       "401": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/401",
-          "spec_url": "https://httpwg.org/specs/rfc7235.html#status.401",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.401",
           "support": {
             "chrome": {
               "version_added": true
@@ -472,7 +472,7 @@
       "403": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/403",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#status.403",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.403",
           "support": {
             "chrome": {
               "version_added": true
@@ -508,7 +508,7 @@
       "404": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/404",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#status.404",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.404",
           "support": {
             "chrome": {
               "version_added": true
@@ -544,7 +544,7 @@
       "406": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/406",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#status.406",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.406",
           "support": {
             "chrome": {
               "version_added": true
@@ -580,7 +580,7 @@
       "407": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/407",
-          "spec_url": "https://httpwg.org/specs/rfc7235.html#status.407",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.407",
           "support": {
             "chrome": {
               "version_added": true
@@ -616,7 +616,7 @@
       "409": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/409",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#status.409",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.409",
           "support": {
             "chrome": {
               "version_added": true
@@ -652,7 +652,7 @@
       "410": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/410",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#status.410",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.410",
           "support": {
             "chrome": {
               "version_added": true
@@ -688,7 +688,7 @@
       "412": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/412",
-          "spec_url": "https://httpwg.org/specs/rfc7232.html#status.412",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.412",
           "support": {
             "chrome": {
               "version_added": true
@@ -724,7 +724,7 @@
       "416": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/416",
-          "spec_url": "https://httpwg.org/specs/rfc7233.html#status.416",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.416",
           "support": {
             "chrome": {
               "version_added": true
@@ -866,7 +866,7 @@
       "500": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/500",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#status.500",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.500",
           "support": {
             "chrome": {
               "version_added": true
@@ -902,7 +902,7 @@
       "501": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/501",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#status.501",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.501",
           "support": {
             "chrome": {
               "version_added": true
@@ -938,7 +938,7 @@
       "502": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/502",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#status.502",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.502",
           "support": {
             "chrome": {
               "version_added": true
@@ -974,7 +974,7 @@
       "503": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/503",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#status.503",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.503",
           "support": {
             "chrome": {
               "version_added": true
@@ -1010,7 +1010,7 @@
       "504": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Status/504",
-          "spec_url": "https://httpwg.org/specs/rfc7231.html#status.504",
+          "spec_url": "https://httpwg.org/specs/rfc9110.html#status.504",
           "support": {
             "chrome": {
               "version_added": true


### PR DESCRIPTION
https://github.com/w3c/browser-specs/pull/688 landed the updated HTTP Core specs browser-specs, so I guess we now need to wait on https://github.com/w3c/browser-specs/pull/690 to be merged