### PR TITLE
Remove document.createEntityReference/height/width

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -1740,43 +1740,6 @@
           }
         }
       },
-      "createEntityReference": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createEntityReference",
-          "spec_url": "https://dom.spec.whatwg.org/#dom-document-createentityreference",
-          "support": {
-            "chrome": {
-              "version_added": "1",
-              "version_removed": "29"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "1",
-              "version_removed": "7"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "1",
-              "version_removed": "10"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
-      },
       "createEvent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/createEvent",
@@ -4525,48 +4488,6 @@
           }
         }
       },
-      "height": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/height",
-          "support": {
-            "chrome": {
-              "version_added": "1",
-              "version_removed": "31"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "1",
-              "version_removed": "6"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "1",
-              "version_removed": "10"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "1.0",
-              "version_removed": "3.0"
-            },
-            "webview_android": {
-              "version_added": "1",
-              "version_removed": "4.4.3"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "hidden": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/hidden",
@@ -7097,48 +7018,6 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
-          }
-        }
-      },
-      "width": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/width",
-          "support": {
-            "chrome": {
-              "version_added": "1",
-              "version_removed": "31"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "1",
-              "version_removed": "6"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "1",
-              "version_removed": "10"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "1.0",
-              "version_removed": "3.0"
-            },
-            "webview_android": {
-              "version_added": "1",
-              "version_removed": "4.4.3"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
These 3 features were deprecated in 2003, and the last browser to implement them stopped doing this in 2014.

We are removing them from the content in : mdn/content#20128

Time to go.