### PR TITLE
Update data for numalign/denomalign/align attributes

### DIFF
--- a/mathml/elements/mfrac.json
+++ b/mathml/elements/mfrac.json
@@ -87,10 +87,11 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "1",
-                "notes": "Removed from Firefox Nightly 71 in <a href='https://bugzil.la/1548530'>bug 1548530</a>."
+                "version_removed": "71"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": "4",
+                "version_removed": "79"
               },
               "ie": {
                 "version_added": false
@@ -99,9 +100,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "5.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "5"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -157,10 +160,11 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "1",
-                "notes": "Removed from Firefox Nightly 71 in <a href='https://bugzil.la/1548530'>bug 1548530</a>."
+                "version_removed": "71"
               },
               "firefox_android": {
-                "version_added": "4"
+                "version_added": "4",
+                "version_removed": "79"
               },
               "ie": {
                 "version_added": false
@@ -169,9 +173,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "5.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "5"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/mathml/elements/mover.json
+++ b/mathml/elements/mover.json
@@ -75,41 +75,6 @@
               "deprecated": false
             }
           }
-        },
-        "align": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "12",
-                "notes": "Removed from Firefox Nightly 71 in <a href='https://bugzil.la/1548530'>bug 1548530</a>."
-              },
-              "firefox_android": {
-                "version_added": "14"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
-            }
-          }
         }
       }
     }

--- a/mathml/elements/munder.json
+++ b/mathml/elements/munder.json
@@ -75,41 +75,6 @@
               "deprecated": false
             }
           }
-        },
-        "align": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "12",
-                "notes": "Removed from Firefox Nightly 71 in <a href='https://bugzil.la/1548530'>bug 1548530</a>."
-              },
-              "firefox_android": {
-                "version_added": "14"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
-            }
-          }
         }
       }
     }

--- a/mathml/elements/munderover.json
+++ b/mathml/elements/munderover.json
@@ -107,41 +107,6 @@
               "deprecated": false
             }
           }
-        },
-        "align": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "12",
-                "notes": "Removed from Firefox Nightly 71 in <a href='https://bugzil.la/1548530'>bug 1548530</a>."
-              },
-              "firefox_android": {
-                "version_added": "14"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
This is about removing mfrac's numalign/denomalign attributes
and munder/mover/munderover's align attribute. The latter
can be removed per our data guidelines.

- All these attributes have been removed from Gecko 71 [1].
- numalign/denomalign is implemented in WebKit [2] and
  that was initially released in Safari 5 [3].
- align is not implemented in WebKit [4] and that was
  already the case in the previous refactoring [5].

#### Test results and supporting details

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1548530#c10
[2] https://github.com/WebKit/WebKit/blob/14c0a0df4180c23444c0c87502e96020065d0585/Source/WebCore/mathml/MathMLFractionElement.cpp#L107
[3] https://github.com/WebKit/WebKit/commit/b99813910c1d650256643dfc0178eba25c7a1a0c
[4] https://github.com/WebKit/WebKit/blob/14c0a0df4180c23444c0c87502e96020065d0585/Source/WebCore/mathml/MathMLUnderOverElement.cpp#L61
[5] https://github.com/WebKit/WebKit/commit/9e5fa8e77c1ebff9d39ff61fc17bea4209186324

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
