### PR TITLE
:modal support on Chrome

### DIFF
--- a/css/selectors/modal.json
+++ b/css/selectors/modal.json
@@ -8,7 +8,7 @@
           "spec_url": "https://drafts.csswg.org/selectors/#modal-state",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "105"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
The `:modal` pseudo-class is now supported in Chrome, from 105. https://chromestatus.com/feature/5192833009975296
