### PR TITLE
Add CSS font-palette property

### DIFF
--- a/css/properties/font-palette.json
+++ b/css/properties/font-palette.json
@@ -1,0 +1,38 @@
+{
+  "css": {
+    "properties": {
+      "font-palette": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "101"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.3> ≤15.6"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/font-palette.json
+++ b/css/properties/font-palette.json
@@ -3,6 +3,8 @@
     "properties": {
       "font-palette": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/font-palette",
+          "spec_url": "https://drafts.csswg.org/css-fonts-4/#font-palette-prop",
           "support": {
             "chrome": {
               "version_added": "101"
@@ -20,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15.3> ≤15.6"
+              "version_added": "15.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/font-palette.json
+++ b/css/properties/font-palette.json
@@ -3,7 +3,7 @@
     "properties": {
       "font-palette": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/font-palette",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-palette",
           "spec_url": "https://drafts.csswg.org/css-fonts-4/#font-palette-prop",
           "support": {
             "chrome": {


### PR DESCRIPTION
This is from mdn-bcd-collector v6.1.2 results:
https://github.com/foolip/mdn-bcd-results/tree/49c3be3152b42f3b85aa645a4e27879527bc92c6

To pick the exact Safari version, assume that it should match `@font-palette-values`, Safari 15.4.