### PR TITLE
Remove compat data for deprecated math@mode attribute

### DIFF
--- a/mathml/elements/math.json
+++ b/mathml/elements/math.json
@@ -130,43 +130,6 @@
               "deprecated": false
             }
           }
-        },
-        "mode": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/math#attr-mode",
-            "support": {
-              "chrome": {
-                "version_added": "24",
-                "version_removed": "25"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "1",
-                "version_removed": "70"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
#### Summary

Remove compat data for deprecated math@mode attribute
This was only implemented in Gecko and removed in version 70.
Currently, we state support on Firefox Android, which is incorrect.

#### Test results and supporting details

See below.

#### Related issues

https://bugzilla.mozilla.org/show_bug.cgi?id=1573438#c10
https://github.com/mdn/browser-compat-data/pull/5047
