### PR TITLE
Fix spec_url of margin-block-start

### DIFF
--- a/css/properties/margin-block-end.json
+++ b/css/properties/margin-block-end.json
@@ -4,7 +4,7 @@
       "margin-block-end": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/margin-block-end",
-          "spec_url": "https://drafts.csswg.org/css-scroll-snap/#scroll-padding",
+          "spec_url": "https://drafts.csswg.org/css-logical/#margin-properties",
           "support": {
             "chrome": {
               "version_added": "87"


### PR DESCRIPTION
This was reported in https://github.com/mdn/content/discussions/20175.

The spec_url was completely wrong (to scroll-snap).