### PR TITLE
Update mfenced support for Firefox Android

### DIFF
--- a/mathml/elements/mfenced.json
+++ b/mathml/elements/mfenced.json
@@ -15,7 +15,8 @@
               "version_removed": "73"
             },
             "firefox_android": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "79"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
#### Summary

Update mfenced support for Firefox Android:
This was removed from Mozilla 73, so from Android 79.

#### Test results and supporting details

Per https://bugzilla.mozilla.org/show_bug.cgi?id=1603773#c11
and `browsers/firefox_android.json`

#### Related issues

https://github.com/mdn/browser-compat-data/pull/5458
