### PR TITLE
Mirror Samsung Internet data for SubtleCrypto

### DIFF
--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -39,9 +39,7 @@
             }
           ],
           "safari_ios": "mirror",
-          "samsunginternet_android": {
-            "version_added": "6.0"
-          },
+          "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
         "status": {
@@ -120,9 +118,7 @@
               "version_added": "11"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -188,9 +184,7 @@
               "version_added": "7"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -255,9 +249,7 @@
               "version_added": "11"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -314,9 +306,7 @@
               "version_added": "11"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -368,9 +358,7 @@
               "version_added": "7"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -436,9 +424,7 @@
               "version_added": "7"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -511,9 +497,7 @@
               "version_added": "7"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -582,9 +566,7 @@
               "version_added": "7"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -660,9 +642,7 @@
               "version_added": "7"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -715,9 +695,7 @@
               "version_added": "7"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -773,9 +751,7 @@
               "version_added": "7"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -836,9 +812,7 @@
               "version_added": "7"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -890,9 +864,7 @@
               "version_added": "7"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "6.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {


### PR DESCRIPTION
The source of this data is a semi-automated PR to derive data from
Chrome Android:
https://github.com/mdn/browser-compat-data/pull/1606

At the time, the Chrome Android data was "53", and when this was fixed
the Samsung Internet data was apparently not updated.
