### PR TITLE
MathML: Mark 'maction' deprecated

### DIFF
--- a/mathml/elements/maction.json
+++ b/mathml/elements/maction.json
@@ -76,7 +76,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           },
           "restyle": {
@@ -220,7 +220,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         }

--- a/mathml/elements/maction.json
+++ b/mathml/elements/maction.json
@@ -43,7 +43,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         },
         "actiontype": {


### PR DESCRIPTION
It has been deprecated.

#### Supporting details
- https://developer.mozilla.org/en-US/docs/Web/MathML/Element/maction
- https://github.com/mdn/content/pull/18650
- https://github.com/w3c/mathml-core/pull/25