### PR TITLE
Correcting and updating WCO compat data

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4658,7 +4658,7 @@
           "spec_url": "https://wicg.github.io/window-controls-overlay/#windowcontrolsoverlay-interface",
           "support": {
             "chrome": {
-              "version_added": "98"
+              "version_added": "105"
             },
             "chrome_android": {
               "version_added": false
@@ -4682,7 +4682,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/WindowControlsOverlay.json
+++ b/api/WindowControlsOverlay.json
@@ -6,7 +6,7 @@
         "spec_url": "https://wicg.github.io/window-controls-overlay/#windowcontrolsoverlay-interface",
         "support": {
           "chrome": {
-            "version_added": "98"
+            "version_added": "105"
           },
           "chrome_android": {
             "version_added": false
@@ -30,7 +30,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -42,7 +42,7 @@
           "spec_url": "https://wicg.github.io/window-controls-overlay/#the-ongeometrychange-attribute",
           "support": {
             "chrome": {
-              "version_added": "98"
+              "version_added": "105"
             },
             "chrome_android": {
               "version_added": false
@@ -66,7 +66,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -78,7 +78,7 @@
           "spec_url": "https://wicg.github.io/window-controls-overlay/#the-gettitlebararearect-method",
           "support": {
             "chrome": {
-              "version_added": "98"
+              "version_added": "105"
             },
             "chrome_android": {
               "version_added": false
@@ -102,7 +102,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -114,7 +114,7 @@
           "spec_url": "https://wicg.github.io/window-controls-overlay/#the-visible-attribute",
           "support": {
             "chrome": {
-              "version_added": "98"
+              "version_added": "105"
             },
             "chrome_android": {
               "version_added": false
@@ -138,7 +138,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/WindowControlsOverlayGeometryChangeEvent.json
+++ b/api/WindowControlsOverlayGeometryChangeEvent.json
@@ -6,7 +6,7 @@
         "spec_url": "https://wicg.github.io/window-controls-overlay/#windowcontrolsoverlay-interface",
         "support": {
           "chrome": {
-            "version_added": "98"
+            "version_added": "105"
           },
           "chrome_android": {
             "version_added": false
@@ -30,7 +30,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -42,7 +42,7 @@
           "spec_url": "https://wicg.github.io/window-controls-overlay/#windowcontrolsoverlay-interface",
           "support": {
             "chrome": {
-              "version_added": "98"
+              "version_added": "105"
             },
             "chrome_android": {
               "version_added": false
@@ -66,7 +66,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -78,7 +78,7 @@
           "spec_url": "https://wicg.github.io/window-controls-overlay/#windowcontrolsoverlay-interface",
           "support": {
             "chrome": {
-              "version_added": "98"
+              "version_added": "105"
             },
             "chrome_android": {
               "version_added": false
@@ -102,7 +102,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -114,7 +114,7 @@
           "spec_url": "https://wicg.github.io/window-controls-overlay/#windowcontrolsoverlay-interface",
           "support": {
             "chrome": {
-              "version_added": "98"
+              "version_added": "105"
             },
             "chrome_android": {
               "version_added": false
@@ -138,7 +138,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -263,7 +263,7 @@
                 }
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -314,7 +314,7 @@
                 }
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -365,7 +365,7 @@
                 }
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -416,7 +416,7 @@
                 }
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The **Window Controls Overlay** feature is useful for Progressive Web Apps to take advantage of the full window area when installed on desktop.

This was documented on MDN and BCD about a year ago and the chrome/edge version numbers set at the time were 98. Unfortunately the feature did not ship with 98. It was available only behind a flag at that time, and remained like this until 105 (which just shipped for Chrome, and is about to ship for Edge).

This PR updates the 98 version numbers to 105, for the corresponding APIs (navigator.windowControlsOverlay) and removes the `experimental` flag since the feature is now stable on those browsers (it went through origin trial already and the spec hasn't changed for about a year, and is now shipping on-by-default).

#### Test results and supporting details

I tested today with Chrome 105 (I made sure the flag was set to its default value). To test it yourself: open Chrome 105, go to an app that uses the feature: https://microsoftedge.github.io/Demos/pwamp/ install the app, and click the "hide title bar" button in the title bar (chevron icon).

See the chrome 105 release notes: https://developer.chrome.com/blog/new-in-chrome-105/#more