### PR TITLE
Fontface openfont tables

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -46,10 +46,6 @@
         "OpenType_CBDT_CBLC": {
           "__compat": {
             "description": "OpenType CBDT and CBLC rendering",
-            "spec_url": [
-              "https://docs.microsoft.com/en-us/typography/opentype/spec/cbdt",
-              "https://docs.microsoft.com/en-us/typography/opentype/spec/cblc"
-            ],
             "support": {
               "chrome": {
                 "version_added": "66"
@@ -83,7 +79,6 @@
         "OpenType_COLRv0": {
           "__compat": {
             "description": "OpenType COLRv0 rendering",
-            "spec_url": "https://docs.microsoft.com/en-us/typography/opentype/spec/colr",
             "support": {
               "chrome": {
                 "version_added": "53"
@@ -117,7 +112,6 @@
         "OpenType_COLRv1": {
           "__compat": {
             "description": "OpenType COLRv1 rendering",
-            "spec_url": "https://docs.microsoft.com/en-us/typography/opentype/spec/colr",
             "support": {
               "chrome": {
                 "version_added": "98"
@@ -158,7 +152,6 @@
         "OpenType_SBIX": {
           "__compat": {
             "description": "OpenType SBIX rendering",
-            "spec_url": "https://docs.microsoft.com/en-us/typography/opentype/spec/sbix",
             "support": {
               "chrome": {
                 "version_added": "66"
@@ -192,7 +185,6 @@
         "OpenType_SVG": {
           "__compat": {
             "description": "OpenType SVG rendering",
-            "spec_url": "https://docs.microsoft.com/en-us/typography/opentype/spec/svg",
             "support": {
               "chrome": {
                 "version_added": false

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -43,6 +43,178 @@
             "deprecated": false
           }
         },
+        "OpenType_CBDT_CBLC": {
+          "__compat": {
+            "description": "OpenType CBDT and CBLC rendering",
+            "support": {
+              "chrome": {
+                "version_added": "66"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "OpenType_COLRv0": {
+          "__compat": {
+            "description": "OpenType COLRv0 rendering",
+            "support": {
+              "chrome": {
+                "version_added": "53"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "31"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "11.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "OpenType_COLRv1": {
+          "__compat": {
+            "description": "OpenType COLRv1 rendering",
+            "support": {
+              "chrome": {
+                "version_added": "98"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "105",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "gfx.font_rendering.colr_v1.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "OpenType_SBIX": {
+          "__compat": {
+            "description": "OpenType SBIX rendering",
+            "support": {
+              "chrome": {
+                "version_added": "66"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "9.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "OpenType_SVG": {
+          "__compat": {
+            "description": "OpenType SVG rendering",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "31"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "12.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "SVG_fonts": {
           "__compat": {
             "description": "SVG fonts",

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -46,6 +46,10 @@
         "OpenType_CBDT_CBLC": {
           "__compat": {
             "description": "OpenType CBDT and CBLC rendering",
+            "spec_url": [
+              "https://docs.microsoft.com/en-us/typography/opentype/spec/cbdt",
+              "https://docs.microsoft.com/en-us/typography/opentype/spec/cblc"
+            ],
             "support": {
               "chrome": {
                 "version_added": "66"
@@ -79,6 +83,7 @@
         "OpenType_COLRv0": {
           "__compat": {
             "description": "OpenType COLRv0 rendering",
+            "spec_url": "https://docs.microsoft.com/en-us/typography/opentype/spec/colr",
             "support": {
               "chrome": {
                 "version_added": "53"
@@ -112,6 +117,7 @@
         "OpenType_COLRv1": {
           "__compat": {
             "description": "OpenType COLRv1 rendering",
+            "spec_url": "https://docs.microsoft.com/en-us/typography/opentype/spec/colr",
             "support": {
               "chrome": {
                 "version_added": "98"
@@ -152,6 +158,7 @@
         "OpenType_SBIX": {
           "__compat": {
             "description": "OpenType SBIX rendering",
+            "spec_url": "https://docs.microsoft.com/en-us/typography/opentype/spec/sbix",
             "support": {
               "chrome": {
                 "version_added": "66"
@@ -185,6 +192,7 @@
         "OpenType_SVG": {
           "__compat": {
             "description": "OpenType SVG rendering",
+            "spec_url": "https://docs.microsoft.com/en-us/typography/opentype/spec/svg",
             "support": {
               "chrome": {
                 "version_added": false


### PR DESCRIPTION
FF105 added support for COLRv1 fonts in https://bugzilla.mozilla.org/show_bug.cgi?id=1740530 (this is an extension to openfonts COLR table that allows coloured font gradients etc).

This adds compatibility information for the tables that code can fallback for browser support using the  CSS `@font-face` `src`: descriptor's `tech(...)` syntax. 

I tested these using browserstack with this page: https://pixelambacht.nl/chromacheck/

Other work for this can be tracked in https://github.com/mdn/content/issues/20106

Note: 
1. The specs give me an error because they are microsoft not web wg ones. How should I deal with this case?
2. Should this also be added to the [FontFace](https://developer.mozilla.org/en-US/docs/Web/API/FontFace) BCD? My thinking is yes because this is the other way to load a font of this type.
3. 

@Elchi3 Note that I don't plan on documenting the meaning of COLRv1 in MDN. BCD will (in first instance at least) be only place to find out about support.

@queengooborg Can you please review.