### PR TITLE
Updates to edge browser data

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -199,50 +199,57 @@
         },
         "100": {
           "release_date": "2022-04-01",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1000118529-april-1",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1000118529-april-1",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "100"
         },
         "101": {
           "release_date": "2022-04-29",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1010121032-april-28",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1010121032-april-28",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "101"
         },
         "102": {
           "release_date": "2022-05-31",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1020124530-may-31-2022",
           "status": "retired",
           "engine": "Blink",
-          "engine_version": "102",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1020124530-may-31"
+          "engine_version": "102"
         },
         "103": {
-          "release_date": "2022-06-23",
+          "release_date": "2022-07-01",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1030126437-june-23",
           "status": "retired",
           "engine": "Blink",
-          "engine_version": "103",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1030126437-june-23"
+          "engine_version": "103"
         },
         "104": {
-          "release_date": "2022-08-05",
-          "status": "current",
+          "release_date": "2022-08-09",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1040129347-august-5",
+          "status": "retired",
           "engine": "Blink",
-          "engine_version": "104",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1040129347-august-5"
+          "engine_version": "104"
         },
         "105": {
           "release_date": "2022-09-01",
-          "status": "beta",
+          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1050134325-september-1-2022",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "105"
         },
         "106": {
           "release_date": "2022-09-29",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "106"
+        },
+        "107": {
+          "release_date": "2022-10-27",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "107"
         }
       }
     }


### PR DESCRIPTION
Edge 105 is out, so it's time to update the edge.json data file.
That's what this PR does. It also updates a few release note links to their new correct locations.