### PR TITLE
Update Firefox release data

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -746,28 +746,28 @@
         "103": {
           "release_date": "2022-07-26",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/103",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "103"
         },
         "104": {
           "release_date": "2022-08-23",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/104",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "104"
         },
         "105": {
           "release_date": "2022-09-20",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/105",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "105"
         },
         "106": {
           "release_date": "2022-10-18",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/106",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "106"
         },
@@ -784,6 +784,97 @@
           "status": "planned",
           "engine": "Gecko",
           "engine_version": "108"
+        },
+        "109": {
+          "release_date": "2023-01-17",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/109",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "109"
+        },
+        "110": {
+          "release_date": "2023-02-14",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/110",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "110"
+        },
+        "111": {
+          "release_date": "2023-03-14",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/111",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "111"
+        },
+        "112": {
+          "release_date": "2023-04-11",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/112",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "112"
+        },
+        "113": {
+          "release_date": "2023-05-09",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/113",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "113"
+        },
+        "114": {
+          "release_date": "2023-06-06",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/114",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "114"
+        },
+        "115": {
+          "release_date": "2023-07-04",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/115",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "116"
+        },
+        "116": {
+          "release_date": "2023-08-01",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/116",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "116"
+        },
+        "117": {
+          "release_date": "2023-08-29",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/117",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "117"
+        },
+        "118": {
+          "release_date": "2023-09-26",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/118",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "118"
+        },
+        "119": {
+          "release_date": "2023-10-24",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/119",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "119"
+        },
+        "120": {
+          "release_date": "2023-11-21",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/120",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "120"
+        },
+        "121": {
+          "release_date": "2023-12-19",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/121",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "121"
         }
       }
     }

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -613,28 +613,28 @@
         "103": {
           "release_date": "2022-07-26",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/103",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "103"
         },
         "104": {
           "release_date": "2022-08-23",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/104",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "104"
         },
         "105": {
           "release_date": "2022-09-20",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/105",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "105"
         },
         "106": {
           "release_date": "2022-10-18",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/106",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "106"
         },
@@ -651,6 +651,97 @@
           "status": "planned",
           "engine": "Gecko",
           "engine_version": "108"
+        },
+        "109": {
+          "release_date": "2023-01-17",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/109",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "109"
+        },
+        "110": {
+          "release_date": "2023-02-14",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/110",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "110"
+        },
+        "111": {
+          "release_date": "2023-03-14",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/111",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "111"
+        },
+        "112": {
+          "release_date": "2023-04-11",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/112",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "112"
+        },
+        "113": {
+          "release_date": "2023-05-09",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/113",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "113"
+        },
+        "114": {
+          "release_date": "2023-06-06",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/114",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "114"
+        },
+        "115": {
+          "release_date": "2023-07-04",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/115",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "116"
+        },
+        "116": {
+          "release_date": "2023-08-01",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/116",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "116"
+        },
+        "117": {
+          "release_date": "2023-08-29",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/117",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "117"
+        },
+        "118": {
+          "release_date": "2023-09-26",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/118",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "118"
+        },
+        "119": {
+          "release_date": "2023-10-24",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/119",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "119"
+        },
+        "120": {
+          "release_date": "2023-11-21",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/120",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "120"
+        },
+        "121": {
+          "release_date": "2023-12-19",
+          "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/121",
+          "status": "planned",
+          "engine": "Gecko",
+          "engine_version": "121"
         }
       }
     }


### PR DESCRIPTION
This PR updates the release data for Firefox and Firefox Android, bumping the current version and adding planned versions.  All data comes from https://wiki.mozilla.org/Release_Management/Calendar.
