### PR TITLE
Add missing api.MediaDevices.setCaptureHandleConfig feature

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -404,6 +404,7 @@
       },
       "setCaptureHandleConfig": {
         "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-handle/identity/#dom-mediadevices-setcapturehandleconfig",
           "support": {
             "chrome": {
               "version_added": "102"

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -429,7 +429,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -401,6 +401,38 @@
             "deprecated": false
           }
         }
+      },
+      "setCaptureHandleConfig": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `setCaptureHandleConfig` member of the MediaDevices API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MediaDevices/setCaptureHandleConfig

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
