### PR TITLE
Update data about overflow-clip-margin

### DIFF
--- a/css/properties/overflow-clip-margin.json
+++ b/css/properties/overflow-clip-margin.json
@@ -7,13 +7,16 @@
           "spec_url": "https://drafts.csswg.org/css-overflow/#overflow-clip-margin",
           "support": {
             "chrome": {
-              "version_added": "90"
+              "version_added": "90",
+              "partial_implementation": true,
+              "notes": "Only works when both axes are using <code>overflow: clip</code>. See <a href='https://crbug.com/1354474'>bug 1354474</a>."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1661582'>bug 1661582</a>."
+              "version_added": "102",
+              "partial_implementation": true,
+              "notes": "Only supports using a length, not a visual box. See <a href='https://bugzil.la/1661582'>bug 1661582</a>."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -30,7 +33,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
Firefox shipped support for `overflow-clip-margin: <length>` in Firefox 102 in https://bugzilla.mozilla.org/show_bug.cgi?id=1769512 (it is not mentioned in the release notes, but I confirmed it indeed work in Firefox 104).

And Chromium only supports it when both axes are clipped (otherwise it ignores the property), so I marked this as a partial implementation.

Closes #17306
Closes #17311