### PR TITLE
Add compat data for font-family: math

### DIFF
--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -72,19 +72,8 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": "89",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": false
               },

--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -46,6 +46,59 @@
             "deprecated": false
           }
         },
+        "math": {
+          "__compat": {
+            "description": "<code>math</code>",
+            "support": {
+              "chrome": {
+                "version_added": "103",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": "89",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "system-ui": {
           "__compat": {
             "description": "<code>system-ui</code>",

--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -60,9 +60,7 @@
                   }
                 ]
               },
-              "chrome_android": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": false


### PR DESCRIPTION
This is implemented in Chromium on non-Android platforms since version 103,
under the experimental web platform features flag. Not in any other web
engine.

Spec:
https://drafts.csswg.org/css-fonts/#valdef-font-family-math

Chromium:
https://chromiumdash.appspot.com/commit/52ec74ca677b34eff97085592dc2e1e7cb8c1749
https://docs.google.com/document/d/1bvY_Npe2zLW_705KXdmecsH6P9I9wBMpHRsZ9CxWNOI/edit

Firefox:
https://bugzilla.mozilla.org/show_bug.cgi?id=1788937

WebKit:
https://bugs.webkit.org/show_bug.cgi?id=209595

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
