### PR TITLE
Update data for math-depth property and font-size: math

### DIFF
--- a/css/properties/font-size.json
+++ b/css/properties/font-size.json
@@ -42,6 +42,49 @@
             "deprecated": false
           }
         },
+        "math": {
+          "__compat": {
+            "description": "<code>math</code> keyword",
+            "support": {
+              "chrome": {
+                "version_added": "87",
+                "impl_url": "https://crrev.com/c/2423843",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1667090"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": "4"
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "rem_values": {
           "__compat": {
             "description": "<code>rem</code> values",

--- a/css/properties/math-depth.json
+++ b/css/properties/math-depth.json
@@ -19,8 +19,16 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1667090'>bug 1667090</a>."
+              "version_added": "83",
+              "impl_url": "https://bugzil.la/1667090",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.math-depth.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "notes": "Implementation lacks support for <code>font-size: math</code> to be complete."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
#### Summary

Update data for math-depth property and font-size: math, especially the status in Firefox and Chrome.

#### Test results and supporting details

These features have been implemented in Chrome [1].

`math-depth` was implemented in Firefox 83
but is still under a flag until `font-size: math` is implemented [2] [3].

These features are not implemented in WebKit yet.

[1] https://chromiumdash.appspot.com/commit/0feb1d195c8a413c53e808ed95df7e1b78089703
[2] https://bugzilla.mozilla.org/show_bug.cgi?id=1667118#c11
[3] https://bugzilla.mozilla.org/show_bug.cgi?id=1667090

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
