### PR TITLE
Add missing api.OffscreenCanvas.context[lost/restored]_event feature

### DIFF
--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -100,8 +100,8 @@
         "__compat": {
           "description": "<code>contextlost</code> event",
           "spec_url": [
-            "https://html.spec.whatwg.org/multipage/canvas.html#handler-offscreencanvas-oncontextlost",
-            "https://html.spec.whatwg.org/multipage/indices.html#event-contextlost"
+            "https://html.spec.whatwg.org/multipage/indices.html#event-contextlost",
+            "https://html.spec.whatwg.org/multipage/canvas.html#handler-offscreencanvas-oncontextlost"
           ],
           "support": {
             "chrome": {
@@ -137,8 +137,8 @@
         "__compat": {
           "description": "<code>contextrestored</code> event",
           "spec_url": [
-            "https://html.spec.whatwg.org/multipage/canvas.html#handler-offscreencanvas-oncontextrestored",
-            "https://html.spec.whatwg.org/multipage/indices.html#event-contextrestored"
+            "https://html.spec.whatwg.org/multipage/indices.html#event-contextrestored",
+            "https://html.spec.whatwg.org/multipage/canvas.html#handler-offscreencanvas-oncontextrestored"
           ],
           "support": {
             "chrome": {

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -96,6 +96,80 @@
           }
         }
       },
+      "contextlost_event": {
+        "__compat": {
+          "description": "<code>contextlost</code> event",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/canvas.html#handler-offscreencanvas-oncontextlost",
+            "https://html.spec.whatwg.org/multipage/indices.html#event-contextlost"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "contextrestored_event": {
+        "__compat": {
+          "description": "<code>contextrestored</code> event",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/canvas.html#handler-offscreencanvas-oncontextrestored",
+            "https://html.spec.whatwg.org/multipage/indices.html#event-contextrestored"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "convertToBlob": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/OffscreenCanvas/convertToBlob",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `contextlost_event` and `contextrestored_event` members of the OffscreenCanvas API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.2).

Tests Used:
https://mdn-bcd-collector.appspot.com/tests/api/OffscreenCanvas/contextlost_event
https://mdn-bcd-collector.appspot.com/tests/api/OffscreenCanvas/contextrestored_event

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
