### PR TITLE
Add missing api.Path2D.roundRect feature

### DIFF
--- a/api/Path2D.json
+++ b/api/Path2D.json
@@ -424,7 +424,7 @@
       },
       "roundRect": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-roundrect",
+          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-roundrect-dev",
           "support": {
             "chrome": {
               "version_added": "99"

--- a/api/Path2D.json
+++ b/api/Path2D.json
@@ -449,7 +449,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Path2D.json
+++ b/api/Path2D.json
@@ -421,6 +421,39 @@
             "deprecated": false
           }
         }
+      },
+      "roundRect": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-roundrect",
+          "support": {
+            "chrome": {
+              "version_added": "99"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `roundRect` member of the Path2D API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Path2D/roundRect

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
