### PR TITLE
Add missing api.PublicKeyCredential.authenticatorAttachment feature

### DIFF
--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -50,6 +50,41 @@
           "deprecated": false
         }
       },
+      "authenticatorAttachment": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webauthn/#dom-publickeycredential-authenticatorattachment",
+          "support": {
+            "chrome": {
+              "version_added": "98"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.6"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getClientExtensionResults": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/getClientExtensionResults",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `authenticatorAttachment` member of the PublicKeyCredential API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PublicKeyCredential/authenticatorAttachment

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
