### PR TITLE
Add missing api.Serial.[dis]connect_event feature

### DIFF
--- a/api/Serial.json
+++ b/api/Serial.json
@@ -35,6 +35,84 @@
           "deprecated": false
         }
       },
+      "connect_event": {
+        "__compat": {
+          "description": "<code>connect</code> event",
+          "spec_url": [
+            "https://wicg.github.io/serial/#dfn-connect",
+            "https://wicg.github.io/serial/#dom-serial-onconnect"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "89"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "disconnect_event": {
+        "__compat": {
+          "description": "<code>disconnect</code> event",
+          "spec_url": [
+            "https://wicg.github.io/serial/#dfn-disconnect",
+            "https://wicg.github.io/serial/#dom-serial-ondisconnect"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "89"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getPorts": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Serial/getPorts",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `connect_event` and `disconnect_event` members of the Serial API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.2).

Tests Used:
https://mdn-bcd-collector.appspot.com/tests/api/Serial/connect_event
https://mdn-bcd-collector.appspot.com/tests/api/Serial/disconnect_event

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
