### PR TITLE
Remove Document.visibilityState's prerender value

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6869,51 +6869,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "prerender": {
-          "__compat": {
-            "description": "<code>prerender</code> value",
-            "support": {
-              "chrome": {
-                "version_added": "14",
-                "version_removed": "73"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "49",
-                "version_removed": "59"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": {
-                "version_added": "≤15",
-                "version_removed": "60"
-              },
-              "opera_android": {
-                "version_added": "≤14",
-                "version_removed": "52"
-              },
-              "safari": {
-                "version_added": "7",
-                "version_removed": "14.1"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37",
-                "version_removed": "73"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
         }
       },
       "vlinkColor": {


### PR DESCRIPTION
The `prerender` is gone for years from every browser. Time to let it go.