### PR TITLE
Add missing api.ShadowRoot.slotchange_event feature

### DIFF
--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -531,6 +531,43 @@
           }
         }
       },
+      "slotchange_event": {
+        "__compat": {
+          "description": "<code>slotchange</code> event",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/indices.html#event-slotchange",
+            "https://dom.spec.whatwg.org/#dom-shadowroot-onslotchange"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "97"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "93"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "14.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "styleSheets": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/styleSheets",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `slotchange_event` member of the ShadowRoot API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ShadowRoot/slotchange_event

Safari Source Commit: https://github.com/WebKit/WebKit/commit/3e059eef4d8b201ca9818e8e0cbe106be2aa5e73

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
