### PR TITLE
Add missing api.WebGL2RenderingContext.lineWidth feature

### DIFF
--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -5635,6 +5635,41 @@
           }
         }
       },
+      "lineWidth": {
+        "__compat": {
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.3",
+          "support": {
+            "chrome": {
+              "version_added": "56"
+            },
+            "chrome_android": {
+              "version_added": "58"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "51"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "linkProgram": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/linkProgram",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `lineWidth` member of the WebGL2RenderingContext API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/WebGL2RenderingContext/lineWidth

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
