### PR TITLE
Add missing BrowserCaptureMediaStreamTrack API

### DIFF
--- a/api/BrowserCaptureMediaStreamTrack.json
+++ b/api/BrowserCaptureMediaStreamTrack.json
@@ -1,0 +1,103 @@
+{
+  "api": {
+    "BrowserCaptureMediaStreamTrack": {
+      "__compat": {
+        "spec_url": "https://w3c.github.io/mediacapture-region/#browser-capture-media-stream-track",
+        "support": {
+          "chrome": {
+            "version_added": "104"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "clone": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-region/#dom-browsercapturemediastreamtrack-clone",
+          "support": {
+            "chrome": {
+              "version_added": "104"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "cropTo": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-region/#dom-browsercapturemediastreamtrack-cropto",
+          "support": {
+            "chrome": {
+              "version_added": "104"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `BrowserCaptureMediaStreamTrack` API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.2).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/BrowserCaptureMediaStreamTrack

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
