### PR TITLE
Add compat data for the math-shift property

### DIFF
--- a/css/properties/math-shift.json
+++ b/css/properties/math-shift.json
@@ -1,0 +1,47 @@
+{
+  "css": {
+    "properties": {
+      "math-shift": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/math-shift",
+          "spec_url": "https://w3c.github.io/mathml-core/#the-math-shift",
+          "support": {
+            "chrome": {
+              "version_added": "87",
+              "impl_url": "https://crrev.com/c/2421662",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features"
+                }
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Summary

Add compat data for the math-shift property
It's implemented in Chrome 87 under the "experimental web platform features" flag
but not in other browsers.

#### Test results and supporting details

Chrome:
https://chromiumdash.appspot.com/commit/c82a21d4e24e53d4adf915a6c1f27005db1b5850

#### Related issues

