### PR TITLE
fix the broken link to CSS `path()`

### DIFF
--- a/svg/elements/path.json
+++ b/svg/elements/path.json
@@ -94,7 +94,7 @@
           "path": {
             "__compat": {
               "description": "<code>d</code> as CSS property supports <code>path()</code>",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/path()",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/path",
               "support": {
                 "chrome": {
                   "version_added": "52"


### PR DESCRIPTION
#### Summary

fix the broken link to CSS `path()`

#### Test results and supporting details

See the flaws: <https://pr8323.content.dev.mdn.mozit.cloud/zh-CN/docs/Web/SVG/Attribute/d#_flaws>

The `()` should be removed.

