### PR TITLE
Update compat data for the <semantics> element

### DIFF
--- a/mathml/elements/semantics.json
+++ b/mathml/elements/semantics.json
@@ -16,15 +16,16 @@
                   "value_to_set": "Enabled"
                 }
               ],
-              "notes": "By default, only the first child is rendered while the others have their <code>display</code> set to <code>none</code>."
+              "notes": "This follows MathML Core: Only the first child is rendered while the others have their <code>display</code> set to <code>none</code>."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": "1",
               "notes": [
-                "<code>annotation</code> and <code>annotation-xml</code> elements are ignored if the <code>src</code> attribute is set.",
-                "The algorithm for determining the visible child has been corrected in Firefox 23 to match the MathML specification. In prior versions only the first child element was rendered."
+                "In Firefox 1, only the first child element is rendered.",
+                "In Firefox 23, the algorithm to determine the visible child <a href='https://developer.mozilla.org/docs/Web/MathML/Element/semantics#sect1'>described on MDN</a> has been implemented.",
+                "Firefox 106 and later versions follow MathML Core: Only the first child is rendered while the others have their <code>display</code> set to <code>none</code>."
               ]
             },
             "firefox_android": "mirror",
@@ -35,7 +36,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "5",
+              "notes": [
+                "In Safari 5, only the first child element is rendered.",
+                "In Safari 8, the algorithm to determine the visible child <a href='https://developer.mozilla.org/docs/Web/MathML/Element/semantics#sect1'>described on MDN</a> has been implemented."
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

- Clarify that Chrome follows MathML Core
- Clarify that Firefox 23 uses the algo described on the MDN note.
- Add that Firefox 106 follows MathML Core [1]
- Add that this was initially implemented in Safari 5 [2] and
  later aligned with the algo described on the MDN note [3].

#### Test results and supporting details

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1588733
[2] https://github.com/WebKit/WebKit/commit/f1e006a82bf306be22b840f487beb8c5aa70d9bb#diff-4636b0a9c02b507bc231efbe1f4728d177176b4e4c329aa2ddefc869347ae40eR91
[3] https://github.com/WebKit/WebKit/commit/81754afb378a328f709a373986b86439daedeb64

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
