### PR TITLE
Remove release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,6 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-permissions:
-  contents: read
-
 jobs:
   build:
     name: Publish release


### PR DESCRIPTION
This PR removes the permissions for the release workflow for now, to mitigate https://github.com/mdn/browser-compat-data/runs/8206452724?check_suite_focus=true.