### PR TITLE
Remove api.CanvasRenderingContext2D.drawWindow from BCD

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -815,39 +815,6 @@
           }
         }
       },
-      "drawWindow": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/drawWindow",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "1.5"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "ellipse": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/ellipse",


### PR DESCRIPTION
This PR removes the `drawWindow` member of the `CanvasRenderingContext2D` API from BCD.  This is a webextension-only feature, but as mentioned in https://github.com/mdn/browser-compat-data/pull/17414#issuecomment-1219639766, it should probably not be used by web developers.
