### PR TITLE
Move api.Element.openOrClosedShadowRoot to webext/

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -5733,40 +5733,6 @@
           }
         }
       },
-      "openOrClosedShadowRoot": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/openOrClosedShadowRoot",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "63",
-              "notes": "Available only to <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions'>WebExtensions</a>."
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
       "outerHTML": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/outerHTML",

--- a/webextensions/api/dom.json
+++ b/webextensions/api/dom.json
@@ -7,7 +7,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/dom/openOrClosedShadowRoot",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "88"
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/api/dom.json
+++ b/webextensions/api/dom.json
@@ -9,29 +9,16 @@
               "chrome": {
                 "version_added": false
               },
-              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": "63"
               },
               "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
               "safari": {
                 "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": false
+              "safari_ios": "mirror"
             }
           }
         }

--- a/webextensions/api/dom.json
+++ b/webextensions/api/dom.json
@@ -1,0 +1,41 @@
+{
+  "webextensions": {
+    "api": {
+      "dom": {
+        "openOrClosedShadowRoot": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/dom/openOrClosedShadowRoot",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "63"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR moves `api.Element.openOrClosedShadowRoot` to `webextensions.api.dom.openOrClosedShadowRoot` to better match where this function can be used.  The placement was chosen based on Chrome's implementation (see https://github.com/mdn/browser-compat-data/pull/17414#issuecomment-1220022812).

Fixes #16986.
