### PR TITLE
Update Firefox versions for api.CloseEvent.CloseEvent

### DIFF
--- a/api/CloseEvent.json
+++ b/api/CloseEvent.json
@@ -65,7 +65,7 @@
               "version_added": "14"
             },
             "firefox": {
-              "version_added": "8"
+              "version_added": "11"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `CloseEvent` member of the `CloseEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.3).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CloseEvent/CloseEvent

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
