### PR TITLE
Update Firefox versions for Console API

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -300,7 +300,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "5"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -703,7 +703,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "9"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects the real values for Firefox and Firefox Android for the `Console` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.3).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Console

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
