### PR TITLE
Mirror javascript.builtins to Opera

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -122,9 +122,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "15.4"
               },
@@ -557,9 +555,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "15.4"
               },
@@ -599,9 +595,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "15.4"
               },

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -72,9 +72,7 @@
                 "version_added": "7.0.0"
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": "10.1"

--- a/javascript/builtins/Intl/Locale.json
+++ b/javascript/builtins/Intl/Locale.json
@@ -187,9 +187,7 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": {
-                  "version_added": false
-                },
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": "15.4"
                 },
@@ -402,9 +400,7 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": {
-                  "version_added": false
-                },
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": "15.4"
                 },
@@ -604,9 +600,7 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": {
-                  "version_added": false
-                },
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": "15.4"
                 },
@@ -766,9 +760,7 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": {
-                  "version_added": false
-                },
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": "15.4"
                 },
@@ -808,9 +800,7 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": {
-                  "version_added": false
-                },
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": "15.4"
                 },
@@ -890,9 +880,7 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": {
-                  "version_added": false
-                },
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": "15.4"
                 },

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -882,12 +882,8 @@
                 "version_added": "6.0.0"
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "9.1"
               },

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -167,9 +167,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "15.4"
               },

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -539,9 +539,7 @@
                 "version_added": "4.0.0"
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": "9.1"

--- a/javascript/builtins/WeakRef.json
+++ b/javascript/builtins/WeakRef.json
@@ -36,12 +36,8 @@
               }
             ],
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "14.1"
             },
@@ -91,12 +87,8 @@
                 }
               ],
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "14.1"
               },
@@ -146,12 +138,8 @@
                 }
               ],
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "14.1"
               },

--- a/javascript/builtins/WebAssembly/Global.json
+++ b/javascript/builtins/WebAssembly/Global.json
@@ -26,12 +26,8 @@
                 "version_added": "11.0.0"
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "13.1"
               },
@@ -73,12 +69,8 @@
                   "notes": "Constructing a <code>Global</code> with a value of <code>v128</code> produces a <code>TypeError</code>."
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
+                "opera": "mirror",
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": "13.1"
                 },
@@ -117,12 +109,8 @@
                   "version_added": "11.0.0"
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
+                "opera": "mirror",
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": "13.1"
                 },
@@ -161,12 +149,8 @@
                   "version_added": "11.0.0"
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": false
-                },
-                "opera_android": {
-                  "version_added": false
-                },
+                "opera": "mirror",
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": "13.1"
                 },


### PR DESCRIPTION
This PR mirrors the JavaScript builtins data from Chrome to Opera where it differs and the collector states the support should match.
