### PR TITLE
Update Chromium versions for javascript.builtins.Intl.Locale.collations

### DIFF
--- a/javascript/builtins/Intl/Locale.json
+++ b/javascript/builtins/Intl/Locale.json
@@ -290,22 +290,13 @@
               "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.collations",
               "support": {
                 "chrome": {
-                  "version_added": "92",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-javascript-harmony",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
+                  "version_added": "99"
                 },
                 "chrome_android": "mirror",
                 "deno": {
                   "version_added": false
                 },
-                "edge": {
-                  "version_added": "99"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
@@ -317,18 +308,14 @@
                   "version_added": false
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": "85"
-                },
+                "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": "15.4"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
-                "webview_android": {
-                  "version_added": "99"
-                }
+                "webview_android": "mirror"
               },
               "status": {
                 "experimental": false,


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `collations` member of the `Intl.Locale` JavaScript builtin, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.3).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/javascript/builtins/Intl/Locale/collations

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
