### PR TITLE
Update Chromium versions for javascript.builtins.Array.isArray

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -981,7 +981,7 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.isarray",
             "support": {
               "chrome": {
-                "version_added": "5"
+                "version_added": "4"
               },
               "chrome_android": "mirror",
               "deno": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `isArray` member of the `Array` JavaScript builtin, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.3).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/javascript/builtins/Array/isArray

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
