### PR TITLE
Update Edge versions for javascript.builtins.Array.values

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -2070,7 +2070,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "60"


### PR DESCRIPTION
This PR updates and corrects the real values for Microsoft Edge for the `values` member of the `Array` JavaScript builtin, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.3).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/javascript/builtins/Array/values

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
