### PR TITLE
Update Opera versions for align-content CSS property

### DIFF
--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -42,12 +42,8 @@
               "version_added": "11"
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "12.1"
-            },
-            "opera_android": {
-              "version_added": "12.1"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": [
               {
                 "version_added": "9"
@@ -98,12 +94,8 @@
                 "version_added": "11"
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": "12.1"
-              },
-              "opera_android": {
-                "version_added": "12.1"
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "9"
               },


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `align-content` CSS property, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.3).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/css/properties/align-content

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
