### PR TITLE
Update Opera versions for align-items CSS property

### DIFF
--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -42,12 +42,8 @@
               "version_added": "11"
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "12.1"
-            },
-            "opera_android": {
-              "version_added": "12.1"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": [
               {
                 "version_added": "9"
@@ -100,12 +96,8 @@
                 "notes": "In Internet Explorer 10 and 11, if column flex items have <code>align-items: center;</code> set on them and their content is too large, then they will overflow the bounds of their container. See <a href='https://github.com/philipwalton/flexbugs#2-column-flex-items-set-to-align-itemscenter-overflow-their-container'>Flexbug #2</a>."
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": "12.1"
-              },
-              "opera_android": {
-                "version_added": "12.1"
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "7"
               },


### PR DESCRIPTION
This PR updates and corrects the real values for Opera and Opera Android for the `align-items` CSS property, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.3).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/css/properties/align-items

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
