### PR TITLE
Add Global Privacy Control data

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1320,6 +1320,52 @@
           }
         }
       },
+      "globalPrivacyControl": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/globalPrivacyControl",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "95",
+              "impl_url": "https://hg.mozilla.org/mozilla-central/rev/09e51e6d4a7e",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "privacy.globalprivacycontrol.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "privacy.globalprivacycontrol.functionality.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "hardwareConcurrency": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/hardwareConcurrency",

--- a/http/headers/Sec-GPC.json
+++ b/http/headers/Sec-GPC.json
@@ -1,0 +1,52 @@
+{
+  "http": {
+    "headers": {
+      "Sec-GPC": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-GPC",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "95",
+              "impl_url": "https://hg.mozilla.org/mozilla-central/rev/09e51e6d4a7e",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "privacy.globalprivacycontrol.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "privacy.globalprivacycontrol.functionality.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webextensions/api/privacy.json
+++ b/webextensions/api/privacy.json
@@ -3,6 +3,25 @@
     "api": {
       "privacy": {
         "network": {
+          "globalPrivacyControl": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "95"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "networkPredictionEnabled": {
             "__compat": {
               "support": {


### PR DESCRIPTION
#### Summary

Added compatibility data for GPC's http header, navigator property, and webextension api property.

As far as I know the only browsers that currently implement this are us (as of 95) and Brave (as of 1.18.70).

#### Test results and supporting details

Ran this repo's tests via `npm test` and received no errors.

https://globalprivacycontrol.github.io/gpc-spec/
https://hg.mozilla.org/mozilla-central/rev/09e51e6d4a7e
https://github.com/brave/brave-browser/releases/tag/v1.18.70

#### Related issues

Corresponds to PR[11884](https://github.com/mdn/content/pull/11884) in mdn/content.
