### PR TITLE
Don't consider IE support in obsolete checks

### DIFF
--- a/test/linter/test-obsolete.ts
+++ b/test/linter/test-obsolete.ts
@@ -53,6 +53,11 @@ export const implementedAndRemoved = (
     BrowserName,
     SupportStatement,
   ][]) {
+    if (browser === 'ie') {
+      // Don't consider IE support in obsolete checks
+      continue;
+    }
+
     for (const d of Array.isArray(data) ? data : [data]) {
       // Feature is still supported or it is not known when feature was dropped
       if (!d.version_removed || typeof d.version_removed === 'boolean') {


### PR DESCRIPTION
This PR updates the `test-obsolete` check to ignore IE when checking for feature obselescence.  That is, if a feature is supported in IE11, but not supported in any other browser, the feature will be considered obsolete.
