### PR TITLE
Finalize freeze of IE data

### DIFF
--- a/.github/ISSUE_TEMPLATE/data-problem.yml
+++ b/.github/ISSUE_TEMPLATE/data-problem.yml
@@ -53,7 +53,7 @@ body:
       options:
         - Chromium (Chrome, Edge 79+, Opera, Samsung Internet)
         - Firefox
-        - Internet Explorer/Legacy Edge (12-18)
+        - Legacy Edge (12-18)
         - Safari
         - Node.js
         - Deno

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -144,7 +144,7 @@ Per request, we have added a new `timestamp` property to the top-level `__meta` 
 
 #### Internet Explorer data is now in "legacy mode"
 
-The [death of Internet Explorer](http://death-to-ie11.com/) had finally arrived about two months ago (whoo!), and as such we have de-prioritized updates to IE's data. While we will not reject updates to IE data, we will not be spending much time on this browser, and eventually, we will remove the data entirely from BCD in a year or two. We strongly recommend that all developers writing IE-compatible websites drop support and focus on modern browsers, such as Chrome, Firefox and Safari.
+The [death of Internet Explorer](http://death-to-ie11.com/) had finally arrived about two months ago (whoo!), and as such we have frozen the BCD for IE. We will no longer be maintaining the data for IE and will remove the data entirely from BCD in a year or two. We strongly recommend that all developers writing IE-compatible websites drop support and focus on modern browsers, such as Chrome, Firefox and Safari.
 
 ### Removals
 

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -181,7 +181,7 @@ The currently accepted browser identifiers should be declared in alphabetical or
 - `edge`, Microsoft Edge (on Windows), based on the EdgeHTML version (before version 79), and later on the Chromium version
 - `firefox`, Mozilla Firefox (on desktops)
 - `firefox_android`, Firefox for Android, sometimes nicknamed Fennec
-- `ie`, Microsoft Internet Explorer (discontinued)
+- `ie`, Microsoft Internet Explorer (discontinued; BCD is frozen)
 - `nodejs` Node.js JavaScript runtime built on Chrome's V8 JavaScript engine
 - `oculus`, Meta Quest Browser (formerly Oculus Quest), based on Google Chrome (on Android)
 - `opera`, the Opera browser (desktop), based on Blink since Opera 15


### PR DESCRIPTION
This PR finalizes the freezing of Internet Explorer within BCD, further clarifying we are not planning to update IE data.
