### PR TITLE
Remove compat data for mfrac@bevelled

### DIFF
--- a/mathml/elements/mfrac.json
+++ b/mathml/elements/mfrac.json
@@ -44,39 +44,6 @@
             "deprecated": false
           }
         },
-        "bevelled": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "1",
-                "version_removed": "71"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "denomalign": {
           "__compat": {
             "support": {


### PR DESCRIPTION

#### Summary

Remove compatibility data for the `bevelled` attribute of the `mfrac` element. It has only been implemented in Firefox and removed from Firefox 71 (december 2019) so considered irrelevant per [1].

#### Test results and supporting details

[1] https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features

#### Related issues


