### PR TITLE
Add compat data for deprecated MathML 1 style attributes

### DIFF
--- a/mathml/elements/mstyle.json
+++ b/mathml/elements/mstyle.json
@@ -70,6 +70,191 @@
             "deprecated": false
           }
         },
+        "background": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mstyle#attr-background",
+            "support": {
+              "chrome": {
+                "version_added": "24",
+                "version_removed": "25"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1",
+                "version_removed": "83"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "5.1"
+              },
+              "safari_ios": {
+                "version_added": "5"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "color": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mstyle#attr-color",
+            "support": {
+              "chrome": {
+                "version_added": "24",
+                "version_removed": "25"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1",
+                "version_removed": "83"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "5.1"
+              },
+              "safari_ios": {
+                "version_added": "5"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "fontsize": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mstyle#attr-fontsize",
+            "support": {
+              "chrome": {
+                "version_added": "24",
+                "version_removed": "25"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1",
+                "version_removed": "83"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "5.1"
+              },
+              "safari_ios": {
+                "version_added": "5"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "fontstyle": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mstyle#attr-fontstyle",
+            "support": {
+              "chrome": {
+                "version_added": "24",
+                "version_removed": "25"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1",
+                "version_removed": "83"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "5.1"
+              },
+              "safari_ios": {
+                "version_added": "5"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "fontweight": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mstyle#attr-fontweight",
+            "support": {
+              "chrome": {
+                "version_added": "24",
+                "version_removed": "25"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1",
+                "version_removed": "83"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "5.1"
+              },
+              "safari_ios": {
+                "version_added": "5"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
         "scriptminsize": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mstyle#attr-scriptminsize",


### PR DESCRIPTION
#### Summary

These are very old attributes which were implemented in Gecko before the first release of Firefox and finally removed in version 83 [1] [2].

They were also in the initial MathML implementation of Safari and are still present in WebKit [3] [4]. They were briefly implemented in Chrome 24 (WebKit-based) when MathML was enabled but they are not implemented in the new version based on MathML Core [5].

#### Test results and supporting details

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1548524#c10
[2] https://bugzilla.mozilla.org/show_bug.cgi?id=1664488
[3] https://github.com/WebKit/WebKit/commit/a1eb879cbccd72892925967313a3e4be243d8dc7
[4] https://github.com/WebKit/WebKit/blob/881a95924a0bece5346f923ab6e163d8ebf05b08/Source/WebCore/mathml/MathMLElement.cpp#L157
[5] https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/mathml/mathml_attribute_names.json5

#### Related issues

https://github.com/mdn/content/pull/20481