### PR TITLE
Deprecate RTCIceServer»credentialType & RTCIceCredentialType

### DIFF
--- a/api/RTCIceCredentialType.json
+++ b/api/RTCIceCredentialType.json
@@ -3,7 +3,6 @@
     "RTCIceCredentialType": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCredentialType",
-        "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcicecredentialtype",
         "support": {
           "chrome": {
             "version_added": false
@@ -29,8 +28,8 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
-          "deprecated": false
+          "standard_track": false,
+          "deprecated": true
         }
       },
       "oauth": {
@@ -61,8 +60,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -128,8 +127,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }

--- a/api/RTCIceCredentialType.json
+++ b/api/RTCIceCredentialType.json
@@ -32,39 +32,6 @@
           "deprecated": true
         }
       },
-      "oauth": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCredentialType#oauth",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "password": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCredentialType#password",

--- a/api/RTCIceServer.json
+++ b/api/RTCIceServer.json
@@ -82,7 +82,6 @@
       "credentialType": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceServer/credentialType",
-          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtciceserver-credentialtype",
           "support": {
             "chrome": {
               "version_added": false
@@ -110,8 +109,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
https://github.com/w3c/webrtc-pc/commit/0cba163 (https://github.com/w3c/webrtc-pc/pull/2767) removed RTCIceServer»credentialType and RTCIceCredentialType from the WebRTC spec. Related MDN change: https://github.com/mdn/content/pull/20505.