### PR TITLE
webNavigation.TransitionQualifier from_address_bar support udate

### DIFF
--- a/webextensions/api/webNavigation.json
+++ b/webextensions/api/webNavigation.json
@@ -36,7 +36,7 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "49"
                 },
                 "firefox_android": "mirror",
                 "opera": {


### PR DESCRIPTION
#### Summary

Add the details of the version in which `from_address_bar` support was added to `webNavigation.TransitionQualifier` in Firefox.  

#### Test results and supporting details

Support for `from_address_bar` was added to Firefox 49 as a result of [Bug 1263723](https://bugzilla.mozilla.org/show_bug.cgi?id=1263723) "WebNavigation API should keep track of the user interaction with the urlbar and set transition types and qualifiers accordingly". See https://searchfox.org/mozilla-central/diff/92282aa3cbbb5ff1739b8180ac63aede50cd9748/toolkit/components/extensions/ext-webNavigation.js#37.

#### Related issues

Addresses "from_address_bar qualifier is supported on firefox, but that's not indicated in the doc" [#19203](https://github.com/mdn/content/issues/19203)
