### PR TITLE
Better word guideline for unsupported features

### DIFF
--- a/docs/data-guidelines/index.md
+++ b/docs/data-guidelines/index.md
@@ -108,7 +108,7 @@ This guideline was proposed in [#6670](https://github.com/mdn/browser-compat-dat
 
 ## Features with no browser support
 
-Browser features that have not been implemented in any browser, or are planned to be implemented, should not be added to BCD. A feature should not be added if all of the following conditions are met:
+Browser features that have not been implemented (or planned to be implemented) in any browser, should not be added to BCD. A feature should not be added if all of the following conditions are met:
 
 - The feature has not been included in a stable browser release.
 - The feature is not implemented behind a current flag (or Chrome origin trial).


### PR DESCRIPTION
This PR fixes the wording for the "features with no support" guideline to make it easier to understand.