### PR TITLE
Update Safari versions for Array JavaScript builtin

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -1420,11 +1420,9 @@
               },
               "opera_android": "mirror",
               "safari": {
-                "version_added": "5"
-              },
-              "safari_ios": {
                 "version_added": "4"
               },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
                 "version_added": "≤37"
@@ -1468,11 +1466,9 @@
               },
               "opera_android": "mirror",
               "safari": {
-                "version_added": "5"
-              },
-              "safari_ios": {
                 "version_added": "4"
               },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
                 "version_added": "≤37"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `Array` JavaScript builtin, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.3).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/javascript/builtins/Array

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
