### PR TITLE
Update Chromium versions for javascript.builtins.Date.now

### DIFF
--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -1020,7 +1020,7 @@
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.now",
             "support": {
               "chrome": {
-                "version_added": "5"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "deno": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `now` member of the `Date` JavaScript builtin, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.3).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/javascript/builtins/Date/now

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
