### PR TITLE
Update Safari versions for Date JavaScript builtin

### DIFF
--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2016,7 +2016,7 @@
                 "version_added": "11"
               },
               "safari": {
-                "version_added": "5"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -2064,7 +2064,7 @@
                 "version_added": "11"
               },
               "safari": {
-                "version_added": "5"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `Date` JavaScript builtin, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.3).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/javascript/builtins/Date

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
