### PR TITLE
Update Chromium versions for javascript.builtins.Function.name

### DIFF
--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -507,7 +507,7 @@
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function-instances-name",
             "support": {
               "chrome": {
-                "version_added": "15"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "deno": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `name` member of the `Function` JavaScript builtin, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.3).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/javascript/builtins/Function/name

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
