### PR TITLE
Update Chromium versions for javascript.builtins.Map.@@iterator

### DIFF
--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -755,7 +755,7 @@
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype-@@iterator",
             "support": {
               "chrome": {
-                "version_added": "43"
+                "version_added": "38"
               },
               "chrome_android": "mirror",
               "deno": {


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `@@iterator` member of the `Map` JavaScript builtin, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.3).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/javascript/builtins/Map/@@iterator

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
