### PR TITLE
FF105 TextEncoderStream and TextDecoderStream

### DIFF
--- a/api/TextDecoderStream.json
+++ b/api/TextDecoderStream.json
@@ -14,7 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "105"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -58,7 +58,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -98,7 +98,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -138,7 +138,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -178,7 +178,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -218,7 +218,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -258,7 +258,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/TextEncoderStream.json
+++ b/api/TextEncoderStream.json
@@ -14,7 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "105"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -58,7 +58,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -98,7 +98,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -138,7 +138,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -178,7 +178,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF105 adds support for [TextDecoderStream](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoderStream)  and [TextEncoderStream](https://developer.mozilla.org/en-US/docs/Web/API/TextEncoderStream) in https://bugzilla.mozilla.org/show_bug.cgi?id=1486949

Other docs work can be tracked in https://github.com/mdn/content/issues/20572