### PR TITLE
Safari 16 is released

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -216,14 +216,16 @@
         "15.6": {
           "release_date": "2022-07-20",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15_6-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "613.3.9"
         },
         "16": {
+          "release_date": "2022-09-12",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes",
-          "status": "beta",
-          "engine": "WebKit"
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "614.1.25"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -188,14 +188,16 @@
         "15.6": {
           "release_date": "2022-07-20",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15_6-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "613.3.9"
         },
         "16": {
+          "release_date": "2022-09-12",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes",
-          "status": "beta",
-          "engine": "WebKit"
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "614.1.25"
         }
       }
     }


### PR DESCRIPTION
This PR updates the Safari browser data to indicate that Safari 16 is released and is the current version.
