### PR TITLE
Update partial support for CSS.supports()

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -20,12 +20,8 @@
             "version_added": false
           },
           "oculus": "mirror",
-          "opera": {
-            "version_added": "12.1"
-          },
-          "opera_android": {
-            "version_added": "12.1"
-          },
+          "opera": "mirror",
+          "opera_android": "mirror",
           "safari": {
             "version_added": "9"
           },
@@ -1077,24 +1073,32 @@
               },
               {
                 "version_added": "28",
+                "version_removed": "61",
                 "partial_implementation": true,
-                "notes": "Version 60 or older didn't support parentheses-less one-argument version."
+                "notes": "The parentheses-less one-argument version is not supported."
               }
             ],
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "12",
-              "partial_implementation": true,
-              "notes": "Edge doesn't support parentheses-less one-argument version."
-            },
+            "edge": [
+              {
+                "version_added": "79"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79",
+                "partial_implementation": true,
+                "notes": "The parentheses-less one-argument version is not supported."
+              }
+            ],
             "firefox": [
               {
                 "version_added": "55"
               },
               {
                 "version_added": "22",
+                "version_removed": "55",
                 "partial_implementation": true,
-                "notes": "Version 54 or older didn't support parentheses-less one-argument version."
+                "notes": "The parentheses-less one-argument version is not supported."
               }
             ],
             "firefox_android": "mirror",
@@ -1102,36 +1106,22 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "12.1"
-            },
-            "opera_android": {
-              "version_added": "12.1"
-            },
-            "safari": {
-              "version_added": "9"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": [
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": [
               {
-                "version_added": "8.0"
+                "version_added": "11"
               },
               {
+                "version_added": "9",
+                "version_removed": "11",
                 "partial_implementation": true,
-                "version_added": "1.5",
-                "notes": "Samsung Internet 8.0 or older didn't support parentheses-less one-argument version."
+                "notes": "The parentheses-less one-argument version is not supported."
               }
             ],
-            "webview_android": [
-              {
-                "version_added": "61"
-              },
-              {
-                "version_added": "37",
-                "partial_implementation": true,
-                "notes": "Version 60 or older didn't support parentheses-less one-argument version."
-              }
-            ]
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
Test case used:
http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=4881

Browsers tested to confirm:
- Chrome 60 and 61
- Edge 18 and 80 (79 not available on BrowserStack)
- Firefox 54 and 55
- Safari was not tested

Source commits confirming Chromium/Gecko/WebKit:
https://storage.googleapis.com/chromium-find-releases-static/b54.html#b5416b84aba8ec3442788d6bbea54091ef18b6b0
https://bugzilla.mozilla.org/show_bug.cgi?id=1338486
https://github.com/WebKit/WebKit/commit/fce934737d2900de595097e4b880fe87c1917564
https://github.com/WebKit/WebKit/blob/fce934737d2900de595097e4b880fe87c1917564/Source/WebCore/Configurations/Version.xcconfig

Additionally, the CSS global wasn't supported at all in Opera 12.16, so
update that to just mirror.
