### PR TITLE
Add CSSContainerRule interface

### DIFF
--- a/api/CSSContainerRule.json
+++ b/api/CSSContainerRule.json
@@ -1,0 +1,38 @@
+{
+  "api": {
+    "CSSContainerRule": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSContainerRule",
+        "spec_url": "https://w3c.github.io/csswg-drafts/css-contain-3/#the-csscontainerrule-interface",
+        "support": {
+          "chrome": {
+            "version_added": "105"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": "16"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The data was generated by mdn-bcd-collector's add-new-bcd script, and
matches the `@container` rule already added:
https://github.com/mdn/browser-compat-data/pull/17619
