### PR TITLE
Update Safari versions for ApplicationCache API

### DIFF
--- a/api/ApplicationCache.json
+++ b/api/ApplicationCache.json
@@ -29,10 +29,12 @@
             "version_removed": "60"
           },
           "safari": {
-            "version_added": "4"
+            "version_added": "4",
+            "version_removed": "16"
           },
           "safari_ios": {
-            "version_added": "3"
+            "version_added": "3",
+            "version_removed": "16"
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
@@ -69,7 +71,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "6"
+              "version_added": "6",
+              "version_removed": "16"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -109,10 +112,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "16"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "16"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -151,10 +156,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "16"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "16"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -193,10 +200,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "16"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "16"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -235,10 +244,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "16"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "16"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -277,10 +288,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "16"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "16"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -319,10 +332,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "16"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "16"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -361,10 +376,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "16"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "16"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -408,10 +425,12 @@
               "version_removed": "60"
             },
             "safari": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "16"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "16"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -455,10 +474,12 @@
               "version_removed": "60"
             },
             "safari": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "16"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "16"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -502,10 +523,12 @@
               "version_removed": "60"
             },
             "safari": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "16"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "16"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -544,10 +567,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "16"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "16"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `ApplicationCache` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.3).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/ApplicationCache

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
