### PR TITLE
Add Safari versions for EXT_texture_norm16 API

### DIFF
--- a/api/EXT_texture_norm16.json
+++ b/api/EXT_texture_norm16.json
@@ -25,7 +25,7 @@
           },
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "16"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `EXT_texture_norm16` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.3).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/EXT_texture_norm16

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
