### PR TITLE
Update early support for CanvasGradient and CanvasPattern

### DIFF
--- a/api/CanvasGradient.json
+++ b/api/CanvasGradient.json
@@ -6,7 +6,7 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#canvasgradient",
         "support": {
           "chrome": {
-            "version_added": "6"
+            "version_added": "1"
           },
           "chrome_android": "mirror",
           "edge": {
@@ -30,13 +30,11 @@
             "version_added": "10.1"
           },
           "safari": {
-            "version_added": "5.1"
+            "version_added": "2"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": "3"
-          }
+          "webview_android": "mirror"
         },
         "status": {
           "experimental": false,
@@ -50,7 +48,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-canvasgradient-addcolorstop-dev",
           "support": {
             "chrome": {
-              "version_added": "6"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -71,13 +69,11 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "2"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "3"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/api/CanvasPattern.json
+++ b/api/CanvasPattern.json
@@ -27,15 +27,11 @@
             "version_added": "10.1"
           },
           "safari": {
-            "version_added": "≤4"
+            "version_added": "2"
           },
-          "safari_ios": {
-            "version_added": "1"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": "≤37"
-          }
+          "webview_android": "mirror"
         },
         "status": {
           "experimental": false,


### PR DESCRIPTION
Support for CanvasPattern is implied by support for ctx.createPattern(),
since that's how a CanvasPattern instance is created. Similarly, support
for CanvasGradient is implied by support for either
createLinearGradient() or createRadialGradient().

The support data for CanvasRenderingContext2D looks reliable based on
the PRs that updated it to the current state:
https://github.com/mdn/browser-compat-data/pull/7465
https://github.com/mdn/browser-compat-data/pull/8666

Update CanvasGradient and CanvasPattern to match. The versions now match
for all browsers except Opera, where some ≤12.1 versions were left alone
rather than trying to confirm the correct versions.