### PR TITLE
Synchronize pre-commit hook with mdn/content

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-node node_modules/.bin/lint-staged
+npx lint-staged


### PR DESCRIPTION
This PR synchronizes the `pre-commit` Husky Git hook with `mdn/content` (https://github.com/mdn/content/blob/main/.husky/pre-commit).
