### PR TITLE
Label any PR changing files starting with a dot as "infra"

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -26,13 +26,7 @@ dependencies :chains::
 docs :writing_hand::
   - "**/*.md"
 infra :building_construction::
-  - ".editorconfig"
-  - ".git*"
-  - ".gitattributes"
-  - ".github/**"
-  - ".gitignore"
-  - ".npm*"
-  - ".prettier*"
+  - ".*"
   - "/*.js"
   - "*.ts"
   - "**/*.d.ts"


### PR DESCRIPTION
This PR updates the labeler rules to mark any files starting with a dot as "infra".
