### PR TITLE
Updates opera browser to version 91

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -690,19 +690,26 @@
         "90": {
           "release_date": "2022-08-18",
           "release_notes": "https://blogs.opera.com/desktop/2022/08/opera-90-stable/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "104"
         },
         "91": {
-          "status": "beta",
+          "release_date": "2022-09-14",
+          "release_notes": "https://blogs.opera.com/desktop/2022/09/opera-91-stable/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "105"
         },
         "92": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "106"
+        },
+        "93": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "107"
         }
       }
     }


### PR DESCRIPTION
Hello everyone!

According to this [release note](https://blogs.opera.com/desktop/2022/09/opera-91-stable/) opera browser has updated to version 91. 

😉