### PR TITLE
Add Chromium versions for api.Request.body

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -396,8 +396,8 @@
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-body-body①",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/688906'>bug 688906</a>."
+              "version_added": "105",
+              "impl_url": "https://crbug.com/688906"
             },
             "chrome_android": "mirror",
             "deno": {


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `body` member of the `Request` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.3).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Request/body

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
