### PR TITLE
Fix .lintstagedrc

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,5 +1,5 @@
 {
     "*": "prettier --ignore-unknown --write",
     "*.{js,jsx,tsx}": "eslint --fix",
-    "*.{json}": "npm run lint:fix"
+    "*.json": "npm run lint:fix"
 }


### PR DESCRIPTION
This PR removes the redundant brackets within the `.lintstagedrc` file.
