### PR TITLE
Update Chromium versions for api.Sanitizer.getConfiguration

### DIFF
--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -132,19 +132,7 @@
           "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-getconfiguration",
           "support": {
             "chrome": {
-              "version_added": "93",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                },
-                {
-                  "type": "preference",
-                  "name": "sanitizer-api",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": "105"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects the real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `getConfiguration` member of the `Sanitizer` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Sanitizer/getConfiguration

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
