### PR TITLE
Update compat data for accent/accentunder on mover/munder/munderover

### DIFF
--- a/mathml/elements/mover.json
+++ b/mathml/elements/mover.json
@@ -32,9 +32,7 @@
             "safari": {
               "version_added": "6"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -48,7 +46,14 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -63,7 +68,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/mathml/elements/munder.json
+++ b/mathml/elements/munder.json
@@ -48,7 +48,14 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -63,7 +70,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/mathml/elements/munderover.json
+++ b/mathml/elements/munderover.json
@@ -32,9 +32,7 @@
             "safari": {
               "version_added": "6"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -48,7 +46,14 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -63,7 +68,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -80,7 +85,14 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -95,7 +107,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION

#### Summary

These attributes have been implemented in Chrome and WebKit [1] [2], so add data for them. Also fix missing "mirror" for Safari iOS.

#### Test results and supporting details

[1] https://chromiumdash.appspot.com/commit/68a1bfbbbde11b778ddb8eca4759cb9218715206
[2] https://commits.webkit.org/177780@main

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
