### PR TITLE
Remove "default values" notes for Web Audio constructors

### DIFF
--- a/api/AudioBufferSourceNode.json
+++ b/api/AudioBufferSourceNode.json
@@ -44,8 +44,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-constructor-audiobuffersourcenode",
           "support": {
             "chrome": {
-              "version_added": "55",
-              "notes": "Before version 59, the default values were not supported."
+              "version_added": "55"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -59,20 +58,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "42"
-            },
-            "opera_android": {
-              "version_added": "42"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "14.1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "6.0",
-              "notes": "Before Samsung Internet 7.0, the default values were not supported."
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {

--- a/api/BiquadFilterNode.json
+++ b/api/BiquadFilterNode.json
@@ -44,8 +44,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-biquadfilternode-biquadfilternode-context-options",
           "support": {
             "chrome": {
-              "version_added": "55",
-              "notes": "Before Chrome 59, the default values were not supported."
+              "version_added": "55"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -60,19 +59,13 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": "42",
-              "notes": "Before Opera 46, the default values were not supported."
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "55",
-              "notes": "Before version 59, the default values were not supported."
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/api/DelayNode.json
+++ b/api/DelayNode.json
@@ -44,8 +44,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-delaynode-constructor-delaynode",
           "support": {
             "chrome": {
-              "version_added": "55",
-              "notes": "Before version 59, the default values were not supported."
+              "version_added": "55"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -59,20 +58,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "42"
-            },
-            "opera_android": {
-              "version_added": "42"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "14.1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "6.0",
-              "notes": "Before Samsung Internet 7.0, the default values were not supported."
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {

--- a/api/DynamicsCompressorNode.json
+++ b/api/DynamicsCompressorNode.json
@@ -44,8 +44,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-dynamicscompressornode-constructor-dynamicscompressornode",
           "support": {
             "chrome": {
-              "version_added": "55",
-              "notes": "Before Chrome 59, the default values were not supported."
+              "version_added": "55"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -59,21 +58,14 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "42"
-            },
-            "opera_android": {
-              "version_added": "42"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "55",
-              "notes": "Before version 59, the default values were not supported."
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/api/GainNode.json
+++ b/api/GainNode.json
@@ -44,8 +44,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-gainnode-constructor-gainnode",
           "support": {
             "chrome": {
-              "version_added": "55",
-              "notes": "Before Chrome 59, the default values were not supported."
+              "version_added": "55"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -59,12 +58,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "42"
-            },
-            "opera_android": {
-              "version_added": "42"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "14.1"
             },

--- a/api/IIRFilterNode.json
+++ b/api/IIRFilterNode.json
@@ -42,8 +42,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-iirfilternode-constructor-iirfilternode",
           "support": {
             "chrome": {
-              "version_added": "55",
-              "notes": "Before version 59, the default values were not supported."
+              "version_added": "55"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -57,20 +56,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "42"
-            },
-            "opera_android": {
-              "version_added": "42"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "14.1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "6.0",
-              "notes": "Before Samsung Internet 7.0, the default values were not supported."
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {

--- a/api/MediaElementAudioSourceNode.json
+++ b/api/MediaElementAudioSourceNode.json
@@ -44,8 +44,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-mediaelementaudiosourcenode-mediaelementaudiosourcenode",
           "support": {
             "chrome": {
-              "version_added": "55",
-              "notes": "Before Chrome 59, the default values were not supported."
+              "version_added": "55"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -59,21 +58,14 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "42"
-            },
-            "opera_android": {
-              "version_added": "42"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "55",
-              "notes": "Before version 59, the default values were not supported."
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/api/MediaStreamAudioDestinationNode.json
+++ b/api/MediaStreamAudioDestinationNode.json
@@ -44,8 +44,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-mediastreamaudiodestinationnode-mediastreamaudiodestinationnode",
           "support": {
             "chrome": {
-              "version_added": "55",
-              "notes": "Before Chrome 59, the default values were not supported."
+              "version_added": "55"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -59,12 +58,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "42"
-            },
-            "opera_android": {
-              "version_added": "42"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "14.1"
             },

--- a/api/MediaStreamAudioSourceNode.json
+++ b/api/MediaStreamAudioSourceNode.json
@@ -42,8 +42,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-mediastreamaudiosourcenode-mediastreamaudiosourcenode",
           "support": {
             "chrome": {
-              "version_added": "55",
-              "notes": "Before Chrome 59, the default values were not supported."
+              "version_added": "55"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -57,12 +56,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "42"
-            },
-            "opera_android": {
-              "version_added": "42"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "14.1"
             },

--- a/api/OfflineAudioCompletionEvent.json
+++ b/api/OfflineAudioCompletionEvent.json
@@ -44,8 +44,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-offlineaudiocompletionevent-offlineaudiocompletionevent",
           "support": {
             "chrome": {
-              "version_added": "57",
-              "notes": "Before Chrome 59, the default values were not supported."
+              "version_added": "57"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -59,24 +58,14 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "42"
-            },
-            "opera_android": {
-              "version_added": "42"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "14"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "6.0",
-              "notes": "Before Samsung Internet 7.0, the default values were not supported."
-            },
-            "webview_android": {
-              "version_added": "57",
-              "notes": "Before version 59, the default values were not supported."
-            }
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/api/OscillatorNode.json
+++ b/api/OscillatorNode.json
@@ -42,8 +42,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-oscillatornode-oscillatornode",
           "support": {
             "chrome": {
-              "version_added": "55",
-              "notes": "Before Chrome 59, the default values were not supported."
+              "version_added": "55"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -57,21 +56,14 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "42"
-            },
-            "opera_android": {
-              "version_added": "42"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "55",
-              "notes": "Before version 59, the default values were not supported."
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/api/PannerNode.json
+++ b/api/PannerNode.json
@@ -51,8 +51,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-pannernode-pannernode",
           "support": {
             "chrome": {
-              "version_added": "55",
-              "notes": "Before Chrome 59, the default values were not supported."
+              "version_added": "55"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -66,21 +65,14 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "42"
-            },
-            "opera_android": {
-              "version_added": "42"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "55",
-              "notes": "Before version 59, the default values were not supported."
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/api/PeriodicWave.json
+++ b/api/PeriodicWave.json
@@ -46,8 +46,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-periodicwave-periodicwave",
           "support": {
             "chrome": {
-              "version_added": "55",
-              "notes": "Before Chrome 59, the default values were not supported."
+              "version_added": "55"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -61,12 +60,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "42"
-            },
-            "opera_android": {
-              "version_added": "42"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "14.1"
             },

--- a/api/StereoPannerNode.json
+++ b/api/StereoPannerNode.json
@@ -42,8 +42,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-stereopannernode-stereopannernode",
           "support": {
             "chrome": {
-              "version_added": "55",
-              "notes": "Before Chrome 59, the default values were not supported."
+              "version_added": "55"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -57,12 +56,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "42"
-            },
-            "opera_android": {
-              "version_added": "42"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "14.1"
             },

--- a/api/WaveShaperNode.json
+++ b/api/WaveShaperNode.json
@@ -44,8 +44,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-waveshapernode-waveshapernode",
           "support": {
             "chrome": {
-              "version_added": "55",
-              "notes": "Before Chrome 59, the default values were not supported."
+              "version_added": "55"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -59,12 +58,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "42"
-            },
-            "opera_android": {
-              "version_added": "42"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "14.1"
             },


### PR DESCRIPTION
These notes have been in BCD since the very beginning:
https://github.com/mdn/browser-compat-data/pull/433

Chrome 55 is the right version for the constructors overall:
https://storage.googleapis.com/chromium-find-releases-static/579.html#57909df69be0cf0b2ac42e5c9c018d4a00ee9766

The Chrome 59 change is this one:
https://storage.googleapis.com/chromium-find-releases-static/ef0.html#ef006156fd62853a893617ca104f4ac2045e19c1

Adding default values to dictionary members is by itself not necessarily
a web observable changes at all. This was confirmed with one case
comparing Chrome 58 and 59:
http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=10708

One part of this was observable, with the OscillatorNode constructor:
https://bugs.chromium.org/p/chromium/issues/detail?id=710471

This was a spec bug, and fixed in the spec around the same time:
https://github.com/WebAudio/web-audio-api/issues/1173

Overall, this change does not seem noteworthy enough to record in BCD.
