### PR TITLE
Sort out Safari 5.1 vs iOS 6 data

### DIFF
--- a/api/HTMLMarqueeElement.json
+++ b/api/HTMLMarqueeElement.json
@@ -68,9 +68,7 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "6"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -109,9 +107,7 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "6"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -186,9 +182,7 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "6"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -263,9 +257,7 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "6"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -304,9 +296,7 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "6"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -345,9 +335,7 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "6"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -386,9 +374,7 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "6"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -427,9 +413,7 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "6"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -578,9 +562,7 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "6"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -619,9 +601,7 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "6"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -660,9 +640,7 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "6"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/HashChangeEvent.json
+++ b/api/HashChangeEvent.json
@@ -106,9 +106,7 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "6"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -148,9 +146,7 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "6"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/Window.json
+++ b/api/Window.json
@@ -1338,9 +1338,7 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "6"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -180,9 +180,7 @@
               "safari": {
                 "version_added": "5.1"
               },
-              "safari_ios": {
-                "version_added": "6"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
                 "version_added": "≤37"

--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -391,10 +391,7 @@
                 "version_added": "5.1",
                 "notes": "For English, Safari uses different en-GB and en-US dictionaries."
               },
-              "safari_ios": {
-                "version_added": "6",
-                "notes": "For English, Safari uses different en-GB and en-US dictionaries."
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -238,15 +238,7 @@
                   "version_added": "5.1"
                 }
               ],
-              "safari_ios": [
-                {
-                  "version_added": "7"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "6"
-                }
-              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": [
                 {
@@ -420,19 +412,7 @@
                     ]
                   }
                 ],
-                "safari_ios": [
-                  {
-                    "version_added": "7"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "6",
-                    "notes": [
-                      "Safari 4 was supporting an experimental <code><a href='https://developer.apple.com/library/archive/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(linear,…)</a></code> function. It is more limited than the later standard version: you cannot specify both a position and an angle like in <code>linear-gradient()</code>. This old outdated syntax is still supported for compatibility purposes.",
-                      "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
-                    ]
-                  }
-                ],
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": [
                   {
@@ -676,16 +656,7 @@
                     "notes": "Safari 4 was supporting an experimental <code><a href='https://developer.apple.com/library/archive/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(radial,…)</a></code> function. This old outdated syntax is still supported for compatibility purposes."
                   }
                 ],
-                "safari_ios": [
-                  {
-                    "version_added": "7"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "6",
-                    "notes": "Safari 4 was supporting an experimental <code><a href='https://developer.apple.com/library/archive/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(radial,…)</a></code> function. This old outdated syntax is still supported for compatibility purposes."
-                  }
-                ],
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": [
                   {
@@ -966,19 +937,7 @@
                     ]
                   }
                 ],
-                "safari_ios": [
-                  {
-                    "version_added": "7"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "6",
-                    "notes": [
-                      "Safari 4 was supporting an experimental <code><a href='https://developer.apple.com/library/archive/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(linear,…)</a></code> function. It is more limited than the later standard version: you cannot specify both a position and an angle like in <code>repeating-linear-gradient()</code>. This old outdated syntax is still supported for compatibility purposes.",
-                      "Considers <code>&lt;angle&gt;</code> to start to the right, instead of the top. I.e. it considered an angle of <code>0deg</code> as a direction indicator pointing to the right."
-                    ]
-                  }
-                ],
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": [
                   {
@@ -1235,16 +1194,7 @@
                     "notes": "Safari 4 was supporting an experimental <code><a href='https://developer.apple.com/library/archive/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(radial,…)</a></code> function. This old outdated syntax is still supported for compatibility purposes."
                   }
                 ],
-                "safari_ios": [
-                  {
-                    "version_added": "7"
-                  },
-                  {
-                    "prefix": "-webkit-",
-                    "version_added": "6",
-                    "notes": "Safari 4 was supporting an experimental <code><a href='https://developer.apple.com/library/archive/documentation/InternetWeb/Conceptual/SafariVisualEffectsProgGuide/Gradients/Gradient.html'>-webkit-gradient(radial,…)</a></code> function. This old outdated syntax is still supported for compatibility purposes."
-                  }
-                ],
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": [
                   {

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -526,9 +526,7 @@
               "safari": {
                 "version_added": "5.1"
               },
-              "safari_ios": {
-                "version_added": "6"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -990,9 +988,7 @@
               "safari": {
                 "version_added": "5.1"
               },
-              "safari_ios": {
-                "version_added": "6"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1038,9 +1034,7 @@
               "safari": {
                 "version_added": "5.1"
               },
-              "safari_ios": {
-                "version_added": "6"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1134,9 +1128,7 @@
               "safari": {
                 "version_added": "5.1"
               },
-              "safari_ios": {
-                "version_added": "6"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1328,9 +1320,7 @@
               "safari": {
                 "version_added": "5.1"
               },
-              "safari_ios": {
-                "version_added": "6"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1514,9 +1504,7 @@
               "safari": {
                 "version_added": "5.1"
               },
-              "safari_ios": {
-                "version_added": "6"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -287,9 +287,7 @@
             "safari": {
               "version_added": "5.1"
             },
-            "safari_ios": {
-              "version_added": "6"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
This revisits cases of Safari 5.1 + iOS 6 in the data preserved here:
https://github.com/mdn/browser-compat-data/pull/17772

All features touched there are accounted for in the following...

Handled in other PRs
====================

api.CanvasGradient:
https://github.com/mdn/browser-compat-data/pull/17794
https://github.com/mdn/browser-compat-data/pull/17843

css.selectors.left/right:
https://github.com/mdn/browser-compat-data/pull/17852

Confirmed via source
====================

These features were confirmed to map to Safari 5.1 / iOS 5 via source,
landing in WebKit versions 534.7 through 534.16.

api.HTMLMarqueeElement, WebKit version 534.14:
https://github.com/mdn/browser-compat-data/pull/17011

api.HashChangeEvent, WebKit version 534.9:
https://github.com/WebKit/WebKit/commit/a3f483bbf1936c76f44387cde8fac903a86e69d0
https://github.com/WebKit/WebKit/blob/a3f483bbf1936c76f44387cde8fac903a86e69d0/WebCore/Configurations/Version.xcconfig

css.properties.border-radius.percentages, WebKit version 534.7:
https://github.com/WebKit/WebKit/commit/1c44c69b77bddd43c8f5786fc27369cae9b9d3b2
https://github.com/WebKit/WebKit/blob/1c44c69b77bddd43c8f5786fc27369cae9b9d3b2/WebCore/Configurations/Version.xcconfig

css.types.image.gradient.linear-gradient/radial-gradient, WebKit 534.16:
https://github.com/WebKit/WebKit/commit/68c9486e0c50d5e468c9473685824b50d54ef15e
https://github.com/WebKit/WebKit/blob/68c9486e0c50d5e468c9473685824b50d54ef15e/WebCore/Configurations/Version.xcconfig

css.types.image.gradient.repeating-linear-gradient/repeating-radial-gradient, WebKit 534.16:
https://github.com/WebKit/WebKit/commit/b03353e8249b7a3a50cc42173bb4c8d6ea733ef3
https://github.com/WebKit/WebKit/blob/b03353e8249b7a3a50cc42173bb4c8d6ea733ef3/WebCore/Configurations/Version.xcconfig

Confirmed with testing
======================

api.Window.error_event:
http://software.hixie.ch/utilities/js/live-dom-viewer/?saved=10758 was
run in iOS 4.2 and 5 to confirm iOS 5 is correct. Adapted from the test
in the PR that last updated this data:
https://github.com/mdn/browser-compat-data/pull/13053

Previously mirrored
===================

These features were previously mirrored, so the choice of iOS 6 was not
deliberate.

css.properties.hyphens.english:
https://github.com/mdn/browser-compat-data/pull/4636

javascript.builtins.Object.freeze,
javascript.builtins.Object.isExtensible,
javascript.builtins.Object.isFrozen,
javascript.builtins.Object.isSealed,
javascript.builtins.Object.preventExtensions,
javascript.builtins.Object.seal,
javascript.statements.const:
https://github.com/mdn/browser-compat-data/pull/5483

Backported to Safari 5.1
========================

A bunch of JSC changes were backported to the Safari 5.1 release branch.
It's hard to determine if these were also backported to any iOS 5
release, so these are left as 5.1/6 pairs.

javascript.builtins.ArrayBuffer.slice:
https://github.com/mdn/browser-compat-data/pull/17717#issuecomment-1248093102

javascript.builtins.Function.bind:
https://github.com/WebKit/WebKit/commit/ec2129f880eb0e0ce38c9295bcda401d1815bcc9
https://github.com/WebKit/WebKit/commit/bb7691c889c89ec01e7000a1068ad82d14192713