### PR TITLE
Update Chromium compat data for math@display

### DIFF
--- a/mathml/elements/math.json
+++ b/mathml/elements/math.json
@@ -90,8 +90,14 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/math#attr-display",
             "support": {
               "chrome": {
-                "version_added": "24",
-                "version_removed": "25"
+                "version_added": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
#### Summary

- Add new implementation performed in [1].

- Also remove legacy implementation from Chrome 24, there is already some documentation about this MathML implementation for the mathml.elements.math feature and not documenting Chrome 24 is consistent with what we do for other MathML subfeatures that have been re-implemented later.

#### Test results and supporting details

[1] https://chromiumdash.appspot.com/commit/94e1142bd73bebfdce14bc779601bad8277fc4c6

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
