### PR TITLE
FF105 @font-face src: tech() option

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -903,6 +903,51 @@
                 "deprecated": false
               }
             }
+          },
+          "tech_keyword": {
+            "__compat": {
+              "description": "<code>tech(keyword)</code>",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": [
+                  {
+                    "version_added": "preview"
+                  },
+                  {
+                    "version_added": "105",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "layout.css.font-tech.enabled",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "unicode-range": {


### PR DESCRIPTION
FF105 adds support for the `@font-face` CSS declaration `src` descriptor "`tech()` syntax behind a pref and in nightly.

This was done in 
- https://bugzilla.mozilla.org/show_bug.cgi?id=1786804
- https://bugzilla.mozilla.org/show_bug.cgi?id=1715546

Chrome is proposing this for v108 but it isn't in yet: https://chromestatus.com/feature/5088679224147968

Safari not giving any signals.

Other docs work for this can be tracked in https://github.com/mdn/content/issues/19833

FYI @queengooborg 

