### PR TITLE
Add Chrome data for mfrac@linethickness

### DIFF
--- a/mathml/elements/mfrac.json
+++ b/mathml/elements/mfrac.json
@@ -83,7 +83,14 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
#### Summary

Chrome support for the linethickness attribute of the mfrac element was implemented in [1], so add it.

#### Test results and supporting details


[1] https://chromiumdash.appspot.com/commit/be67bb3749103109f3f62384f091e511b254a139

#### Related issues

N/A