### PR TITLE
NetworkInformation is removed from Firefox Desktop in version 32

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -635,19 +635,12 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "31",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.netinfo.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "31"
+              "version_removed": "32"
             },
             "firefox_android": {
               "version_added": "14",
-              "version_removed": "99",
-              "notes": "The Network API is enabled by default. Can be disabled using the <code>dom.netinfo.enabled</code> preference."
+              "version_removed": "99"
             },
             "ie": {
               "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -635,7 +635,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "31"
+              "version_added": "31",
               "version_removed": "32"
             },
             "firefox_android": {

--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -55,13 +55,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "31",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.netinfo.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_removed": "32"
             },
             "firefox_android": {
               "version_added": "53",
@@ -353,13 +347,7 @@
             },
             "firefox": {
               "version_added": "31",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.netinfo.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_removed": "32"
             },
             "firefox_android": {
               "version_added": "31",
@@ -407,13 +395,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "31",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.netinfo.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_removed": "32"
             },
             "firefox_android": {
               "version_added": "31",

--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -14,6 +14,7 @@
           "edge": "mirror",
           "firefox": {
             "version_added": "31",
+            "version_removed": "32",
             "flags": [
               {
                 "type": "preference",

--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -14,14 +14,7 @@
           "edge": "mirror",
           "firefox": {
             "version_added": "31",
-            "version_removed": "32",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.netinfo.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_removed": "32"
           },
           "firefox_android": {
             "version_added": "31",

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -183,7 +183,7 @@
               "version_added": false
             },
             "firefox_android": {
-              "version_added": "53"
+              "version_added": "53",
               "version_removed": "99"
             },
             "ie": {

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -184,6 +184,7 @@
             },
             "firefox_android": {
               "version_added": "53"
+              "version_removed": "99"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
It's exposed in 31 but that was accidental; it was soon removed in version 32 by https://bugzilla.mozilla.org/show_bug.cgi?id=1020758.

And it was enabled by default.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Version 32 indeed has no `navigator.connection` while v31 does, per builds from mozregression.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
