### PR TITLE
update subgrid and animation support

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -55,8 +55,7 @@
             "description": "Animation of tracks",
             "support": {
               "chrome": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/759665'>bug 759665</a>."
+                "version_added": "106"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -281,8 +280,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/202115'>bug 202115</a>."
+                "version_added": "16"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -55,8 +55,7 @@
             "description": "Animation of tracks",
             "support": {
               "chrome": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/759665'>bug 759665</a>."
+                "version_added": "106"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -282,8 +281,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/202115'>bug 202115</a>."
+                "version_added": "16"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
Chrome 106 includes animation of the `grid-template-columns` and `grid-template-rows` properties: https://chromestatus.com/feature/6037871692611584

Safari 16 includes the `subgrid` value for these properties: https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes

This PR updates both.