### PR TITLE
Chrome support for ic unit

### DIFF
--- a/css/types/length.json
+++ b/css/types/length.json
@@ -194,8 +194,7 @@
             "description": "<code>ic</code> unit",
             "support": {
               "chrome": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/937101'>bug 937101</a>."
+                "version_added": "106"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
Chrome 106 supports the ic unit for `<length>`: https://chromestatus.com/feature/5193188445257728