### PR TITLE
Chrome support unprefixed hyphenate-character

### DIFF
--- a/css/properties/hyphenate-character.json
+++ b/css/properties/hyphenate-character.json
@@ -6,10 +6,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/hyphenate-character",
           "spec_url": "https://w3c.github.io/csswg-drafts/css-text-4/#propdef-hyphenate-character",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "6"
-            },
+            "chrome": [
+              {
+                "version_added": "106"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "6"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/css/properties/hyphenate-character.json
+++ b/css/properties/hyphenate-character.json
@@ -36,10 +36,7 @@
               "version_added": "5"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
Chrome support for unprefixed hyphenate-character is in 106: https://chromestatus.com/feature/5169156928831488