### PR TITLE
add the WebCodecs dequeue event

### DIFF
--- a/api/AudioDecoder.json
+++ b/api/AudioDecoder.json
@@ -204,6 +204,39 @@
           }
         }
       },
+      "dequeue": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webcodecs/#eventdef-audiodecoder-dequeue",
+          "support": {
+            "chrome": {
+              "version_added": "106"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "flush": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioDecoder/flush",

--- a/api/AudioDecoder.json
+++ b/api/AudioDecoder.json
@@ -206,6 +206,7 @@
       },
       "dequeue_event": {
         "__compat": {
+          "description": "<code>dequeue</code> event",
           "spec_url": "https://w3c.github.io/webcodecs/#eventdef-audiodecoder-dequeue",
           "support": {
             "chrome": {

--- a/api/AudioDecoder.json
+++ b/api/AudioDecoder.json
@@ -204,7 +204,7 @@
           }
         }
       },
-      "dequeue": {
+      "dequeue_event": {
         "__compat": {
           "spec_url": "https://w3c.github.io/webcodecs/#eventdef-audiodecoder-dequeue",
           "support": {

--- a/api/AudioEncoder.json
+++ b/api/AudioEncoder.json
@@ -136,6 +136,39 @@
           }
         }
       },
+      "dequeue": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webcodecs/#eventdef-audioencoder-dequeue",
+          "support": {
+            "chrome": {
+              "version_added": "106"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "encode": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioEncoder/encode",

--- a/api/AudioEncoder.json
+++ b/api/AudioEncoder.json
@@ -138,6 +138,7 @@
       },
       "dequeue_event": {
         "__compat": {
+          "description": "<code>dequeue</code> event",
           "spec_url": "https://w3c.github.io/webcodecs/#eventdef-audioencoder-dequeue",
           "support": {
             "chrome": {

--- a/api/AudioEncoder.json
+++ b/api/AudioEncoder.json
@@ -136,7 +136,7 @@
           }
         }
       },
-      "dequeue": {
+      "dequeue_event": {
         "__compat": {
           "spec_url": "https://w3c.github.io/webcodecs/#eventdef-audioencoder-dequeue",
           "support": {

--- a/api/VideoDecoder.json
+++ b/api/VideoDecoder.json
@@ -206,6 +206,7 @@
       },
       "dequeue_event": {
         "__compat": {
+          "description": "<code>dequeue</code> event",
           "spec_url": "https://w3c.github.io/webcodecs/#eventdef-videodecoder-dequeue",
           "support": {
             "chrome": {

--- a/api/VideoDecoder.json
+++ b/api/VideoDecoder.json
@@ -204,7 +204,7 @@
           }
         }
       },
-      "dequeue": {
+      "dequeue_event": {
         "__compat": {
           "spec_url": "https://w3c.github.io/webcodecs/#eventdef-videodecoder-dequeue",
           "support": {

--- a/api/VideoDecoder.json
+++ b/api/VideoDecoder.json
@@ -204,6 +204,39 @@
           }
         }
       },
+      "dequeue": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webcodecs/#eventdef-videodecoder-dequeue",
+          "support": {
+            "chrome": {
+              "version_added": "106"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "flush": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoDecoder/flush",

--- a/api/VideoEncoder.json
+++ b/api/VideoEncoder.json
@@ -138,6 +138,7 @@
       },
       "dequeue_event": {
         "__compat": {
+          "description": "<code>dequeue</code> event",
           "spec_url": "https://w3c.github.io/webcodecs/#eventdef-videencoder-dequeue",
           "support": {
             "chrome": {

--- a/api/VideoEncoder.json
+++ b/api/VideoEncoder.json
@@ -136,6 +136,39 @@
           }
         }
       },
+      "dequeue": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webcodecs/#eventdef-videencoder-dequeue",
+          "support": {
+            "chrome": {
+              "version_added": "106"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "encode": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoEncoder/encode",

--- a/api/VideoEncoder.json
+++ b/api/VideoEncoder.json
@@ -136,7 +136,7 @@
           }
         }
       },
-      "dequeue": {
+      "dequeue_event": {
         "__compat": {
           "spec_url": "https://w3c.github.io/webcodecs/#eventdef-videencoder-dequeue",
           "support": {

--- a/mathml/elements/math.json
+++ b/mathml/elements/math.json
@@ -90,8 +90,14 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/math#attr-display",
             "support": {
               "chrome": {
-                "version_added": "24",
-                "version_removed": "25"
+                "version_added": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
Chrome 106 supports the dequeue event for WebCodecs https://chromestatus.com/feature/5195706034290688

This PR adds the data for `AudioEncoder`, `AudioDecoder`, `VideoEncoder`, and `VideoDecoder`.