### PR TITLE
FF105 CSP script- and style- src-elem and src-attr directives

### DIFF
--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -1132,10 +1132,21 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1529337'>bug 1529337</a>."
-              },
+              "firefox": [
+                {
+                  "version_added": "preview"
+                },
+                {
+                  "version_added": "105",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "security.csp.script-src-attr-elem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -1171,10 +1182,21 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1529337'>bug 1529337</a>."
-              },
+              "firefox": [
+                {
+                  "version_added": "preview"
+                },
+                {
+                  "version_added": "105",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "security.csp.script-src-attr-elem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -1285,10 +1307,21 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1529338'>bug 1529338</a>."
-              },
+              "firefox": [
+                {
+                  "version_added": "preview"
+                },
+                {
+                  "version_added": "105",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "security.csp.style-src-attr-elem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -1324,10 +1357,21 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1529338'>bug 1529338</a>."
-              },
+              "firefox": [
+                {
+                  "version_added": "preview"
+                },
+                {
+                  "version_added": "105",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "security.csp.style-src-attr-elem.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false


### PR DESCRIPTION
FF105 adds support for  CSP 'script-src-elem' and 'script-src-attr' directives and CSP 'style-src-elem' and 'style-src-attr' directives in  https://bugzilla.mozilla.org/show_bug.cgi?id=1529337 and https://bugzilla.mozilla.org/show_bug.cgi?id=1529338 respectively - enabled in nightly and behind preferences.

Other docs work tracked in https://github.com/mdn/content/issues/20878

FYI  @jpmedley I noticed that Opera Android support is marked as Null - there is nothing to indicate why that would be in https://chromestatus.com/feature/5141352765456384 or the issue in which it was updated: https://github.com/mdn/browser-compat-data/pull/4529
