### PR TITLE
Updates opera for android to version 71

### DIFF
--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -393,9 +393,16 @@
         },
         "70": {
           "release_date": "2022-06-29",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "102"
+        },
+        "71": {
+          "release_date": "2022-09-16",
+          "release_notes": "https://blogs.opera.com/mobile/2022/09/version-71-opera-for-android/",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "104"
         }
       }
     }


### PR DESCRIPTION
Hello!

According to [this release note](https://blogs.opera.com/mobile/2022/09/version-71-opera-for-android/), opera for android has updated to version 71. 

But, I don't know if the engine version 104 is correctly. 

I need mdn contributors review to check this.