### PR TITLE
FF104 supports CSS contains-intrinsic-size behind pref

### DIFF
--- a/css/properties/contain-intrinsic-size.json
+++ b/css/properties/contain-intrinsic-size.json
@@ -12,7 +12,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "104",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.contain-intrinsic-size.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF104 supports CSS `contains-intrinsic-size` behind pref in https://bugzilla.mozilla.org/show_bug.cgi?id=1597529

This adds the preference information.

Other docs work can be tracked in https://github.com/mdn/content/issues/20876