### PR TITLE
Support for non-persistent event pages in MV2

### DIFF
--- a/webextensions/manifest/background.json
+++ b/webextensions/manifest/background.json
@@ -64,7 +64,7 @@
               "firefox": {
                 "version_added": "48",
                 "notes": [
-                  "From Firefox 106, persistent and non-persistent pages are supported for Manifest V2."
+                  "From Firefox 106, persistent and non-persistent pages are supported for Manifest V2.",
                   "To Firefox 105, only persistent pages are supported. However, extension developers can turn on event pages for testing:<ul><li>in Manifest V2, using the <code>extensions.eventPages.enabled</code> preference from Firefox 101 to 105.</li><li>in Manifest V3, using the <code>extensions.manifestV3.enabled</code> preference from Firefox 101.</li></ul>",
                   "Before version 66, Firefox would log a warning even if the value was set to <code>true</code>."
                 ]

--- a/webextensions/manifest/background.json
+++ b/webextensions/manifest/background.json
@@ -64,7 +64,8 @@
               "firefox": {
                 "version_added": "48",
                 "notes": [
-                  "Only persistent pages are supported. As of version 101, extension developers can turn on event pages for testing in Manifest V2 using the <code>extensions.eventPages.enabled</code> preference and in Manifest V3 using the <code>extensions.manifestV3.enabled</code> preference.",
+                  "From Firefox 106, persistent and non-persistent pages are supported for Manifest V2."
+                  "To Firefox 105, only persistent pages are supported. However, extension developers can turn on event pages for testing:<ul><li>in Manifest V2, using the <code>extensions.eventPages.enabled</code> preference from Firefox 101 to 105.</li><li>in Manifest V3, using the <code>extensions.manifestV3.enabled</code> preference from Firefox 101.</li></ul>",
                   "Before version 66, Firefox would log a warning even if the value was set to <code>true</code>."
                 ]
               },

--- a/webextensions/manifest/background.json
+++ b/webextensions/manifest/background.json
@@ -65,7 +65,9 @@
                 "version_added": "48",
                 "notes": [
                   "From Firefox 106, persistent and non-persistent pages are supported for Manifest V2.",
-                  "To Firefox 105, only persistent pages are supported. However, extension developers can turn on event pages for testing:<ul><li>in Manifest V2, using the <code>extensions.eventPages.enabled</code> preference from Firefox 101 to 105.</li><li>in Manifest V3, using the <code>extensions.manifestV3.enabled</code> preference from Firefox 101.</li></ul>",
+                  "To Firefox 105, only persistent pages are supported.",
+                  "From Firefox 101 to 105, extension developers can turn on event pages for testing in Manifest V2 using the <code>extensions.eventPages.enabled</code> preference.",
+                  "From Firefox 101, extension developers can turn on event pages for testing in Manifest V3 using the <code>extensions.manifestV3.enabled</code> preference.",
                   "Before version 66, Firefox would log a warning even if the value was set to <code>true</code>."
                 ]
               },


### PR DESCRIPTION
#### Summary

Support for non-persistent background pages was introduced behind a preference flag in Firefox 101. This preference flag requirement is removed in Firefox 106. This change updates the notes for the `background` manifest key `persistent` property to describe the changes.
 
See also https://github.com/mdn/content/pull/20907