### PR TITLE
Mirror Safari iOS support for CanvasGradient

### DIFF
--- a/api/CanvasGradient.json
+++ b/api/CanvasGradient.json
@@ -32,9 +32,7 @@
           "safari": {
             "version_added": "2"
           },
-          "safari_ios": {
-            "version_added": "6"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -73,9 +71,7 @@
             "safari": {
               "version_added": "2"
             },
-            "safari_ios": {
-              "version_added": "6"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
This data ended up with Safari 2 / iOS 6 because of two PRs that don't
make sense when put together:
https://github.com/mdn/browser-compat-data/pull/17772
https://github.com/mdn/browser-compat-data/pull/17794

Mirror the data, matching CanvasPattern, createLinearGradient(), and
other related data.
