### PR TITLE
docs(CSS): add compat info on color-scheme for embedded elements

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1138,6 +1138,47 @@
                 "deprecated": true
               }
             }
+          },
+          "respects-inherited-scheme": {
+            "__compat": {
+              "description": "Respects <code>color-scheme</code> inherited from parent",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "105"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": {
+                  "version_added": false
+                },
+                "opera_android": {
+                  "version_added": false
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": false
+              }
+            }
           }
         },
         "prefers-contrast": {


### PR DESCRIPTION
__Background:__
Embedded SVGs and iframes can use the `prefers-color-scheme` media query to access the `color-scheme` of the embedding element.

This PR adds a subfeature `respects-inherited-scheme` which is supported in Fx 105

__Other issues and PRs:__
 - Parent issue: https://github.com/mdn/content/issues/19449