### PR TITLE
Update compat data for the mspace element

### DIFF
--- a/mathml/elements/mspace.json
+++ b/mathml/elements/mspace.json
@@ -30,7 +30,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "7"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -46,7 +46,14 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "81",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -61,7 +68,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "7"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -78,7 +85,14 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "81",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -93,7 +107,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "7"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -110,7 +124,14 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "81",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -126,7 +147,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "7"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Add compat data for Chrome and Safari for the mspace element. This was fully implemented in Chrome 81 [1] and Safari 7 [2].


#### Test results and supporting details

[1] https://chromiumdash.appspot.com/commit/9ead940b1b7ad68132fc7b49de4675e3a87826a8
[2] https://commits.webkit.org/136288@main and `safari.json`

#### Related issues

N/A