### PR TITLE
Change share_target to level 2 spec url

### DIFF
--- a/html/manifest/share_target.json
+++ b/html/manifest/share_target.json
@@ -4,7 +4,7 @@
       "share_target": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/share_target",
-          "spec_url": "https://w3c.github.io/web-share-target/#share_target-member",
+          "spec_url": "https://w3c.github.io/web-share-target/level-2/#share_target-member",
           "support": {
             "chrome": {
               "version_added": "89"


### PR DESCRIPTION
Level 2 has file sharing and that's implemented in Chromiums.  