### PR TITLE
Mark support for UrlFilter in Safari.

### DIFF
--- a/webextensions/api/events.json
+++ b/webextensions/api/events.json
@@ -218,9 +218,11 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
-              "safari_ios": "mirror"
+              "safari_ios": {
+                "version_added": "15"
+              }
             }
           }
         }


### PR DESCRIPTION
It has been supported since adding WebExtensions.