### PR TITLE
Update support for @page :left/:right pseudo-classes

### DIFF
--- a/css/selectors/left.json
+++ b/css/selectors/left.json
@@ -29,11 +29,9 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
-            "safari_ios": {
-              "version_added": "6"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"

--- a/css/selectors/right.json
+++ b/css/selectors/right.json
@@ -29,11 +29,9 @@
               "version_added": "10.1"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "5"
             },
-            "safari_ios": {
-              "version_added": "6"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"


### PR DESCRIPTION
The Safari data for this comes from research in this PR:
https://github.com/mdn/browser-compat-data/pull/4448

If WebKit 533.7 is correct, that maps to Safari 5.
