### PR TITLE
Mark pageshow/pagehide events as not supported in Opera Presto

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3586,10 +3586,10 @@
             },
             "oculus": "mirror",
             "opera": {
-              "version_added": "≤15"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "≤14"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "5"
@@ -3629,10 +3629,10 @@
             },
             "oculus": "mirror",
             "opera": {
-              "version_added": "≤15"
+              "version_added": "15"
             },
             "opera_android": {
-              "version_added": "≤14"
+              "version_added": "14"
             },
             "safari": {
               "version_added": "5"


### PR DESCRIPTION
This is based on manual testing, trying all kinds of things to get the
events to fire. The most conclusive test was this:

- Start at example.com, edit the link to be a same-origin navigation:
  `document.querySelector('a').href = Math.random()`
- Set up `window.fired = []` and event handlers to populate it:
  `window.addEventListener('pageshow', `function(event){window.fired.push[event.type]})`
  `window.addEventListener('pagehide', function(event){window.fired.push[event.type]})`
- Navigate away via the link and go back in the UI
- `window.fired` is still the empty array, meaning the page was kept
  in memory but no events were fired.
