### PR TITLE
Remove onvisibilitychange notes from webkitvisibilitychange

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6778,9 +6778,7 @@
               },
               {
                 "version_added": "13",
-                "prefix": "webkit",
-                "partial_implementation": true,
-                "notes": "The <code>onvisibilitychange</code> event handler property is not supported."
+                "prefix": "webkit"
               }
             ],
             "chrome_android": "mirror",
@@ -6815,9 +6813,7 @@
               },
               {
                 "version_added": "15",
-                "prefix": "webkit",
-                "partial_implementation": true,
-                "notes": "The <code>onvisibilitychange</code> event handler property is not supported."
+                "prefix": "webkit"
               },
               {
                 "version_added": "12.1",
@@ -6837,9 +6833,7 @@
               },
               {
                 "version_added": "14",
-                "prefix": "webkit",
-                "partial_implementation": true,
-                "notes": "The <code>onvisibilitychange</code> event handler property is not supported."
+                "prefix": "webkit"
               },
               {
                 "version_added": "12.1",
@@ -6874,22 +6868,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "62"
-              },
-              {
-                "version_added": "4.4.3",
-                "partial_implementation": true,
-                "notes": "The <code>onvisibilitychange</code> event handler property is not supported."
-              },
-              {
-                "version_added": "≤37",
-                "prefix": "webkit",
-                "partial_implementation": true,
-                "notes": "The <code>onvisibilitychange</code> event handler property is not supported."
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
The prefixed event shouldn't be assoicated with the unprefixed event
handler property.
