### PR TITLE
Add Safari versions for animation-composition CSS property

### DIFF
--- a/css/properties/animation-composition.json
+++ b/css/properties/animation-composition.json
@@ -29,7 +29,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "16"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `animation-composition` CSS property, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.1.4).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/css/properties/animation-composition

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
