### PR TITLE
feat(css): Add CSS Values Level 4 `sqrt()` compatibility data

### DIFF
--- a/css/types/sqrt.json
+++ b/css/types/sqrt.json
@@ -1,0 +1,41 @@
+{
+  "css": {
+    "types": {
+      "sqrt": {
+        "__compat": {
+          "description": "<code>sqrt()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/sqrt",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-values/#exponent-funcs",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add browser compatibility data for the CSS sqrt() function to contain the new additions from CSS Values and Units Level 4.
