### PR TITLE
feat(css): Add CSS Values Level 4 `hypot()` compatibility data

### DIFF
--- a/css/types/hypot.json
+++ b/css/types/hypot.json
@@ -1,0 +1,41 @@
+{
+  "css": {
+    "types": {
+      "hypot": {
+        "__compat": {
+          "description": "<code>hypot()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/hypot",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-values/#exponent-funcs",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add browser compatibility data for the CSS hypot() function to contain the new additions from CSS Values and Units Level 4.