### PR TITLE
FF105 gfx.offscreencanvas.enabled enabled by default

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -1207,22 +1207,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "44",
-                "version_removed": "105",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "105"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -1209,10 +1209,11 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "105"
               },
               {
                 "version_added": "44",
+                "version_removed": "105",
                 "flags": [
                   {
                     "type": "preference",
@@ -1237,7 +1238,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -82,7 +82,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -99,7 +99,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -119,7 +119,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -136,7 +136,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -43,7 +43,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -61,7 +61,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "105",
+                "version_added": "105"
               },
               {
                 "version_added": "46",
@@ -92,7 +92,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -217,7 +217,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -303,7 +303,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -352,7 +352,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -402,7 +402,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -452,7 +452,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -487,7 +487,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -537,7 +537,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -586,7 +586,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -635,7 +635,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -232,11 +232,9 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "96"
+                "version_added": "105"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -12,10 +12,11 @@
           "edge": "mirror",
           "firefox": [
             {
-              "version_added": "preview"
+              "version_added": "105"
             },
             {
               "version_added": "44",
+              "version_removed": "105",
               "partial_implementation": true,
               "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
               "flags": [
@@ -60,10 +61,11 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "105",
               },
               {
                 "version_added": "46",
+                "version_removed": "105",
                 "partial_implementation": true,
                 "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
                 "flags": [
@@ -182,12 +184,13 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview",
+                "version_added": "105",
                 "alternative_name": "toBlob"
               },
               {
                 "alternative_name": "toBlob",
                 "version_added": "46",
+                "version_removed": "105",
                 "partial_implementation": true,
                 "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
                 "flags": [
@@ -269,10 +272,11 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "105"
               },
               {
                 "version_added": "44",
+                "version_removed": "105",
                 "partial_implementation": true,
                 "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
                 "flags": [
@@ -315,10 +319,11 @@
               "edge": "mirror",
               "firefox": [
                 {
-                  "version_added": "preview"
+                  "version_added": "105"
                 },
                 {
                   "version_added": "46",
+                  "version_removed": "105",
                   "partial_implementation": true,
                   "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
                   "flags": [
@@ -364,10 +369,11 @@
               "edge": "mirror",
               "firefox": [
                 {
-                  "version_added": "preview"
+                  "version_added": "105"
                 },
                 {
                   "version_added": "44",
+                  "version_removed": "105",
                   "partial_implementation": true,
                   "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
                   "flags": [
@@ -413,10 +419,11 @@
               "edge": "mirror",
               "firefox": [
                 {
-                  "version_added": "preview"
+                  "version_added": "105"
                 },
                 {
                   "version_added": "44",
+                  "version_removed": "105",
                   "partial_implementation": true,
                   "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
                   "flags": [
@@ -461,7 +468,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "105"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -499,10 +506,11 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "105"
               },
               {
                 "version_added": "44",
+                "version_removed": "105",
                 "partial_implementation": true,
                 "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
                 "flags": [
@@ -547,10 +555,11 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "105"
               },
               {
                 "version_added": "46",
+                "version_removed": "105",
                 "partial_implementation": true,
                 "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
                 "flags": [
@@ -595,10 +604,11 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "105"
               },
               {
                 "version_added": "44",
+                "version_removed": "105",
                 "partial_implementation": true,
                 "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
                 "flags": [

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -10,24 +10,9 @@
           },
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": [
-            {
-              "version_added": "105"
-            },
-            {
-              "version_added": "44",
-              "version_removed": "105",
-              "partial_implementation": true,
-              "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "gfx.offscreencanvas.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "105"
+          },
           "firefox_android": "mirror",
           "ie": {
             "version_added": false
@@ -59,24 +44,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "46",
-                "version_removed": "105",
-                "partial_implementation": true,
-                "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "105"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -182,26 +152,10 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "105",
-                "alternative_name": "toBlob"
-              },
-              {
-                "alternative_name": "toBlob",
-                "version_added": "46",
-                "version_removed": "105",
-                "partial_implementation": true,
-                "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "105",
+              "alternative_name": "toBlob"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -268,24 +222,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "44",
-                "version_removed": "105",
-                "partial_implementation": true,
-                "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "105"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -315,24 +254,9 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "105"
-                },
-                {
-                  "version_added": "46",
-                  "version_removed": "105",
-                  "partial_implementation": true,
-                  "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "gfx.offscreencanvas.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "105"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -365,24 +289,9 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "105"
-                },
-                {
-                  "version_added": "44",
-                  "version_removed": "105",
-                  "partial_implementation": true,
-                  "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "gfx.offscreencanvas.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "105"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -415,24 +324,9 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "105"
-                },
-                {
-                  "version_added": "44",
-                  "version_removed": "105",
-                  "partial_implementation": true,
-                  "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "gfx.offscreencanvas.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "105"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -502,24 +396,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "44",
-                "version_removed": "105",
-                "partial_implementation": true,
-                "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "105"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -551,24 +430,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "46",
-                "version_removed": "105",
-                "partial_implementation": true,
-                "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "105"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -600,24 +464,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "44",
-                "version_removed": "105",
-                "partial_implementation": true,
-                "notes": "See <a href='https://bugzil.la/1390089'>bug 1390089</a>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "105"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -10,7 +10,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "105"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -42,7 +42,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -75,7 +75,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -108,7 +108,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -141,7 +141,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -174,7 +174,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -207,7 +207,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -240,7 +240,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -273,7 +273,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -306,7 +306,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -339,7 +339,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -372,7 +372,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -405,7 +405,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -438,7 +438,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -471,7 +471,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -504,7 +504,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -537,7 +537,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -570,7 +570,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -603,7 +603,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -636,7 +636,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -669,7 +669,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -702,7 +702,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -735,7 +735,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -768,7 +768,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -801,7 +801,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -818,7 +818,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -834,7 +834,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -867,7 +867,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -900,7 +900,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -933,7 +933,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -966,7 +966,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -999,7 +999,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1032,7 +1032,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1065,7 +1065,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1098,7 +1098,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1131,7 +1131,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1164,7 +1164,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1197,7 +1197,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1230,7 +1230,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1263,7 +1263,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1296,7 +1296,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1329,7 +1329,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1362,7 +1362,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1395,7 +1395,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1428,7 +1428,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1461,7 +1461,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1494,7 +1494,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1527,7 +1527,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1560,7 +1560,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1593,7 +1593,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1626,7 +1626,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1659,7 +1659,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1692,7 +1692,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1725,7 +1725,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1758,7 +1758,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1791,7 +1791,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1824,7 +1824,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1857,7 +1857,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1890,7 +1890,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1923,7 +1923,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1956,7 +1956,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1989,7 +1989,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -2,6 +2,7 @@
   "api": {
     "OffscreenCanvasRenderingContext2D": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/OffscreenCanvasRenderingContext2D",
         "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#the-offscreen-2d-rendering-context",
         "support": {
           "chrome": {
@@ -266,6 +267,40 @@
       "closePath": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-closepath-dev",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "105"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "commit": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/OffscreenCanvasRenderingContext2D/commit",
+          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#offscreencontext2d-commit",
           "support": {
             "chrome": {
               "version_added": "69"

--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -945,22 +945,9 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "105"
-                },
-                {
-                  "version_added": "44",
-                  "version_removed": "105",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "gfx.offscreencanvas.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "105"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -1491,22 +1478,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "44",
-                "version_removed": "105",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "105"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -951,7 +951,7 @@
                 },
                 {
                   "version_added": "44",
-                  "version_removed": "105"
+                  "version_removed": "105",
                   "flags": [
                     {
                       "type": "preference",

--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -945,16 +945,22 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "44",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "105"
+                },
+                {
+                  "version_added": "44",
+                  "version_removed": "105"
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "gfx.offscreencanvas.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -1485,16 +1491,22 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "44",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "gfx.offscreencanvas.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "105"
+              },
+              {
+                "version_added": "44",
+                "version_removed": "105",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "gfx.offscreencanvas.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/WebGLActiveInfo.json
+++ b/api/WebGLActiveInfo.json
@@ -54,10 +54,11 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "105"
               },
               {
                 "version_added": "44",
+                "version_removed": "105",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/WebGLActiveInfo.json
+++ b/api/WebGLActiveInfo.json
@@ -52,22 +52,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "44",
-                "version_removed": "105",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "105"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/WebGLBuffer.json
+++ b/api/WebGLBuffer.json
@@ -54,10 +54,11 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "105"
               },
               {
                 "version_added": "44",
+                "version_removed": "105",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/WebGLBuffer.json
+++ b/api/WebGLBuffer.json
@@ -52,22 +52,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "44",
-                "version_removed": "105",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "105"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/WebGLContextEvent.json
+++ b/api/WebGLContextEvent.json
@@ -92,22 +92,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "49",
-                "version_removed": "105",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "105"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/WebGLContextEvent.json
+++ b/api/WebGLContextEvent.json
@@ -94,10 +94,11 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "105"
               },
               {
                 "version_added": "49",
+                "version_removed": "105",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/WebGLFramebuffer.json
+++ b/api/WebGLFramebuffer.json
@@ -54,10 +54,11 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "105"
               },
               {
                 "version_added": "44",
+                "version_removed": "105",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/WebGLFramebuffer.json
+++ b/api/WebGLFramebuffer.json
@@ -52,22 +52,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "44",
-                "version_removed": "105",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "105"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/WebGLProgram.json
+++ b/api/WebGLProgram.json
@@ -54,10 +54,11 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "105"
               },
               {
                 "version_added": "44",
+                "version_removed": "105",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/WebGLProgram.json
+++ b/api/WebGLProgram.json
@@ -52,22 +52,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "44",
-                "version_removed": "105",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "105"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/WebGLRenderbuffer.json
+++ b/api/WebGLRenderbuffer.json
@@ -54,10 +54,11 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "105"
               },
               {
                 "version_added": "44",
+                "version_removed": "105",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/WebGLRenderbuffer.json
+++ b/api/WebGLRenderbuffer.json
@@ -52,22 +52,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "44",
-                "version_removed": "105",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "105"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -58,10 +58,11 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "105"
               },
               {
                 "version_added": "44",
+                "version_removed": "105",
                 "flags": [
                   {
                     "type": "preference",
@@ -835,10 +836,11 @@
               "edge": "mirror",
               "firefox": [
                 {
-                  "version_added": "preview"
+                  "version_added": "105"
                 },
                 {
                   "version_added": "44",
+                  "version_removed": "105",
                   "flags": [
                     {
                       "type": "preference",
@@ -1161,10 +1163,11 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "105"
               },
               {
                 "version_added": "44",
+                "version_removed": "105",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -56,22 +56,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "44",
-                "version_removed": "105",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "105"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -834,22 +821,9 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "105"
-                },
-                {
-                  "version_added": "44",
-                  "version_removed": "105",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "gfx.offscreencanvas.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "105"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -1161,22 +1135,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "44",
-                "version_removed": "105",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "105"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/WebGLShader.json
+++ b/api/WebGLShader.json
@@ -54,10 +54,11 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "105"
               },
               {
                 "version_added": "44",
+                "version_removed": "105",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/WebGLShader.json
+++ b/api/WebGLShader.json
@@ -52,22 +52,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "44",
-                "version_removed": "105",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "105"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/WebGLShaderPrecisionFormat.json
+++ b/api/WebGLShaderPrecisionFormat.json
@@ -54,10 +54,11 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "105"
               },
               {
                 "version_added": "44",
+                "version_removed": "105",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/WebGLShaderPrecisionFormat.json
+++ b/api/WebGLShaderPrecisionFormat.json
@@ -52,22 +52,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "44",
-                "version_removed": "105",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "105"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/WebGLTexture.json
+++ b/api/WebGLTexture.json
@@ -54,10 +54,11 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "105"
               },
               {
                 "version_added": "44",
+                "version_removed": "105",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/WebGLTexture.json
+++ b/api/WebGLTexture.json
@@ -52,22 +52,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "44",
-                "version_removed": "105",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "105"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/WebGLUniformLocation.json
+++ b/api/WebGLUniformLocation.json
@@ -54,10 +54,11 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "105"
               },
               {
                 "version_added": "44",
+                "version_removed": "105",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/WebGLUniformLocation.json
+++ b/api/WebGLUniformLocation.json
@@ -52,22 +52,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "44",
-                "version_removed": "105",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.offscreencanvas.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "105"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/css/types/abs.json
+++ b/css/types/abs.json
@@ -1,0 +1,41 @@
+{
+  "css": {
+    "types": {
+      "abs": {
+        "__compat": {
+          "description": "<code>abs()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/abs",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-values/#sign-funcs",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
FF105 enables `OffScreenCanvas` by default in https://bugzilla.mozilla.org/show_bug.cgi?id=1779009.

@queengooborg 

1. I have removed the preference versions `gfx.offscreencanvas.enabled` now that 105 is released. I can put it back if needed (all done in one commit).
2. Note that the preference was "partial implementation" and points to the meta bug: https://bugzil.la/1390089 - that appears to be mostly done, and the outstanding stuff is just bugs. So I have NOT marked the released version as partial. 

Other docs work for this tracked in https://github.com/mdn/content/issues/11591.

FYI @bsmth 