### PR TITLE
Add two mdn_urls

### DIFF
--- a/api/ImageData.json
+++ b/api/ImageData.json
@@ -115,6 +115,7 @@
       },
       "colorSpace": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ImageData/colorSpace",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-imagedata-colorspace",
           "support": {
             "chrome": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4691,6 +4691,7 @@
       },
       "windowControlsOverlay": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/windowControlsOverlay",
           "spec_url": "https://wicg.github.io/window-controls-overlay/#windowcontrolsoverlay-interface",
           "support": {
             "chrome": {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Navigator/windowControlsOverlay exists
and https://developer.mozilla.org/en-US/docs/Web/API/ImageData/colorSpace will be added in https://github.com/mdn/content/pull/21073