### PR TITLE
FF105 Font Loading API in Workers shipped

### DIFF
--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -82,14 +82,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "104",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.font-loading-api.workers.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -77,14 +77,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "104",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.font-loading-api.workers.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/FontFaceSetLoadEvent.json
+++ b/api/FontFaceSetLoadEvent.json
@@ -82,14 +82,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "104",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.font-loading-api.workers.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -137,14 +137,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "104",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.font-loading-api.workers.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "105"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF105 enables font loading API in workers permanently in https://bugzilla.mozilla.org/show_bug.cgi?id=1779009 (not obvious, but you can see in https://hg.mozilla.org/mozilla-central/rev/ca0fc9488e5d that `layout.css.font-loading-api.workers.enabled` is set true.

As FF105 is released I have removed the pref version and just made it "added in FF105".

Other docs work can be tracked in https://github.com/mdn/content/issues/21070

FYI @queengooborg 