### PR TITLE
Add missing contain-intrinsic-* properties

### DIFF
--- a/css/properties/contain-intrinsic-block-size.json
+++ b/css/properties/contain-intrinsic-block-size.json
@@ -1,0 +1,47 @@
+{
+  "css": {
+    "properties": {
+      "contain-intrinsic-block-size": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-contain-intrinsic-block-size",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-sizing-4/#propdef-contain-intrinsic-block-size",
+          "support": {
+            "chrome": {
+              "version_added": "95"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "104",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.contain-intrinsic-size.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/contain-intrinsic-height.json
+++ b/css/properties/contain-intrinsic-height.json
@@ -1,0 +1,47 @@
+{
+  "css": {
+    "properties": {
+      "contain-intrinsic-height": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-height",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-sizing-4/#propdef-contain-intrinsic-height",
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "104",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.contain-intrinsic-size.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/contain-intrinsic-inline-size.json
+++ b/css/properties/contain-intrinsic-inline-size.json
@@ -1,0 +1,47 @@
+{
+  "css": {
+    "properties": {
+      "contain-intrinsic-inline-size": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-contain-intrinsic-inline-size",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-sizing-4/#propdef-contain-intrinsic-inline-size",
+          "support": {
+            "chrome": {
+              "version_added": "95"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "104",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.contain-intrinsic-size.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/contain-intrinsic-width.json
+++ b/css/properties/contain-intrinsic-width.json
@@ -1,0 +1,47 @@
+{
+  "css": {
+    "properties": {
+      "contain-intrinsic-width": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/contain-intrinsic-width",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-sizing-4/#propdef-contain-intrinsic-width",
+          "support": {
+            "chrome": {
+              "version_added": "83"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "104",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.contain-intrinsic-size.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds entries for the missing `contain-intrinsic-*` properties:
- contain-intrinsic-width
- contain-intrinsic-height
- contain-intrinsic-block-size
- contain-intrinsic-inline-size

FF support was added behind pref in 104. Chrome support for width/height was in 83 (https://chromestatus.com/feature/5737051062272000) and for the logical properties in 95 (https://chromestatus.com/feature/5709654999957504)

Other associated docs work can be tracked in https://github.com/mdn/content/issues/20876

FYI @queengooborg 