### PR TITLE
Update based on mdn-bcd-collector results from Safari Technology Preview 154

### DIFF
--- a/api/CompressionStream.json
+++ b/api/CompressionStream.json
@@ -24,9 +24,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
+            "version_added": "preview"
+          },
+          "safari_ios": {
             "version_added": false
           },
-          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -221,9 +223,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": {
               "version_added": false
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -261,9 +265,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": {
               "version_added": false
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/DecompressionStream.json
+++ b/api/DecompressionStream.json
@@ -24,9 +24,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
+            "version_added": "preview"
+          },
+          "safari_ios": {
             "version_added": false
           },
-          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -221,9 +223,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": {
               "version_added": false
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -261,9 +265,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": {
               "version_added": false
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -21,10 +21,12 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false,
+            "version_added": "preview",
             "notes": "See <a href='https://webkit.org/b/197960'>bug 197960</a>."
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": false
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -1684,9 +1686,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": {
               "version_added": false
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -544,10 +544,12 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
+              "version_added": "preview",
               "notes": "See <a href='https://webkit.org/b/196698'>bug 196698</a>."
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -54,9 +54,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": {
               "version_added": false
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -263,9 +263,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": {
               "version_added": false
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/PermissionStatus.json
+++ b/api/PermissionStatus.json
@@ -58,9 +58,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": {
               "version_added": false
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false

--- a/api/RTCIceTransport.json
+++ b/api/RTCIceTransport.json
@@ -385,9 +385,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": {
               "version_added": false
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -459,9 +461,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": {
               "version_added": false
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -160,10 +160,11 @@
               }
             ],
             "safari": {
-              "version_added": "3"
+              "version_added": "preview",
+              "notes": "See <a href='https://webkit.org/b/163324'>bug 163324</a>."
             },
             "safari_ios": {
-              "version_added": "1"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -518,9 +518,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": {
               "version_added": false
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/Window.json
+++ b/api/Window.json
@@ -5742,7 +5742,8 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "5.1",
-              "notes": "See <a href='https://webkit.org/b/151885'>WebKit bug 151885</a> for possible future removal from Safari."
+              "notes": "See <a href='https://webkit.org/b/151885'>WebKit bug 151885</a> for possible future removal from Safari.",
+              "version_removed": "preview"
             },
             "safari_ios": {
               "version_added": false

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -520,9 +520,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": {
               "version_added": false
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Based on Safari 16.0 and Safari Technology Preview 154 on macOS 12.6, run mdn-bcd-collector's update-bcd.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

Tested with mdn-bcd-collector.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

There are various release notes for these changes; I've not collected them all myself, but hopefully we trust mdn-bcd-collector to do its job.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
