### PR TITLE
Don't manually remap drafts.csswg.org -> w3c.github.io

### DIFF
--- a/test/linter/test-spec-urls.ts
+++ b/test/linter/test-spec-urls.ts
@@ -43,6 +43,9 @@ const specsExceptions = [
 
   // Remove when added to browser-specs
   'https://w3c.github.io/csswg-drafts/css-color-6/',
+
+  // Remove if https://github.com/w3c/browser-specs/issues/730 is resolved
+  'https://w3c.github.io/csswg-drafts/css2',
 ];
 
 const allowedSpecURLs = [
@@ -55,10 +58,7 @@ const allowedSpecURLs = [
     ])
     .flat(),
   ...specsExceptions,
-].map((s) =>
-  // Since drafts.csswg.org is down too often, use an alternative canonical URL
-  s.replace('drafts.csswg.org', 'w3c.github.io/csswg-drafts'),
-);
+];
 
 /**
  * Process the data for spec URL errors


### PR DESCRIPTION
With the release of `browser-specs` 3.26.0, we no longer have to perform manual remapping of CSSWG draft URLs.

Note: there's currently an issue with the CSS spec itself, so we have to add it as an exception for now.  Reported in https://github.com/w3c/browser-specs/issues/730.
