### PR TITLE
extension_ids in web_accessible_resources

### DIFF
--- a/webextensions/manifest/web_accessible_resources.json
+++ b/webextensions/manifest/web_accessible_resources.json
@@ -33,7 +33,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": 105
+                "version_added": "105"
               },
               "firefox_android": "mirror",
               "opera": "mirror",

--- a/webextensions/manifest/web_accessible_resources.json
+++ b/webextensions/manifest/web_accessible_resources.json
@@ -33,7 +33,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": 105
               },
               "firefox_android": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
#### Summary

Documents the support for `extension_ids` in `web_accessible_resources` added in [Bug 1711168](https://bugzilla.mozilla.org/show_bug.cgi?id=1711168) support extensions in web_accessible_resources
