### PR TITLE
Update support data for Meta Quest browser

### DIFF
--- a/api/AmbientLightSensor.json
+++ b/api/AmbientLightSensor.json
@@ -49,7 +49,9 @@
             "chrome": {
               "version_added": "56"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/AudioProcessingEvent.json
+++ b/api/AudioProcessingEvent.json
@@ -7,7 +7,9 @@
           "chrome": {
             "version_added": "14"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "12"
           },
@@ -74,7 +76,9 @@
             "chrome": {
               "version_added": "14"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -109,7 +113,9 @@
             "chrome": {
               "version_added": "14"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -144,7 +150,9 @@
             "chrome": {
               "version_added": "14"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },

--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -82,7 +82,9 @@
             "chrome": {
               "version_added": "56"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -195,7 +197,9 @@
             "chrome": {
               "version_added": "56"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/BrowserCaptureMediaStreamTrack.json
+++ b/api/BrowserCaptureMediaStreamTrack.json
@@ -7,7 +7,9 @@
           "chrome": {
             "version_added": "104"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -39,7 +41,9 @@
             "chrome": {
               "version_added": "104"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -72,7 +76,9 @@
             "chrome": {
               "version_added": "104"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/CSPViolationReportBody.json
+++ b/api/CSPViolationReportBody.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "74"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -47,7 +49,9 @@
             "chrome": {
               "version_added": "74"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -87,7 +91,9 @@
             "chrome": {
               "version_added": "74"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -127,7 +133,9 @@
             "chrome": {
               "version_added": "74"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -167,7 +175,9 @@
             "chrome": {
               "version_added": "74"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -207,7 +217,9 @@
             "chrome": {
               "version_added": "74"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -247,7 +259,9 @@
             "chrome": {
               "version_added": "74"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -287,7 +301,9 @@
             "chrome": {
               "version_added": "74"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -327,7 +343,9 @@
             "chrome": {
               "version_added": "74"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -367,7 +385,9 @@
             "chrome": {
               "version_added": "74"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -407,7 +427,9 @@
             "chrome": {
               "version_added": "74"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -447,7 +469,9 @@
             "chrome": {
               "version_added": "74"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -485,7 +509,9 @@
             "chrome": {
               "version_added": "74"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/CrashReportBody.json
+++ b/api/CrashReportBody.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "72"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -43,7 +45,9 @@
             "chrome": {
               "version_added": "72"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -78,7 +82,9 @@
             "chrome": {
               "version_added": "72"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/CropTarget.json
+++ b/api/CropTarget.json
@@ -7,7 +7,9 @@
           "chrome": {
             "version_added": "104"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -39,7 +41,9 @@
             "chrome": {
               "version_added": "104"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -1636,7 +1636,9 @@
             "chrome": {
               "version_added": "61"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "33",

--- a/api/DeprecationReportBody.json
+++ b/api/DeprecationReportBody.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "69"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -41,7 +43,9 @@
             "chrome": {
               "version_added": "69"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -75,7 +79,9 @@
             "chrome": {
               "version_added": "69"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -109,7 +115,9 @@
             "chrome": {
               "version_added": "69"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -143,7 +151,9 @@
             "chrome": {
               "version_added": "69"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -177,7 +187,9 @@
             "chrome": {
               "version_added": "69"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -211,7 +223,9 @@
             "chrome": {
               "version_added": "69"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -245,7 +259,9 @@
             "chrome": {
               "version_added": "69"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/DragEvent.json
+++ b/api/DragEvent.json
@@ -9,7 +9,7 @@
             "version_added": "3"
           },
           "chrome_android": {
-            "version_added": "≤105"
+            "version_added": "54"
           },
           "edge": {
             "version_added": "12"
@@ -52,7 +52,7 @@
               "version_added": "46"
             },
             "chrome_android": {
-              "version_added": "≤105"
+              "version_added": "54"
             },
             "edge": {
               "version_added": "12"
@@ -94,7 +94,7 @@
               "version_added": "46"
             },
             "chrome_android": {
-              "version_added": "≤105"
+              "version_added": "54"
             },
             "edge": {
               "version_added": "12"

--- a/api/DragEvent.json
+++ b/api/DragEvent.json
@@ -9,7 +9,7 @@
             "version_added": "3"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "≤105"
           },
           "edge": {
             "version_added": "12"
@@ -52,7 +52,7 @@
               "version_added": "46"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "≤105"
             },
             "edge": {
               "version_added": "12"
@@ -94,7 +94,7 @@
               "version_added": "46"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "≤105"
             },
             "edge": {
               "version_added": "12"

--- a/api/EXT_frag_depth.json
+++ b/api/EXT_frag_depth.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "38"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "12",
             "version_removed": "79"

--- a/api/EXT_shader_texture_lod.json
+++ b/api/EXT_shader_texture_lod.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "38"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "17",
             "version_removed": "79"

--- a/api/EXT_texture_compression_bptc.json
+++ b/api/EXT_texture_compression_bptc.json
@@ -29,7 +29,9 @@
           "ie": {
             "version_added": false
           },
-          "oculus": "mirror",
+          "oculus": {
+            "version_added": "≤23.0"
+          },
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {

--- a/api/EXT_texture_compression_bptc.json
+++ b/api/EXT_texture_compression_bptc.json
@@ -17,7 +17,7 @@
             }
           ],
           "chrome_android": {
-            "version_added": "92"
+            "version_added": false
           },
           "edge": "mirror",
           "firefox": {

--- a/api/EXT_texture_compression_rgtc.json
+++ b/api/EXT_texture_compression_rgtc.json
@@ -17,7 +17,7 @@
             }
           ],
           "chrome_android": {
-            "version_added": "83"
+            "version_added": false
           },
           "edge": "mirror",
           "firefox": {

--- a/api/EXT_texture_compression_rgtc.json
+++ b/api/EXT_texture_compression_rgtc.json
@@ -31,7 +31,9 @@
           "ie": {
             "version_added": false
           },
-          "oculus": "mirror",
+          "oculus": {
+            "version_added": "≤23.0"
+          },
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -953,7 +953,9 @@
             "chrome": {
               "version_added": "81"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -1835,7 +1837,9 @@
             "chrome": {
               "version_added": "81"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -2397,7 +2401,9 @@
             "chrome": {
               "version_added": "83"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -3167,7 +3173,9 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -3259,7 +3267,9 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -3523,7 +3533,9 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -3566,7 +3578,9 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -5923,7 +5937,9 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },

--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -246,7 +246,9 @@
             "chrome": {
               "version_added": "81"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -1128,7 +1130,9 @@
             "chrome": {
               "version_added": "81"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/FileSystem.json
+++ b/api/FileSystem.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "7"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "≤18",
             "notes": "Edge only supports this API in drag-and-drop scenarios using the <code><a href='https://developer.mozilla.org/docs/Web/API/DataTransferItem/webkitGetAsEntry'>DataTransferItem.webkitGetAsEntry()</a></code> method. It's not available for use in file or folder picker panels (such as when you use an <code><a href='https://developer.mozilla.org/docs/Web/HTML/Element/input'>&lt;input&gt;</a></code> element with the <code><a href='https://developer.mozilla.org/docs/Web/API/HTMLInputElement/webkitdirectory'>HTMLInputElement.webkitdirectory</a></code> attribute."
@@ -46,7 +48,9 @@
             "chrome": {
               "version_added": "7"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "≤18"
             },
@@ -84,7 +88,9 @@
             "chrome": {
               "version_added": "7"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "≤18"
             },

--- a/api/FileSystemDirectoryEntry.json
+++ b/api/FileSystemDirectoryEntry.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "8"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": "50"
@@ -45,7 +47,9 @@
             "chrome": {
               "version_added": "13"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "50"
@@ -85,7 +89,9 @@
             "chrome": {
               "version_added": "8"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "50",
@@ -126,7 +132,9 @@
             "chrome": {
               "version_added": "8"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "50",
@@ -166,7 +174,9 @@
             "chrome": {
               "version_added": "8"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "50",

--- a/api/FileSystemDirectoryHandle.json
+++ b/api/FileSystemDirectoryHandle.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "86"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -45,7 +47,9 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -83,7 +87,9 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -121,7 +127,9 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -159,7 +167,9 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -197,7 +207,9 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -235,7 +247,9 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -273,7 +287,9 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/FileSystemDirectoryReader.json
+++ b/api/FileSystemDirectoryReader.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "8"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "≤18"
           },
@@ -47,7 +49,9 @@
             "chrome": {
               "version_added": "8"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "50"

--- a/api/FileSystemEntry.json
+++ b/api/FileSystemEntry.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "8"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": "50"
@@ -46,7 +48,9 @@
             "chrome": {
               "version_added": "8"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -86,7 +90,9 @@
             "chrome": {
               "version_added": "8"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "50"
@@ -126,7 +132,9 @@
             "chrome": {
               "version_added": "8"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "50"
@@ -165,7 +173,9 @@
             "chrome": {
               "version_added": "8"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -205,7 +215,9 @@
             "chrome": {
               "version_added": "8"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "52"
@@ -245,7 +257,9 @@
             "chrome": {
               "version_added": "8"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "50"
@@ -285,7 +299,9 @@
             "chrome": {
               "version_added": "8"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "50"
@@ -324,7 +340,9 @@
             "chrome": {
               "version_added": "8"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -364,7 +382,9 @@
             "chrome": {
               "version_added": "8"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "50"
@@ -403,7 +423,9 @@
             "chrome": {
               "version_added": "8"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -442,7 +464,9 @@
             "chrome": {
               "version_added": "8"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/FileSystemFileEntry.json
+++ b/api/FileSystemFileEntry.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "8"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": "50"
@@ -46,7 +48,9 @@
             "chrome": {
               "version_added": "8"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "50",
@@ -88,7 +92,9 @@
             "chrome": {
               "version_added": "8"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "50"

--- a/api/FileSystemFileHandle.json
+++ b/api/FileSystemFileHandle.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "86"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -45,7 +47,9 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -85,7 +89,9 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/FileSystemHandle.json
+++ b/api/FileSystemHandle.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "86"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -45,7 +47,9 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -83,7 +87,9 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -121,7 +127,9 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -159,7 +167,9 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -197,7 +207,9 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/FileSystemSync.json
+++ b/api/FileSystemSync.json
@@ -7,7 +7,9 @@
           "chrome": {
             "version_added": "13"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -40,7 +42,9 @@
             "chrome": {
               "version_added": "13"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -74,7 +78,9 @@
             "chrome": {
               "version_added": "13"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/FontData.json
+++ b/api/FontData.json
@@ -7,7 +7,9 @@
           "chrome": {
             "version_added": "103"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -39,7 +41,9 @@
             "chrome": {
               "version_added": "103"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -72,7 +76,9 @@
             "chrome": {
               "version_added": "103"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -105,7 +111,9 @@
             "chrome": {
               "version_added": "103"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -138,7 +146,9 @@
             "chrome": {
               "version_added": "103"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -171,7 +181,9 @@
             "chrome": {
               "version_added": "103"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -581,7 +581,9 @@
             "chrome": {
               "version_added": "62"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "62"

--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -326,7 +326,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": "≤23.0"
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {

--- a/api/GamepadHapticActuator.json
+++ b/api/GamepadHapticActuator.json
@@ -133,7 +133,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": "≤23.0"
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {

--- a/api/HTMLAllCollection.json
+++ b/api/HTMLAllCollection.json
@@ -47,7 +47,9 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -87,7 +89,9 @@
             "chrome": {
               "version_added": "6"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -127,7 +131,9 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -336,7 +336,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2792,7 +2792,9 @@
             "chrome": {
               "version_added": "49"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "17"
             },

--- a/api/ImageBitmap.json
+++ b/api/ImageBitmap.json
@@ -41,7 +41,9 @@
             "chrome": {
               "version_added": "52"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "46"
@@ -79,7 +81,9 @@
             "chrome": {
               "version_added": "50"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "42"
@@ -113,7 +117,9 @@
             "chrome": {
               "version_added": "50"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "42"

--- a/api/InstallEvent.json
+++ b/api/InstallEvent.json
@@ -75,7 +75,9 @@
             "chrome": {
               "version_added": "40"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "17"
             },

--- a/api/InterventionReportBody.json
+++ b/api/InterventionReportBody.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "69"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -41,7 +43,9 @@
             "chrome": {
               "version_added": "69"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -75,7 +79,9 @@
             "chrome": {
               "version_added": "69"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -109,7 +115,9 @@
             "chrome": {
               "version_added": "69"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -143,7 +151,9 @@
             "chrome": {
               "version_added": "69"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -177,7 +187,9 @@
             "chrome": {
               "version_added": "69"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -211,7 +223,9 @@
             "chrome": {
               "version_added": "69"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/KHR_parallel_shader_compile.json
+++ b/api/KHR_parallel_shader_compile.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "76"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false

--- a/api/LaunchParams.json
+++ b/api/LaunchParams.json
@@ -7,7 +7,9 @@
           "chrome": {
             "version_added": "102"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -39,7 +41,9 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/LaunchQueue.json
+++ b/api/LaunchQueue.json
@@ -7,7 +7,9 @@
           "chrome": {
             "version_added": "102"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -39,7 +41,9 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/Magnetometer.json
+++ b/api/Magnetometer.json
@@ -49,7 +49,9 @@
             "chrome": {
               "version_added": "56"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -89,7 +91,9 @@
             "chrome": {
               "version_added": "56"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -129,7 +133,9 @@
             "chrome": {
               "version_added": "56"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -169,7 +175,9 @@
             "chrome": {
               "version_added": "56"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -409,7 +409,9 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -786,7 +786,9 @@
             "chrome": {
               "version_added": "49"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "25",

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -82,7 +82,9 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -294,7 +296,9 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/MediaStreamTrackProcessor.json
+++ b/api/MediaStreamTrackProcessor.json
@@ -7,7 +7,9 @@
           "chrome": {
             "version_added": "94"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -40,7 +42,9 @@
             "chrome": {
               "version_added": "94"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -74,7 +78,9 @@
             "chrome": {
               "version_added": "94"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/Metadata.json
+++ b/api/Metadata.json
@@ -7,7 +7,9 @@
           "chrome": {
             "version_added": "13"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -45,7 +47,9 @@
             "chrome": {
               "version_added": "13"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -84,7 +88,9 @@
             "chrome": {
               "version_added": "13"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/MimeType.json
+++ b/api/MimeType.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "1"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "12"
           },
@@ -50,7 +52,9 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -93,7 +97,9 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -136,7 +142,9 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
@@ -179,7 +187,9 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -36,7 +36,9 @@
           "ie": {
             "version_added": false
           },
-          "oculus": "mirror",
+          "oculus": {
+            "version_added": false
+          },
           "opera": {
             "version_added": "23",
             "notes": [
@@ -217,7 +219,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "39"
             },
@@ -257,7 +261,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "39"
             },
@@ -299,7 +305,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "23"
             },
@@ -344,7 +352,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "23"
             },
@@ -388,7 +398,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "23"
             },
@@ -433,7 +445,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "23"
             },
@@ -475,7 +489,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -517,7 +533,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "23"
             },
@@ -562,7 +580,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "23"
             },
@@ -606,7 +626,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "23"
             },
@@ -648,7 +670,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -688,7 +712,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "23"
             },
@@ -730,7 +756,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -770,7 +798,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "23"
             },
@@ -810,7 +840,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -860,7 +892,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "23"
             },
@@ -910,7 +944,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -951,7 +987,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "23"
             },
@@ -993,7 +1031,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -1033,7 +1073,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "23"
             },
@@ -1075,7 +1117,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -1115,7 +1159,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "23"
             },
@@ -1158,7 +1204,10 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false,
+              "notes": "<a href='https://crbug.com/971422'>Does not work</a> on Android O or later regardless of Chrome version."
+            },
             "opera": "mirror",
             "opera_android": {
               "version_added": "41",

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -87,7 +87,7 @@
               "version_added": "20"
             },
             "chrome_android": {
-              "version_added": "≤105"
+              "version_added": false
             },
             "edge": {
               "version_added": "14"

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -87,7 +87,7 @@
               "version_added": "20"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "≤105"
             },
             "edge": {
               "version_added": "14"

--- a/api/NotificationEvent.json
+++ b/api/NotificationEvent.json
@@ -19,7 +19,9 @@
           "ie": {
             "version_added": false
           },
-          "oculus": "mirror",
+          "oculus": {
+            "version_added": false
+          },
           "opera": {
             "version_added": "37"
           },
@@ -66,7 +68,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "37"
             },
@@ -112,7 +116,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": false
             },
@@ -154,7 +160,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "37"
             },

--- a/api/OES_draw_buffers_indexed.json
+++ b/api/OES_draw_buffers_indexed.json
@@ -7,7 +7,9 @@
           "chrome": {
             "version_added": "100"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -39,7 +41,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -72,7 +76,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -105,7 +111,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -138,7 +146,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -171,7 +181,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -204,7 +216,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -237,7 +251,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/OES_texture_half_float_linear.json
+++ b/api/OES_texture_half_float_linear.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "29"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "14"
           },

--- a/api/OVR_multiview2.json
+++ b/api/OVR_multiview2.json
@@ -60,7 +60,16 @@
                 "alternative_name": "framebufferTextureMultiviewWEBGL"
               }
             ],
-            "chrome_android": "mirror",
+            "chrome_android": [
+              {
+                "version_added": false
+              },
+              {
+                "version_added": "70",
+                "version_removed": "75",
+                "alternative_name": "framebufferTextureMultiviewWEBGL"
+              }
+            ],
             "edge": "mirror",
             "firefox": {
               "version_added": "71"

--- a/api/OVR_multiview2.json
+++ b/api/OVR_multiview2.json
@@ -25,7 +25,20 @@
           "ie": {
             "version_added": false
           },
-          "oculus": "mirror",
+          "oculus": [
+            {
+              "version_added": "≤23.0"
+            },
+            {
+              "version_added": "7.0",
+              "alternative_name": "OVRMultiview2"
+            },
+            {
+              "version_added": "6.0",
+              "version_removed": "7.0",
+              "alternative_name": "WebGLMultiview"
+            }
+          ],
           "opera": {
             "version_added": false
           },
@@ -78,7 +91,16 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": [
+              {
+                "version_added": "≤23.0"
+              },
+              {
+                "version_added": "6.0",
+                "version_removed": "7.0",
+                "alternative_name": "framebufferTextureMultiviewWEBGL"
+              }
+            ],
             "opera": {
               "version_added": false
             },

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -581,7 +581,9 @@
             "chrome": {
               "version_added": "89"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": false
             },

--- a/api/PermissionsPolicyViolationReportBody.json
+++ b/api/PermissionsPolicyViolationReportBody.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "88"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -43,7 +45,9 @@
             "chrome": {
               "version_added": "88"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -79,7 +83,9 @@
             "chrome": {
               "version_added": "88"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -115,7 +121,9 @@
             "chrome": {
               "version_added": "88"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -151,7 +159,9 @@
             "chrome": {
               "version_added": "88"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -222,7 +232,9 @@
             "chrome": {
               "version_added": "88"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/PushEvent.json
+++ b/api/PushEvent.json
@@ -21,7 +21,9 @@
           "ie": {
             "version_added": false
           },
-          "oculus": "mirror",
+          "oculus": {
+            "version_added": false
+          },
           "opera": {
             "version_added": "37"
           },
@@ -70,7 +72,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "37"
             },
@@ -118,7 +122,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {

--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -21,7 +21,9 @@
           "ie": {
             "version_added": false
           },
-          "oculus": "mirror",
+          "oculus": {
+            "version_added": false
+          },
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
@@ -104,7 +106,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -189,7 +193,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -320,7 +326,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "29"
             },
@@ -366,7 +374,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {

--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -134,7 +134,9 @@
             "chrome": {
               "version_added": "42"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "17"
             },
@@ -217,7 +219,9 @@
             "chrome": {
               "version_added": "42"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "17"
             },
@@ -256,7 +260,9 @@
             "chrome": {
               "version_added": "42"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "17"
             },
@@ -392,7 +398,9 @@
             "chrome": {
               "version_added": "42"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "17"
             },

--- a/api/PushSubscription.json
+++ b/api/PushSubscription.json
@@ -226,7 +226,9 @@
             "chrome": {
               "version_added": "42"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "≤18"
             },

--- a/api/PushSubscription.json
+++ b/api/PushSubscription.json
@@ -21,7 +21,9 @@
           "ie": {
             "version_added": false
           },
-          "oculus": "mirror",
+          "oculus": {
+            "version_added": false
+          },
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
@@ -65,7 +67,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -107,7 +111,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -152,7 +158,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -196,7 +204,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -282,7 +292,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -329,7 +341,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {

--- a/api/PushSubscriptionOptions.json
+++ b/api/PushSubscriptionOptions.json
@@ -21,7 +21,9 @@
           "ie": {
             "version_added": false
           },
-          "oculus": "mirror",
+          "oculus": {
+            "version_added": false
+          },
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
@@ -65,7 +67,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -107,7 +111,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {

--- a/api/RTCIceTransport.json
+++ b/api/RTCIceTransport.json
@@ -42,7 +42,9 @@
             "chrome": {
               "version_added": "75"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "13"
             },

--- a/api/Report.json
+++ b/api/Report.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "69"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -41,7 +43,9 @@
             "chrome": {
               "version_added": "69"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -74,7 +78,9 @@
             "chrome": {
               "version_added": "69"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -108,7 +114,9 @@
             "chrome": {
               "version_added": "69"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -142,7 +150,9 @@
             "chrome": {
               "version_added": "69"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/ReportBody.json
+++ b/api/ReportBody.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "69"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -40,7 +42,9 @@
             "chrome": {
               "version_added": "69"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/Request.json
+++ b/api/Request.json
@@ -1073,7 +1073,9 @@
             "chrome": {
               "version_added": "101"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": false
             },

--- a/api/SVGAltGlyphElement.json
+++ b/api/SVGAltGlyphElement.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "1"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": "4",
@@ -50,7 +52,9 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "4"
@@ -92,7 +96,9 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "4"

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -625,7 +625,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "24"
             },
@@ -668,7 +670,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "34"
             },
@@ -793,7 +797,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "24"
             },

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -162,7 +162,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -387,7 +389,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -466,7 +470,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {

--- a/api/SharedWorkerGlobalScope.json
+++ b/api/SharedWorkerGlobalScope.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "4"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": "29"
@@ -139,7 +141,9 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "29"
@@ -195,7 +199,9 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "29",
@@ -250,7 +256,9 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "29"

--- a/api/SpeechGrammar.json
+++ b/api/SpeechGrammar.json
@@ -105,7 +105,9 @@
             "chrome": {
               "version_added": "25"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "44",
@@ -153,7 +155,9 @@
             "chrome": {
               "version_added": "25"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "44",

--- a/api/SpeechGrammarList.json
+++ b/api/SpeechGrammarList.json
@@ -86,7 +86,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -124,7 +126,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -162,7 +166,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -200,7 +206,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -97,7 +97,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -135,7 +137,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -173,7 +177,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -207,7 +213,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -245,7 +253,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -283,7 +293,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -317,7 +329,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -351,7 +365,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -385,7 +401,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -419,7 +437,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -457,7 +477,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -495,7 +517,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -533,7 +557,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -571,7 +597,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -609,7 +637,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -647,7 +677,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -681,7 +713,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -719,7 +753,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -753,7 +789,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {

--- a/api/SpeechRecognitionAlternative.json
+++ b/api/SpeechRecognitionAlternative.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "33"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -45,7 +47,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -83,7 +87,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/SpeechRecognitionErrorEvent.json
+++ b/api/SpeechRecognitionErrorEvent.json
@@ -89,7 +89,9 @@
             "chrome": {
               "version_added": "77"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -127,7 +129,9 @@
             "chrome": {
               "version_added": "77"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/SpeechRecognitionEvent.json
+++ b/api/SpeechRecognitionEvent.json
@@ -84,7 +84,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -121,7 +123,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -159,7 +163,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -197,7 +203,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/SpeechRecognitionResult.json
+++ b/api/SpeechRecognitionResult.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "33"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -45,7 +47,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -83,7 +87,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -121,7 +127,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/SpeechRecognitionResultList.json
+++ b/api/SpeechRecognitionResultList.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "33"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -45,7 +47,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -83,7 +87,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/SpeechSynthesis.json
+++ b/api/SpeechSynthesis.json
@@ -21,7 +21,9 @@
           "ie": {
             "version_added": false
           },
-          "oculus": "mirror",
+          "oculus": {
+            "version_added": false
+          },
           "opera": {
             "version_added": "21"
           },
@@ -67,7 +69,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "21"
             },
@@ -113,7 +117,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "21"
             },
@@ -163,7 +169,10 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false,
+              "notes": "In Android, <code>pause()</code> ends the current utterance. <code>pause()</code> behaves the same as <code>cancel()</code>."
+            },
             "opera": {
               "version_added": "21"
             },
@@ -210,7 +219,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "21"
             },
@@ -256,7 +267,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "21"
             },
@@ -302,7 +315,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "21"
             },
@@ -348,7 +363,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "21"
             },
@@ -394,7 +411,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "21"
             },
@@ -444,7 +463,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "21"
             },

--- a/api/SpeechSynthesisErrorEvent.json
+++ b/api/SpeechSynthesisErrorEvent.json
@@ -67,7 +67,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": {
               "version_added": false

--- a/api/SpeechSynthesisErrorEvent.json
+++ b/api/SpeechSynthesisErrorEvent.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "33"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "≤18"
           },
@@ -94,7 +96,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "≤18"
             },

--- a/api/SpeechSynthesisEvent.json
+++ b/api/SpeechSynthesisEvent.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "33"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "14"
           },
@@ -96,7 +98,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "14"
             },
@@ -141,7 +145,9 @@
             "chrome": {
               "version_added": "77"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "15"
             },
@@ -183,7 +189,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "14"
             },
@@ -278,7 +286,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "14"
             },
@@ -324,7 +334,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "14"
             },

--- a/api/SpeechSynthesisEvent.json
+++ b/api/SpeechSynthesisEvent.json
@@ -69,7 +69,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": {
               "version_added": false

--- a/api/SpeechSynthesisUtterance.json
+++ b/api/SpeechSynthesisUtterance.json
@@ -68,7 +68,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "21"
             },

--- a/api/SpeechSynthesisVoice.json
+++ b/api/SpeechSynthesisVoice.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "33"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "14"
           },
@@ -54,7 +56,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "14"
             },
@@ -100,7 +104,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "14"
             },
@@ -146,7 +152,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "14"
             },
@@ -192,7 +200,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "14"
             },
@@ -238,7 +248,9 @@
             "chrome": {
               "version_added": "33"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "14"
             },

--- a/api/TransformStreamDefaultController.json
+++ b/api/TransformStreamDefaultController.json
@@ -31,7 +31,9 @@
           "nodejs": {
             "version_added": "16.5.0"
           },
-          "oculus": "mirror",
+          "oculus": {
+            "version_added": false
+          },
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
@@ -70,7 +72,9 @@
             "nodejs": {
               "version_added": "16.5.0"
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -110,7 +114,9 @@
             "nodejs": {
               "version_added": "16.5.0"
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -150,7 +156,9 @@
             "nodejs": {
               "version_added": "16.5.0"
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
@@ -190,7 +198,9 @@
             "nodejs": {
               "version_added": "16.5.0"
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {

--- a/api/USBPermissionResult.json
+++ b/api/USBPermissionResult.json
@@ -7,7 +7,9 @@
           "chrome": {
             "version_added": "61"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -42,7 +44,9 @@
             "chrome": {
               "version_added": "61"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -171,7 +171,9 @@
             "chrome": {
               "version_added": "23"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },

--- a/api/WEBGL_compressed_texture_pvrtc.json
+++ b/api/WEBGL_compressed_texture_pvrtc.json
@@ -9,7 +9,7 @@
             "version_added": false
           },
           "chrome_android": {
-            "version_added": "28"
+            "version_added": false
           },
           "edge": "mirror",
           "firefox": {

--- a/api/WEBGL_compressed_texture_s3tc.json
+++ b/api/WEBGL_compressed_texture_s3tc.json
@@ -37,7 +37,9 @@
           "ie": {
             "version_added": "11"
           },
-          "oculus": "mirror",
+          "oculus": {
+            "version_added": "≤23.0"
+          },
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {

--- a/api/WEBGL_compressed_texture_s3tc_srgb.json
+++ b/api/WEBGL_compressed_texture_s3tc_srgb.json
@@ -23,7 +23,9 @@
           "ie": {
             "version_added": false
           },
-          "oculus": "mirror",
+          "oculus": {
+            "version_added": "≤23.0"
+          },
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {

--- a/api/WEBGL_compressed_texture_s3tc_srgb.json
+++ b/api/WEBGL_compressed_texture_s3tc_srgb.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "60"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "80"
           },

--- a/api/Window.json
+++ b/api/Window.json
@@ -1715,9 +1715,7 @@
               "notes": "The <code>ongamepadconnected</code> event handler property is not supported. See <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "chrome_android": {
-              "version_added": "37",
-              "partial_implementation": true,
-              "notes": "The <code>ongamepadconnected</code> event handler property is not supported. See <a href='https://crbug.com/1192878'>bug 1192878</a>."
+              "version_added": false
             },
             "edge": {
               "version_added": "≤18",
@@ -1782,9 +1780,7 @@
               "notes": "The <code>ongamepaddisconnected</code> event handler property is not supported. See <a href='https://crbug.com/1192878'>bug 1192878</a>."
             },
             "chrome_android": {
-              "version_added": "37",
-              "partial_implementation": true,
-              "notes": "The <code>ongamepaddisconnected</code> event handler property is not supported. See <a href='https://crbug.com/1192878'>bug 1192878</a>."
+              "version_added": false
             },
             "edge": {
               "version_added": "≤18",
@@ -2298,7 +2294,9 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -4059,7 +4057,9 @@
             "chrome": {
               "version_added": "103"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -6623,7 +6623,7 @@
               "version_added": false
             },
             "chrome_android": {
-              "version_added": "56",
+              "version_added": false,
               "notes": [
                 "Chrome for Android 56 supports only Google Daydream View.",
                 "Chrome for Android 57 adds support for Google Cardboard."

--- a/api/Window.json
+++ b/api/Window.json
@@ -5884,7 +5884,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": {
               "version_added": false

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -438,7 +438,9 @@
             "chrome": {
               "version_added": "60"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": "1.0"
             },

--- a/api/XRCubeLayer.json
+++ b/api/XRCubeLayer.json
@@ -90,7 +90,7 @@
               "version_added": false
             },
             "oculus": {
-              "version_added": "16.1"
+              "version_added": false
             },
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/XRCylinderLayer.json
+++ b/api/XRCylinderLayer.json
@@ -162,7 +162,7 @@
               "version_added": false
             },
             "oculus": {
-              "version_added": "16.1"
+              "version_added": false
             },
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/XREquirectLayer.json
+++ b/api/XREquirectLayer.json
@@ -162,7 +162,7 @@
               "version_added": false
             },
             "oculus": {
-              "version_added": "16.1"
+              "version_added": false
             },
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/XRQuadLayer.json
+++ b/api/XRQuadLayer.json
@@ -90,7 +90,7 @@
               "version_added": false
             },
             "oculus": {
-              "version_added": "16.1"
+              "version_added": false
             },
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/XRSubImage.json
+++ b/api/XRSubImage.json
@@ -18,7 +18,7 @@
             "version_added": false
           },
           "oculus": {
-            "version_added": "16.1"
+            "version_added": false
           },
           "opera": "mirror",
           "opera_android": "mirror",
@@ -53,7 +53,7 @@
               "version_added": false
             },
             "oculus": {
-              "version_added": "16.1"
+              "version_added": false
             },
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/XRSystem.json
+++ b/api/XRSystem.json
@@ -9,7 +9,15 @@
             "alternative_name": "XR",
             "version_added": "79"
           },
-          "chrome_android": "mirror",
+          "chrome_android": [
+            {
+              "version_added": "≤105"
+            },
+            {
+              "alternative_name": "XR",
+              "version_added": "79"
+            }
+          ],
           "edge": "mirror",
           "firefox": {
             "version_added": false

--- a/api/XRSystem.json
+++ b/api/XRSystem.json
@@ -11,7 +11,7 @@
           },
           "chrome_android": [
             {
-              "version_added": "≤105"
+              "version_added": "83"
             },
             {
               "alternative_name": "XR",

--- a/api/XRWebGLSubImage.json
+++ b/api/XRWebGLSubImage.json
@@ -18,7 +18,7 @@
             "version_added": false
           },
           "oculus": {
-            "version_added": "16.1"
+            "version_added": false
           },
           "opera": "mirror",
           "opera_android": "mirror",
@@ -53,7 +53,7 @@
               "version_added": false
             },
             "oculus": {
-              "version_added": "16.1"
+              "version_added": false
             },
             "opera": "mirror",
             "opera_android": "mirror",
@@ -89,7 +89,7 @@
               "version_added": false
             },
             "oculus": {
-              "version_added": "16.1"
+              "version_added": false
             },
             "opera": "mirror",
             "opera_android": "mirror",
@@ -125,7 +125,7 @@
               "version_added": false
             },
             "oculus": {
-              "version_added": "16.1"
+              "version_added": false
             },
             "opera": "mirror",
             "opera_android": "mirror",

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -330,6 +330,8 @@ For certain browsers, ranged versions are allowed as it is sometimes impractical
 - Opera Android
   - "≤12.1" (the last Presto-based Opera and possibly earlier)
   - "≤14" (the first Chromium-based Opera and possibly in Presto-based Opera)
+- Quest
+  - "≤23.0" (the first publicly-available Quest version which was programmatically measured)
 - Safari
   - "≤4" (the earliest Safari version testable in BrowserStack and possibly earlier)
 - Safari iOS


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
    
These changes were generated procedurally by the mdn-bcd-collector project using data collected from the Meta Quest browser.

#### Test results and supporting details

This patch is reproducible using the mdn-bcd-collector project at revision 4c430c1bb8bc2fcd3f72778e1dbe62bbb565587b and the data submitted to mdn-bcd-results here: https://github.com/foolip/mdn-bcd-results/pull/3278

#### Related issues

This is based on gh-17908 which has not been accepted at the time of submission. Although it may be technically possible to express this patch as an independent change set, the semantics of the "mirror" support value mean that there will be less churn if the Chrome for Android data is modified first. Feedback regarding the changes to Chrome for Android may be better shared in gh-17908.