### PR TITLE
Update name of Quest browser

### DIFF
--- a/browsers/oculus.json
+++ b/browsers/oculus.json
@@ -1,7 +1,7 @@
 {
   "browsers": {
     "oculus": {
-      "name": "Oculus Browser",
+      "name": "Quest Browser",
       "type": "xr",
       "upstream": "chrome_android",
       "pref_url": "chrome://flags",


### PR DESCRIPTION
#### Summary

Change the name associated with the "oculus" browser from "Oculus Browser" to "Quest Browser".

#### Test results and supporting details

n/a

#### Related issues

This change occured in concert with the larger branding change from Facebook to Meta:

https://www.facebook.com/boz/posts/10114026973983491
