### PR TITLE
Update compat data for mfrac@linethickness

### DIFF
--- a/mathml/elements/mfrac.json
+++ b/mathml/elements/mfrac.json
@@ -100,13 +100,17 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": {
-                "version_added": "5.1",
-                "notes": "Before Safari 9, &lt;length&gt; values are not supported. Only <code>0</code>, <code>thin</code>, <code>medium</code>, and <code>thick</code> are supported."
-              },
-              "safari_ios": {
-                "version_added": false
-              },
+              "safari": [
+                {
+                  "version_added": "9"
+                },
+                {
+                  "version_added": "5.1",
+                  "partial_implementation": true,
+                  "notes": "Only <code>0</code>, <code>thin</code>, <code>medium</code>, and <code>thick</code> are supported."
+                }
+              ],
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -114,6 +118,39 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "thin_medium_thick": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "1",
+                  "version_removed": "83"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "5.1"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": true
+              }
             }
           }
         },

--- a/mathml/elements/mfrac.json
+++ b/mathml/elements/mfrac.json
@@ -122,6 +122,7 @@
           },
           "thin_medium_thick": {
             "__compat": {
+              "description": "<code>thin</code>, <code>medium</code>, <code>thick</code> values",
               "support": {
                 "chrome": {
                   "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

This commit updates compat data for the linethickness attribute of the <mfrac> element:

- Replace notes about partial implementation in Safari with the use of of array of implementations.
- Use "mirror" for Safari iOS, its MathML implementation matches the macOS one.
- Add a subfeature for deprecated named values thin, medium, thick values that are not part of MathML Core. These were removed in Firefox 83 [1] but are still supported by WebKit [2].

#### Test results and supporting details

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1664488
[2] https://github.com/WebKit/WebKit/blob/0b0b865747d48a813eee3c2f52da026714bd61aa/Source/WebCore/mathml/MathMLFractionElement.cpp#L59

#### Related issues

N/A