### PR TITLE
Add subfeature for deprecated named values of the mathsize attribute

### DIFF
--- a/mathml/global_attributes.json
+++ b/mathml/global_attributes.json
@@ -279,6 +279,7 @@
           }
         },
         "small_normal_big": {
+          "description": "<code>small</code>, <code>normal</code>, <code>big</code> values",
           "__compat": {
             "support": {
               "chrome": {

--- a/mathml/global_attributes.json
+++ b/mathml/global_attributes.json
@@ -279,7 +279,6 @@
           }
         },
         "small_normal_big": {
-          "description": "<code>small</code>, <code>normal</code>, <code>big</code> values",
           "__compat": {
             "support": {
               "chrome": {

--- a/mathml/global_attributes.json
+++ b/mathml/global_attributes.json
@@ -280,6 +280,7 @@
         },
         "small_normal_big": {
           "__compat": {
+            "description": "<code>small</code>, <code>normal</code>, <code>big</code> values",
             "support": {
               "chrome": {
                 "version_added": false

--- a/mathml/global_attributes.json
+++ b/mathml/global_attributes.json
@@ -268,10 +268,7 @@
               "version_added": "5",
               "impl_url": "https://trac.webkit.org/changeset/63079"
             },
-            "safari_ios": {
-              "version_added": "4",
-              "impl_url": "https://trac.webkit.org/changeset/63079"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -279,6 +276,41 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": true
+          }
+        },
+        "small_normal_big": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "70",
+                "version_removed": "83"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "5"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
           }
         }
       },


### PR DESCRIPTION
#### Summary

Add subfeature for deprecated named values "small", "normal", "big" of the mathsize attribute. These were removed in Firefox 83 [1] but are still supported by WebKit [2]. Also use "mirror" for Safari iOS, it has the same MathML support as macOS.

#### Test results and supporting details

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1664488
[2] https://github.com/WebKit/WebKit/blob/cd711e64b46522100059a32e3025f7875e4861c0/Source/WebCore/mathml/MathMLElement.cpp#L117

#### Related issues

N/A