### PR TITLE
Split 'color keywords' into named-color and system-color

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -84,11 +84,11 @@
             }
           }
         },
-        "color_keywords": {
+        "named-color": {
           "__compat": {
-            "description": "Color keywords",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/color_keywords",
-            "spec_url": "https://w3c.github.io/csswg-drafts/css-color/#color-keywords",
+            "description": "Named colors",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/named-color",
+            "spec_url": "https://w3c.github.io/csswg-drafts/css-color/#named-colors",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -983,6 +983,49 @@
                 "standard_track": true,
                 "deprecated": false
               }
+            }
+          }
+        },
+        "system-color": {
+          "__compat": {
+            "description": "System colors",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/system-color",
+            "spec_url": "https://w3c.github.io/csswg-drafts/css-color/#system-colors",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "3"
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": "3.5"
+              },
+              "opera_android": {
+                "version_added": "10.1"
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": "≤37"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         },

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -84,87 +84,6 @@
             }
           }
         },
-        "named-color": {
-          "__compat": {
-            "description": "Named colors",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/named-color",
-            "spec_url": "https://w3c.github.io/csswg-drafts/css-color/#named-colors",
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "3",
-                "notes": "Internet Explorer 8 and later support gray color keywords spelled with an <em>e</em> (<code>grey</code>, <code>darkgrey</code>, <code>darkslategrey</code>, <code>dimgrey</code>, <code>lightgrey</code>, and <code>lightslategrey</code>). Internet Explorer 3 to Internet Explorer 7 only support the keywords spelled with <em>a</em> (<code>gray</code>, <code>darkgray</code>, <code>darkslategray</code>, <code>dimgray</code>, <code>lightgray</code>, and <code>lightslategray</code>)."
-              },
-              "oculus": "mirror",
-              "opera": {
-                "version_added": "3.5"
-              },
-              "opera_android": {
-                "version_added": "10.1"
-              },
-              "safari": {
-                "version_added": "1"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          },
-          "rebeccapurple": {
-            "__compat": {
-              "description": "<code>rebeccapurple</code>",
-              "support": {
-                "chrome": {
-                  "version_added": "38"
-                },
-                "chrome_android": "mirror",
-                "edge": {
-                  "version_added": "12"
-                },
-                "firefox": {
-                  "version_added": "33"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": "11"
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "9"
-                },
-                "safari_ios": {
-                  "version_added": "8"
-                },
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
         "color-contrast": {
           "__compat": {
             "description": "<code>color-contrast()</code>",
@@ -582,6 +501,87 @@
               "experimental": true,
               "standard_track": true,
               "deprecated": false
+            }
+          }
+        },
+        "named-color": {
+          "__compat": {
+            "description": "Named colors",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/named-color",
+            "spec_url": "https://w3c.github.io/csswg-drafts/css-color/#named-colors",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "3",
+                "notes": "Internet Explorer 8 and later support gray color keywords spelled with an <em>e</em> (<code>grey</code>, <code>darkgrey</code>, <code>darkslategrey</code>, <code>dimgrey</code>, <code>lightgrey</code>, and <code>lightslategrey</code>). Internet Explorer 3 to Internet Explorer 7 only support the keywords spelled with <em>a</em> (<code>gray</code>, <code>darkgray</code>, <code>darkslategray</code>, <code>dimgray</code>, <code>lightgray</code>, and <code>lightslategray</code>)."
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": "3.5"
+              },
+              "opera_android": {
+                "version_added": "10.1"
+              },
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": "≤37"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "rebeccapurple": {
+            "__compat": {
+              "description": "<code>rebeccapurple</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "38"
+                },
+                "chrome_android": "mirror",
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "33"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": "11"
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "9"
+                },
+                "safari_ios": {
+                  "version_added": "8"
+                },
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         },


### PR DESCRIPTION
This PR splits the "Color keywords" subfeature into two:

- "named-color", reflecting the `<named-color>` type documented at https://developer.mozilla.org/en-US/docs/Web/CSS/named-color, 
- "system-color", reflecting the `<system-color>` type documented (currently) at https://developer.mozilla.org/en-US/docs/web/css/color_value/system_color_keywords, but which I am in the process of making into a proper CSS data type page and moving to https://developer.mozilla.org/en-US/docs/web/css/system-color . When I do that it will want its own BCD table, which is why I need a "system-color" subfeature.

This is also more accurate, since per spec https://w3c.github.io/csswg-drafts/css-color-4/#color-keywords includes four features, two of which (`transparent` and `currentcolor`) are already split out as subfeatures in BCD.