### PR TITLE
Add subfeature for <ms> lquote/rquote attributes

### DIFF
--- a/mathml/elements/ms.json
+++ b/mathml/elements/ms.json
@@ -30,7 +30,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "9"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -40,6 +40,39 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "lquote_rquote_attributes": {
+          "__compat": {
+            "description": "Surround the content of the <code>&lt;ms&gt;</code> element with quotes, specifiable via the <code>lquote</code> and <code>rquote</code> attributes.",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
           }
         }
       }


### PR DESCRIPTION
#### Summary

In MathML Core the `<ms>` element behaves like an `<mtext>` [1] and this is how it was implementated in Safari 9 [2] and Chromium. Firefox still supports a legacy implementation from MathML3 (surround content with quotes, specifiable via attributes) but will be removed in the future [3]. To facilitate comparison of browser support, this commit introduces a subfeature for that legacy implementation.

#### Test results and supporting details

[1] https://w3c.github.io/mathml-core/#string-literal-ms
[2] https://commits.webkit.org/157302@main
[3] https://bugzilla.mozilla.org/show_bug.cgi?id=1793387

#### Related issues

https://github.com/mdn/content/pull/21248