### PR TITLE
Add compatibility data for legacy MathML lengths

### DIFF
--- a/mathml/attribute_values.json
+++ b/mathml/attribute_values.json
@@ -1,0 +1,76 @@
+{
+  "mathml": {
+    "attribute_values": {
+      "named_space": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "nonzero_unitless_values": {
+        "__compat": {
+          "description": "Nonzero unitless values (e.g. 5 to mean 500% the default thickness)",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/mathml/elements/mfrac.json
+++ b/mathml/elements/mfrac.json
@@ -120,6 +120,75 @@
               "deprecated": false
             }
           },
+          "named_spaces": {
+            "__compat": {
+              "description": "Named spaces (e.g. <code>thinmathspace</code> to mean 3/18em)",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "1"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": true
+              }
+            }
+          },
+          "nonzero_unitless_values": {
+            "__compat": {
+              "description": "Nonzero unitless values (e.g. 5 to mean 500% the default thickness)",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "1",
+                  "version_removed": "70"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "10"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": true
+              }
+            }
+          },
           "thin_medium_thick": {
             "__compat": {
               "description": "<code>thin</code>, <code>medium</code>, <code>thick</code> values",

--- a/mathml/elements/mo.json
+++ b/mathml/elements/mo.json
@@ -232,6 +232,75 @@
             }
           }
         },
+        "named_spaces": {
+          "__compat": {
+            "description": "Named spaces (e.g. <code>thinmathspace</code> to mean 3/18em) for <code>lspace</code>, <code>maxsize</code>, <code>minsize</code> and <code>rspace</code> attributes",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "nonzero_unitless_values": {
+          "__compat": {
+            "description": "Nonzero unitless values (e.g. 5 to mean 500%) for <code>lspace</code>, <code>maxsize</code>, <code>minsize</code> and <code>rspace</code> attributes",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1",
+                "version_removed": "70"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
         "rspace": {
           "__compat": {
             "support": {

--- a/mathml/elements/mspace.json
+++ b/mathml/elements/mspace.json
@@ -120,6 +120,40 @@
             }
           }
         },
+        "named_spaces": {
+          "__compat": {
+            "description": "Named spaces (e.g. <code>thinmathspace</code> to mean 3/18em) for <code>width</code>, <code>height</code> and <code>depth</code> attributes",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
         "width": {
           "__compat": {
             "support": {

--- a/mathml/elements/mtable.json
+++ b/mathml/elements/mtable.json
@@ -372,6 +372,75 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "named_spaces": {
+            "__compat": {
+              "description": "Named spaces (e.g. <code>thinmathspace</code> to mean 3/18em)",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "13"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": true
+              }
+            }
+          },
+          "nonzero_unitless_values": {
+            "__compat": {
+              "description": "Nonzero unitless values (e.g. 5 to mean 500%)",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "13",
+                  "version_removed": "70"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": true
+              }
+            }
           }
         }
       }

--- a/mathml/global_attributes.json
+++ b/mathml/global_attributes.json
@@ -250,11 +250,17 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "70",
-              "impl_url": "https://hg.mozilla.org/mozilla-central/rev/3b30c8db537c",
-              "notes": "Prior to Firefox 70, the attribute was only accepted on a few elements, as specified in MathML 3."
-            },
+            "firefox": [
+              {
+                "version_added": "70",
+                "impl_url": "https://hg.mozilla.org/mozilla-central/rev/3b30c8db537c"
+              },
+              {
+                "version_added": "1",
+                "partial_implementation": true,
+                "notes": "Attribute only accepted on a few elements, as specified in MathML 3."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -278,6 +284,75 @@
             "deprecated": true
           }
         },
+        "named_spaces": {
+          "__compat": {
+            "description": "Named spaces (e.g. <code>thinmathspace</code> to mean 3/18em)",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "nonzero_unitless_values": {
+          "__compat": {
+            "description": "Nonzero unitless values (e.g. 5 to mean 500%)",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1",
+                "version_removed": "70"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
         "small_normal_big": {
           "__compat": {
             "description": "<code>small</code>, <code>normal</code>, <code>big</code> values",
@@ -288,7 +363,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "70",
+                "version_added": "1",
                 "version_removed": "83"
               },
               "firefox_android": "mirror",


### PR DESCRIPTION
#### Summary

MDN contains a section about legacy MathML lengths [1] and refers to a browser compatibility table `mathml.attribute_values` that is currently missing. This commit adds relevant compatibility data for two kinds of accepted values mentioned in this section:

- non-zero unitless length values (e.g. `5` to mean 500%),
- named spaces (e.g. `thinmathspace` to mean 3/18em)

The edge case numbers ending with a dot (e.g. `34.px`) is ignored, that seems a bug in MathML 3 that is not even mention in version 4 [2] and is not super important for web developers.

Corresponding data is added for length attributes, namely mfrac's linethickness, mo's lspace/rspace/maxsize/minsize, mspace's depth/height/width, mtable's width and the global mathsize attribute (note that non-zero unitless is not added for mspace, it's not relevant since the default dimensions are 0 anyway).

#### Test results and supporting details

These features have been implemented a long time in Gecko, before the first release of Firefox. Unitless values have been removed in Firefox 70 [3] and the there is plan to disable the pref for named spaces [4]. The two features have also been implemented in Safari 10 [5] and there is no plan to implement them in Chromium since they are not part of MathML Core.

[1] https://developer.mozilla.org/en-US/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths
[2] https://w3c.github.io/mathml/#fund_units
|3] https://bugzilla.mozilla.org/show_bug.cgi?id=1574749#c8
[4] https://bugzilla.mozilla.org/show_bug.cgi?id=1793549
[5] https://commits.webkit.org/136199@main

#### Related issues

N/A