### PR TITLE
New Edge release and new release note links

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -10,49 +10,49 @@
       "releases": {
         "12": {
           "release_date": "2015-07-28",
-          "release_notes": "https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-12",
+          "release_notes": "https://learn.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-12",
           "status": "retired",
           "engine": "EdgeHTML",
           "engine_version": "12"
         },
         "13": {
           "release_date": "2015-11-12",
-          "release_notes": "https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-13",
+          "release_notes": "https://learn.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-13",
           "status": "retired",
           "engine": "EdgeHTML",
           "engine_version": "13"
         },
         "14": {
           "release_date": "2016-08-02",
-          "release_notes": "https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-14",
+          "release_notes": "https://learn.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-14",
           "status": "retired",
           "engine": "EdgeHTML",
           "engine_version": "14"
         },
         "15": {
           "release_date": "2017-04-05",
-          "release_notes": "https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-15",
+          "release_notes": "https://learn.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-15",
           "status": "retired",
           "engine": "EdgeHTML",
           "engine_version": "15"
         },
         "16": {
           "release_date": "2017-10-17",
-          "release_notes": "https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-16",
+          "release_notes": "https://learn.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-16",
           "status": "retired",
           "engine": "EdgeHTML",
           "engine_version": "16"
         },
         "17": {
           "release_date": "2018-04-30",
-          "release_notes": "https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-17",
+          "release_notes": "https://learn.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-17",
           "status": "retired",
           "engine": "EdgeHTML",
           "engine_version": "17"
         },
         "18": {
           "release_date": "2018-10-02",
-          "release_notes": "https://docs.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new",
+          "release_notes": "https://learn.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new",
           "status": "retired",
           "engine": "EdgeHTML",
           "engine_version": "18"
@@ -66,190 +66,197 @@
         },
         "80": {
           "release_date": "2020-02-07",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-80036148-february-7",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-80036148-february-7",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "80"
         },
         "81": {
           "release_date": "2020-04-13",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-81041653-april-13",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-81041653-april-13",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "81"
         },
         "83": {
           "release_date": "2020-05-21",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-83047837-may-21",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-83047837-may-21",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "83"
         },
         "84": {
           "release_date": "2020-07-16",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-84052240-july-16",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-84052240-july-16",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "84"
         },
         "85": {
           "release_date": "2020-08-27",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-85056441-august-27",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-85056441-august-27",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "85"
         },
         "86": {
           "release_date": "2020-10-09",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-86062238-october-9",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-86062238-october-9",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "86"
         },
         "87": {
           "release_date": "2020-11-19",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-87066441-november-19",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-87066441-november-19",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "87"
         },
         "88": {
           "release_date": "2021-01-21",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-88070550-january-21",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-88070550-january-21",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "88"
         },
         "89": {
           "release_date": "2021-03-04",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-89077445-march-4",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-89077445-march-4",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "89"
         },
         "90": {
           "release_date": "2021-04-15",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-90081839-april-15",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-90081839-april-15",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "90"
         },
         "91": {
           "release_date": "2021-05-27",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-91086437-may-27",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-91086437-may-27",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "91"
         },
         "92": {
           "release_date": "2021-07-22",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-92090255-july-22",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-92090255-july-22",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "92"
         },
         "93": {
           "release_date": "2021-09-02",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-93096138-september-02",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-93096138-september-02",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "93"
         },
         "94": {
           "release_date": "2021-09-24",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-94099231-september-24",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-94099231-september-24",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "94"
         },
         "95": {
           "release_date": "2021-10-21",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-950102030-october-21",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-950102030-october-21",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "95"
         },
         "96": {
           "release_date": "2021-11-19",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-960105429-november-19",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-960105429-november-19",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "96"
         },
         "97": {
           "release_date": "2022-01-06",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-970107255-january-6",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-970107255-january-6",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "97"
         },
         "98": {
           "release_date": "2022-02-03",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-980110843-february-3",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-980110843-february-3",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "98"
         },
         "99": {
           "release_date": "2022-03-03",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-990115030-march-3",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-990115030-march-3",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "99"
         },
         "100": {
           "release_date": "2022-04-01",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1000118529-april-1",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1000118529-april-1",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "100"
         },
         "101": {
           "release_date": "2022-04-29",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1010121032-april-28",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1010121032-april-28",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "101"
         },
         "102": {
           "release_date": "2022-05-31",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1020124530-may-31-2022",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1020124530-may-31-2022",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "102"
         },
         "103": {
           "release_date": "2022-07-01",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1030126437-june-23",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1030126437-june-23",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "103"
         },
         "104": {
           "release_date": "2022-08-09",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1040129347-august-5",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1040129347-august-5",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "104"
         },
         "105": {
           "release_date": "2022-09-01",
-          "release_notes": "https://docs.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1050134325-september-1-2022",
-          "status": "current",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1050134325-september-1-2022",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "105"
         },
         "106": {
-          "release_date": "2022-09-29",
-          "status": "beta",
+          "release_date": "2022-10-03",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1060137034-october-3-2022",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "106"
         },
         "107": {
           "release_date": "2022-10-27",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "107"
+        },
+        "108": {
+          "release_date": "2022-12-01",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "108"
         }
       }
     }


### PR DESCRIPTION
#### Summary

Edge 106 is out since yesterday, this PR updates the edge.json file with new dates.
In it, I also updated all release note links from docs.microsoft.com to learn.microsoft.com (although redirects are in place, the domain name just changed 2 weeks ago).
