### PR TITLE
Use MathML 4 as a spec for the mfenced element

### DIFF
--- a/mathml/elements/mfenced.json
+++ b/mathml/elements/mfenced.json
@@ -4,6 +4,7 @@
       "mfenced": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mfenced",
+          "spec_url": "https://w3c.github.io/mathml/#presm_mfenced",
           "support": {
             "chrome": {
               "version_added": false
@@ -30,7 +31,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": true
           }
         }


### PR DESCRIPTION
#### Summary

This MathML element is not part of MathML Core and has been removed from Firefox, but it's still implemented in WebKit and documented on MDN. Let's use MathML 4 as a reference spec for it, just like we do for `<menclose>`.

#### Test results and supporting details

N/A

#### Related issues

https://github.com/mdn/content/pull/21308