### PR TITLE
Remove spec_url for features defined in MathML4

### DIFF
--- a/mathml/elements/menclose.json
+++ b/mathml/elements/menclose.json
@@ -4,7 +4,6 @@
       "menclose": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/menclose",
-          "spec_url": "https://w3c.github.io/mathml/#presm_menclose",
           "support": {
             "chrome": {
               "version_added": false

--- a/mathml/global_attributes.json
+++ b/mathml/global_attributes.json
@@ -99,7 +99,6 @@
       "href": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/href",
-          "spec_url": "https://w3c.github.io/mathml/#fund_globatt",
           "support": {
             "chrome": {
               "version_added": false

--- a/test/linter/test-spec-urls.ts
+++ b/test/linter/test-spec-urls.ts
@@ -38,9 +38,6 @@ const specsExceptions = [
   // Remove if https://github.com/w3c/webrtc-extensions/issues/108 is closed
   'https://w3c.github.io/webrtc-extensions/',
 
-  // Remove if https://github.com/w3c/mathml/issues/216 is resolved
-  'https://w3c.github.io/mathml/',
-
   // Remove when added to browser-specs
   'https://w3c.github.io/csswg-drafts/css-color-6/',
 


### PR DESCRIPTION
#### Summary

Remove spec_url for features defined in MathML4

#### Test results and supporting details

See discussion on https://github.com/mdn/browser-compat-data/pull/17941

#### Related issues

N/A