### PR TITLE
Update version ranges for Safari snap scroll implementation bug

### DIFF
--- a/css/properties/scroll-margin-bottom.json
+++ b/css/properties/scroll-margin-bottom.json
@@ -23,13 +23,13 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "14.1"
+                "version_added": "16"
               },
               {
                 "version_added": "11",
                 "alternative_name": "scroll-snap-margin-bottom",
                 "partial_implementation": true,
-                "notes": "Before version 14.1, scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+                "notes": "Before version 16, scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
               }
             ],
             "safari_ios": [

--- a/css/properties/scroll-margin-left.json
+++ b/css/properties/scroll-margin-left.json
@@ -23,13 +23,13 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "14.1"
+                "version_added": "16"
               },
               {
                 "version_added": "11",
                 "alternative_name": "scroll-snap-margin-left",
                 "partial_implementation": true,
-                "notes": "Before version 14.1, scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+                "notes": "Before version 16, scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
               }
             ],
             "safari_ios": [

--- a/css/properties/scroll-margin-right.json
+++ b/css/properties/scroll-margin-right.json
@@ -23,13 +23,13 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "14.1"
+                "version_added": "16"
               },
               {
                 "version_added": "11",
                 "alternative_name": "scroll-snap-margin-right",
                 "partial_implementation": true,
-                "notes": "Before version 14.1, scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+                "notes": "Before version 16, scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
               }
             ],
             "safari_ios": [

--- a/css/properties/scroll-margin-top.json
+++ b/css/properties/scroll-margin-top.json
@@ -23,13 +23,13 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "14.1"
+                "version_added": "16"
               },
               {
                 "version_added": "11",
                 "alternative_name": "scroll-snap-margin-top",
                 "partial_implementation": true,
-                "notes": "Before version 14.1, scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+                "notes": "Before version 16, scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
               }
             ],
             "safari_ios": [

--- a/css/properties/scroll-margin.json
+++ b/css/properties/scroll-margin.json
@@ -31,13 +31,13 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "14.1"
+                "version_added": "16"
               },
               {
                 "version_added": "11",
                 "alternative_name": "scroll-snap-margin",
                 "partial_implementation": true,
-                "notes": "Before version 14.1, scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
+                "notes": "Before version 16, scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
               }
             ],
             "safari_ios": [

--- a/css/properties/scroll-padding-bottom.json
+++ b/css/properties/scroll-padding-bottom.json
@@ -23,11 +23,11 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "14.1"
+                "version_added": "16"
               },
               {
                 "version_added": "11",
-                "version_removed": "14.1",
+                "version_removed": "16",
                 "partial_implementation": true,
                 "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
               }

--- a/css/properties/scroll-padding-left.json
+++ b/css/properties/scroll-padding-left.json
@@ -23,11 +23,11 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "14.1"
+                "version_added": "16"
               },
               {
                 "version_added": "11",
-                "version_removed": "14.1",
+                "version_removed": "16",
                 "partial_implementation": true,
                 "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
               }

--- a/css/properties/scroll-padding-right.json
+++ b/css/properties/scroll-padding-right.json
@@ -23,11 +23,11 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "14.1"
+                "version_added": "16"
               },
               {
                 "version_added": "11",
-                "version_removed": "14.1",
+                "version_removed": "16",
                 "partial_implementation": true,
                 "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
               }

--- a/css/properties/scroll-padding-top.json
+++ b/css/properties/scroll-padding-top.json
@@ -23,11 +23,11 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "14.1"
+                "version_added": "16"
               },
               {
                 "version_added": "11",
-                "version_removed": "14.1",
+                "version_removed": "16",
                 "partial_implementation": true,
                 "notes": "Scroll padding is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/179379'>bug 179379</a>."
               }


### PR DESCRIPTION
#### Summary

Update the version ranges for scroll margin / padding not applying for scrolls to fragment target.

#### Test results and supporting details

Tested manually by @thibaultamartin while working on a site with me.

#### Notes

There seem to be some discrepancies in wording and metadata between the margin and padding properties (padding has `version_removed`, margin doesn't but has the version in the note text). I'm happy to fix that as well if you tell me which version is preferred.