### PR TITLE
CSS scroll-timelines-*

### DIFF
--- a/css/properties/scroll-timeline-axis.json
+++ b/css/properties/scroll-timeline-axis.json
@@ -1,0 +1,47 @@
+{
+  "css": {
+    "properties": {
+      "scroll-timeline-axis": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-timeline-axis",
+          "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#propdef-scroll-timeline-axis",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "103",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.scroll-linked-animations.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/scroll-timeline-name.json
+++ b/css/properties/scroll-timeline-name.json
@@ -1,0 +1,47 @@
+{
+  "css": {
+    "properties": {
+      "scroll-timeline-name": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-timeline-name",
+          "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#scroll-timeline-name",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "103",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.scroll-linked-animations.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/scroll-timeline.json
+++ b/css/properties/scroll-timeline.json
@@ -1,0 +1,47 @@
+{
+  "css": {
+    "properties": {
+      "scroll-timeline": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-timeline",
+          "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#scroll-timeline-shorthand",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "103",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.scroll-linked-animations.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
FF103 adds  the following CSS properties behind a preference in https://bugzilla.mozilla.org/show_bug.cgi?id=1754897:
- scroll-timeline-name
- scroll-timeline-axis
- scroll-timeline (shorthand)

This adds the CSS properties to BCD

Note, normally I wouldn't document these, but they are in the spec, FF is moving fast on them, and Chrome also has this in Canary 107 behind experimental web preferences.

Note, I did not include the Chrome stuff because it is still early days. Tracking but is here though https://bugs.chromium.org/p/chromium/issues/detail?id=1317765

Other docs work for this can be tracked in https://github.com/mdn/content/issues/21069
