### PR TITLE
Update compat data for the mpadded element

### DIFF
--- a/mathml/elements/mpadded.json
+++ b/mathml/elements/mpadded.json
@@ -20,11 +20,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "1",
-              "notes": "<code>&lt;mpadded&gt;</code> within <code>&lt;mtable&gt;</code> is not supported before Firefox 20, see <a href='https://bugzil.la/459363'>bug 459363</a>."
-            },
-            "firefox_android": {
-              "version_added": "4"
+              "version_added": "1"
             },
             "ie": {
               "version_added": false
@@ -35,9 +31,7 @@
             "safari": {
               "version_added": "6"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -47,11 +41,19 @@
             "deprecated": false
           }
         },
-        "height": {
+        "depth": {
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "86",
+                "impl_url": "https://crrev.com/c/2288388",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -66,13 +68,49 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "10",
-                "partial_implementation": true,
-                "notes": "Relative and pseudo-unit values are not supported, see <a href='https://webkit.org/b/85730'>bug 85730</a>."
+                "version_added": "10"
               },
-              "safari_ios": {
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "height": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "86",
+                "impl_url": "https://crrev.com/c/2288388",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
                 "version_added": false
               },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -87,6 +125,48 @@
           "__compat": {
             "support": {
               "chrome": {
+                "version_added": "86",
+                "impl_url": "https://crrev.com/c/2288388",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "named_spaces": {
+          "__compat": {
+            "description": "Named spaces (e.g. <code>thinmathspace</code> to mean 3/18em)",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths",
+            "support": {
+              "chrome": {
                 "version_added": false
               },
               "chrome_android": "mirror",
@@ -102,20 +182,150 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "10",
-                "partial_implementation": true,
-                "notes": "Relative and pseudo-unit values are not supported, see <a href='https://webkit.org/b/85730'>bug 85730</a>."
-              },
-              "safari_ios": {
                 "version_added": false
               },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "nonzero_unitless_values": {
+          "__compat": {
+            "description": "Nonzero unitless values (e.g. 5 to mean 500%)",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "10"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "pseudo_units": {
+          "__compat": {
+            "description": "Pseudo units (e.g. <code>width</code> to mean content width)",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
+        "relative_values": {
+          "__compat": {
+            "description": "Relative values (e.g. <code>\"+10px\"</code>)",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
               "deprecated": false
+            }
+          }
+        },
+        "scale_factor": {
+          "__compat": {
+            "description": "<a href='https://developer.mozilla.org/docs/Web/MathML/Attribute/Values#mathml-specific_types'>&lt;unsigned-number&gt;</a> as a scale factor or percent",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         },
@@ -123,7 +333,15 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "86",
+                "impl_url": "https://crrev.com/c/2288388",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -138,13 +356,9 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "10",
-                "partial_implementation": true,
-                "notes": "Relative and pseudo-unit values are not supported, see <a href='https://webkit.org/b/85730'>bug 85730</a>."
+                "version_added": "10"
               },
-              "safari_ios": {
-                "version_added": false
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -159,7 +373,15 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "86",
+                "impl_url": "https://crrev.com/c/2288388",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -174,13 +396,9 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "10",
-                "partial_implementation": true,
-                "notes": "Relative and pseudo-unit values are not supported, see <a href='https://webkit.org/b/85730'>bug 85730</a>."
+                "version_added": "10"
               },
-              "safari_ios": {
-                "version_added": false
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/mathml/elements/mpadded.json
+++ b/mathml/elements/mpadded.json
@@ -22,6 +22,7 @@
             "firefox": {
               "version_added": "1"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
#### Summary

- State that Chrome and Safari fully supports mpadded attributes as defined in MathML Core and remove old notes for partial implementation.
- Also remove old note about a bug in Firefox too that is not super important.
- Add subfeatures to describe non-standard features from legacy MathML implementations and indicate support for Safari and Firefox (see below).
- Add missing subfeature for the depth attribute.

#### Test results and supporting details

As explained on MDN [1], MathML Core accepts `<length-percentage>` for mpadded attributes but some browsers also support more values. More precisely:

- Chrome parses them as `<length-percentage>` [2]
- WebKit parses them as a legacy MathML length [3] [4]
- Firefox parses them witht the complete legacy syntax [5] [6]

[1] https://developer.mozilla.org/en-US/docs/Web/MathML/Element/mpadded
[2] https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/mathml/mathml_padded_element.cc;l=15;drc=047c7dc4ee1ce908d7fea38ca063fa2f80f92c77
[3] https://searchfox.org/wubkat/rev/e8e9be7353991aee7df45aa62f0e0148f16e6f9f/Source/WebCore/mathml/MathMLPaddedElement.cpp#51
[4] https://developer.mozilla.org/en-US/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths
[5] https://searchfox.org/mozilla-central/rev/d416a7b827c2d76b12848e355a4e03dde49ece25/layout/mathml/nsMathMLmpaddedFrame.cpp#117
[6] https://developer.mozilla.org/en-US/docs/Web/MathML/Element/mpadded#legacy_syntax

#### Related issues

https://github.com/mdn/content/pull/21258