### PR TITLE
Remove support for MathML <ms>'s lquote/rquote in Firefox 107

### DIFF
--- a/mathml/elements/ms.json
+++ b/mathml/elements/ms.json
@@ -52,7 +52,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "107"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
#### Summary

Remove support for MathML `<ms>`'s lquote/rquote in Firefox 107

#### Test results and supporting details

https://bugzilla.mozilla.org/show_bug.cgi?id=1793387#c5
https://groups.google.com/a/mozilla.org/g/dev-platform/c/ZxXQPGN5m2A/m/ggO04WVkFgAJ

#### Related issues

N/A