### PR TITLE
Indicate Safari 15.4 support for implicit rollback sRD subfeature

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -2649,9 +2649,7 @@
               "safari": {
                 "version_added": "15.4"
               },
-              "safari_ios": {
-                "version_added": "15.4"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -2647,10 +2647,10 @@
                 "version_added": "66"
               },
               "safari": {
-                "version_added": "preview"
+                "version_added": "15.4"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "15.4"
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"


### PR DESCRIPTION
#### Summary

Indicate Safari support for implicit rollback on `setRemoteDescription()` (aka WebRTC "perfect negotiation," in the words of the release notes), which was added to Safari 15.4.

#### Test results and supporting details

Safari 15.4 Release notes:
https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes

Tested on MacOS and iOS (Safari 16, admittedly) against @jan-ivar's SRD implicit rollback test: https://jsfiddle.net/jib1/hmgdu1rz/
