### PR TITLE
Add BCD for beforematch_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2354,6 +2354,43 @@
           }
         }
       },
+      "beforematch_event": {
+        "__compat": {
+          "description": "<code>beforematch</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/beforematch_event",
+          "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-beforematch",
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "beforescriptexecute_event": {
         "__compat": {
           "description": "<code>beforescriptexecute</code> event",


### PR DESCRIPTION
This PR adds BCD for the `beforematch` event, which has a corresponding content PR at https://github.com/mdn/content/pull/21494.

I have assumed that compat is the same as for `hidden=until-found`: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden#browser_compatibility since these things really need to go together.
