### PR TITLE
Update spec URLs for “input” and “slotchange” events

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1359,7 +1359,7 @@
           "description": "<code>input</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/input_event",
           "spec_url": [
-            "https://html.spec.whatwg.org/multipage/indices.html#event-input-input",
+            "https://w3c.github.io/uievents/#event-type-input",
             "https://html.spec.whatwg.org/multipage/webappapis.html#handler-oninput"
           ],
           "support": {

--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -174,7 +174,7 @@
           "description": "<code>slotchange</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSlotElement/slotchange_event",
           "spec_url": [
-            "https://html.spec.whatwg.org/multipage/indices.html#event-slotchange",
+            "https://dom.spec.whatwg.org/#eventdef-htmlslotelement-slotchange",
             "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onslotchange"
           ],
           "support": {


### PR DESCRIPTION
https://github.com/whatwg/html/commit/627ee28 (https://github.com/whatwg/html/pull/8351) removed these events from the HTML event index.