### PR TITLE
EventCounts is standardized; add spec/mdn_urls

### DIFF
--- a/api/EventCounts.json
+++ b/api/EventCounts.json
@@ -2,6 +2,8 @@
   "api": {
     "EventCounts": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/EventCounts",
+        "spec_url": "https://w3c.github.io/event-timing/#sec-event-counts",
         "support": {
           "chrome": {
             "version_added": "85"
@@ -27,7 +29,7 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": false,
+          "standard_track": true,
           "deprecated": false
         }
       },
@@ -58,7 +60,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -90,7 +92,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -122,7 +124,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -154,7 +156,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -186,7 +188,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -218,7 +220,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -250,7 +252,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -213,6 +213,7 @@
       },
       "eventCounts": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Performance/eventCounts",
           "spec_url": "https://w3c.github.io/event-timing/#dom-performance-eventcounts",
           "support": {
             "chrome": {


### PR DESCRIPTION
The MDN URLs are 404 right now but filing a content PR soon for these.