### PR TITLE
docs(DOM): Support for meta media added in 106

### DIFF
--- a/api/HTMLMetaElement.json
+++ b/api/HTMLMetaElement.json
@@ -127,7 +127,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "106"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
Fx 106 adds support for the following:

```html
<meta
    name="theme-color"
    media="(prefers-color-scheme: light)"
    content="#4285f4"
/>
```


```js
let meta1 = document.querySelector("meta[name='theme-color']");
// should not return undefined
console.log(meta1.media);
```

https://codepen.io/bsmth/pen/PoeVJgE

__Bugzilla:__
https://bugzilla.mozilla.org/show_bug.cgi?id=1706179

__Parent task:__
- https://github.com/mdn/content/issues/20928
