### PR TITLE
Add missing mdn_urls for PerformanceEventTiming

### DIFF
--- a/api/PerformanceEventTiming.json
+++ b/api/PerformanceEventTiming.json
@@ -69,6 +69,7 @@
       },
       "interactionId": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceEventTiming/interactionId",
           "spec_url": "https://w3c.github.io/event-timing/#dom-performanceeventtiming-interactionid",
           "support": {
             "chrome": {
@@ -204,6 +205,7 @@
       },
       "toJSON": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceEventTiming/toJSON",
           "spec_url": "https://w3c.github.io/event-timing/#dom-performanceeventtiming-tojson",
           "support": {
             "chrome": {


### PR DESCRIPTION
I'm writing these docs. The other mdn_urls in this file are 404 but won't be anymore soon.

I think it really is time to remove 404 mdn_urls. Having a mix of omitting them or pointing to 404 documents (even in the same file!) is far from ideal.