### PR TITLE
Update Safari versions for api.AudioDestinationNode.maxChannelCount

### DIFF
--- a/api/AudioDestinationNode.json
+++ b/api/AudioDestinationNode.json
@@ -59,9 +59,17 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "7"
-            },
+            "safari": [
+              {
+                "version_added": "14.1"
+              },
+              {
+                "version_added": "7",
+                "version_removed": "14.1",
+                "partial_implementation": true,
+                "notes": "This property always returns <code>0</code>."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/api/AudioDestinationNode.json
+++ b/api/AudioDestinationNode.json
@@ -60,7 +60,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `maxChannelCount` member of the `AudioDestinationNode` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.2.6).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AudioDestinationNode/maxChannelCount

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
