### PR TITLE
Update Safari versions for AudioTrack API

### DIFF
--- a/api/AudioTrack.json
+++ b/api/AudioTrack.json
@@ -50,7 +50,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "7"
+            "version_added": "8"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -112,7 +112,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -175,7 +175,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -238,7 +238,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -301,7 +301,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -364,7 +364,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -420,7 +420,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": {
               "version_added": "13",


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `AudioTrack` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.2.6).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/AudioTrack

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
