### PR TITLE
Update Safari versions for EXT_blend_minmax API

### DIFF
--- a/api/EXT_blend_minmax.json
+++ b/api/EXT_blend_minmax.json
@@ -33,7 +33,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "7"
+            "version_added": "9"
           },
           "safari_ios": {
             "version_added": "9"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `EXT_blend_minmax` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.2.6).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/EXT_blend_minmax

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
