### PR TITLE
Add Safari versions for EXT_frag_depth API

### DIFF
--- a/api/EXT_frag_depth.json
+++ b/api/EXT_frag_depth.json
@@ -26,7 +26,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "7"
+            "version_added": "9"
           },
           "safari_ios": {
             "version_added": "15"


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `EXT_frag_depth` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.2.6).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/EXT_frag_depth

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
