### PR TITLE
Update Safari versions for EXT_sRGB API

### DIFF
--- a/api/EXT_sRGB.json
+++ b/api/EXT_sRGB.json
@@ -33,7 +33,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "7"
+            "version_added": "9"
           },
           "safari_ios": {
             "version_added": "9"


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `EXT_sRGB` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.2.6).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/EXT_sRGB

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
