### PR TITLE
Update Safari versions for EXT_texture_filter_anisotropic API

### DIFF
--- a/api/EXT_texture_filter_anisotropic.json
+++ b/api/EXT_texture_filter_anisotropic.json
@@ -35,7 +35,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "7"
+            "version_added": "9.1"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": [


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `EXT_texture_filter_anisotropic` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.2.6).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/EXT_texture_filter_anisotropic

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
