### PR TITLE
Update Safari versions for File API

### DIFF
--- a/api/File.json
+++ b/api/File.json
@@ -212,7 +212,7 @@
               "version_added": "≤14"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -257,7 +257,7 @@
               "version_added": "≤14"
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `File` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.2.6).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/File

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
