### PR TITLE
Update Safari versions for MutationRecord API

### DIFF
--- a/api/MutationRecord.json
+++ b/api/MutationRecord.json
@@ -58,7 +58,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -94,7 +94,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -130,7 +130,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -166,7 +166,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -202,7 +202,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -238,7 +238,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -274,7 +274,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -310,7 +310,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -346,7 +346,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "8"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `MutationRecord` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.2.6).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/MutationRecord

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
