### PR TITLE
Update Safari versions for api.Navigator.registerProtocolHandler

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2413,7 +2413,8 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "5",
+              "version_removed": "5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `registerProtocolHandler` member of the `Navigator` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.2.6).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Navigator/registerProtocolHandler

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
