### PR TITLE
Update Safari versions for OfflineAudioContext API

### DIFF
--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -34,7 +34,7 @@
               "version_added": "14.1"
             },
             {
-              "version_added": "6",
+              "version_added": "7",
               "version_removed": "14.1",
               "prefix": "webkit"
             }
@@ -84,7 +84,7 @@
                 "version_added": "14.1"
               },
               {
-                "version_added": "6",
+                "version_added": "7",
                 "version_removed": "14.1",
                 "prefix": "webkit"
               }

--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -162,7 +162,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -270,7 +270,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `OfflineAudioContext` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.2.6).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/OfflineAudioContext

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
