### PR TITLE
Update Safari versions for api.PerformanceObserver.supportedEntryTypes

### DIFF
--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -212,7 +212,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "12.1"
+              "version_added": "13"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `supportedEntryTypes` member of the `PerformanceObserver` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.2.6).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/PerformanceObserver/supportedEntryTypes

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
