### PR TITLE
RTCRtpEncodingParameters.maxFramerate now part of proper spec

### DIFF
--- a/api/RTCRtpEncodingParameters.json
+++ b/api/RTCRtpEncodingParameters.json
@@ -207,7 +207,7 @@
       "maxFramerate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpEncodingParameters/maxFramerate",
-          "spec_url": "https://w3c.github.io/webrtc-extensions/#dom-rtcrtpencodingparameters-maxframerate",
+          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcrtpencodingparameters-maxframerate",
           "support": {
             "chrome": {
               "version_added": "81"


### PR DESCRIPTION
`RTCRtpEncodingParameters.maxFramerate` as in an extension spec; it just got promoted to being part of the proper spec. See https://github.com/w3c/webrtc-extensions/issues/108

Other implemented features are intended to move too (as they are implemented).