### PR TITLE
Update compatibility for Blob on Node.js

### DIFF
--- a/api/Blob.json
+++ b/api/Blob.json
@@ -24,7 +24,7 @@
           },
           "nodejs": [
             {
-              "version_added": "18.0.0",
+              "version_added": "18.0.0"
             },
             {
               "version_added": "15.7.0",

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -22,14 +22,20 @@
           "ie": {
             "version_added": "10"
           },
-          "nodejs": {
-            "version_added": "15.7.0",
-            "alternative_name": "buffer.Blob",
-            "notes": [
-              "Experimental implementation.",
-              "Must be imported using <code>require('buffer').Blob</code> or <code>import { Blob } from 'buffer'</code>."
-            ]
-          },
+          "nodejs": [
+            {
+              "version_added": "18.0.0",
+            },
+            {
+              "version_added": "15.7.0",
+              "version_removed": "18.0.0",
+              "alternative_name": "buffer.Blob",
+              "notes": [
+                "Experimental implementation.",
+                "Must be imported using <code>require('buffer').Blob</code> or <code>import { Blob } from 'buffer'</code>."
+              ]
+            }
+          ],
           "oculus": "mirror",
           "opera": {
             "version_added": "11"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

In Node.js 18, Blob is now a global.

https://nodejs.org/api/globals.html#class-blob
https://github.com/nodejs/node/pull/41270
