### PR TITLE
FF107 SVGSVGElement.useCurrentView - removed

### DIFF
--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -1543,7 +1543,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "15",
-              "notes": "See <a href='https://bugzil.la/1174097'>bug 1174097</a>."
+              "version_removed": "107"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF107 removes the non-standard deprecated `SVGSVGElement.useCurrentView` in https://bugzilla.mozilla.org/show_bug.cgi?id=1174097

This marks the change. NOthing supports it now, so on track for eventual removal from data and docs.

Other docs work for release can be tracked in https://github.com/mdn/content/issues/21539