### PR TITLE
Opera Android 72 is released

### DIFF
--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -7,13 +7,6 @@
       "accepts_flags": false,
       "accepts_webextensions": false,
       "releases": {
-        "10.1": {
-          "release_date": "2010-11-09",
-          "release_notes": "https://dev.opera.com/blog/opera-mobile-10-1-beta-for-android-is-here/",
-          "status": "retired",
-          "engine": "Presto",
-          "engine_version": "2.5"
-        },
         "11": {
           "release_date": "2011-03-22",
           "release_notes": "https://dev.opera.com/blog/opera-mobile-11-for-maemo-meego-windows/",
@@ -21,32 +14,12 @@
           "engine": "Presto",
           "engine_version": "2.7"
         },
-        "11.1": {
-          "release_date": "2011-06-30",
-          "release_notes": "https://dev.opera.com/blog/opera-mobile-11-1-new-features-and-additions/",
-          "status": "retired",
-          "engine": "Presto",
-          "engine_version": "2.8"
-        },
-        "11.5": {
-          "release_date": "2011-10-12",
-          "status": "retired",
-          "engine": "Presto",
-          "engine_version": "2.9"
-        },
         "12": {
           "release_date": "2012-02-25",
           "release_notes": "https://dev.opera.com/blog/opera-mobile-12-and-introducing-opera-mini-next/",
           "status": "retired",
           "engine": "Presto",
           "engine_version": "2.10"
-        },
-        "12.1": {
-          "release_date": "2012-10-09",
-          "release_notes": "https://dev.opera.com/blog/opera-mobile-12-1-with-spdy-web-sockets-flexbox-and-more/",
-          "status": "retired",
-          "engine": "Presto",
-          "engine_version": "2.11"
         },
         "14": {
           "release_date": "2013-05-21",
@@ -400,9 +373,43 @@
         "71": {
           "release_date": "2022-09-16",
           "release_notes": "https://blogs.opera.com/mobile/2022/09/version-71-opera-for-android/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "104"
+        },
+        "72": {
+          "release_date": "2022-10-21",
+          "release_notes": "https://blogs.opera.com/mobile/2022/10/ofa-72/",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "106"
+        },
+        "10.1": {
+          "release_date": "2010-11-09",
+          "release_notes": "https://dev.opera.com/blog/opera-mobile-10-1-beta-for-android-is-here/",
+          "status": "retired",
+          "engine": "Presto",
+          "engine_version": "2.5"
+        },
+        "11.1": {
+          "release_date": "2011-06-30",
+          "release_notes": "https://dev.opera.com/blog/opera-mobile-11-1-new-features-and-additions/",
+          "status": "retired",
+          "engine": "Presto",
+          "engine_version": "2.8"
+        },
+        "11.5": {
+          "release_date": "2011-10-12",
+          "status": "retired",
+          "engine": "Presto",
+          "engine_version": "2.9"
+        },
+        "12.1": {
+          "release_date": "2012-10-09",
+          "release_notes": "https://dev.opera.com/blog/opera-mobile-12-1-with-spdy-web-sockets-flexbox-and-more/",
+          "status": "retired",
+          "engine": "Presto",
+          "engine_version": "2.11"
         }
       }
     }


### PR DESCRIPTION
This PR updates the Opera Android browser data to reflect that Opera Android 72 is now released.
