### PR TITLE
FF101 CSS scroll() function on animation_timeline

### DIFF
--- a/css/properties/animation-timeline.json
+++ b/css/properties/animation-timeline.json
@@ -54,7 +54,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "101",
-                "notes": "Zero scroll range is treated as 100% but should be 0% (see <a href='https://github.com/w3c/csswg-drafts/issues/7401'>csswg-drafts#7401</a>).",
+                "notes": "Zero scroll range is treated as 100% but should be 0% (see <a href='https://bugzil.la/1780865'>bug 1780865</a>).",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/animation-timeline.json
+++ b/css/properties/animation-timeline.json
@@ -40,6 +40,48 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "scroll": {
+          "__compat": {
+            "description": "<code>scroll()</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-timeline/scroll",
+            "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#funcdef-scroll",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "101",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-linked-animations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/animation-timeline.json
+++ b/css/properties/animation-timeline.json
@@ -54,6 +54,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "101",
+                "notes": "Zero scroll range is treated as 100% but should be 0% (see <a href='https://github.com/w3c/csswg-drafts/issues/7401'>csswg-drafts#7401</a>).",
                 "flags": [
                   {
                     "type": "preference",


### PR DESCRIPTION
FF101 added support for the `scroll()` CSS functional notation in https://bugzilla.mozilla.org/show_bug.cgi?id=1737918 behind a preference.

I haven't added data for one of these before, but the `scroll()` appears to only be applicable on an `animation-timeline` as an option, so I have added it there. I would have made the "key" into `scroll()` but the linter wouldn't let me, so I followed the pattern of `font-variant-alternates` and used the description to clarify it as a function - that OK?

Other docs work for this can be tracked in https://github.com/mdn/content/issues/15467

FYI @queengooborg 


