### PR TITLE
EXT_float_blend removed in Safari IOS 16

### DIFF
--- a/api/EXT_float_blend.json
+++ b/api/EXT_float_blend.json
@@ -31,7 +31,8 @@
             "version_added": "14.1"
           },
           "safari_ios": {
-            "version_added": "15"
+            "version_added": "15",
+            "version_removed": "16"
           },
           "samsunginternet_android": {
             "version_added": "11.0"


### PR DESCRIPTION
Fixes #18061