### PR TITLE
Add FileSystemSyncAccessHandle data

### DIFF
--- a/api/FileSystemFileHandle.json
+++ b/api/FileSystemFileHandle.json
@@ -37,6 +37,46 @@
           "deprecated": false
         }
       },
+      "createSyncAccessHandle": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemFileHandle/createSyncAccessHandle",
+          "spec_url": "https://fs.spec.whatwg.org/#api-filesystemfilehandle-createsyncaccesshandle",
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.2"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "createWritable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemFileHandle/createWritable",
@@ -100,7 +140,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "15.2"
+              "version_added": "15.5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/FileSystemSyncAccessHandle.json
+++ b/api/FileSystemSyncAccessHandle.json
@@ -1,0 +1,466 @@
+{
+  "api": {
+    "FileSystemSyncAccessHandle": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemSyncAccessHandle",
+        "spec_url": "https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle",
+        "support": {
+          "chrome": {
+            "version_added": "102"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
+          "safari": {
+            "version_added": "15.2"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "close": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemSyncAccessHandle/close",
+          "spec_url": "https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-close",
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.2"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "sync_version": {
+          "__compat": {
+            "description": "Synchronous implementation of the <code>close()</code> method",
+            "support": {
+              "chrome": {
+                "version_added": "108",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Sync Access Handle All Sync Surface",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "flush": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemSyncAccessHandle/flush",
+          "spec_url": "https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-flush",
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.2"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "sync_version": {
+          "__compat": {
+            "description": "Synchronous implementation of the <code>flush()</code> method",
+            "support": {
+              "chrome": {
+                "version_added": "108",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Sync Access Handle All Sync Surface",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "getSize": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemSyncAccessHandle/getSize",
+          "spec_url": "https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-getsize",
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.2"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "sync_version": {
+          "__compat": {
+            "description": "Synchronous implementation of the <code>getSize()</code> method",
+            "support": {
+              "chrome": {
+                "version_added": "108",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Sync Access Handle All Sync Surface",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "read": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemSyncAccessHandle/read",
+          "spec_url": "https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-read",
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.2"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "truncate": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemSyncAccessHandle/truncate",
+          "spec_url": "https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-truncate",
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.2"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "sync_version": {
+          "__compat": {
+            "description": "Synchronous implementation of the <code>truncate()</code> method",
+            "support": {
+              "chrome": {
+                "version_added": "108",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Sync Access Handle All Sync Surface",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "write": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemSyncAccessHandle/write",
+          "spec_url": "https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-write",
+          "support": {
+            "chrome": {
+              "version_added": "102"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": "15.2"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

This PR adds BCD for:

* FileSystemFileHandle ([already exists](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileHandle))
   * Add createSyncAccessHandle()
* FileSystemSyncAccessHandle
   * read()
   * write()
   * truncate()
   * getSize()
   * flush()
   * close()

In the current spec, `close()`, `flush()`, `getSize()`, and `truncate()` are specified as asynchronous — they return promises. Chrome 108 has introduced new synchronous versions of these methods, behind a flag.

Specs:

* https://fs.spec.whatwg.org/#api-filesystemfilehandle
* https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

Tested in Safari and Chrome with these samples:

* Async demo: https://glitch.com/edit/#!/reliable-ballistic-process?path=index.html%3A10%3A14
* Sync demo: https://glitch.com/edit/#!/scintillating-internal-crowd?path=index.html%3A10%3A13

The Gecko source code contains WebIDL for these features, preffed off by default (see https://searchfox.org/mozilla-central/source/dom/webidl/FileSystemSyncAccessHandle.webidl). I enabled the pref and tried my demos in Firefox, but they didn't work (failed silently), and I'm not sure why. So I've just left Fx support as `false` for now. 

Other supporting pages and evidence:

* Safari blog post detailing support: https://webkit.org/blog/12257/the-file-system-access-api-with-origin-private-file-system/
* Chrome Status for the original feature addition: https://chromestatus.com/feature/5702777582911488
* Chrome status for adding the experimental sync methods: https://chromestatus.com/feature/5149644305203200

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixes #18065 

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
