### PR TITLE
CSP: Set SecurityPolicyViolationEvent not deprecated

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -8105,7 +8105,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -485,7 +485,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": true
+            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
Fixes: https://github.com/mdn/browser-compat-data/issues/15280

### Summary

In BCD the event is not marked deprecated in it's json file and in Document, but it's been marked deprecated in Element and WorkerGlobalScope json.

### Test results and supporting details

- https://w3c.github.io/webappsec-csp/#violation-events
- https://github.com/mdn/browser-compat-data/issues/15280#issuecomment-1289033786