### PR TITLE
Update grid animation support

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -55,7 +55,7 @@
             "description": "Animation of tracks",
             "support": {
               "chrome": {
-                "version_added": "106"
+                "version_added": "107"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -55,7 +55,7 @@
             "description": "Animation of tracks",
             "support": {
               "chrome": {
-                "version_added": "106"
+                "version_added": "107"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
Support for interpolating `grid-template-rows` and `grid-template-columns` slipped the Chrome 106 release due to a late discovered bug. The feature got included in Chrome 107.

Also see:
- Bug Report: https://bugs.chromium.org/p/chromium/issues/detail?id=1356060
- Announcement post: https://web.dev/css-animated-grid-layouts/
