### PR TITLE
Firefox supports PerfMark/Measure.detail & PerfMark ctor

### DIFF
--- a/api/PerformanceMark.json
+++ b/api/PerformanceMark.json
@@ -46,6 +46,7 @@
       "PerformanceMark": {
         "__compat": {
           "description": "<code>PerformanceMark()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceMark/PerformanceMark",
           "spec_url": "https://w3c.github.io/user-timing/#dom-performancemark-constructor",
           "support": {
             "chrome": {
@@ -57,7 +58,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "101"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -87,6 +88,7 @@
       },
       "detail": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceMark/detail",
           "spec_url": "https://w3c.github.io/user-timing/#dom-performancemark-detail",
           "support": {
             "chrome": {
@@ -98,7 +100,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "101"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/PerformanceMeasure.json
+++ b/api/PerformanceMeasure.json
@@ -47,6 +47,7 @@
       },
       "detail": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceMeasure/detail",
           "spec_url": "https://w3c.github.io/user-timing/#dom-performancemeasure-detail",
           "support": {
             "chrome": {
@@ -58,7 +59,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "103"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
#### Summary

Firefox 101 supports the PerformanceMark constructor and PerformanceMark.detail:
https://bugzilla.mozilla.org/show_bug.cgi?id=1724645

Firefox 103 supports PerformanceMeasure.detail:
https://bugzilla.mozilla.org/show_bug.cgi?id=1762482

#### Related issues

Content PRs:
https://github.com/mdn/content/pull/21823
https://github.com/mdn/content/pull/21821