### PR TITLE
Fix Safari support for `at` in `radial-gradient`

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -734,7 +734,7 @@
                     }
                   ],
                   "safari": {
-                    "version_added": false
+                    "version_added": "7"
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
@@ -1264,7 +1264,7 @@
                     }
                   ],
                   "safari": {
-                    "version_added": false
+                    "version_added": "7"
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",


### PR DESCRIPTION
It supported it from the moment `radial-gradient` was unprefixed, not sure why it was marked as not supported. In fact, the relevant examples on the MDN page with `at` work fine in Safari.

This is the bug where support was added: https://bugs.webkit.org/show_bug.cgi?id=67166