### PR TITLE
FF106 - i18n.detectLanguage supported on Android

### DIFF
--- a/webextensions/api/i18n.json
+++ b/webextensions/api/i18n.json
@@ -38,7 +38,7 @@
                 "version_added": "47"
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "106"
               },
               "opera": "mirror",
               "safari": {


### PR DESCRIPTION
FF106 fixes a long standing bug that `i18n.detectLanguage` existed on Android but always returned an error in https://bugzilla.mozilla.org/show_bug.cgi?id=1712214#c5

As per that bug, effectively Android support for this exists from FF106 and not 48 as indicated by the data.