### PR TITLE
FF99 CSS scroll-snap-type bug in macOS fixed

### DIFF
--- a/css/properties/scroll-snap-type.json
+++ b/css/properties/scroll-snap-type.json
@@ -23,13 +23,18 @@
             ],
             "firefox": [
               {
-                "version_added": "68",
-                "notes": "On macOS 12, scroll snapping does not complete reliably. See <a href='https://bugzil.la/1749352'>bug 1749352</a>"
+                "version_added": "99"
               },
               {
                 "version_added": "39",
                 "version_removed": "68",
                 "notes": "An earlier draft of CSS Scroll Snap without axis values."
+              },
+              {
+                "version_added": "68",
+                "version_removed": "99",
+                "partial_implementation": true,
+                "notes": "On macOS 12, scroll snapping does not complete reliably. See <a href='https://bugzil.la/1749352'>bug 1749352</a>"
               }
             ],
             "firefox_android": [


### PR DESCRIPTION
FF99 fixes a macOS bug in https://bugzilla.mozilla.org/show_bug.cgi?id=1749352

I marked the previous release as partial and removed, and added the new release at 99.

FYI @queengooborg 