### PR TITLE
Update PerformanceResourceTiming»renderBlockingStatus spec URL

### DIFF
--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -483,7 +483,7 @@
       "renderBlockingStatus": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/renderBlockingStatus",
-          "spec_url": "https://www.w3.org/TR/resource-timing/#dom-performanceresourcetiming-renderblockingstatus",
+          "spec_url": "https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-renderblockingstatus",
           "support": {
             "chrome": {
               "version_added": "107"


### PR DESCRIPTION
This should use the w3c.github.io URL rather than www.w3.org/TR