### PR TITLE
Remove percentage subfeature from word-spacing property

### DIFF
--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -38,6 +38,39 @@
             "deprecated": false
           }
         },
+        "percentages": {
+          "__compat": {
+            "description": "<code>&lt;percentage&gt;</code> values",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
         "svg": {
           "__compat": {
             "description": "SVG support",

--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -38,39 +38,6 @@
             "deprecated": false
           }
         },
-        "percentages": {
-          "__compat": {
-            "description": "<code>&lt;percentage&gt;</code> values",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "45"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "7"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "svg": {
           "__compat": {
             "description": "SVG support",


### PR DESCRIPTION
I'm not 100% sure about this but I think it is probably the right thing to do.

BCD currently has a subfeature for [`word-spacing`](https://developer.mozilla.org/en-US/docs/Web/CSS/word-spacing) taking a percentage. The subfeature has only Firefox supporting it. All that is still true.

However in 2019 percentages were removed as a value for this property (https://www.w3.org/TR/2019/WD-css-text-3-20191113/#changes-2018-12-06), see also https://github.com/mdn/content/pull/21861. 

So it seemed better to remove the subfeature, since it's no longer specced behavior. We could I suppose add a note to the main feature, like "Firefox also supports percentage values", but I wasn't sure it is worth it.

