### PR TITLE
Set Opera to mirror for Content-Security-Policy headers

### DIFF
--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -81,12 +81,8 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "10"
               },
@@ -122,9 +118,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "10"
               },
@@ -161,9 +155,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": null
               },
@@ -201,9 +193,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "10"
               },
@@ -246,9 +236,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "7"
               },
@@ -286,9 +274,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "7"
               },
@@ -326,9 +312,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "7"
               },
@@ -366,9 +350,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "10"
               },
@@ -414,9 +396,7 @@
               "opera": {
                 "version_added": "26"
               },
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "10"
               },
@@ -424,9 +404,7 @@
                 "version_added": "9.3"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": null
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -458,9 +436,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "7"
               },
@@ -498,9 +474,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "7"
               },
@@ -536,9 +510,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": false
               },
@@ -576,9 +548,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "7"
               },
@@ -651,9 +621,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "7"
               },
@@ -693,9 +661,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "10"
               },
@@ -768,14 +734,8 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": true,
-                "version_removed": "43"
-              },
-              "opera_android": {
-                "version_added": true,
-                "version_removed": "43"
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": false
               },
@@ -842,12 +802,8 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": false
               },
@@ -885,9 +841,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "7"
               },
@@ -992,9 +946,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "7"
               },
@@ -1032,9 +984,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "7"
               },
@@ -1067,12 +1017,8 @@
                   "version_added": false
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
+                "opera": "mirror",
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": null
                 },
@@ -1104,12 +1050,8 @@
                   "version_added": false
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": null
-                },
-                "opera_android": {
-                  "version_added": null
-                },
+                "opera": "mirror",
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": "16"
                 },
@@ -1156,9 +1098,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "preview"
               },
@@ -1206,9 +1146,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "preview"
               },
@@ -1283,9 +1221,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "7"
               },
@@ -1331,9 +1267,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "preview"
               },
@@ -1381,9 +1315,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "preview"
               },
@@ -1527,12 +1459,8 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": "48"
-              },
-              "opera_android": {
-                "version_added": "45"
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "15.5"
               },


### PR DESCRIPTION
This is a follow-up to #17947.  In that PR, Opera couldn't be set to mirror for a subfeature due to it being set to `null` in the parent feature.  This PR sets all such statements to mirror from Chrome.
