### PR TITLE
Updating data for api.NavigateEvent

### DIFF
--- a/api/NavigateEvent.json
+++ b/api/NavigateEvent.json
@@ -70,12 +70,12 @@
           }
         }
       },
-      "canTransition": {
+      "canIntercept": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigateevent-cantransition",
+          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigateevent-canintercept",
           "support": {
             "chrome": {
-              "version_added": "102"
+              "version_added": "105"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -102,6 +102,41 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        }
+      },
+      "canTransition": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "102",
+              "version_removed": "108"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -352,10 +387,10 @@
       },
       "restoreScroll": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigateevent-restorescroll",
           "support": {
             "chrome": {
-              "version_added": "102"
+              "version_added": "102",
+              "version_removed": "108"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -380,7 +415,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -457,10 +492,10 @@
       },
       "transitionWhile": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigateevent-transitionwhile",
           "support": {
             "chrome": {
-              "version_added": "102"
+              "version_added": "102",
+              "version_removed": "108"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -485,7 +520,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

The `NavigateEvent` interface has been updated in the spec, and Chrome. The changes are as follows:

* canIntercept - see https://chromestatus.com/feature/5194055716700160.  Added in Chrome 105
* restoreScroll() - See https://chromestatus.com/feature/5029730789621760. replaced with scroll() in Chrome and spec. Needs deprecating/not standards track, removed in Chrome 108.
* transitionWhile() - see https://chromestatus.com/feature/5169970311856128 and https://chromestatus.com/feature/5194055716700160. replaced with intercept() in Chrome and spec. Needs deprecating/not standards track, removed in Chrome 108.
* canTransition - see above bugs for details. Needs deprecating/not standards track, removed in Chrome 108

#### Test results and supporting details

I have looked at the spec (https://wicg.github.io/navigation-api/#navigate-event-class), and confirmed the changes described above. I also looked through the Chrome source code and ran some demos, and confirmed the situation in the browser.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
