### PR TITLE
Chrome does not support FontFace#variationSettings

### DIFF
--- a/api/FontFace.json
+++ b/api/FontFace.json
@@ -572,7 +572,7 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-font-loading/#dom-fontfacedescriptors-variationsettings",
           "support": {
             "chrome": {
-              "version_added": "62"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -594,7 +594,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

#10955 somehow marked it as supported since 62, but no proof is there.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Per https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/css/font_face.idl;drc=9ae59b83308c7fe67d693a6c6271dfd459fd51d8.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
Fixes #18106