### PR TITLE
Add Safari 16.1

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -13,24 +13,6 @@
           "engine": "WebKit",
           "engine_version": "85"
         },
-        "1.1": {
-          "release_date": "2003-10-24",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "100"
-        },
-        "1.2": {
-          "release_date": "2004-02-02",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "125"
-        },
-        "1.3": {
-          "release_date": "2005-04-15",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "312"
-        },
         "2": {
           "release_date": "2005-04-29",
           "status": "retired",
@@ -42,12 +24,6 @@
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "523.10"
-        },
-        "3.1": {
-          "release_date": "2008-03-18",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "525.13"
         },
         "4": {
           "release_date": "2009-06-08",
@@ -61,12 +37,6 @@
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "533.16"
-        },
-        "5.1": {
-          "release_date": "2011-07-20",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "534.48"
         },
         "6": {
           "release_date": "2012-07-25",
@@ -96,26 +66,12 @@
           "engine": "WebKit",
           "engine_version": "601.1.56"
         },
-        "9.1": {
-          "release_date": "2016-03-21",
-          "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_9_1.html",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "601.5.17"
-        },
         "10": {
           "release_date": "2016-09-20",
           "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_10_0.html",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "602.1.50"
-        },
-        "10.1": {
-          "release_date": "2017-03-27",
-          "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_10_1.html",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "603.2.1"
         },
         "11": {
           "release_date": "2017-09-19",
@@ -124,26 +80,12 @@
           "engine": "WebKit",
           "engine_version": "604.2.4"
         },
-        "11.1": {
-          "release_date": "2018-04-12",
-          "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_11_1.html",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "605.1.33"
-        },
         "12": {
           "release_date": "2018-09-24",
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_release_notes",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "606.1.36"
-        },
-        "12.1": {
-          "release_date": "2019-03-25",
-          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_1_release_notes",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "607.1.40"
         },
         "13": {
           "release_date": "2019-09-19",
@@ -152,13 +94,6 @@
           "engine": "WebKit",
           "engine_version": "608.2.11"
         },
-        "13.1": {
-          "release_date": "2020-03-24",
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-13_1-release_notes",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "609.1.20"
-        },
         "14": {
           "release_date": "2020-09-16",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-release-notes",
@@ -166,19 +101,91 @@
           "engine": "WebKit",
           "engine_version": "610.1.28"
         },
-        "14.1": {
-          "release_date": "2021-04-26",
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "611.1.21"
-        },
         "15": {
           "release_date": "2021-09-20",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "612.1.29"
+        },
+        "16": {
+          "release_date": "2022-09-12",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "614.1.25"
+        },
+        "1.1": {
+          "release_date": "2003-10-24",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "100"
+        },
+        "1.2": {
+          "release_date": "2004-02-02",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "125"
+        },
+        "1.3": {
+          "release_date": "2005-04-15",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "312"
+        },
+        "3.1": {
+          "release_date": "2008-03-18",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "525.13"
+        },
+        "5.1": {
+          "release_date": "2011-07-20",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "534.48"
+        },
+        "9.1": {
+          "release_date": "2016-03-21",
+          "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_9_1.html",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "601.5.17"
+        },
+        "10.1": {
+          "release_date": "2017-03-27",
+          "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_10_1.html",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "603.2.1"
+        },
+        "11.1": {
+          "release_date": "2018-04-12",
+          "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_11_1.html",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "605.1.33"
+        },
+        "12.1": {
+          "release_date": "2019-03-25",
+          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_1_release_notes",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "607.1.40"
+        },
+        "13.1": {
+          "release_date": "2020-03-24",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-13_1-release_notes",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "609.1.20"
+        },
+        "14.1": {
+          "release_date": "2021-04-26",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "611.1.21"
         },
         "15.1": {
           "release_date": "2021-10-25",
@@ -220,12 +227,12 @@
           "engine": "WebKit",
           "engine_version": "613.3.9"
         },
-        "16": {
-          "release_date": "2022-09-12",
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes",
+        "16.1": {
+          "release_date": "2022-10-24",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_1-release-notes",
           "status": "current",
           "engine": "WebKit",
-          "engine_version": "614.1.25"
+          "engine_version": "614.2.9"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -25,23 +25,11 @@
           "engine_version": "528.18",
           "release_date": "2009-06-17"
         },
-        "3.2": {
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "531.21",
-          "release_date": "2010-04-03"
-        },
         "4": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "532.9",
           "release_date": "2010-06-21"
-        },
-        "4.2": {
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "533.17",
-          "release_date": "2010-11-22"
         },
         "5": {
           "status": "retired",
@@ -73,35 +61,17 @@
           "engine_version": "601.1.56",
           "release_date": "2015-09-16"
         },
-        "9.3": {
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "601.5.17",
-          "release_date": "2016-03-21"
-        },
         "10": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "602.1.50",
           "release_date": "2016-09-13"
         },
-        "10.3": {
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "603.2.1",
-          "release_date": "2017-03-27"
-        },
         "11": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "604.2.4",
           "release_date": "2017-09-19"
-        },
-        "11.3": {
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "605.1.33",
-          "release_date": "2018-03-29"
         },
         "12": {
           "release_date": "2018-09-17",
@@ -110,26 +80,12 @@
           "engine": "WebKit",
           "engine_version": "606.1.36"
         },
-        "12.2": {
-          "release_date": "2019-03-25",
-          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_1_release_notes",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "607.1.40"
-        },
         "13": {
           "release_date": "2019-09-19",
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_release_notes",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "608.2.11"
-        },
-        "13.4": {
-          "release_date": "2020-03-24",
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-13_1-release_notes",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "609.1.20"
         },
         "14": {
           "release_date": "2020-09-16",
@@ -138,19 +94,70 @@
           "engine": "WebKit",
           "engine_version": "610.1.28"
         },
-        "14.5": {
-          "release_date": "2021-04-26",
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "611.1.21"
-        },
         "15": {
           "release_date": "2021-09-20",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "612.1.27"
+        },
+        "16": {
+          "release_date": "2022-09-12",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "614.1.25"
+        },
+        "3.2": {
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "531.21",
+          "release_date": "2010-04-03"
+        },
+        "4.2": {
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "533.17",
+          "release_date": "2010-11-22"
+        },
+        "9.3": {
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "601.5.17",
+          "release_date": "2016-03-21"
+        },
+        "10.3": {
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "603.2.1",
+          "release_date": "2017-03-27"
+        },
+        "11.3": {
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "605.1.33",
+          "release_date": "2018-03-29"
+        },
+        "12.2": {
+          "release_date": "2019-03-25",
+          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_1_release_notes",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "607.1.40"
+        },
+        "13.4": {
+          "release_date": "2020-03-24",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-13_1-release_notes",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "609.1.20"
+        },
+        "14.5": {
+          "release_date": "2021-04-26",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "611.1.21"
         },
         "15.1": {
           "release_date": "2021-10-25",
@@ -192,12 +199,12 @@
           "engine": "WebKit",
           "engine_version": "613.3.9"
         },
-        "16": {
-          "release_date": "2022-09-12",
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes",
+        "16.1": {
+          "release_date": "2022-10-24",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_1-release-notes",
           "status": "current",
           "engine": "WebKit",
-          "engine_version": "614.1.25"
+          "engine_version": "614.2.9"
         }
       }
     }


### PR DESCRIPTION
This PR adds Safari 16.1 to BCD.  The release date comes from the date macOS Ventura was released, and the engine version comes from a local copy of Safari 16.1.
