### PR TITLE
Update CSS <length> viewport units in Chrome 108

### DIFF
--- a/css/types/length.json
+++ b/css/types/length.json
@@ -340,7 +340,7 @@
             "description": "<code>vb</code> unit",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "108"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -411,7 +411,7 @@
             "description": "<code>vi</code> unit",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "108"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -444,7 +444,7 @@
             "description": "<code>dvb</code>, <code>dvh</code>, <code>dvi</code>, <code>dvmax</code>, <code>dvmin</code>, <code>dvw</code> units",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "108"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -477,7 +477,7 @@
             "description": "<code>lvb</code>, <code>lvh</code>, <code>lvi</code>, <code>lvmax</code>, <code>lvmin</code>, <code>lvw</code> units",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "108"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -510,7 +510,7 @@
             "description": "<code>svb</code>, <code>svh</code>, <code>svi</code>, <code>svmax</code>, <code>svmin</code>, <code>svw</code> units",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "108"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
Chrome 108 has support sv* units, lv* units, dv* units and the logical vi/vb units.

https://chromestatus.com/feature/5170718078140416