### PR TITLE
Add spec_url for HTMLElement.inputMode

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1411,6 +1411,7 @@
       "inputMode": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/inputMode",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-inputmode",
           "support": {
             "chrome": {
               "version_added": "66"


### PR DESCRIPTION
For https://github.com/mdn/content/issues/22003 I'm adding a page for `HTMLElement.inputMode`. We already have a BCD entry for this property, but it's missing spec URL, so this PR adds one.
