### PR TITLE
FF107 ships CSS contains-intrinsic-* properties

### DIFF
--- a/css/properties/contain-intrinsic-block-size.json
+++ b/css/properties/contain-intrinsic-block-size.json
@@ -12,14 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "104",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.contain-intrinsic-size.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "107"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -36,7 +29,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/contain-intrinsic-height.json
+++ b/css/properties/contain-intrinsic-height.json
@@ -12,14 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "104",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.contain-intrinsic-size.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "107"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -36,7 +29,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/contain-intrinsic-inline-size.json
+++ b/css/properties/contain-intrinsic-inline-size.json
@@ -12,14 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "104",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.contain-intrinsic-size.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "107"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -36,7 +29,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/contain-intrinsic-size.json
+++ b/css/properties/contain-intrinsic-size.json
@@ -12,14 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "104",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.contain-intrinsic-size.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "107"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -36,7 +29,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/contain-intrinsic-width.json
+++ b/css/properties/contain-intrinsic-width.json
@@ -12,14 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "104",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.contain-intrinsic-size.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "107"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -36,7 +29,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
FF107 ships the CSS `contains-intrinsic-*` properties in https://bugzilla.mozilla.org/show_bug.cgi?id=1792886 (these were added in FF104 in #17890).

This changes the release to 107 for the properties, and marks them as no longer experimental.

@queengooborg Given that we now don't keep preference after a feature is released I removed the pref version. Is this the right thing to do? I mean it will be correct in 2 weeks when FF107 releases, but should I instead keep pref version and have a separate entry for FF107?

Other docs work for this tracked in https://github.com/mdn/content/issues/21274