### PR TITLE
Update Chrome compat data for MathMLElement

### DIFF
--- a/api/MathMLElement.json
+++ b/api/MathMLElement.json
@@ -6,8 +6,14 @@
         "spec_url": "https://w3c.github.io/mathml-core/#dom-mathmlelement",
         "support": {
           "chrome": {
-            "version_added": false,
-            "notes": "See <a href='https://crbug.com/6606'>bug 6606</a>."
+            "version_added": "80",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#enable-experimental-web-platform-features",
+                "value_to_set": "Enabled"
+              }
+            ]
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -38,7 +44,14 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "80",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -70,7 +83,14 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "80",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -102,7 +122,14 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "80",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -135,7 +162,14 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/cssom/#dom-elementcssinlinestyle-style",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "80",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -167,7 +201,14 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "80",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
#### Summary

The `MathMLElement` IDL was implemented in Chromium 80 under a flag [1] and is basically including existing IDL for `GlobalEventHandlers`, `DocumentAndElementEventHandlers`, `HTMLOrForeignElement` and `ElementCSSInlineStyle` [2]. This implies that all the subfeatures are also supported [3], [4], [5], [6], [7].

#### Test results and supporting details

[1] https://chromiumdash.appspot.com/commit/e4f3a0881c7a63f5ed0ff9dd68ef04d84a535969
[2] https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/mathml/mathml_element.idl?q=MathMLElement
[3] https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/global_event_handlers.idl?q=onblur
[4] https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/html/html_or_foreign_element.idl?q=dataset
[5] https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/global_event_handlers.idl?q=onfocus
[6] https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/element_css_inline_style.idl?q=style
[7] https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/html/html_or_foreign_element.idl?q=tabIndex


#### Related issues

N/A