### PR TITLE
Update compat data for requiredExtensions

### DIFF
--- a/svg/attributes/conditional_processing.json
+++ b/svg/attributes/conditional_processing.json
@@ -7,12 +7,12 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/requiredExtensions",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "81"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": null
+                "version_added": "2"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -22,7 +22,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": "8"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -32,6 +32,46 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "mathml": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "81",
+                  "impl_url": "https://crrev.com/c/2007454",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "2"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": null
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "8"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         },

--- a/svg/attributes/conditional_processing.json
+++ b/svg/attributes/conditional_processing.json
@@ -36,6 +36,7 @@
           },
           "mathml": {
             "__compat": {
+              "description": "Recognizes MathML namespace",
               "support": {
                 "chrome": {
                   "version_added": "81",


### PR DESCRIPTION
#### Summary

Update compat data for SVG attribute `requiredExtensions`:

- Basic support (i.e. recognize XHTML namespace) was added in Firefox 1.9.1 [1], Safari 8 [2] and Chromium 81 [3].
- MathML support (i.e. recognize MathML namespace) was added in the same browser versions [1] [2] [4], although Chromium's one is still under a flag.

#### Test results and supporting details

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=449746 (Firefox 1.9.1, MathML & XHTML)
[2] https://bugs.webkit.org/show_bug.cgi?id=88188 (Safari 8, MathML & XHTML)
[3] https://chromiumdash.appspot.com/commit/c78acd517835db96c3b50f11d30eb2a77e9910c1 (Chromium 81, XHTML)
[4] https://chromiumdash.appspot.com/commit/719b33b59410a6a4623769c3a93220db03dfa51b (Chromium 81, MathML)

#### Related issues

N/A