### PR TITLE
Update Compat Data for display: math

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -578,6 +578,45 @@
             }
           }
         },
+        "math": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "87",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "multi-keyword_values": {
           "__compat": {
             "description": "Multi-keyword values",


### PR DESCRIPTION
#### Summary

Update Compat Data for display: math
This was implemented in Chrome 87 under the MathML Core flag. [1]

#### Test results and supporting details

[1] https://chromiumdash.appspot.com/commit/6fbfb08fb4af24d97db9956fe8b8639f83866aae

#### Related issues

N/A