### PR TITLE
Update Compat Data for text-transform: math-auto

### DIFF
--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -251,6 +251,46 @@
             }
           }
         },
+        "math-auto": {
+          "__compat": {
+            "spec_url": "https://w3c.github.io/mathml-core/#new-text-transform-values",
+            "support": {
+              "chrome": {
+                "version_added": "84",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "turkic_is": {
           "__compat": {
             "description": "<code>i</code> → <code>İ</code> and <code>ı</code> → <code>I</code>",


### PR DESCRIPTION
#### Summary

Update Compat Data for text-transform: math-auto
This was implemented in Chrome 84 under a flag [1].

#### Test results and supporting details

[1] https://chromiumdash.appspot.com/commit/cf2c907c89530be0c460f513437277be0353e14f

#### Related issues

N/A