### PR TITLE
Add CSS `hyphenate-limit-chars` property

### DIFF
--- a/css/properties/hyphenate-limit-chars.json
+++ b/css/properties/hyphenate-limit-chars.json
@@ -1,0 +1,41 @@
+{
+  "css": {
+    "properties": {
+      "hyphenate-limit-chars": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-text-4/#propdef-hyphenate-limit-chars",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "109"
+              }
+            ],
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/hyphenate-limit-chars.json
+++ b/css/properties/hyphenate-limit-chars.json
@@ -5,11 +5,9 @@
         "__compat": {
           "spec_url": "https://w3c.github.io/csswg-drafts/css-text-4/#propdef-hyphenate-limit-chars",
           "support": {
-            "chrome": [
-              {
-                "version_added": "109"
-              }
-            ],
+            "chrome": {
+              "version_added": "109"
+            },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
Chrome 109 has support the CSS `hyphenate-limit-chars` property.

https://chromestatus.com/feature/5150761588097024
