### PR TITLE
Map preview -> false during mirroring for browsers w/o preview versions

### DIFF
--- a/scripts/release/mirror.ts
+++ b/scripts/release/mirror.ts
@@ -80,7 +80,8 @@ export const getMatchingBrowserVersion = (
   releaseKeys.sort(compareVersions);
 
   if (sourceVersion == 'preview') {
-    return 'preview';
+    // If target browser doesn't have a preview version, map preview -> false
+    return browserData.preview_name ? 'preview' : false;
   }
 
   const range = sourceVersion.includes('≤');


### PR DESCRIPTION
This PR updates the mirroring script to map `"preview"` to `false` when the target browser doesn't have a preview release.  This will unblock #18121.
