### PR TITLE
Add Safari versions for api.FileSystemFileHandle.createWritable

### DIFF
--- a/api/FileSystemFileHandle.json
+++ b/api/FileSystemFileHandle.json
@@ -100,11 +100,9 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "preview"
-            },
-            "safari_ios": {
               "version_added": false
             },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `createWritable` member of the `FileSystemFileHandle` API.  This feature was marked as "preview" almost a year ago but has never been introduced in any official Safari version.  This fixes #18084.
