### PR TITLE
Update Safari versions for GeolocationPositionError API

### DIFF
--- a/api/GeolocationPositionError.json
+++ b/api/GeolocationPositionError.json
@@ -50,10 +50,15 @@
             "alternative_name": "PositionError",
             "version_added": "16"
           },
-          "safari": {
-            "alternative_name": "PositionError",
-            "version_added": "5"
-          },
+          "safari": [
+            {
+              "version_added": "13.1"
+            },
+            {
+              "alternative_name": "PositionError",
+              "version_added": "5"
+            }
+          ],
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": [


### PR DESCRIPTION
This PR updates and corrects the real values for Safari (Desktop and iOS/iPadOS) for the `GeolocationPositionError` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.2.6).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/GeolocationPositionError

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
