### PR TITLE
Chrome supports ReadableStream in request body; update feature name

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -233,12 +233,12 @@
             }
           }
         },
-        "readablestream_request_body": {
+        "request_body_readablestream": {
           "__compat": {
             "description": "Send <code>ReadableStream</code> in request body",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "105"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -271,7 +271,7 @@
         },
         "response_body_readablestream": {
           "__compat": {
-            "description": "Consume response body as a <code>ReadableStream</code>",
+            "description": "Consume <code>ReadableStream</code> as a response body",
             "support": {
               "chrome": {
                 "version_added": "43"


### PR DESCRIPTION
This PR performs three changes:

- Sets Chrome to 105 for ReadableStream support (fixes #17835)
- Changes the feature identifier of `readablestream_request_body` to `request_body_readablestream` to conform to existing conventions
- Updates the description of `response_body_readablestream` to match its sister feature better
