### PR TITLE
Add missing api.Credential.isConditionalMediationAvailable feature

### DIFF
--- a/api/Credential.json
+++ b/api/Credential.json
@@ -71,6 +71,39 @@
           }
         }
       },
+      "isConditionalMediationAvailable": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webappsec-credential-management/#dom-credential-isconditionalmediationavailable",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "type": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Credential/type",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `isConditionalMediationAvailable` member of the Credential API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.2.6).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Credential/isConditionalMediationAvailable

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
