### PR TITLE
Add Edge versions for api.CanvasRenderingContext2D.drawImage.SVGImageElement_source_image

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -788,7 +788,9 @@
                 "version_added": "59"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
                 "version_added": "56"
               },


### PR DESCRIPTION
This PR adds real values for Microsoft Edge for the `drawImage.SVGImageElement_source_image` member of the `CanvasRenderingContext2D` API, based upon commit history and date.

Commit:
