### PR TITLE
Update Edge versions for api.CanvasRenderingContext2D.drawImage.SVGImageElement_source_image

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -788,7 +788,9 @@
                 "version_added": "59"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
                 "version_added": "56"
               },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `drawImage.SVGImageElement_source_image` member of the `CanvasRenderingContext2D` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.2.6).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/CanvasRenderingContext2D/drawImage.SVGImageElement_source_image

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
