### PR TITLE
Update Edge versions for api.Document.pointerLockElement

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5405,7 +5405,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "13"
             },
             "firefox": [
               {


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `pointerLockElement` member of the `Document` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.appspot.com) project (v6.2.6).

Tests Used: https://mdn-bcd-collector.appspot.com/tests/api/Document/pointerLockElement

_Check out the [collector's guide on how to review this PR](https://github.com/foolip/mdn-bcd-collector#reviewing-bcd-changes)._
