### PR TITLE
CSS round - better spec link

### DIFF
--- a/css/types/round.json
+++ b/css/types/round.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>round()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/round",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-values/#exponent-funcs",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-values/#funcdef-round",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
The old spec link takes you to "exponential functions" https://w3c.github.io/csswg-drafts/css-values/#exponent-funcs which is clearly incorrect.

This takes you direct to the round() function