### PR TITLE
Change preview -> false for outdated preview values

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1287,11 +1287,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
-            },
-            "firefox_android": {
               "version_added": false
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/MIDIAccess.json
+++ b/api/MIDIAccess.json
@@ -10,21 +10,16 @@
           },
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": [
-            {
-              "version_added": "preview"
-            },
-            {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "97",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webmidi.enabled",
+                "value_to_set": "true"
+              }
+            ]
+          },
           "firefox_android": {
             "version_added": false
           },
@@ -57,21 +52,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -105,21 +95,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -154,21 +139,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -202,21 +182,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },

--- a/api/MIDIConnectionEvent.json
+++ b/api/MIDIConnectionEvent.json
@@ -10,21 +10,16 @@
           },
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": [
-            {
-              "version_added": "preview"
-            },
-            {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "97",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webmidi.enabled",
+                "value_to_set": "true"
+              }
+            ]
+          },
           "firefox_android": {
             "version_added": false
           },
@@ -58,21 +53,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -106,21 +96,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },

--- a/api/MIDIInput.json
+++ b/api/MIDIInput.json
@@ -10,21 +10,16 @@
           },
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": [
-            {
-              "version_added": "preview"
-            },
-            {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "97",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webmidi.enabled",
+                "value_to_set": "true"
+              }
+            ]
+          },
           "firefox_android": {
             "version_added": false
           },
@@ -58,21 +53,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },

--- a/api/MIDIInputMap.json
+++ b/api/MIDIInputMap.json
@@ -10,21 +10,16 @@
           },
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": [
-            {
-              "version_added": "preview"
-            },
-            {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "97",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webmidi.enabled",
+                "value_to_set": "true"
+              }
+            ]
+          },
           "firefox_android": {
             "version_added": false
           },
@@ -55,21 +50,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -101,21 +91,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -147,21 +132,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -193,21 +173,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -239,21 +214,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -285,21 +255,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -331,21 +296,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },

--- a/api/MIDIMessageEvent.json
+++ b/api/MIDIMessageEvent.json
@@ -10,21 +10,16 @@
           },
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": [
-            {
-              "version_added": "preview"
-            },
-            {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "97",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webmidi.enabled",
+                "value_to_set": "true"
+              }
+            ]
+          },
           "firefox_android": {
             "version_added": false
           },
@@ -60,21 +55,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -110,21 +100,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },

--- a/api/MIDIOutput.json
+++ b/api/MIDIOutput.json
@@ -10,21 +10,16 @@
           },
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": [
-            {
-              "version_added": "preview"
-            },
-            {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "97",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webmidi.enabled",
+                "value_to_set": "true"
+              }
+            ]
+          },
           "firefox_android": {
             "version_added": false
           },
@@ -60,21 +55,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -108,21 +98,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },

--- a/api/MIDIOutputMap.json
+++ b/api/MIDIOutputMap.json
@@ -10,21 +10,16 @@
           },
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": [
-            {
-              "version_added": "preview"
-            },
-            {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "97",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webmidi.enabled",
+                "value_to_set": "true"
+              }
+            ]
+          },
           "firefox_android": {
             "version_added": false
           },
@@ -55,21 +50,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -101,21 +91,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -147,21 +132,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -193,21 +173,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -239,21 +214,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -285,21 +255,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -331,21 +296,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },

--- a/api/MIDIPort.json
+++ b/api/MIDIPort.json
@@ -10,21 +10,16 @@
           },
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": [
-            {
-              "version_added": "preview"
-            },
-            {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.webmidi.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "97",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.webmidi.enabled",
+                "value_to_set": "true"
+              }
+            ]
+          },
           "firefox_android": {
             "version_added": false
           },
@@ -57,21 +52,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -105,21 +95,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -153,21 +138,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -201,21 +181,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -249,21 +224,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -297,21 +267,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -345,21 +310,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -394,21 +354,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -442,21 +397,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -490,21 +440,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3742,21 +3742,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.webmidi.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "97",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webmidi.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },

--- a/api/RTCError.json
+++ b/api/RTCError.json
@@ -127,11 +127,9 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
-            },
-            "safari_ios": {
               "version_added": false
             },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/Scheduler.json
+++ b/api/Scheduler.json
@@ -10,21 +10,16 @@
           },
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": [
-            {
-              "version_added": "preview"
-            },
-            {
-              "version_added": "101",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.enable_web_task_scheduling",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "101",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.enable_web_task_scheduling",
+                "value_to_set": "true"
+              }
+            ]
+          },
           "firefox_android": {
             "version_added": false
           },
@@ -57,21 +52,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "101",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.enable_web_task_scheduling",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "101",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.enable_web_task_scheduling",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },

--- a/api/TaskController.json
+++ b/api/TaskController.json
@@ -10,21 +10,16 @@
           },
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": [
-            {
-              "version_added": "preview"
-            },
-            {
-              "version_added": "101",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.enable_web_task_scheduling",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "101",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.enable_web_task_scheduling",
+                "value_to_set": "true"
+              }
+            ]
+          },
           "firefox_android": {
             "version_added": false
           },
@@ -58,21 +53,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "101",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.enable_web_task_scheduling",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "101",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.enable_web_task_scheduling",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -106,21 +96,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "101",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.enable_web_task_scheduling",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "101",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.enable_web_task_scheduling",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },

--- a/api/TaskPriorityChangeEvent.json
+++ b/api/TaskPriorityChangeEvent.json
@@ -10,21 +10,16 @@
           },
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": [
-            {
-              "version_added": "preview"
-            },
-            {
-              "version_added": "101",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.enable_web_task_scheduling",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "101",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.enable_web_task_scheduling",
+                "value_to_set": "true"
+              }
+            ]
+          },
           "firefox_android": {
             "version_added": false
           },
@@ -58,21 +53,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "101",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.enable_web_task_scheduling",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "101",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.enable_web_task_scheduling",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -106,21 +96,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "101",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.enable_web_task_scheduling",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "101",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.enable_web_task_scheduling",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },

--- a/api/TaskSignal.json
+++ b/api/TaskSignal.json
@@ -10,21 +10,16 @@
           },
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": [
-            {
-              "version_added": "preview"
-            },
-            {
-              "version_added": "101",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.enable_web_task_scheduling",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "101",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.enable_web_task_scheduling",
+                "value_to_set": "true"
+              }
+            ]
+          },
           "firefox_android": {
             "version_added": false
           },
@@ -57,21 +52,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "101",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.enable_web_task_scheduling",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "101",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.enable_web_task_scheduling",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },
@@ -109,21 +99,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "101",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.enable_web_task_scheduling",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "101",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.enable_web_task_scheduling",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": {
               "version_added": false
             },

--- a/api/_globals/reportError.json
+++ b/api/_globals/reportError.json
@@ -65,11 +65,9 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
-            },
-            "safari_ios": {
               "version_added": false
             },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/_globals/scheduler.json
+++ b/api/_globals/scheduler.json
@@ -10,21 +10,16 @@
           },
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": [
-            {
-              "version_added": "preview"
-            },
-            {
-              "version_added": "101",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.enable_web_task_scheduling",
-                  "value_to_set": "true"
-                }
-              ]
-            }
-          ],
+          "firefox": {
+            "version_added": "101",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.enable_web_task_scheduling",
+                "value_to_set": "true"
+              }
+            ]
+          },
           "firefox_android": {
             "version_added": false
           },

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -161,11 +161,9 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "preview"
-              },
-              "safari_ios": {
                 "version_added": false
               },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/text-indent.json
+++ b/css/properties/text-indent.json
@@ -60,11 +60,9 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
-              },
-              "safari_ios": {
                 "version_added": false
               },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -95,11 +93,9 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
-              },
-              "safari_ios": {
                 "version_added": false
               },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -22,21 +22,12 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "11.1",
-                "partial_implementation": true,
-                "notes": "Safari support is limited to <code>color</code> and <code>font-size</code>. See <a href='https://webkit.org/b/204163'>bug 204163</a>."
-              }
-            ],
-            "safari_ios": {
-              "version_added": "11.3",
+            "safari": {
+              "version_added": "11.1",
               "partial_implementation": true,
               "notes": "Safari support is limited to <code>color</code> and <code>font-size</code>. See <a href='https://webkit.org/b/204163'>bug 204163</a>."
             },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -816,11 +816,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
-            },
-            "firefox_android": {
               "version_added": false
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -1100,11 +1100,9 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
-              },
-              "safari_ios": {
                 "version_added": false
               },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1148,11 +1146,9 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
-              },
-              "safari_ios": {
                 "version_added": false
               },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1269,11 +1265,9 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
-              },
-              "safari_ios": {
                 "version_added": false
               },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1317,11 +1311,9 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
-              },
-              "safari_ios": {
                 "version_added": false
               },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/http/headers/Service-Worker-Navigation-Preload.json
+++ b/http/headers/Service-Worker-Navigation-Preload.json
@@ -29,9 +29,7 @@
                 ]
               }
             ],
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -796,11 +796,9 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
-              },
-              "firefox_android": {
                 "version_added": false
               },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -838,11 +836,9 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
-              },
-              "firefox_android": {
                 "version_added": false
               },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/javascript/builtins/Intl/NumberFormat.json
+++ b/javascript/builtins/Intl/NumberFormat.json
@@ -326,7 +326,7 @@
                   },
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": "preview"
+                    "version_added": false
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -364,7 +364,7 @@
                   },
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": "preview"
+                    "version_added": false
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -402,7 +402,7 @@
                   },
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": "preview"
+                    "version_added": false
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -518,7 +518,7 @@
                   },
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": "preview"
+                    "version_added": false
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -682,7 +682,7 @@
                     },
                     "edge": "mirror",
                     "firefox": {
-                      "version_added": "preview"
+                      "version_added": false
                     },
                     "firefox_android": "mirror",
                     "ie": {
@@ -768,7 +768,7 @@
                   },
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": "preview"
+                    "version_added": false
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -809,7 +809,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -849,7 +849,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -975,7 +975,7 @@
                   },
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": "preview"
+                    "version_added": false
                   },
                   "firefox_android": "mirror",
                   "ie": {

--- a/javascript/builtins/Intl/PluralRules.json
+++ b/javascript/builtins/Intl/PluralRules.json
@@ -194,7 +194,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
I decided to verify all of the features that are set to preview to see if they’re still accurate or if they were left behind.  Turns out, nearly EVERY instance of `version_added: preview` was outdated and simply incorrect.  Most of the ones for Safari were added a year ago and never touched since, and hardly any of the features marked as preview for Firefox were supported in the latest nightly build.

This PR is the result of this verification.  This PR sets all of the invalid `preview` values to `false` for all categories, and then updates derivative browsers to mirror where applicable.  The Temporal JS API was left alone in this PR as I am not yet sure how to test it.
