### PR TITLE
Don't run fix script on browsers JSON files; restore original order

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,5 +1,5 @@
 {
     "*": "prettier --ignore-unknown --write",
     "*.{js,jsx,tsx}": "eslint --fix",
-    "*.json": "npm run lint:fix"
+    "{!browsers/}*.json": "npm run lint:fix"
 }

--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -7,6 +7,13 @@
       "accepts_flags": false,
       "accepts_webextensions": false,
       "releases": {
+        "10.1": {
+          "release_date": "2010-11-09",
+          "release_notes": "https://dev.opera.com/blog/opera-mobile-10-1-beta-for-android-is-here/",
+          "status": "retired",
+          "engine": "Presto",
+          "engine_version": "2.5"
+        },
         "11": {
           "release_date": "2011-03-22",
           "release_notes": "https://dev.opera.com/blog/opera-mobile-11-for-maemo-meego-windows/",
@@ -14,12 +21,32 @@
           "engine": "Presto",
           "engine_version": "2.7"
         },
+        "11.1": {
+          "release_date": "2011-06-30",
+          "release_notes": "https://dev.opera.com/blog/opera-mobile-11-1-new-features-and-additions/",
+          "status": "retired",
+          "engine": "Presto",
+          "engine_version": "2.8"
+        },
+        "11.5": {
+          "release_date": "2011-10-12",
+          "status": "retired",
+          "engine": "Presto",
+          "engine_version": "2.9"
+        },
         "12": {
           "release_date": "2012-02-25",
           "release_notes": "https://dev.opera.com/blog/opera-mobile-12-and-introducing-opera-mini-next/",
           "status": "retired",
           "engine": "Presto",
           "engine_version": "2.10"
+        },
+        "12.1": {
+          "release_date": "2012-10-09",
+          "release_notes": "https://dev.opera.com/blog/opera-mobile-12-1-with-spdy-web-sockets-flexbox-and-more/",
+          "status": "retired",
+          "engine": "Presto",
+          "engine_version": "2.11"
         },
         "14": {
           "release_date": "2013-05-21",
@@ -383,33 +410,6 @@
           "status": "current",
           "engine": "Blink",
           "engine_version": "106"
-        },
-        "10.1": {
-          "release_date": "2010-11-09",
-          "release_notes": "https://dev.opera.com/blog/opera-mobile-10-1-beta-for-android-is-here/",
-          "status": "retired",
-          "engine": "Presto",
-          "engine_version": "2.5"
-        },
-        "11.1": {
-          "release_date": "2011-06-30",
-          "release_notes": "https://dev.opera.com/blog/opera-mobile-11-1-new-features-and-additions/",
-          "status": "retired",
-          "engine": "Presto",
-          "engine_version": "2.8"
-        },
-        "11.5": {
-          "release_date": "2011-10-12",
-          "status": "retired",
-          "engine": "Presto",
-          "engine_version": "2.9"
-        },
-        "12.1": {
-          "release_date": "2012-10-09",
-          "release_notes": "https://dev.opera.com/blog/opera-mobile-12-1-with-spdy-web-sockets-flexbox-and-more/",
-          "status": "retired",
-          "engine": "Presto",
-          "engine_version": "2.11"
         }
       }
     }

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -13,6 +13,24 @@
           "engine": "WebKit",
           "engine_version": "85"
         },
+        "1.1": {
+          "release_date": "2003-10-24",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "100"
+        },
+        "1.2": {
+          "release_date": "2004-02-02",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "125"
+        },
+        "1.3": {
+          "release_date": "2005-04-15",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "312"
+        },
         "2": {
           "release_date": "2005-04-29",
           "status": "retired",
@@ -24,6 +42,12 @@
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "523.10"
+        },
+        "3.1": {
+          "release_date": "2008-03-18",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "525.13"
         },
         "4": {
           "release_date": "2009-06-08",
@@ -37,6 +61,12 @@
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "533.16"
+        },
+        "5.1": {
+          "release_date": "2011-07-20",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "534.48"
         },
         "6": {
           "release_date": "2012-07-25",
@@ -66,91 +96,19 @@
           "engine": "WebKit",
           "engine_version": "601.1.56"
         },
-        "10": {
-          "release_date": "2016-09-20",
-          "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_10_0.html",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "602.1.50"
-        },
-        "11": {
-          "release_date": "2017-09-19",
-          "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Safari_11_0/Safari_11_0.html",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "604.2.4"
-        },
-        "12": {
-          "release_date": "2018-09-24",
-          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_release_notes",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "606.1.36"
-        },
-        "13": {
-          "release_date": "2019-09-19",
-          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_release_notes",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "608.2.11"
-        },
-        "14": {
-          "release_date": "2020-09-16",
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-release-notes",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "610.1.28"
-        },
-        "15": {
-          "release_date": "2021-09-20",
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "612.1.29"
-        },
-        "16": {
-          "release_date": "2022-09-12",
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "614.1.25"
-        },
-        "1.1": {
-          "release_date": "2003-10-24",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "100"
-        },
-        "1.2": {
-          "release_date": "2004-02-02",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "125"
-        },
-        "1.3": {
-          "release_date": "2005-04-15",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "312"
-        },
-        "3.1": {
-          "release_date": "2008-03-18",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "525.13"
-        },
-        "5.1": {
-          "release_date": "2011-07-20",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "534.48"
-        },
         "9.1": {
           "release_date": "2016-03-21",
           "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_9_1.html",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "601.5.17"
+        },
+        "10": {
+          "release_date": "2016-09-20",
+          "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_10_0.html",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "602.1.50"
         },
         "10.1": {
           "release_date": "2017-03-27",
@@ -159,12 +117,26 @@
           "engine": "WebKit",
           "engine_version": "603.2.1"
         },
+        "11": {
+          "release_date": "2017-09-19",
+          "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Safari_11_0/Safari_11_0.html",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "604.2.4"
+        },
         "11.1": {
           "release_date": "2018-04-12",
           "release_notes": "https://developer.apple.com/library/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_11_1.html",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "605.1.33"
+        },
+        "12": {
+          "release_date": "2018-09-24",
+          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_release_notes",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "606.1.36"
         },
         "12.1": {
           "release_date": "2019-03-25",
@@ -173,6 +145,13 @@
           "engine": "WebKit",
           "engine_version": "607.1.40"
         },
+        "13": {
+          "release_date": "2019-09-19",
+          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_release_notes",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "608.2.11"
+        },
         "13.1": {
           "release_date": "2020-03-24",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-13_1-release_notes",
@@ -180,12 +159,26 @@
           "engine": "WebKit",
           "engine_version": "609.1.20"
         },
+        "14": {
+          "release_date": "2020-09-16",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-release-notes",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "610.1.28"
+        },
         "14.1": {
           "release_date": "2021-04-26",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "611.1.21"
+        },
+        "15": {
+          "release_date": "2021-09-20",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "612.1.29"
         },
         "15.1": {
           "release_date": "2021-10-25",
@@ -226,6 +219,13 @@
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "613.3.9"
+        },
+        "16": {
+          "release_date": "2022-09-12",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "614.1.25"
         },
         "16.1": {
           "release_date": "2022-10-24",

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -25,11 +25,23 @@
           "engine_version": "528.18",
           "release_date": "2009-06-17"
         },
+        "3.2": {
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "531.21",
+          "release_date": "2010-04-03"
+        },
         "4": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "532.9",
           "release_date": "2010-06-21"
+        },
+        "4.2": {
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "533.17",
+          "release_date": "2010-11-22"
         },
         "5": {
           "status": "retired",
@@ -61,17 +73,35 @@
           "engine_version": "601.1.56",
           "release_date": "2015-09-16"
         },
+        "9.3": {
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "601.5.17",
+          "release_date": "2016-03-21"
+        },
         "10": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "602.1.50",
           "release_date": "2016-09-13"
         },
+        "10.3": {
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "603.2.1",
+          "release_date": "2017-03-27"
+        },
         "11": {
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "604.2.4",
           "release_date": "2017-09-19"
+        },
+        "11.3": {
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "605.1.33",
+          "release_date": "2018-03-29"
         },
         "12": {
           "release_date": "2018-09-17",
@@ -80,70 +110,19 @@
           "engine": "WebKit",
           "engine_version": "606.1.36"
         },
-        "13": {
-          "release_date": "2019-09-19",
-          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_release_notes",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "608.2.11"
-        },
-        "14": {
-          "release_date": "2020-09-16",
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-release-notes",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "610.1.28"
-        },
-        "15": {
-          "release_date": "2021-09-20",
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "612.1.27"
-        },
-        "16": {
-          "release_date": "2022-09-12",
-          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes",
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "614.1.25"
-        },
-        "3.2": {
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "531.21",
-          "release_date": "2010-04-03"
-        },
-        "4.2": {
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "533.17",
-          "release_date": "2010-11-22"
-        },
-        "9.3": {
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "601.5.17",
-          "release_date": "2016-03-21"
-        },
-        "10.3": {
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "603.2.1",
-          "release_date": "2017-03-27"
-        },
-        "11.3": {
-          "status": "retired",
-          "engine": "WebKit",
-          "engine_version": "605.1.33",
-          "release_date": "2018-03-29"
-        },
         "12.2": {
           "release_date": "2019-03-25",
           "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_1_release_notes",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "607.1.40"
+        },
+        "13": {
+          "release_date": "2019-09-19",
+          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_release_notes",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "608.2.11"
         },
         "13.4": {
           "release_date": "2020-03-24",
@@ -152,12 +131,26 @@
           "engine": "WebKit",
           "engine_version": "609.1.20"
         },
+        "14": {
+          "release_date": "2020-09-16",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14-release-notes",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "610.1.28"
+        },
         "14.5": {
           "release_date": "2021-04-26",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "611.1.21"
+        },
+        "15": {
+          "release_date": "2021-09-20",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "612.1.27"
         },
         "15.1": {
           "release_date": "2021-10-25",
@@ -198,6 +191,13 @@
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "613.3.9"
+        },
+        "16": {
+          "release_date": "2022-09-12",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes",
+          "status": "retired",
+          "engine": "WebKit",
+          "engine_version": "614.1.25"
         },
         "16.1": {
           "release_date": "2022-10-24",


### PR DESCRIPTION
This PR updates the `lint-staged` configuration to ensure that the fix script is not run on the browser JSON files.  The fix script ruins the order of the browser versions due to the way JSON orders the object.  Additionally, this restores the browser files to their original state.
