### PR TITLE
feat(css): Update CSS Values Level 4 `round()` compatibility data

### DIFF
--- a/css/types/round.json
+++ b/css/types/round.json
@@ -13,7 +13,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "108"
+              "version_added": "108",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.round.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -30,7 +37,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/types/round.json
+++ b/css/types/round.json
@@ -12,16 +12,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "108",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.round.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "108",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.round.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/css/types/round.json
+++ b/css/types/round.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "108"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -30,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
#### Summary

Firefox 108 adds support for CSS `round()` function meaning that it's not longer an experimental feature.

Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1764850

#### Related issues

Related: https://github.com/mdn/content/issues/22114
