### PR TITLE
CSS(trig) CSS trig functions enabled by default in Fx 108

### DIFF
--- a/css/types/acos.json
+++ b/css/types/acos.json
@@ -13,14 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "103",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.trig.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "108"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -37,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/types/asin.json
+++ b/css/types/asin.json
@@ -13,14 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "103",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.trig.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "108"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/asin.json
+++ b/css/types/asin.json
@@ -30,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/types/atan.json
+++ b/css/types/atan.json
@@ -13,14 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "103",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.trig.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "108"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/atan.json
+++ b/css/types/atan.json
@@ -30,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/types/atan2.json
+++ b/css/types/atan2.json
@@ -13,14 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "103",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.trig.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "108"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/atan2.json
+++ b/css/types/atan2.json
@@ -30,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/types/calc-constant.json
+++ b/css/types/calc-constant.json
@@ -45,7 +45,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "108"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -111,7 +111,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "108"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/types/calc-constant.json
+++ b/css/types/calc-constant.json
@@ -30,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -62,7 +62,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -95,7 +95,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/types/calc-constant.json
+++ b/css/types/calc-constant.json
@@ -13,14 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "103",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.trig.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "108"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -85,14 +78,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "103",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.trig.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "108"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -158,14 +144,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "103",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.trig.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "108"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/types/calc-constant.json
+++ b/css/types/calc-constant.json
@@ -161,7 +161,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/types/calc-constant.json
+++ b/css/types/calc-constant.json
@@ -62,7 +62,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/types/cos.json
+++ b/css/types/cos.json
@@ -13,14 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "103",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.trig.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "108"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/cos.json
+++ b/css/types/cos.json
@@ -30,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/types/sin.json
+++ b/css/types/sin.json
@@ -13,14 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "103",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.trig.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "108"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/sin.json
+++ b/css/types/sin.json
@@ -30,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/types/tan.json
+++ b/css/types/tan.json
@@ -13,14 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "103",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.trig.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "108"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/tan.json
+++ b/css/types/tan.json
@@ -30,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
CSS trig support for functions (`cos()`, `tan()`, etc.) are enabled by default in Fx 108.

Additionally, constants (`e`, `pi` etc.) can be used inside CSS `calc()` function

### Related issues

- [ ] Parent issue: https://github.com/mdn/content/issues/22115