### PR TITLE
Add mdn_urls for Long Task toJSON methods

### DIFF
--- a/api/PerformanceLongTaskTiming.json
+++ b/api/PerformanceLongTaskTiming.json
@@ -70,6 +70,7 @@
       },
       "toJSON": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceLongTaskTiming/toJSON",
           "spec_url": "https://w3c.github.io/longtasks/#dom-performancelongtasktiming-tojson",
           "support": {
             "chrome": {

--- a/api/TaskAttributionTiming.json
+++ b/api/TaskAttributionTiming.json
@@ -172,6 +172,7 @@
       },
       "toJSON": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/TaskAttributionTiming/toJSON",
           "spec_url": "https://w3c.github.io/longtasks/#dom-taskattributiontiming-tojson",
           "support": {
             "chrome": {


### PR DESCRIPTION
This PR adds two mdn_urls. Docs are created in https://github.com/mdn/content/pull/22223.

