### PR TITLE
Add `idle-detection` to `http.headers.Feature-Policy`

### DIFF
--- a/http/headers/Feature-Policy.json
+++ b/http/headers/Feature-Policy.json
@@ -509,6 +509,43 @@
             }
           }
         },
+        "idle-detection": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/idle-detection",
+            "spec_url": "https://wicg.github.io/idle-detection/#api-permissions-policy",
+            "support": {
+              "chrome": {
+                "version_added": "94"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "94",
+                "version_removed": "96"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "layout-animations": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/layout-animations",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Complete the features required to represent all of the features implied by the Idle Detection spec.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

I didn't actually test this. The data here is cribbed from the existing `api.IdleDetector` features, but I did a little independent verification via:

- https://chromestatus.com/feature/4590256452009984
- https://storage.googleapis.com/chromium-find-releases-static/487.html#487196e61e193ee2511231e3cbe4229c26687ec2

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

- https://github.com/mdn/browser-compat-data/issues/9556 — There's whole _thing_ here about how Permissions Policy (PP) is the new Feature Policy (FP). Nominally, _this_ feature ought to be a PP feature too, but that's a can of worms affecting many, many features and I refuse to do any more than acknowledge that fact here. A close inspection of the links above reveal that `idle-detection` is enabled for both PP and FP, so this PR is merely incomplete, not wrong.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
