### PR TITLE
Add notes for action.openPopup API in Firefox

### DIFF
--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -238,7 +238,11 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "101"
+                "version_added": "101",
+                "notes": [
+                  "Must be called from inside the handler for a <a href='/en-US/docs/Mozilla/Add-ons/WebExtensions/User_actions'>user action</a>. From Firefox 108, this restriction has been lifted behind a preference. See <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1799344'>bug 1799344</a>.",
+                  "Support for the <code>windowId</code> parameter was added in Firefox 108."
+                ]
               },
               "firefox_android": "mirror",
               "opera": "mirror",

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -456,7 +456,11 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "57"
+                "version_added": "57",
+                "notes": [
+                  "Must be called from inside the handler for a <a href='/en-US/docs/Mozilla/Add-ons/WebExtensions/User_actions'>user action</a>. From Firefox 108, this restriction has been lifted behind a preference. See <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1799344'>bug 1799344</a>.",
+                  "Support for the <code>windowId</code> parameter was added in Firefox 108."
+                ]
               },
               "firefox_android": {
                 "version_added": "79"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates the compatibility information for the WebExtension `action.openPopup` API following the changes in https://phabricator.services.mozilla.com/D139796. In particular, Firefox now has support for a `windowId` parameter and the user gesture requirement has been removed behind a preference currently enabled in Nightly.

I have a similar PR coming to update the main MDN page, which this one is intended to land at the same time as.

#### Test results and supporting details

Original bug (including `windowId` support): https://bugzilla.mozilla.org/show_bug.cgi?id=1755763

Removing preference: https://bugzilla.mozilla.org/show_bug.cgi?id=1799344

I've been working on these changes with @Rob--W.

#### Related issues

NA
