### PR TITLE
Add data for two client hints

### DIFF
--- a/http/headers/Sec-CH-Prefers-Color-Scheme.json
+++ b/http/headers/Sec-CH-Prefers-Color-Scheme.json
@@ -1,0 +1,41 @@
+{
+  "http": {
+    "headers": {
+      "Sec-CH-Prefers-Color-Scheme": {
+        "__compat": {
+          "description": "<code>Sec-CH-Prefers-Color-Scheme</code> request header",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-CH-Prefers-Color-Scheme",
+          "spec_url": "https://wicg.github.io/user-preference-media-features-headers/#sec-ch-prefers-color-scheme",
+          "support": {
+            "chrome": {
+              "version_added": "93"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/Sec-CH-Prefers-Reduced-Motion.json
+++ b/http/headers/Sec-CH-Prefers-Reduced-Motion.json
@@ -1,0 +1,41 @@
+{
+  "http": {
+    "headers": {
+      "Sec-CH-Prefers-Reduced-Motion": {
+        "__compat": {
+          "description": "<code>Sec-CH-Prefers-Reduced-Motion</code> request header",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-CH-Prefers-Reduced-Motion",
+          "spec_url": "https://wicg.github.io/user-preference-media-features-headers/#sec-ch-prefers-reduced-motion",
+          "support": {
+            "chrome": {
+              "version_added": "108"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Add data for HTTP headers `Sec-CH-Prefers-Color-Scheme` and `Sec-CH-Prefers-Reduced-Motion`.
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details
- `Sec-CH-Prefers-Color-Scheme`
   - chromestatus entry: https://chromestatus.com/feature/5642300464037888
   - Demo: https://sec-ch-prefers-color-scheme.glitch.me/
- `Sec-CH-Prefers-Reduced-Motion`
   - chromestatus entry: https://chromestatus.com/feature/5141804190531584
   - Demo: https://sec-ch-prefers-reduced-motion.glitch.me/
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
Related content PR: https://github.com/mdn/content/pull/22266
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
