### PR TITLE
Array group()/groupByToMap() available behind a flag

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -796,7 +796,14 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.experimental.array_grouping",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": {
                 "version_added": false
@@ -838,7 +845,14 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.experimental.array_grouping",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
From FF108 the `Array.group()` and `groupByToMap()` are not enabled by default https://bugzilla.mozilla.org/show_bug.cgi?id=1799619

On further investigation there was a flag introduced in FF98, that was enabed in nightly prior to 108. So all I've done is added that, and omitted the fact this was ever enabled in preview.

FYI @queengooborg 