### PR TITLE
Ff018 csp script src

### DIFF
--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -1079,7 +1079,7 @@
               "edge": "mirror",
               "firefox": [
                 {
-                  "version_added": "preview"
+                  "version_added": "108"
                 },
                 {
                   "version_added": "105",
@@ -1127,7 +1127,7 @@
               "edge": "mirror",
               "firefox": [
                 {
-                  "version_added": "preview"
+                  "version_added": "108"
                 },
                 {
                   "version_added": "105",

--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -1083,6 +1083,7 @@
                 },
                 {
                   "version_added": "105",
+                  "version_removed": "108",
                   "flags": [
                     {
                       "type": "preference",
@@ -1131,6 +1132,7 @@
                 },
                 {
                   "version_added": "105",
+                  "version_removed": "108",
                   "flags": [
                     {
                       "type": "preference",

--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -1250,10 +1250,11 @@
               "edge": "mirror",
               "firefox": [
                 {
-                  "version_added": "preview"
+                  "version_added": "108"
                 },
                 {
                   "version_added": "105",
+                  "version_removed": "108",
                   "flags": [
                     {
                       "type": "preference",
@@ -1298,10 +1299,11 @@
               "edge": "mirror",
               "firefox": [
                 {
-                  "version_added": "preview"
+                  "version_added": "108"
                 },
                 {
                   "version_added": "105",
+                  "version_removed": "108",
                   "flags": [
                     {
                       "type": "preference",

--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -1077,22 +1077,9 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "108"
-                },
-                {
-                  "version_added": "105",
-                  "version_removed": "108",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "security.csp.script-src-attr-elem.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "108"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -1126,22 +1113,9 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "108"
-                },
-                {
-                  "version_added": "105",
-                  "version_removed": "108",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "security.csp.script-src-attr-elem.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "108"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -1248,22 +1222,9 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "108"
-                },
-                {
-                  "version_added": "105",
-                  "version_removed": "108",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "security.csp.style-src-attr-elem.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "108"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -1297,22 +1258,9 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "108"
-                },
-                {
-                  "version_added": "105",
-                  "version_removed": "108",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "security.csp.style-src-attr-elem.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "108"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false


### PR DESCRIPTION
FF108 ships the CSP HTTP header directives `script-src-elem`, `script-src-attr`, `style-src-elem` and style-src-attr` - https://bugzilla.mozilla.org/show_bug.cgi?id=1790621.

This changes "preview" release to "108". Also removes the preferenced version from 108.
- I assume it is OK to lose the information that this is enabled by default in Nightly. 
- I left the preference stuff in there. Release isn't until this time next month, so I'd rather leave it in so people can have the preference if they need it.

Other docs work can be tracked in https://github.com/mdn/content/issues/22113

FYI @queengooborg 