### PR TITLE
HTML script element support for type=importmap

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -472,22 +472,9 @@
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
-                "firefox": [
-                  {
-                    "version_added": "108"
-                  },
-                  {
-                    "version_added": "102",
-                    "version_removed": "108",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "dom.importMaps.enabled",
-                        "value_to_set": "true"
-                      }
-                    ]
-                  }
-                ],
+                "firefox": {
+                  "version_added": "108"
+                },
                 "firefox_android": "mirror",
                 "ie": {
                   "version_added": false

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -465,6 +465,7 @@
           },
           "importmap": {
             "__compat": {
+              "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#import-map",
               "support": {
                 "chrome": {
                   "version_added": "89"

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -463,6 +463,51 @@
               "deprecated": false
             }
           },
+          "importmap": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "89"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": [
+                  {
+                    "version_added": "108"
+                  },
+                  {
+                    "version_added": "102",
+                    "version_removed": "108",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "dom.importMaps.enabled",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  }
+                ],
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "module": {
             "__compat": {
               "support": {


### PR DESCRIPTION
FF108 adds support for "import maps", a mechanisms for providing a mapping between a module name and its location when you're importing a module. The feature is implemented using an HTML script element that has `type="importmap"`, where the element contains the import map as a JSON definition.

Compat:
- Firefox 102 - 108 implemented behind a preference: https://bugzilla.mozilla.org/show_bug.cgi?id=1688879
- FF108 ships: https://bugzilla.mozilla.org/show_bug.cgi?id=1795647
- Chrome 89: https://chromestatus.com/feature/5315286962012160
- Safari - not implemented (see chrome signal, and canIuse).

Fixes #17701

Other docs work can be tracked in: https://github.com/mdn/content/issues/16150

FYI @queengooborg 