### PR TITLE
Update return value entry for performance.measure

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -521,56 +521,42 @@
             "deprecated": false
           }
         },
-        "returns_undefined": {
+        "returns_performancemeasure": {
           "__compat": {
-            "description": "Returns <code>undefined</code>",
+            "description": "Returns <code>PerformanceMeasure</code>",
             "support": {
               "chrome": {
-                "version_added": "25",
-                "version_removed": "95"
+                "version_added": "95"
               },
               "chrome_android": "mirror",
               "deno": {
                 "version_added": false
               },
-              "edge": {
-                "version_added": "12",
-                "version_removed": "95"
-              },
+              "edge": "mirror",
               "firefox": {
-                "version_added": "41"
+                "version_added": "103"
               },
-              "firefox_android": {
-                "version_added": "42"
-              },
+              "firefox_android": "mirror",
               "ie": {
-                "version_added": "10"
+                "version_added": false
               },
               "nodejs": {
-                "version_added": "8.5.0"
+                "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": "33",
-                "version_removed": "81"
-              },
-              "opera_android": {
-                "version_added": "33"
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
-                "version_added": "11",
-                "version_removed": "15"
+                "version_added": "14.1"
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": {
-                "version_added": "1.5"
-              },
+              "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
-              "deprecated": true
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }


### PR DESCRIPTION
#### Summary

This PR updates https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure#browser_compatibility to change from "Returns undefined" to "Returns PerformanceMeasure". I think it is backwards to talk about undefined as the return value here. 

#### Test results and supporting details

Firefox implemented "Returns PerformanceMeasure" in 103: https://hg.mozilla.org/mozilla-central/rev/2d93cc964b79

Safari implemented "Returns PerformanceMeasure" in Preview 114: https://webkit.org/blog/11333/release-notes-for-safari-technology-preview-115/ ("Update User Timing interfaces to User Timing Level 3"). 114 is in Safari 14.1 per https://webkit.org/blog/11648/new-webkit-features-in-safari-14-1/ 

#### Related issues

This was introduced in https://github.com/mdn/browser-compat-data/pull/13478
