### PR TITLE
add fixes for wolenetz comments

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2871,17 +2871,20 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/srcObject",
           "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-media-srcobject-dev",
           "support": {
-            "chrome": {
-              "version_added": "52",
-              "partial_implementation": true,
-              "notes": "Only supports <code>MediaStream</code> objects (see <a href='https://crbug.com/506273'>bug 506273</a>)."
-            },
+            "chrome": [
+              {
+                "version_added": "108",
+                "partial_implementation": true,
+                "notes": "Support added for <code>MediaSource</code> objects transferred from dedicated workers via <code>MediaSource.handle</code> (see <a href='https://crbug.com/878133'>bug 878133</a>)."
+              },
+              {
+                "version_added": "52",
+                "partial_implementation": true,
+                "notes": "Support added for <code>MediaStream</code> objects (see <a href='https://crbug.com/506273'>bug 506273</a>)."
+              }
+            ],
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "12",
-              "partial_implementation": true,
-              "notes": "Only supports <code>MediaStream</code> objects (see <a href='https://crbug.com/506273'>bug 506273</a>)."
-            },
+            "edge": "mirror",
             "firefox": [
               {
                 "version_added": "42",
@@ -2906,11 +2909,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "52",
-              "partial_implementation": true,
-              "notes": "Only supports <code>MediaStream</code> objects (see <a href='https://crbug.com/506273'>bug 506273</a>."
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2875,7 +2875,7 @@
               {
                 "version_added": "108",
                 "partial_implementation": true,
-                "notes": "Support added for <code>MediaSource</code> objects transferred from dedicated workers via <code>MediaSource.handle</code> (see <a href='https://crbug.com/878133'>bug 878133</a>)."
+                "notes": "Support added for <code>MediaSourceHandle</code> objects transferred from dedicated workers where they were obtained from <code>MediaSource.handle</code> (see <a href='https://crbug.com/878133'>bug 878133</a>)."
               },
               {
                 "version_added": "52",

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -153,8 +153,8 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
                 }
               ]
             },
@@ -3115,8 +3115,8 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
                 }
               ]
             },

--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -103,38 +103,38 @@
             "standard_track": true,
             "deprecated": false
           }
-        }
-      },
-      "worker_support": {
-        "__compat": {
-          "description": "Available in workers",
-          "support": {
-            "chrome": {
-              "version_added": "108"
+        },
+        "worker_support": {
+          "__compat": {
+            "description": "Available in workers",
+            "support": {
+              "chrome": {
+                "version_added": "108"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/MediaSourceHandle.json
+++ b/api/MediaSourceHandle.json
@@ -18,7 +18,7 @@
             "version_added": false
           },
           "oculus": "mirror",
-          "opera": "mirror",
+          "opera": "94",
           "opera_android": "mirror",
           "safari": {
             "version_added": false

--- a/api/MediaSourceHandle.json
+++ b/api/MediaSourceHandle.json
@@ -18,7 +18,7 @@
             "version_added": false
           },
           "oculus": "mirror",
-          "opera": "94",
+          "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
             "version_added": false

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -626,7 +626,7 @@
                     "value_to_set": "Enabled"
                   }
                 ],
-                "notes": "Currently doesn't work, even with the flag set. If invoked from a dedicated worker, Chromium crashes the renderer to avoid undesirable behavior. Spec and implementation work needed."
+                "notes": "Currently doesn't work, even with the flag set. If invoked from a dedicated worker, Chromium crashes the renderer to avoid undesirable behavior (see <a href='https://crbug.com/487288#c24'>bug 487288</a>)."
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1687,7 +1687,7 @@
                     "value_to_set": "Enabled"
                   }
                 ],
-                "notes": "Currently doesn't work, even with the flag set. If invoked from a dedicated worker, Chromium crashes the renderer to avoid undesirable behavior. Spec and implementation work needed."
+                "notes": "Currently doesn't work, even with the flag set. If invoked from a dedicated worker, Chromium crashes the renderer to avoid undesirable behavior (see <a href='https://crbug.com/487288#c24'>bug 487288</a>)."
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -56,39 +56,6 @@
           "deprecated": false
         }
       },
-      "worker_support": {
-        "__compat": {
-          "description": "Available in workers",
-          "support": {
-            "chrome": {
-              "version_added": "108"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "abort": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SourceBuffer/abort",
@@ -592,7 +559,14 @@
           "spec_url": "https://w3c.github.io/media-source/#dom-sourcebuffer-audiotracks",
           "support": {
             "chrome": {
-              "version_added": "70"
+              "version_added": "70",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": [
@@ -644,7 +618,14 @@
             "description": "Available in workers",
             "support": {
               "chrome": {
-                "version_added": "108"
+                "version_added": "108",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1132,7 +1113,7 @@
           "spec_url": "https://w3c.github.io/media-source/#dom-sourcebuffer-texttracks",
           "support": {
             "chrome": {
-              "version_added": "70"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": {
@@ -1163,39 +1144,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "worker_support": {
-          "__compat": {
-            "description": "Available in workers",
-            "support": {
-              "chrome": {
-                "version_added": "108"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -1671,7 +1619,14 @@
           "spec_url": "https://w3c.github.io/media-source/#dom-sourcebuffer-videotracks",
           "support": {
             "chrome": {
-              "version_added": "70"
+              "version_added": "70",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": [
@@ -1723,7 +1678,14 @@
             "description": "Available in workers",
             "support": {
               "chrome": {
-                "version_added": "108"
+                "version_added": "108",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -625,7 +625,8 @@
                     "name": "#enable-experimental-web-platform-features",
                     "value_to_set": "Enabled"
                   }
-                ]
+                ],
+                "notes": "Currently doesn't work, even with the flag set. If invoked from a dedicated worker, Chromium crashes the renderer to avoid undesirable behavior. Spec and implementation work needed."
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1117,7 +1118,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "18"
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -1141,7 +1142,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -1685,7 +1686,8 @@
                     "name": "#enable-experimental-web-platform-features",
                     "value_to_set": "Enabled"
                   }
-                ]
+                ],
+                "notes": "Currently doesn't work, even with the flag set. If invoked from a dedicated worker, Chromium crashes the renderer to avoid undesirable behavior. Spec and implementation work needed."
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/api/SourceBufferList.json
+++ b/api/SourceBufferList.json
@@ -62,39 +62,6 @@
           "deprecated": false
         }
       },
-      "worker_support": {
-        "__compat": {
-          "description": "Available in workers",
-          "support": {
-            "chrome": {
-              "version_added": "108"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "addsourcebuffer_event": {
         "__compat": {
           "description": "<code>addsourcebuffer</code> event",

--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -40,39 +40,6 @@
           "deprecated": false
         }
       },
-      "worker_support": {
-        "__compat": {
-          "description": "Available in workers",
-          "support": {
-            "chrome": {
-              "version_added": "108"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "corruptedVideoFrames": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoPlaybackQuality/corruptedVideoFrames",
@@ -112,39 +79,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": true
-          }
-        },
-        "worker_support": {
-          "__compat": {
-            "description": "Available in workers",
-            "support": {
-              "chrome": {
-                "version_added": "108"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -187,39 +121,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "worker_support": {
-          "__compat": {
-            "description": "Available in workers",
-            "support": {
-              "chrome": {
-                "version_added": "108"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "droppedVideoFrames": {
@@ -261,39 +162,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "worker_support": {
-          "__compat": {
-            "description": "Available in workers",
-            "support": {
-              "chrome": {
-                "version_added": "108"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "totalFrameDelay": {
@@ -333,39 +201,6 @@
             "experimental": false,
             "standard_track": false,
             "deprecated": true
-          }
-        },
-        "worker_support": {
-          "__compat": {
-            "description": "Available in workers",
-            "support": {
-              "chrome": {
-                "version_added": "108"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -407,39 +242,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "worker_support": {
-          "__compat": {
-            "description": "Available in workers",
-            "support": {
-              "chrome": {
-                "version_added": "108"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR adds fixes in response to the review comments provided by @wolenetz in https://github.com/mdn/browser-compat-data/issues/18220

<!-- ✍️ In a sentence or two, describe your changes. -->

I did the following:

* Removed the separate `worker_support` items from the top-level interface support items, as the extra rows in the support tables were confusing and unnecessary
* Marked `audioTracks` and `videoTracks` support as experimental, for `SourceBuffer` and `HTMLMediaElement`
* Marked `SourceBuffer.textTracks` support as `false` for Chromium
* Reverted `VideoPlaybackQuality` changes
* Verified that MSE-in-workers works in Opera 94, not Opera 93, by testing @wolenetz's demo in beta and developer versions. To fix this, I'm not going to change every Opera support number individually, as that is not maintainable, and the linter complained. Instead, I'm going to fix the mirroring code so that it reports the correct Opera version for Chrome 106/107/108. I've filed an issue for that at https://github.com/mdn/browser-compat-data/issues/18224, which I'll have a go at fixing next.

#### Test results and supporting details

Testing was done using the demo available at https://wolenetz.github.io/mse-in-workers-demo/mse-in-workers-demo.html

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixes https://github.com/mdn/browser-compat-data/issues/18220

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
