### PR TITLE
Add details for CSS container query relative length units

### DIFF
--- a/css/types/length.json
+++ b/css/types/length.json
@@ -150,6 +150,39 @@
             }
           }
         },
+        "container_query_length_units": {
+          "__compat": {
+            "description": "Container query length units <code>cqw</code>, <code>cqh</code>, <code>cqi</code>, <code>cqb</code>, <code>cqmin</code>, <code>cqmax</code>",
+            "support": {
+              "chrome": {
+                "version_added": "105"
+              },
+              "chrome_android": "mirror",
+              "edge": "105",
+              "firefox": {
+                "version_added": "108"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "91",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "16"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "ex": {
           "__compat": {
             "description": "<code>ex</code> unit",

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -162,7 +162,14 @@
                 "version_added": "105"
               },
               "firefox": {
-                "version_added": "108"
+                "version_added": "108",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.container-queries.enabled",
+                    "value_to_set": "false"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -158,9 +158,7 @@
                 "version_added": "105"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "105"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "108",
                 "flags": [
@@ -176,9 +174,7 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": "91"
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": "16"

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -167,7 +167,7 @@
                   {
                     "type": "preference",
                     "name": "layout.css.container-queries.enabled",
-                    "value_to_set": "false"
+                    "value_to_set": "true"
                   }
                 ]
               },

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -158,7 +158,9 @@
                 "version_added": "105"
               },
               "chrome_android": "mirror",
-              "edge": "105",
+              "edge": {
+                "version_added": "105"
+              },
               "firefox": {
                 "version_added": "108"
               },
@@ -167,7 +169,9 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": "91",
+              "opera": {
+                "version_added": "91"
+              },
               "opera_android": "mirror",
               "safari": {
                 "version_added": "16"


### PR DESCRIPTION
This PR adds details about container query length units which are behind a pref `layout.css.container-queries.enabled`.

Tested on other browsers using BrowserStack

- [ ] Parent issue https://github.com/mdn/content/issues/22119


| Browser | Support added |
|---| --- |
| Webkit | https://bugs.webkit.org/show_bug.cgi?id=238021 |
| Firefox | https://bugzilla.mozilla.org/show_bug.cgi?id=1744231 |