### PR TITLE
Add measureOptions parameter to performance.measure

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -521,12 +521,51 @@
             "deprecated": false
           }
         },
+        "measureOptions_parameter": {
+          "__compat": {
+            "description": "<code>measureOptions</code> parameter",
+            "support": {
+              "chrome": {
+                "version_added": "78"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "103"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "14.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "returns_performancemeasure": {
           "__compat": {
             "description": "Returns <code>PerformanceMeasure</code>",
             "support": {
               "chrome": {
-                "version_added": "95"
+                "version_added": "78"
               },
               "chrome_android": "mirror",
               "deno": {


### PR DESCRIPTION
#### Summary

Fixes https://github.com/mdn/browser-compat-data/issues/14405 and also updates "returns_performancemeasure" for Chromium which should be the same version as this. (no idea where 95 comes from).

#### Test results and supporting details

Safari 14.1 / TP 115: https://webkit.org/blog/11333/release-notes-for-safari-technology-preview-115/
Firefox 103: https://hg.mozilla.org/mozilla-central/rev/2d93cc964b79
Chromium 78: https://chromestatus.com/feature/5149401886490624
