### PR TITLE
Add markOptions and return value to performance.mark

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -465,6 +465,84 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "markOptions_parameter": {
+          "__compat": {
+            "description": "<code>markOptions</code> parameter",
+            "support": {
+              "chrome": {
+                "version_added": "78"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "103"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "14.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "returns_performancemark": {
+          "__compat": {
+            "description": "Returns <code>PerformanceMark</code>",
+            "support": {
+              "chrome": {
+                "version_added": "78"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "103"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "14.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "measure": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Analog to https://github.com/mdn/browser-compat-data/pull/18228 and https://github.com/mdn/browser-compat-data/pull/18216 but for performance.mark

#### Test results and supporting details

Safari 14.1 / TP 115: https://webkit.org/blog/11333/release-notes-for-safari-technology-preview-115/
Firefox 103: https://hg.mozilla.org/mozilla-central/rev/2d93cc964b79
Chromium 78: https://chromestatus.com/feature/5149401886490624

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/9419