### PR TITLE
update support for CSS Values and Units Module Level 4 in chromium

### DIFF
--- a/css/types/length.json
+++ b/css/types/length.json
@@ -340,7 +340,7 @@
             "description": "<code>vb</code> unit",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "108"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -411,7 +411,7 @@
             "description": "<code>vi</code> unit",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "108"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -444,7 +444,7 @@
             "description": "<code>dvb</code>, <code>dvh</code>, <code>dvi</code>, <code>dvmax</code>, <code>dvmin</code>, <code>dvw</code> units",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "108"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

[CSS Values and Units Module Level 4:](https://chromestatus.com/feature/5170718078140416) are supported in Chromium 108 and higher

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
