### PR TITLE
Update viewport units support

### DIFF
--- a/css/types/length.json
+++ b/css/types/length.json
@@ -444,7 +444,7 @@
             "description": "<code>dvb</code>, <code>dvh</code>, <code>dvi</code>, <code>dvmax</code>, <code>dvmin</code>, <code>dvw</code> units",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "108"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -477,7 +477,7 @@
             "description": "<code>lvb</code>, <code>lvh</code>, <code>lvi</code>, <code>lvmax</code>, <code>lvmin</code>, <code>lvw</code> units",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "108"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -510,7 +510,7 @@
             "description": "<code>svb</code>, <code>svh</code>, <code>svi</code>, <code>svmax</code>, <code>svmin</code>, <code>svw</code> units",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "108"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
These units are shipping in Chrome 108.

- ChromeStatus: https://chromestatus.com/feature/5170718078140416
- CrBug: https://bugs.chromium.org/p/chromium/issues/detail?id=1093055
- Announcement post on DCC: https://developer.chrome.com/blog/chrome-108-beta/#small-large-dynamic-and-logical-viewport-units