### PR TITLE
Firefox 106 is retired

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -767,7 +767,7 @@
         "106": {
           "release_date": "2022-10-18",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/106",
-          "status": "beta",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "106"
         },


### PR DESCRIPTION
Firefox 107 is the current version. Firefox 106 was retired.

This PR fixes #18221