### PR TITLE
Remove logic in mirroring script that inaccurately maps beta->beta

### DIFF
--- a/scripts/release/mirror.ts
+++ b/scripts/release/mirror.ts
@@ -104,19 +104,13 @@ export const getMatchingBrowserVersion = (
     ) {
       // Handle mirroring for Chromium forks when upstream version is pre-Blink
       return range ? `≤${r}` : r;
-    } else if (release.engine == sourceRelease.engine) {
-      if (
-        ['beta', 'nightly'].includes(release.status) &&
-        release.status == sourceRelease.status
-      ) {
-        return r;
-      } else if (
-        release.engine_version &&
-        sourceRelease.engine_version &&
-        compare(release.engine_version, sourceRelease.engine_version, '>=')
-      ) {
-        return r;
-      }
+    } else if (
+      release.engine == sourceRelease.engine &&
+      release.engine_version &&
+      sourceRelease.engine_version &&
+      compare(release.engine_version, sourceRelease.engine_version, '>=')
+    ) {
+      return r;
     }
   }
 


### PR DESCRIPTION
This PR removes the logic in the mirroring script that maps an upstream beta browser to a downstream beta.  This code was most likely added in to handle Safari beta releases, but we will no longer see this as an issue thanks to the `preview` value.  Additionally, as mentioned in the issue this fixes, the downstream beta may have a different engine version than the upstream beta due to different release dates/cycles.

This PR fixes #18224.
