### PR TITLE
Add issue templates for enhancements and infra problems; disable blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Content or feature request
+    url: https://github.com/mdn/mdn/issues/new/choose
+    about: Propose new content for MDN Web Docs or submit a feature request using this link.
+  - name: MDN GitHub Discussions
+    url: https://github.com/orgs/mdn/discussions
+    about: Does the issue involve a lot of pages, or are you not sure how it can be split into actionable tasks? Consider starting a discussion first.
+  - name: MDN Web Docs on Discourse
+    url: https://discourse.mozilla.org/c/mdn/learn/250
+    about: Need help with assessments on MDN Web Docs? We have a support community for this purpose on Discourse.
+  - name: Help with code
+    url: https://stackoverflow.com/
+    about: If you are stuck and need help with code, StackOverflow is a great resource.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,40 @@
+name: "Enhancement"
+title: ""
+description: An enhancement to BCD's infrastructure
+labels: ["needs triage 🔎", "enhancement :1st_place_medal:"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Issue etiquette
+
+        When opening an issue, please:
+        - Follow the project's [Code of Conduct](https://github.com/mdn/browser-compat-data/blob/main/CODE_OF_CONDUCT.md) as well as the [GitHub Community Guidelines](https://docs.github.com/en/site-policy/github-terms/github-community-guidelines). Failure to comply may result in exclusion from MDN Web Docs and/or GitHub.
+        - Check for an [existing issue](https://github.com/mdn/browser-compat-data/issues) first. If someone else has opened an issue describing the same problem, please upvote their issue rather than creating another one.
+        - Keep issues relevant to the project. Irrelevant issues will be automatically closed and marked as spam, and repeated offenses may result in exclusion from MDN Web Docs.
+        - Provide as much detail as possible. The more detail you are able to provide, the better!
+        - Write issues primarily in English. While translation tools are available, we will be able to provide better assistance with pre-translated content. You are more than welcome to include a version of the issue body in your preferred language alongside the English version.
+
+        ---
+  - type: textarea
+    id: enhancement
+    attributes:
+      label: What would you like to see added to BCD?
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: How impactful do you think this enhancement will be?
+    validations:
+      required: true
+  - type: textarea
+    id: more-info
+    attributes:
+      label: Do you have anything more you want to share?
+      description: For example, screenshots, screen recordings, or sample code
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        You're finished! Please click **Submit new issue**.

--- a/.github/ISSUE_TEMPLATE/infra-problem.yml
+++ b/.github/ISSUE_TEMPLATE/infra-problem.yml
@@ -1,0 +1,61 @@
+name: "Infrastructure/Linter Problem"
+title: ""
+description: Report issues with infrastructure, including scripts and linters
+labels: ["needs triage 🔎"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Issue etiquette
+
+        When opening an issue, please:
+        - Follow the project's [Code of Conduct](https://github.com/mdn/browser-compat-data/blob/main/CODE_OF_CONDUCT.md) as well as the [GitHub Community Guidelines](https://docs.github.com/en/site-policy/github-terms/github-community-guidelines). Failure to comply may result in exclusion from MDN Web Docs and/or GitHub.
+        - Check for an [existing issue](https://github.com/mdn/browser-compat-data/issues) first. If someone else has opened an issue describing the same problem, please upvote their issue rather than creating another one.
+        - Keep issues relevant to the project. Irrelevant issues will be automatically closed and marked as spam, and repeated offenses may result in exclusion from MDN Web Docs.
+        - Provide as much detail as possible. The more detail you are able to provide, the better!
+        - Write issues primarily in English. While translation tools are available, we will be able to provide better assistance with pre-translated content. You are more than welcome to include a version of the issue body in your preferred language alongside the English version.
+
+        ---
+  - type: dropdown
+    id: type
+    attributes:
+      label: What type of issue is this?
+      options:
+        - Infrastructure issue
+        - TypeScript definition issue
+        - Linter issue
+        - Script issue
+        - Schema issue
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is the issue?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What behavior were you expecting?
+    validations:
+      required: true
+  - type: checkboxes
+    id: versions
+    attributes:
+      label: What version(s) of BCD is the issue present in?
+      description: If neither are applicable, we cannot and will not provide support.
+      options:
+        - label: The current BCD release
+        - label: The current version of the `main` branch
+  - type: textarea
+    id: more-info
+    attributes:
+      label: Do you have anything more you want to share?
+      description: For example, screenshots, screen recordings, or sample code
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        You're finished! Please click **Submit new issue**.


### PR DESCRIPTION
This PR fixes #18175 by disabling blank issues and adding new issue templates for enhancements and infrastructure issues.  This should help cut down on the spam issues we have been receiving.  The config containing contact links was copied from mdn/content.
