### PR TITLE
Mark .** folders as infra

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -35,6 +35,8 @@ infra :building_construction::
   - "package*"
   - "utils/**"
   - ".github/**"
+  - ".husky/**"
+  - ".vscode/**"
 linter :house_with_garden::
   - "test/**"
 scripts :scroll::

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -34,6 +34,7 @@ infra :building_construction::
   - "LICENSE"
   - "package*"
   - "utils/**"
+  - ".github/**"
 linter :house_with_garden::
   - "test/**"
 scripts :scroll::


### PR DESCRIPTION
This PR marks the `.github`, `.husky` and `.vscode` folders as infrastructure so the auto-labeler will add the `infra` label to any PRs updating these files.
