### PR TITLE
Fix new issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,5 +1,4 @@
 name: "Enhancement"
-title: ""
 description: An enhancement to BCD's infrastructure
 labels: ["needs triage 🔎", "enhancement :1st_place_medal:"]
 body:

--- a/.github/ISSUE_TEMPLATE/infra-problem.yml
+++ b/.github/ISSUE_TEMPLATE/infra-problem.yml
@@ -1,5 +1,4 @@
 name: "Infrastructure/Linter Problem"
-title: ""
 description: Report issues with infrastructure, including scripts and linters
 labels: ["needs triage 🔎"]
 body:


### PR DESCRIPTION
This PR fixes the new issue templates by removing the blank `title` key.
