### PR TITLE
Update Samsung Internet releases

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -217,6 +217,12 @@
           "engine": "Blink",
           "engine_version": "92"
         },
+        "16.2": {
+          "release_date": "2022-03-06",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "92"
+        },
         "17.0": {
           "release_date": "2022-05-04",
           "status": "retired",
@@ -225,9 +231,27 @@
         },
         "18.0": {
           "release_date": "2022-08-08",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "99"
+        },
+        "18.1": {
+          "release_date": "2022-09-09",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "99"
+        },
+        "19.0": {
+          "release_date": "2022-11-01",
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "102"
+        },
+        "19.1": {
+          "release_date": "2022-11-08",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "102"
         }
       }
     }


### PR DESCRIPTION
This PR updates the releases for Samsung Internet.  This adds the new 19.0 and 19.1 releases, as well as a few minor releases.
