### PR TITLE
Add mdn_url for Performance.measureUserAgentSpecificMemory; Deprecate Performance.memory

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -680,6 +680,7 @@
       },
       "measureUserAgentSpecificMemory": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Performance/measureUserAgentSpecificMemory",
           "spec_url": "https://wicg.github.io/performance-measure-memory/#ref-for-dom-performance-measureuseragentspecificmemory⑤",
           "support": {
             "chrome": {

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -755,7 +755,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
I creating the MDN page and adding the deprecation in https://github.com/mdn/content/pull/22476.