### PR TITLE
Make mirror migration script a fix script; test for auto-mirrorable statements

### DIFF
--- a/scripts/fix/index.ts
+++ b/scripts/fix/index.ts
@@ -15,6 +15,7 @@ import fixPropertyOrder from './property-order.js';
 import fixStatementOrder from './statement-order.js';
 import fixLinks from './links.js';
 import fixStatus from './status.js';
+import fixMirror from './mirror.js';
 
 const dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -46,6 +47,7 @@ const load = async (...files: string[]): Promise<void> => {
         fixStatementOrder(file);
         fixLinks(file);
         fixStatus(file);
+        fixMirror(file);
       }
     } else {
       const subFiles = (await fs.readdir(file)).map((subfile) =>

--- a/scripts/fix/mirror.ts
+++ b/scripts/fix/mirror.ts
@@ -8,20 +8,12 @@ import {
 } from '../../types/index.js';
 
 import fs from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
-import esMain from 'es-main';
-import { fdir } from 'fdir';
-import yargs from 'yargs';
-import { hideBin } from 'yargs/helpers';
 import stringify from 'fast-json-stable-stringify';
 
 import bcd from '../../index.js';
 import { walk } from '../../utils/index.js';
 import mirrorSupport from '../release/mirror.js';
-
-const dirname = fileURLToPath(new URL('.', import.meta.url));
 
 const downstreamBrowsers = (
   Object.keys(bcd.browsers) as (keyof typeof bcd.browsers)[]
@@ -62,7 +54,6 @@ export const isMirrorEquivalent = (
  * Set the support statement for each browser to mirror if it matches mirroring
  *
  * @param {CompatData} bcd The compat data to update
- * @param {BrowserName[]} browsers The browsers to test
  */
 export const mirrorIfEquivalent = (bcd: CompatData): void => {
   for (const { compat } of walk(undefined, bcd)) {

--- a/test/linter/index.ts
+++ b/test/linter/index.ts
@@ -9,6 +9,7 @@ import testConsistency from './test-consistency.js';
 import testDescriptions from './test-descriptions.js';
 import testFilename from './test-filename.js';
 import testLinks from './test-links.js';
+import testMirror from './test-mirror.js';
 import testMultipleStatements from './test-multiple-statements.js';
 import testNotes from './test-notes.js';
 import testObsolete from './test-obsolete.js';
@@ -26,6 +27,7 @@ export default new Linters([
   testDescriptions,
   testFilename,
   testLinks,
+  testMirror,
   testMultipleStatements,
   testNotes,
   testObsolete,

--- a/test/linter/test-mirror.ts
+++ b/test/linter/test-mirror.ts
@@ -2,22 +2,13 @@
  * See LICENSE file for more information. */
 
 import { Linter, Logger, LinterData } from '../utils.js';
-import {
-  BrowserName,
-  SimpleSupportStatement,
-  SupportBlock,
-  VersionValue,
-} from '../../types/types.js';
-import {
-  InternalSupportBlock,
-  InternalSupportStatement,
-} from '../../types/index';
+import { BrowserName, SupportBlock } from '../../types/types.js';
+import { InternalSupportBlock } from '../../types/index';
 
 import chalk from 'chalk-template';
 
 import bcd from '../../index.js';
 const { browsers } = bcd;
-import mirrorSupport from '../../scripts/release/mirror.js';
 import { isMirrorEquivalent } from '../../scripts/fix/mirror.js';
 
 /**

--- a/test/linter/test-mirror.ts
+++ b/test/linter/test-mirror.ts
@@ -1,0 +1,64 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import { Linter, Logger, LinterData } from '../utils.js';
+import {
+  BrowserName,
+  SimpleSupportStatement,
+  SupportBlock,
+  VersionValue,
+} from '../../types/types.js';
+import {
+  InternalSupportBlock,
+  InternalSupportStatement,
+} from '../../types/index';
+
+import chalk from 'chalk-template';
+
+import bcd from '../../index.js';
+const { browsers } = bcd;
+import mirrorSupport from '../../scripts/release/mirror.js';
+import { isMirrorEquivalent } from '../../scripts/fix/mirror.js';
+
+/**
+ * Check the data to ensure all statements that should use `mirror` do
+ *
+ * @param {SupportBlock} supportData The data to test
+ * @param {string} category The category the data
+ * @param {Logger} logger The logger to output errors to
+ */
+const checkMirroring = (
+  supportData: InternalSupportBlock,
+  category: string,
+  logger: Logger,
+): void => {
+  const browsersToCheck = Object.keys(browsers)
+    .filter((b) =>
+      category === 'webextensions' ? browsers[b].accepts_webextensions : !!b,
+    )
+    .filter((b) => browsers[b].upstream) as BrowserName[];
+
+  for (const browser of browsersToCheck) {
+    if (isMirrorEquivalent(supportData, browser)) {
+      logger.warning(
+        chalk`Data for {bold ${browser}} can be automatically mirrored, use {bold "${browser}": "mirror"} instead`,
+        { fixable: true },
+      );
+    }
+  }
+};
+
+export default {
+  name: 'Mirroring',
+  description: 'Test statements for pre-mirroring',
+  scope: 'feature',
+  /**
+   * Test the data
+   *
+   * @param {Logger} logger The logger to output errors to
+   * @param {LinterData} root The data to test
+   */
+  check: (logger: Logger, { data, path: { category } }: LinterData) => {
+    checkMirroring(data.support, category, logger);
+  },
+} as Linter;

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -161,6 +161,7 @@ export type LinterMessage = {
   title: string;
   path: string;
   message: string;
+  fixable?: true;
   [k: string]: any;
 };
 
@@ -281,7 +282,7 @@ export class Linters {
         this.messages[linter.name].push({
           level: 'error',
           title: linter.name,
-          path: e.traceback,
+          path: data.path.full,
           message: 'Linter failure! ' + e,
         });
       }


### PR DESCRIPTION
This PR performs two things related to checking and enforcing auto-mirroring:

- Migration script 009 has been reformatted into a fix script
- A linter has been added to check to see if a statement can be auto-mirrored and throw a warning if so
