### PR TITLE
Add missing api.Element.checkVisibility feature

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2511,6 +2511,39 @@
           }
         }
       },
+      "checkVisibility": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/cssom-view-1/#dom-element-checkvisibility",
+          "support": {
+            "chrome": {
+              "version_added": "105"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "106"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "childElementCount": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/childElementCount",

--- a/api/Element.json
+++ b/api/Element.json
@@ -2513,7 +2513,7 @@
       },
       "checkVisibility": {
         "__compat": {
-          "spec_url": "https://drafts.csswg.org/cssom-view-1/#dom-element-checkvisibility",
+          "spec_url": "https://w3c.github.io/csswg-drafts/cssom-view-1/#dom-element-checkvisibility",
           "support": {
             "chrome": {
               "version_added": "105"


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `checkVisibility` member of the Element API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Element/checkVisibility

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
