### PR TITLE
Add missing api.FontFaceSet.@@iterator feature

### DIFF
--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -642,6 +642,39 @@
             "deprecated": false
           }
         }
+      },
+      "@@iterator": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-font-loading/#fontfaceset",
+          "support": {
+            "chrome": {
+              "version_added": "48"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "41"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "10"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `@@iterator` member of the FontFaceSet API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/FontFaceSet/@@iterator

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
