### PR TITLE
Add missing api.HTMLScriptElement.blocking feature

### DIFF
--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -82,7 +82,7 @@
       },
       "blocking": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-style-blocking",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-script-blocking",
           "support": {
             "chrome": {
               "version_added": "105"

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -80,6 +80,38 @@
           }
         }
       },
+      "blocking": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "105"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "charset": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#dom-script-charset",

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -82,6 +82,7 @@
       },
       "blocking": {
         "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-style-blocking",
           "support": {
             "chrome": {
               "version_added": "105"


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `blocking` member of the HTMLScriptElement API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/HTMLScriptElement/blocking

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
