### PR TITLE
Add missing api.MIDIInputMap.@@iterator feature

### DIFF
--- a/api/MIDIInputMap.json
+++ b/api/MIDIInputMap.json
@@ -376,6 +376,38 @@
             "deprecated": false
           }
         }
+      },
+      "@@iterator": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `@@iterator` member of the MIDIInputMap API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/MIDIInputMap/@@iterator

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
