### PR TITLE
Add missing api.NDEFReader.makeReadOnly feature

### DIFF
--- a/api/MIDIOutputMap.json
+++ b/api/MIDIOutputMap.json
@@ -376,38 +376,6 @@
             "deprecated": false
           }
         }
-      },
-      "@@iterator": {
-        "__compat": {
-          "support": {
-            "chrome": {
-              "version_added": "43"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
       }
     }
   }

--- a/api/MIDIOutputMap.json
+++ b/api/MIDIOutputMap.json
@@ -376,6 +376,38 @@
             "deprecated": false
           }
         }
+      },
+      "@@iterator": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "43"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/NDEFReader.json
+++ b/api/NDEFReader.json
@@ -107,6 +107,41 @@
           }
         }
       },
+      "makeReadOnly": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/web-nfc/#the-makereadonly-method",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "89"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "reading_event": {
         "__compat": {
           "description": "<code>reading</code> event",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `makeReadOnly` member of the NDEFReader API.

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/NDEFReader/makeReadOnly

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
