### PR TITLE
Add missing api.PublicKeyCredential.isConditionalMediationAvailable feature

### DIFF
--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -136,6 +136,41 @@
           }
         }
       },
+      "isConditionalMediationAvailable": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webauthn/#dom-publickeycredential-isconditionalmediationavailable",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "isUserVerifyingPlatformAuthenticatorAvailable": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/isUserVerifyingPlatformAuthenticatorAvailable",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `isConditionalMediationAvailable` member of the PublicKeyCredential API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/PublicKeyCredential/isConditionalMediationAvailable

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
