### PR TITLE
Add missing api.Sanitizer.getDefaultConfiguration feature

### DIFF
--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -160,6 +160,39 @@
           }
         }
       },
+      "getDefaultConfiguration": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-getdefaultconfiguration",
+          "support": {
+            "chrome": {
+              "version_added": "105"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "sanitize": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sanitizer/sanitize",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `getDefaultConfiguration` member of the Sanitizer API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Sanitizer/getDefaultConfiguration

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
