### PR TITLE
Add missing api.Screen.change_event feature

### DIFF
--- a/api/Screen.json
+++ b/api/Screen.json
@@ -189,6 +189,7 @@
       },
       "change_event": {
         "__compat": {
+          "description": "<code>change</code> event",
           "spec_url": "https://w3c.github.io/window-placement/#api-screen-onchange-attribute",
           "support": {
             "chrome": {

--- a/api/Screen.json
+++ b/api/Screen.json
@@ -187,6 +187,39 @@
           }
         }
       },
+      "change_event": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/window-placement/#api-screen-onchange-attribute",
+          "support": {
+            "chrome": {
+              "version_added": "100"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "colorDepth": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Screen/colorDepth",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `change_event` member of the Screen API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Screen/change_event

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
