### PR TITLE
Add missing api.XRWebGLBinding.getCameraImage feature

### DIFF
--- a/api/XRWebGLBinding.json
+++ b/api/XRWebGLBinding.json
@@ -252,6 +252,43 @@
           }
         }
       },
+      "getCameraImage": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/raw-camera-access/#dom-xrwebglbinding-getcameraimage",
+          "support": {
+            "chrome": {
+              "version_added": "107"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getDepthInformation": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRWebGLBinding/getDepthInformation",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `getCameraImage` member of the XRWebGLBinding API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/XRWebGLBinding/getCameraImage

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
