### PR TITLE
Add missing RTCRtpScriptTransform API

### DIFF
--- a/api/RTCRtpScriptTransform.json
+++ b/api/RTCRtpScriptTransform.json
@@ -34,6 +34,7 @@
       },
       "RTCRtpScriptTransform": {
         "__compat": {
+          "description": "<code>RTCRtpScriptTransform()<code> constructor",
           "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcrtpscripttransform-rtcrtpscripttransform",
           "support": {
             "chrome": {

--- a/api/RTCRtpScriptTransform.json
+++ b/api/RTCRtpScriptTransform.json
@@ -34,7 +34,7 @@
       },
       "RTCRtpScriptTransform": {
         "__compat": {
-          "description": "<code>RTCRtpScriptTransform()<code> constructor",
+          "description": "<code>RTCRtpScriptTransform()</code> constructor",
           "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcrtpscripttransform-rtcrtpscripttransform",
           "support": {
             "chrome": {

--- a/api/RTCRtpScriptTransform.json
+++ b/api/RTCRtpScriptTransform.json
@@ -1,0 +1,70 @@
+{
+  "api": {
+    "RTCRtpScriptTransform": {
+      "__compat": {
+        "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#rtcrtpscripttransform",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": "15.4"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "RTCRtpScriptTransform": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcrtpscripttransform-rtcrtpscripttransform",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `RTCRtpScriptTransform` API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/RTCRtpScriptTransform

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
