### PR TITLE
Correct data for AmbientLightSensor

### DIFF
--- a/api/AmbientLightSensor.json
+++ b/api/AmbientLightSensor.json
@@ -47,7 +47,14 @@
           "spec_url": "https://w3c.github.io/ambient-light/#dom-ambientlightsensor-ambientlightsensor",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "56",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -60,19 +67,13 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -88,14 +89,17 @@
           "support": {
             "chrome": {
               "version_added": "56",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ],
               "notes": "In Chrome 79, this method stopped returning floats and returned integers to avoid fingerprinting."
             },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": "79"
-            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
This PR copies the flag data for the AmbientLightSensor API to its children.
