### PR TITLE
Update Chromium versions for Bluetooth API

### DIFF
--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -82,7 +82,9 @@
             "chrome": {
               "version_added": "56"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -99,9 +101,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,
@@ -116,7 +116,7 @@
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-getavailability",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "78"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -195,7 +195,9 @@
             "chrome": {
               "version_added": "56"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -212,9 +214,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Bluetooth` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Bluetooth

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
