### PR TITLE
Update Chromium versions for BrowserCaptureMediaStreamTrack API

### DIFF
--- a/api/BrowserCaptureMediaStreamTrack.json
+++ b/api/BrowserCaptureMediaStreamTrack.json
@@ -7,7 +7,9 @@
           "chrome": {
             "version_added": "104"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -39,7 +41,9 @@
             "chrome": {
               "version_added": "104"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -72,7 +76,9 @@
             "chrome": {
               "version_added": "104"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `BrowserCaptureMediaStreamTrack` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/BrowserCaptureMediaStreamTrack

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
