### PR TITLE
Update Chromium versions for ByteLengthQueuingStrategy API

### DIFF
--- a/api/ByteLengthQueuingStrategy.json
+++ b/api/ByteLengthQueuingStrategy.json
@@ -58,7 +58,7 @@
           "spec_url": "https://streams.spec.whatwg.org/#blqs-constructor",
           "support": {
             "chrome": {
-              "version_added": "59"
+              "version_added": "52"
             },
             "chrome_android": "mirror",
             "deno": {
@@ -99,7 +99,7 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-blqs-high-water-mark①",
           "support": {
             "chrome": {
-              "version_added": "78"
+              "version_added": "52"
             },
             "chrome_android": "mirror",
             "deno": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `ByteLengthQueuingStrategy` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/ByteLengthQueuingStrategy

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
