### PR TITLE
Update Edge versions for BeforeUnloadEvent API

### DIFF
--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -12,9 +12,7 @@
           "deno": {
             "version_added": "1.24"
           },
-          "edge": {
-            "version_added": "12"
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": "1.5"
           },
@@ -53,9 +51,7 @@
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "12"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "1.5"
             },

--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -91,9 +91,7 @@
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "18"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "44"
             },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `BeforeUnloadEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/BeforeUnloadEvent

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
