### PR TITLE
Update Chromium versions for api.CountQueuingStrategy.highWaterMark

### DIFF
--- a/api/CountQueuingStrategy.json
+++ b/api/CountQueuingStrategy.json
@@ -93,7 +93,7 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-cqs-high-water-mark①",
           "support": {
             "chrome": {
-              "version_added": "78"
+              "version_added": "52"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `highWaterMark` member of the `CountQueuingStrategy` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CountQueuingStrategy/highWaterMark

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
