### PR TITLE
Update Safari versions for EXT_texture_norm16 API

### DIFF
--- a/api/EXT_texture_norm16.json
+++ b/api/EXT_texture_norm16.json
@@ -25,7 +25,7 @@
           },
           "opera_android": "mirror",
           "safari": {
-            "version_added": "16"
+            "version_added": "16.1"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `EXT_texture_norm16` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/EXT_texture_norm16

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
