### PR TITLE
Update Safari iOS versions for FileSystemSyncAccessHandle API

### DIFF
--- a/api/FileSystemSyncAccessHandle.json
+++ b/api/FileSystemSyncAccessHandle.json
@@ -62,9 +62,7 @@
             "safari": {
               "version_added": "15.2"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
@@ -142,9 +140,7 @@
             "safari": {
               "version_added": "15.2"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
@@ -222,9 +218,7 @@
             "safari": {
               "version_added": "15.2"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
@@ -302,9 +296,7 @@
             "safari": {
               "version_added": "15.2"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
@@ -342,9 +334,7 @@
             "safari": {
               "version_added": "15.2"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
@@ -422,9 +412,7 @@
             "safari": {
               "version_added": "15.2"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `FileSystemSyncAccessHandle` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/FileSystemSyncAccessHandle

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
