### PR TITLE
Update Safari versions for FileSystemFileHandle API

### DIFF
--- a/api/FileSystemFileHandle.json
+++ b/api/FileSystemFileHandle.json
@@ -62,9 +62,7 @@
             "safari": {
               "version_added": "15.2"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
@@ -138,7 +136,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "15.5"
+              "version_added": "15.2"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `FileSystemFileHandle` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/FileSystemFileHandle

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
