### PR TITLE
Update Safari versions for api.IDBObjectStore.openKeyCursor

### DIFF
--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -767,7 +767,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "8"
+              "version_added": "10.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `openKeyCursor` member of the `IDBObjectStore` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/IDBObjectStore/openKeyCursor

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
