### PR TITLE
Add PerformanceResourceTiming.responseStatus

### DIFF
--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -622,6 +622,40 @@
           }
         }
       },
+      "responseStatus": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/responseStatus",
+          "spec_url": "https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-responsestatus",
+          "support": {
+            "chrome": {
+              "version_added": "109"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "secureConnectionStart": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/secureConnectionStart",


### PR DESCRIPTION
Spec: https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-responsestatus

Chromestatus: https://chromestatus.com/feature/5163838794629120 / https://groups.google.com/a/chromium.org/g/blink-dev/c/kZfaF3F2mbs/m/IGDpJca8AwAJ
Webkit: https://bugs.webkit.org/show_bug.cgi?id=246857
Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1796785