### PR TITLE
Add fetch keepalive compat data

### DIFF
--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -138,6 +138,48 @@
           }
         }
       },
+      "init_keepalive_parameter": {
+        "__compat": {
+          "description": "<code>init.keepalive</code> parameter",
+          "support": {
+            "chrome": {
+              "version_added": "66"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "15"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": "43"
+            },
+            "opera_android": {
+              "version_added": "43"
+            },
+            "safari": {
+              "version_added": "13"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "init_referrerPolicy_parameter": {
         "__compat": {
           "description": "<code>init.referrerPolicy</code> parameter",


### PR DESCRIPTION
#### Summary

The keepalive parameter to the Fetch (and Request) API is [still not supported by Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1342484) and this is likely to catch people out.

This PR grabs the fetch param data from the Request API to make this clearer (located in api/Request.json).

#### Test results and supporting details

Symlinked build dir into mdn/content and checked build.

#### Related issues

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
