### PR TITLE
Deno support for Intl Enumeration proposal

### DIFF
--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -98,7 +98,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.19"
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
#### Summary

Deno has supported the Intl Enumeration proposal since version 1.19.0 (V8 9.9).

#### Test results and supporting details

These were enabled in V8 9.9, and Deno 1.19.0 was the first version to use V8
9.9.
