### PR TITLE
Deno support for Intl Locale Info proposal

### DIFF
--- a/javascript/builtins/Intl/Locale.json
+++ b/javascript/builtins/Intl/Locale.json
@@ -172,7 +172,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "1.19"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -292,7 +292,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "1.19"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -372,7 +372,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "1.19"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -572,7 +572,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "1.19"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -732,7 +732,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "1.19"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -772,7 +772,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "1.19"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -852,7 +852,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "1.19"
                 },
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION
#### Summary

Deno has supported the Intl Locale Info proposal since version 1.19.0 (V8 9.9).

#### Test results and supporting details

These were enabled in V8 9.9, and Deno 1.19.0 was the first version to use V8
9.9.
