### PR TITLE
Deno support for Wasm Exceptions

### DIFF
--- a/javascript/builtins/WebAssembly/Exception.json
+++ b/javascript/builtins/WebAssembly/Exception.json
@@ -12,7 +12,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.15"
               },
               "edge": "mirror",
               "firefox": {
@@ -52,7 +52,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "1.15"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -132,7 +132,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "1.15"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -172,7 +172,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "1.15"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -212,7 +212,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "1.15"
                 },
                 "edge": "mirror",
                 "firefox": {

--- a/javascript/builtins/WebAssembly/Tag.json
+++ b/javascript/builtins/WebAssembly/Tag.json
@@ -12,7 +12,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.15"
               },
               "edge": "mirror",
               "firefox": {
@@ -52,7 +52,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "1.15"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -92,7 +92,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "1.15"
                 },
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION
#### Summary

`WebAssembly.Exception` and `WebAssembly.Tag` are part of the Wasm exceptions
proposal. This was enabled in Deno 1.15 (V8 9.5).

#### Test results and supporting details

See
https://wpt.fyi/results/wasm/jsapi/exception?label=master&label=stable&product=deno-1.14.3&product=deno-1.15.0&view=subtest
and
https://wpt.fyi/results/wasm/jsapi/tag?label=master&label=stable&product=deno-1.14.3&product=deno-1.15.0&view=subtest.
