### PR TITLE
Deno does not support Cache.add/addAll/keys

### DIFF
--- a/api/Cache.json
+++ b/api/Cache.json
@@ -93,7 +93,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.26"
+              "version_added": false
             },
             "edge": {
               "version_added": "16"
@@ -136,7 +136,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.26"
+              "version_added": false
             },
             "edge": {
               "version_added": "16"
@@ -215,7 +215,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.26"
+              "version_added": false
             },
             "edge": {
               "version_added": "16"
@@ -294,7 +294,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.26"
+              "version_added": false
             },
             "edge": {
               "version_added": "16"


### PR DESCRIPTION
#### Summary

This was falsely marked as supported in #18056.

#### Test results and supporting details

https://wpt.fyi/results/service-workers/cache-storage?label=master&label=stable&product=deno&view=subtest

#### Related issues

Fixes #18235
