### PR TITLE
Note about dynamic imports in `deno compile`

### DIFF
--- a/javascript/operators/import.json
+++ b/javascript/operators/import.json
@@ -11,7 +11,8 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": "1.0"
+              "version_added": "1.0",
+              "notes": "Bundled Deno applications (using `deno compile`) do not support dynamic imports"
             },
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Deno does not support dynamic imports in `deno compile`'d binaries. This PR adds
a note about this to the dynamic import compat data.

#### Related issues

Fixes #16767
