### PR TITLE
All RegExp legacy features are standard and deprecated

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -498,6 +498,7 @@
           "__compat": {
             "description": "<code>RegExp.input</code> (<code>$_</code>)",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/input",
+            "spec_url": "https://github.com/tc39/proposal-regexp-legacy-features/#additional-properties-of-the-regexp-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -533,8 +534,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
-              "deprecated": false
+              "standard_track": true,
+              "deprecated": true
             }
           }
         },
@@ -588,6 +589,7 @@
           "__compat": {
             "description": "<code>RegExp.lastMatch</code> (<code>$&</code>)",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastMatch",
+            "spec_url": "https://github.com/tc39/proposal-regexp-legacy-features/#additional-properties-of-the-regexp-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -627,8 +629,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
-              "deprecated": false
+              "standard_track": true,
+              "deprecated": true
             }
           }
         },
@@ -636,6 +638,7 @@
           "__compat": {
             "description": "<code>RegExp.lastParen</code> (<code>$+</code>)",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastParen",
+            "spec_url": "https://github.com/tc39/proposal-regexp-legacy-features/#additional-properties-of-the-regexp-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -675,8 +678,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
-              "deprecated": false
+              "standard_track": true,
+              "deprecated": true
             }
           }
         },
@@ -684,6 +687,7 @@
           "__compat": {
             "description": "<code>RegExp.leftContext</code> (<code>$`</code>)",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/leftContext",
+            "spec_url": "https://github.com/tc39/proposal-regexp-legacy-features/#additional-properties-of-the-regexp-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -723,8 +727,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
-              "deprecated": false
+              "standard_track": true,
+              "deprecated": true
             }
           }
         },
@@ -897,7 +901,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },
@@ -1006,6 +1010,7 @@
           "__compat": {
             "description": "<code>RegExp.rightContext</code> (<code>$'</code>)",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/rightContext",
+            "spec_url": "https://github.com/tc39/proposal-regexp-legacy-features/#additional-properties-of-the-regexp-constructor",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1045,8 +1050,8 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
-              "deprecated": false
+              "standard_track": true,
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

https://github.com/mdn/browser-compat-data/pull/10273 added a link to a stage-3 proposal, which is fine, because this feature is de-facto implemented by all browsers anyway. However:

1. The edit isn't propagated to all legacy features.
2. The feature isn't marked as deprecated, causing it to appear as if it's fully standard.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
