### PR TITLE
Remove Firefox note from PerformanceNavigationTiming

### DIFF
--- a/api/PerformanceNavigationTiming.json
+++ b/api/PerformanceNavigationTiming.json
@@ -13,8 +13,7 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "58",
-            "notes": "You can disable this feature using the <code>dom.enable_performance_navigation_timing</code> preference (see <a href='https://bugzil.la/1403926'>bug 1403926</a>)."
+            "version_added": "58"
           },
           "firefox_android": "mirror",
           "ie": {


### PR DESCRIPTION
I don't know what this note brings to anyone. Maybe the pref isn't even in Firefox anymore.

If this is merged, the table on https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming#browser_compatibility will be completely green without any asterisk remarks. 