### PR TITLE
Update Chrome Android and WebView data for OPFS features

### DIFF
--- a/api/FileSystemFileHandle.json
+++ b/api/FileSystemFileHandle.json
@@ -27,9 +27,7 @@
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": false
-          }
+          "webview_android": "mirror"
         },
         "status": {
           "experimental": false,
@@ -45,7 +43,9 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": "109"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -56,17 +56,13 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15.2"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/api/FileSystemSyncAccessHandle.json
+++ b/api/FileSystemSyncAccessHandle.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "102"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": "109"
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -28,7 +30,7 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": false
+            "version_added": "109"
           }
         },
         "status": {
@@ -45,7 +47,9 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": "109"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -65,7 +69,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "109"
             }
           },
           "status": {
@@ -88,7 +92,9 @@
                   }
                 ]
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": "109"
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": false
@@ -105,7 +111,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "109"
+              }
             },
             "status": {
               "experimental": true,
@@ -123,7 +131,9 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": "109"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -143,7 +153,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "109"
             }
           },
           "status": {
@@ -166,7 +176,9 @@
                   }
                 ]
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": "109"
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": false
@@ -183,7 +195,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "109"
+              }
             },
             "status": {
               "experimental": true,
@@ -201,7 +215,9 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": "109"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -221,7 +237,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "109"
             }
           },
           "status": {
@@ -244,7 +260,9 @@
                   }
                 ]
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": "109"
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": false
@@ -261,7 +279,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "109"
+              }
             },
             "status": {
               "experimental": true,
@@ -279,7 +299,9 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": "109"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -299,7 +321,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "109"
             }
           },
           "status": {
@@ -317,7 +339,9 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": "109"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -337,7 +361,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "109"
             }
           },
           "status": {
@@ -360,7 +384,9 @@
                   }
                 ]
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": "109"
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": false
@@ -377,7 +403,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "109"
+              }
             },
             "status": {
               "experimental": true,
@@ -395,7 +423,9 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": "109"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -415,7 +445,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "109"
             }
           },
           "status": {

--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -107,7 +107,7 @@
               "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "109"
             },
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 109 sees the Origin Private File System features of the [File System API](https://fs.spec.whatwg.org/) enabled in Chrome Android and WebView. This PR makes those updates.

See my research document for more details on the changes made: https://docs.google.com/document/d/1rPYCw13kIrTnSvUaStCoDFTyeYHXy7tgykiumnccGTI/edit#

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
