### PR TITLE
add missing data for hyphenate-limit-chars

### DIFF
--- a/css/properties/hyphenate-limit-chars.json
+++ b/css/properties/hyphenate-limit-chars.json
@@ -9,13 +9,22 @@
               "version_added": "109"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "≤79",
+                "prefix": "-ms-"
+              }
+            ],
             "firefox": {
               "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": false
+              "version_added": "10",
+              "prefix": "-ms-"
             },
             "oculus": "mirror",
             "opera": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

As part of my work on the [CSS `hyphenate-limit-chars` property](https://docs.google.com/document/d/1aLdSuLdZEMjdnMpeyBRdwwZyLr1JMbQ39Nk0ZWumLBU/edit#) (added to Chrome in version 109), I checked out the browser-compat-data. I found that the Chrome data was already there, but the [CSS Tricks article](https://css-tricks.com/almanac/properties/h/hyphenate-limit-chars/) mentions support in IE 10 and pre-Chromium versions of Edge with an `-ms-` prefix. I took this opportunity to add that data.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
