### PR TITLE
releases(CSS): Container queries are enabled by default in Fx 109 nightly

### DIFF
--- a/css/at-rules/container.json
+++ b/css/at-rules/container.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "109"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/container-name.json
+++ b/css/properties/container-name.json
@@ -12,7 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "109"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/container-type.json
+++ b/css/properties/container-type.json
@@ -12,7 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "109"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/container.json
+++ b/css/properties/container.json
@@ -12,7 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "109"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
Container queries (and length units) are enabled in 109 nightly

__Bugs:__
- https://bugzilla.mozilla.org/show_bug.cgi?id=1801123

__Related issues and pull requests:__
- [ ] Parent issue https://github.com/mdn/content/issues/22735
- [ ] Content PR https://github.com/mdn/content/pull/22766
