### PR TITLE
Use ED spec version for LargestContentfulPaint

### DIFF
--- a/api/LargestContentfulPaint.json
+++ b/api/LargestContentfulPaint.json
@@ -3,7 +3,7 @@
     "LargestContentfulPaint": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint",
-        "spec_url": "https://www.w3.org/TR/largest-contentful-paint/#sec-largest-contentful-paint-interface",
+        "spec_url": "https://w3c.github.io/largest-contentful-paint/#sec-largest-contentful-paint-interface",
         "support": {
           "chrome": {
             "version_added": "77"
@@ -36,7 +36,7 @@
       "element": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/element",
-          "spec_url": "https://www.w3.org/TR/largest-contentful-paint/#dom-largestcontentfulpaint-element",
+          "spec_url": "https://w3c.github.io/largest-contentful-paint/#dom-largestcontentfulpaint-element",
           "support": {
             "chrome": {
               "version_added": "77"
@@ -104,7 +104,7 @@
       "loadTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/loadTime",
-          "spec_url": "https://www.w3.org/TR/largest-contentful-paint/#dom-largestcontentfulpaint-loadtime",
+          "spec_url": "https://w3c.github.io/largest-contentful-paint/#dom-largestcontentfulpaint-loadtime",
           "support": {
             "chrome": {
               "version_added": "77"
@@ -172,7 +172,7 @@
       "size": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/size",
-          "spec_url": "https://www.w3.org/TR/largest-contentful-paint/#dom-largestcontentfulpaint-size",
+          "spec_url": "https://w3c.github.io/largest-contentful-paint/#dom-largestcontentfulpaint-size",
           "support": {
             "chrome": {
               "version_added": "77"
@@ -206,7 +206,7 @@
       "toJSON": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/toJSON",
-          "spec_url": "https://www.w3.org/TR/largest-contentful-paint/#dom-largestcontentfulpaint-tojson",
+          "spec_url": "https://w3c.github.io/largest-contentful-paint/#dom-largestcontentfulpaint-tojson",
           "support": {
             "chrome": {
               "version_added": "77"
@@ -240,7 +240,7 @@
       "url": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/LargestContentfulPaint/url",
-          "spec_url": "https://www.w3.org/TR/largest-contentful-paint/#dom-largestcontentfulpaint-url",
+          "spec_url": "https://w3c.github.io/largest-contentful-paint/#dom-largestcontentfulpaint-url",
           "support": {
             "chrome": {
               "version_added": "77"


### PR DESCRIPTION
I think we should point to the Editor's Draft which is more recent.