### PR TITLE
[CSS] Implement font-variant-emoji

### DIFF
--- a/css/properties/font-variant-emoji.json
+++ b/css/properties/font-variant-emoji.json
@@ -1,0 +1,40 @@
+{
+  "css": {
+    "properties": {
+      "font-variant-emoji": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-emoji",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts/#font-variant-emoji-prop",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "108"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -73,6 +73,40 @@
             }
           }
         },
+        "font-variant-emoji": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-emoji",
+            "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts/#font-variant-emoji-prop",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "108"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "greek_accented_characters": {
           "__compat": {
             "description": "Greek accented characters",


### PR DESCRIPTION
#### Summary

Added the BCD for `font-variant-emoji` and also to `font-variant`

#### Test results and supporting details

Tested in firefox nightly and firefox with the flag, being released in firefox 108. Other browsers currently have on plans to support this

#### Related issues

https://github.com/mdn/content/issues/22118