### PR TITLE
Apply mirroring to statements that can simply be mirrored

### DIFF
--- a/webextensions/api/omnibox.json
+++ b/webextensions/api/omnibox.json
@@ -9,9 +9,7 @@
               "chrome": {
                 "version_added": "44"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "52"
               },
@@ -33,9 +31,7 @@
               "chrome": {
                 "version_added": "9"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "notes": "'description' is interpreted as plain text, and XML markup is not recognized.",
                 "version_added": "52"
@@ -56,9 +52,7 @@
                 "chrome": {
                   "version_added": "9"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "52"
                 },
@@ -79,9 +73,7 @@
                 "chrome": {
                   "version_added": "63"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "109"
                 },
@@ -102,9 +94,7 @@
                 "chrome": {
                   "version_added": "9"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "52"
                 },
@@ -127,9 +117,7 @@
               "chrome": {
                 "version_added": "63"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "109"
               },
@@ -151,9 +139,7 @@
               "chrome": {
                 "version_added": "9"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "52"
               },
@@ -175,9 +161,7 @@
               "chrome": {
                 "version_added": "9"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "52"
               },
@@ -199,9 +183,7 @@
               "chrome": {
                 "version_added": "9"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "52"
               },
@@ -223,9 +205,7 @@
               "chrome": {
                 "version_added": "9"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "52"
               },
@@ -247,9 +227,7 @@
               "chrome": {
                 "version_added": "9"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "notes": "'description' is interpreted as plain text, and XML markup is not recognized.",
                 "version_added": "52"


### PR DESCRIPTION
This PR is a follow-up to recently merged PRs that runs the `fix` script to automatically mirror statements that should already be mirrored.
