### PR TITLE
Safari supports `start` and `end`

### DIFF
--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -324,7 +324,7 @@
                   "notes": "This value is recognized, but has no effect."
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "16.0"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -324,7 +324,7 @@
                   "notes": "This value is recognized, but has no effect."
                 },
                 "safari": {
-                  "version_added": "16.0"
+                  "version_added": "15.6"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -300,7 +300,7 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "16"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -300,7 +300,7 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": "16"
+                  "version_added": "15.4"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -307,7 +307,7 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": "16.0"
+                  "version_added": "15.4"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -307,7 +307,7 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "16.0"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -248,7 +248,7 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": false
+                  "version_added": "16.0"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -248,7 +248,7 @@
                   "version_added": false
                 },
                 "safari": {
-                  "version_added": "16.0"
+                  "version_added": "15.4"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Add support for `start` and `end` on `align-items` for Safari 16. 

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
Navigate to https://developer.mozilla.org/en-US/docs/Web/CSS/align-items in Chrome (107.0.5304.110) and Safari (16). Visually compare behavior of Results section.

Compared values:
- `normal`
- `flex-start`
- `flex-end`
- `start`
- `end`

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Screenshot of Safari 16 with one of the aforementioned values:

<img width="732" alt="image" src="https://user-images.githubusercontent.com/841084/206583753-344c5dfa-f527-4671-9aa3-e9da9937efad.png">

As for existing bug reports, I didn't find anything specific to `align-items` -- I will admit I am not acquainted with searching for bugs in webkit. A [a comment in a similar report](https://bugs.webkit.org/show_bug.cgi?id=157070#c6) mentions that many flexbox bugs were fixed by Feb 2022. 

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #16049

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
