### PR TITLE
releases(API): Fx 109 enables scrollend event by default which indicates scroll is complete

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6465,6 +6465,44 @@
           }
         }
       },
+      "scrollend_event": {
+        "__compat": {
+          "description": "<code>scrollend</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/scrollend_event",
+          "spec_url": [
+            "https://w3c.github.io/csswg-drafts/cssom-view/#eventdef-document-scrollend",
+            "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onscrollend"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "preview"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "109"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "scrollingElement": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/scrollingElement",

--- a/api/Element.json
+++ b/api/Element.json
@@ -7484,6 +7484,50 @@
           }
         }
       },
+      "scrollend_event": {
+        "__compat": {
+          "description": "<code>scrollend</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/scrollend_event",
+          "spec_url": [
+            "https://w3c.github.io/csswg-drafts/cssom-view/#eventdef-document-scrollend",
+            "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onscrollend"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "preview"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": "109"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "scrollBy": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/scrollBy",

--- a/api/Element.json
+++ b/api/Element.json
@@ -7485,50 +7485,6 @@
           }
         }
       },
-      "scrollend_event": {
-        "__compat": {
-          "description": "<code>scrollend</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/scrollend_event",
-          "spec_url": [
-            "https://w3c.github.io/csswg-drafts/cssom-view/#eventdef-document-scrollend",
-            "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onscrollend"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "preview"
-            },
-            "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
-            "firefox": {
-              "version_added": "109"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "scrollBy": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/scrollBy",
@@ -7659,6 +7615,44 @@
               "standard_track": true,
               "deprecated": false
             }
+          }
+        }
+      },
+      "scrollend_event": {
+        "__compat": {
+          "description": "<code>scrollend</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/scrollend_event",
+          "spec_url": [
+            "https://w3c.github.io/csswg-drafts/cssom-view/#eventdef-document-scrollend",
+            "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onscrollend"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "preview"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "109"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
           }
         }
       },


### PR DESCRIPTION
The `scrollend` event indicates scrolling is complete inside the Document or inside scrollable elements.

__Bugs:__
- https://bugzilla.mozilla.org/show_bug.cgi?id=1797013

__Related issues and pull requests:__
- [x] Content PR https://github.com/mdn/content/pull/22894
- [ ] Parent issue https://github.com/mdn/content/issues/22814

__Support details:__
- Fx:
    - __108__ behind pref `apz.scrollend-event.content.enabled`
    - __109__ pref `apz.scrollend-event.content.enabled` set to `true` by default
- Chrome:
    - __110__ behind [CL flag](https://bugs.chromium.org/p/chromium/issues/detail?id=907601) `use --enable-blink-features=OverscrollCustomization` (see [platform status page](https://chromestatus.com/feature/5186382643855360))