### PR TITLE
Firefox supports `OffscreenCanvas`'s `convertToBlob()`

### DIFF
--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -152,10 +152,15 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "105",
-              "alternative_name": "toBlob"
-            },
+            "firefox": [
+              {
+                "version_added": "105"
+              },
+              {
+                "version_added": "105",
+                "alternative_name": "toBlob"
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
I tested to confirm that Firefox supports both the standard name (`convertToBlob`) in addition to the alternative name (`toBlob`), not merely in place of it.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Firefox supports the standard name (`convertToBlob`) in addition to the alternative name (`toBlob`).

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

- Testing in Firefox 105, `'convertToBlob' in OffscreenCanvas.prototype` → `true`.
- I checked the dependency tree on [bug 1390089](https://bugzilla.mozilla.org/show_bug.cgi?id=1390089) and couldn't find any evidence of problems with the standard name (and found several references to tests of `convertToBlob`).

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
