### PR TITLE
update local font access API data

### DIFF
--- a/api/FontData.json
+++ b/api/FontData.json
@@ -7,7 +7,9 @@
           "chrome": {
             "version_added": "103"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -17,7 +19,9 @@
             "version_added": false
           },
           "oculus": "mirror",
-          "opera": "mirror",
+          "opera": {
+            "version_added": false
+          },
           "opera_android": "mirror",
           "safari": {
             "version_added": false
@@ -39,7 +43,9 @@
             "chrome": {
               "version_added": "103"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -49,7 +55,9 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": false
+            },
             "opera_android": "mirror",
             "safari": {
               "version_added": false
@@ -72,7 +80,9 @@
             "chrome": {
               "version_added": "103"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -82,7 +92,9 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": false
+            },
             "opera_android": "mirror",
             "safari": {
               "version_added": false
@@ -105,7 +117,9 @@
             "chrome": {
               "version_added": "103"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -115,7 +129,9 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": false
+            },
             "opera_android": "mirror",
             "safari": {
               "version_added": false
@@ -138,7 +154,9 @@
             "chrome": {
               "version_added": "103"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -148,7 +166,9 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": false
+            },
             "opera_android": "mirror",
             "safari": {
               "version_added": false
@@ -171,7 +191,9 @@
             "chrome": {
               "version_added": "103"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -181,7 +203,9 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": false
+            },
             "opera_android": "mirror",
             "safari": {
               "version_added": false

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -351,6 +351,49 @@
           }
         }
       },
+      "local-fonts_permission": {
+        "__compat": {
+          "description": "<code>local-fonts</code> permission",
+          "support": {
+            "chrome": {
+              "version_added": "103"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "magnetometer_permission": {
         "__compat": {
           "description": "<code>magnetometer</code> permission",

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -380,12 +380,8 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,

--- a/api/Window.json
+++ b/api/Window.json
@@ -4062,9 +4062,7 @@
             "ie": {
               "version_added": false
             },
-            "oculus": {
-              "version_added": false
-            },
+            "oculus": "mirror",
             "opera": {
               "version_added": false
             },

--- a/api/Window.json
+++ b/api/Window.json
@@ -4071,12 +4071,8 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": false
-            },
-            "webview_android": {
-              "version_added": false
-            }
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,

--- a/api/Window.json
+++ b/api/Window.json
@@ -4051,7 +4051,9 @@
             "chrome": {
               "version_added": "103"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -4060,15 +4062,23 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
-            "opera": "mirror",
+            "oculus": {
+              "version_added": false
+            },
+            "opera": {
+              "version_added": false
+            },
             "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -750,9 +750,7 @@
               "ie": {
                 "version_added": false
               },
-              "oculus": {
-                "version_added": false
-              },
+              "oculus": "mirror",
               "opera": {
                 "version_added": false
               },

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -731,6 +731,50 @@
             }
           }
         },
+        "local-fonts": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/local-fonts",
+            "spec_url": "https://wicg.github.io/local-font-access/#permissions-policy",
+            "support": {
+              "chrome": {
+                "version_added": "103"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "magnetometer": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/magnetometer",

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -759,12 +759,8 @@
                 "version_added": false
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": true,


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR updates the compact data for the [Local Font Access API](https://wicg.github.io/local-font-access/):

* The API features were already there, but the data was slightly wrong (the API is currently available only on Chromium desktop, not mobile).
* I also added data points for the `local-fonts` Permissions Policy header directive, and Permissions API permission.

See my research document for more details of exactly what the larger work involves: https://docs.google.com/document/d/1q1p_wlMe67LYvSuwbTZDOuL0csfG2rw_3qT2ROpC2sY/edit#

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
