### PR TITLE
Update Edge to support 103 Early Hints

### DIFF
--- a/http/status.json
+++ b/http/status.json
@@ -46,9 +46,7 @@
               "version_added": "103"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Edge appears to support 103 Early Hints from WPT, I presume from same version as Chrome (it's not noted at all in the Edge release notes)

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
https://wpt.fyi/results/loading/early-hints?label=experimental&label=master&aligned

You can also see it working from this test, where the fonts load early:
https://www.webpagetest.org/result/221213_BiDcDR_DN3/1/details/

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
