### PR TITLE
Firefox 108 is released

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -774,28 +774,28 @@
         "107": {
           "release_date": "2022-11-15",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/107",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "107"
         },
         "108": {
           "release_date": "2022-12-13",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/108",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "108"
         },
         "109": {
           "release_date": "2023-01-17",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/109",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "109"
         },
         "110": {
           "release_date": "2023-02-14",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/110",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "110"
         },

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -641,28 +641,28 @@
         "107": {
           "release_date": "2022-11-15",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/107",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "107"
         },
         "108": {
           "release_date": "2022-12-13",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/108",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "108"
         },
         "109": {
           "release_date": "2023-01-17",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/109",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "109"
         },
         "110": {
           "release_date": "2023-02-14",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/110",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "110"
         },


### PR DESCRIPTION
This PR marks Firefox 108 as released.
