### PR TITLE
Update Chromium versions for api.CSS.vb/vi

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -1401,8 +1401,7 @@
           "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-vb",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/778495'>bug 778495</a>."
+              "version_added": "108"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -1472,8 +1471,7 @@
           "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-vi",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/778495'>bug 778495</a>."
+              "version_added": "108"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `vb` and `vi` members of the `CSS` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.0).

Tests Used:
https://mdn-bcd-collector.gooborg.com/tests/api/CSS/vb
https://mdn-bcd-collector.gooborg.com/tests/api/CSS/vi

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
