### PR TITLE
Update Firefox versions for OES_draw_buffers_indexed API

### DIFF
--- a/api/OES_draw_buffers_indexed.json
+++ b/api/OES_draw_buffers_indexed.json
@@ -10,7 +10,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "108"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -42,7 +42,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "108"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -75,7 +75,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "108"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -108,7 +108,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "108"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -141,7 +141,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "108"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -174,7 +174,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "108"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -207,7 +207,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "108"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -240,7 +240,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "108"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `OES_draw_buffers_indexed` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/OES_draw_buffers_indexed

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
