### PR TITLE
Update Firefox versions for api.MIDIInputMap.@@iterator

### DIFF
--- a/api/MIDIInputMap.json
+++ b/api/MIDIInputMap.json
@@ -388,7 +388,9 @@
             "firefox": {
               "version_added": "108"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/api/MIDIInputMap.json
+++ b/api/MIDIInputMap.json
@@ -386,7 +386,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "108"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -403,7 +403,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `@@iterator` member of the `MIDIInputMap` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/MIDIInputMap/@@iterator

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
