### PR TITLE
Update Firefox versions for api.HTMLSourceElement.height/width

### DIFF
--- a/api/HTMLSourceElement.json
+++ b/api/HTMLSourceElement.json
@@ -51,7 +51,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "108"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -284,7 +284,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "108"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `height` and `width` members of the `HTMLSourceElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.0).

Tests Used:
https://mdn-bcd-collector.gooborg.com/tests/api/HTMLSourceElement/height
https://mdn-bcd-collector.gooborg.com/tests/api/HTMLSourceElement/width

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
