### PR TITLE
Update Chromium versions for javascript.builtins.Intl.PluralRules.selectRange

### DIFF
--- a/javascript/builtins/Intl/PluralRules.json
+++ b/javascript/builtins/Intl/PluralRules.json
@@ -186,7 +186,7 @@
               "spec_url": "https://tc39.es/proposal-intl-numberformat-v3/out/pluralrules/proposed.html#sec-intl.pluralrules.prototype.selectrange",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "106"
                 },
                 "chrome_android": "mirror",
                 "deno": {
@@ -214,7 +214,7 @@
                 "webview_android": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `selectRange` member of the `Intl/PluralRules` JavaScript builtin, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/javascript/builtins/Intl/PluralRules/selectRange

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
