### PR TITLE
Update Firefox versions for font-palette CSS property

### DIFF
--- a/api/CSSFontPaletteValuesRule.json
+++ b/api/CSSFontPaletteValuesRule.json
@@ -10,7 +10,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "107"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -42,7 +42,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "107"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -75,7 +75,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "107"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -108,7 +108,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "107"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -141,7 +141,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "107"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/font-palette.json
+++ b/css/properties/font-palette.json
@@ -12,7 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "107"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `font-palette` CSS property, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.0).

Tests Used:
https://mdn-bcd-collector.gooborg.com/tests/api/CSSFontPaletteValuesRule
https://mdn-bcd-collector.gooborg.com/tests/css/properties/font-palette

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
