### PR TITLE
Note Safari limited support for hanging-punctuation

### DIFF
--- a/css/properties/hanging-punctuation.json
+++ b/css/properties/hanging-punctuation.json
@@ -24,7 +24,10 @@
             "safari": {
               "version_added": "10",
               "partial_implementation": true,
-              "notes": "The <code>force-end</code> keyword is recognized but has no effect."
+              "notes": [
+                "The <code>force-end</code> keyword is recognized but has no effect.",
+                "The characters <code>U+0027</code> and <code>U+0022</code> are not supported by the <code>first</code> and <code>last</code> keywords."
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR notes Safari's limited support for [`hanging-punctuation`](https://developer.mozilla.org/en-US/docs/Web/CSS/hanging-punctuation), based in the conversation in https://github.com/mdn/content/pull/22022 and in particular https://github.com/mdn/content/pull/22022#issuecomment-1304291411.