### PR TITLE
chore: modulepreload experimental status expire

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -810,7 +810,7 @@
                 "webview_android": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

According to [data-guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#setting-experimental), This API supported by chrome 5 years ago. [feature release blog](https://developer.chrome.com/blog/modulepreload/)
We are now setting modulepreload experimental status to false

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

https://developer.chrome.com/blog/modulepreload/

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/content/issues/23004

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
