### PR TITLE
Update <link crossorigin> data to match API

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -82,35 +82,31 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "25"
+                "version_added": "34"
               },
               "chrome_android": {
-                "version_added": true
+                "version_added": "mirror"
               },
-              "edge": "mirror",
+              "edge": {
+                "version_added": "17"
+              },
               "firefox": {
                 "version_added": "18",
                 "notes": "Before Firefox 83, <code>crossorigin</code> is not supported for <code>rel=\"icon\"</code>."
               },
-              "firefox_android": {
-                "version_added": "18"
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -84,7 +84,7 @@
               "chrome": {
                 "version_added": "34"
               },
-              "chrome_android": "mirror"
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "17"
               },

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -84,9 +84,7 @@
               "chrome": {
                 "version_added": "34"
               },
-              "chrome_android": {
-                "version_added": "mirror"
-              },
+              "chrome_android": "mirror"
               "edge": {
                 "version_added": "17"
               },


### PR DESCRIPTION
Inconsistency pointed out by @gsnedders here:
https://github.com/mdn/browser-compat-data/issues/18368

Most of this is originally from wiki migration:
https://github.com/mdn/browser-compat-data/pull/279

The Chromium implementation was in M34:
https://chromium.googlesource.com/chromium/src/+/21e65a63bf8e3947ff4b4d34cb73866c413106e2
https://www.chromium.org/developers/calendar/

There was no use of "crossorigin" in HTMLLinkElement.cpp before this
point, and https://crbug.com/178787 doesn't say anything to suggest
there was partial support, so assume the old data was wrong.

For Edge and Safari, just trust the data for HTMLLinkElement.
