### PR TITLE
CSS @font-face src string allows invalid items

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -839,7 +839,7 @@
                 "chrome": {
                   "version_added": "108",
                   "partial_implementation": true,
-                  "notes": "Chrome only drops invalid item for tech() (not supported)"
+                  "notes": "Chrome drops invalid item for <code>tech()</code> but not other invalid values"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -832,6 +832,41 @@
               "deprecated": false
             }
           },
+          "drop_invalid_item": {
+            "__compat": {
+              "description": "Drop invalid item (not src string)",
+              "support": {
+                "chrome": {
+                  "version_added": "108",
+                  "partial_implementation": true,
+                  "notes": "Chrome only drops invalid item for tech() (not supported)"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "109"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "format_keyword": {
             "__compat": {
               "description": "<code>format(keyword)</code>",


### PR DESCRIPTION
The CSS [`@font-face`](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face#src) at rule takes as a `src` a comma separate list of possible font descriptors. As per [the spec here](https://w3c.github.io/csswg-drafts/css-fonts/#font-face-src-parsing) the parser is supposed to treat each item in the `src` separately, adding those that are valid and dropping those that are invalid or not supported. However a number of browser will drop the whole `src` string if any item is not understood.

- Firefox starts handling items properly from FF109.
- Chrome "somewhat" handles this properly in FF108. Specifically, even though they do not support `tech()` they will drop an item that uses `tech()` and not the whole string. However if you use another value like `fred()` they will drop the whole line. In other words, not a future proof implementation as new values are added, but works for the currently supported set.
- Safari doesn't want to display its developer tools for me, so I don't know - have put as false.


My test code is to run this in a console:
```
s = document.createElement("style");
document.body.appendChild(s);
s.textContent = "@font-face { font-family: x; src: url('x.woff2') format('woff2'),url('y.otf') format(opentype) fred(incremental); }";
let thingy = document.styleSheets[document.styleSheets.length-1].cssRules[0].cssText
thingy;
```
If the `src` is present in "thingy" then the string is parsed properly. This fails for chrome, but if you change `fred` to `tech` above you can see it works for that single (most important) case.

This comes out of discussion in https://github.com/w3c/csswg-drafts/issues/7753#issuecomment-1358792998

FYI @queengooborg 