### PR TITLE
add data for iframe credentialless

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -907,6 +907,38 @@
           }
         }
       },
+      "credentialless": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "110"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "customElements": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/customElements",

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -237,6 +237,38 @@
             }
           }
         },
+        "credentialless": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "110"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
         "external_protocol_urls_blocked": {
           "__compat": {
             "description": "External protocol URLs blocked",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR adds compact data for iframe credentialless features. See my [research document](https://docs.google.com/document/d/17mT4HI-dRnt6wT58907ubrkyhu1HjTiIH4JAIBqjKng/edit#) for more information about this, and the overall scope of the work.

Note: I have stated the features as `"standard_track": false` for now. There is a community group report at https://wicg.github.io/anonymous-iframe, but this isn’t a proper specification, in terms of specifying API additions, behavioral changes to storage, etc. I think it'd be better to and wait until the open PRs on the other specs are merged. See:

* https://github.com/whatwg/html/pull/7695 
* https://github.com/whatwg/fetch/pull/1416
* https://github.com/whatwg/storage/pull/139 

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Demo available at https://anonymous-iframe.glitch.me/.

I tested this in Chrome, Firefox Nightly, and Safari Preview. No support in the latter two yet.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->