### PR TITLE
update data for requestPointerLock unadjustedMovement option

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -7246,7 +7246,8 @@
             "description": "<code>options.unadjustedMovement</code> parameter",
             "support": {
               "chrome": {
-                "version_added": "92"
+                "version_added": "88",
+                "notes": "Supported on macOS Catalina 10.15.1+, Windows, and ChromeOS. Not yet supported on Linux."
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR adjusts the data for the `Element.requestPointerLock()` method's `unadjustedMovement` option. Upon looking at the [ChromeStatus](https://chromestatus.com/feature/5723553087356928) page and the [Chrome blog post](https://web.dev/disable-mouse-acceleration/), I noticed two things:

* It was launched fully as of Chrome 88. A bunch of different things happened in 81–88, but the full launch happened in 88, not 92.
* It is supported in Windows/macOS/ChromeOS, but not Linux as of yet.

I've updated the BCD entry to cover these points.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
