### PR TITLE
Add `@import layer()`

### DIFF
--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -42,6 +42,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "layer": {
+          "__compat": {
+            "description": "<code>layer(<layer-name>)</code>",
+            "support": {
+              "chrome": {
+                "version_added": "99"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "97"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

This adds a single subfeature to `@import` for the `layer` function.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

I tested this manually to confirm that it works. This isn't surprising, since it matches the data for `@layer`.

I added a single feature, though I'm not 100% certain if that's the right call. There's also a `layer` **keyword** that creates an anonymous layer. The question is: conceptually, is this a single function called with or without an argument? Or is this distinctly two features: a keyword and a function?

I'm not 100% certain and I'd like a review that specifically confirms the answer to that question.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->