### PR TITLE
Remove support for video-dynamic-range

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1475,7 +1475,7 @@
             "spec_url": "https://w3c.github.io/csswg-drafts/mediaqueries-5/#video-dynamic-range",
             "support": {
               "chrome": {
-                "version_added": "98"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1490,7 +1490,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "13.1"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
I have run [test](https://codepen.io/NiedziolkaMichal/pen/YzjPGRr) on Chrome, Firefox, and Safari. Only firefox has this feature working.
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->
[Chromium issue](https://bugs.chromium.org/p/chromium/issues/detail?id=1224711&q=video-dynamic-range&can=2)
[Webkit issue](https://bugs.webkit.org/show_bug.cgi?id=249678)

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
