### PR TITLE
`javascript.builtins.RegExp.hasIndices` supported by Node.js 16

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -388,7 +388,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "16.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Set supported Node.js version for `javascript.builtins.RegExp.hasIndices` to `16.0.0`

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

- Ran `/.../d` and `/.../.hasIndices` in Node.js
- Reviewed [Node.js 16.0.0 release notes](https://nodejs.org/en/blog/release/v16.0.0/#v8-9-0)