### PR TITLE
Updated the input range tickmark version for FF

### DIFF
--- a/html/elements/input/range.json
+++ b/html/elements/input/range.json
@@ -70,8 +70,7 @@
                   "version_added": "≤79"
                 },
                 "firefox": {
-                  "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/841942'>bug 841942</a>."
+                  "version_added": "109"
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
#### Summary

Added the version number for `list` attribute on input type range for FF

#### Test results and supporting details

Tested with Nightly and tagged in [Bug #841942](https://bugzilla.mozilla.org/show_bug.cgi?id=841942)

#### Related issues

[[HTML] Update doc for tick mark support for <input type=range> when @list/<datalist> is used](https://github.com/mdn/content/issues/22892)
[Pull Request](https://github.com/mdn/content/pull/23135)