### PR TITLE
feat(css): Update CSS Values Level 4 `rem()` compatibility data

### DIFF
--- a/css/types/rem.json
+++ b/css/types/rem.json
@@ -17,7 +17,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "layout.css..mod-rem.enabled",
+                  "name": "layout.css.mod-rem.enabled",
                   "value_to_set": "true"
                 }
               ]

--- a/css/types/rem.json
+++ b/css/types/rem.json
@@ -5,16 +5,25 @@
         "__compat": {
           "description": "<code>rem()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/rem",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-values/#exponent-funcs",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-values/#funcdef-rem",
           "support": {
             "chrome": {
               "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.mod-rem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/css/types/rem.json
+++ b/css/types/rem.json
@@ -12,18 +12,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "109",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.mod-rem.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "109",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css..mod-rem.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
#### Summary

Firefox 109 added support for CSS `rem()` function.

Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1785117
