### PR TITLE
feat(css): Update CSS Values Level 4 `mod()` compatibility data

### DIFF
--- a/css/types/mod.json
+++ b/css/types/mod.json
@@ -5,16 +5,25 @@
         "__compat": {
           "description": "<code>mod()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mod",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-values/#exponent-funcs",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-values/#funcdef-mod",
           "support": {
             "chrome": {
               "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.mod-rem.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
#### Summary

Firefox 109 adds support for CSS `mod()` function.

Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1785117
