### PR TITLE
Fix lint-staged configuration

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,5 +1,5 @@
 {
   "*": "prettier --ignore-unknown --write",
   "*.{js,jsx,tsx}": "eslint --fix",
-  "!browsers/*.json": "npm run lint:fix"
+  "./!(browsers)/**/*.json": "npm run lint:fix"
 }


### PR DESCRIPTION
This PR fixes the lint-staged configuration and ensures that `npm run lint:fix` isn't run on `package.json` and other root-level JSON files.
