### PR TITLE
Update background-attachment.json

### DIFF
--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -118,11 +118,9 @@
                 "version_added": "10.5"
               },
               "opera_android": "mirror",
-              "safari": [
-                {
-                  "version_added": "5"
-                }
-              ],
+              "safari": {
+                "version_added": "5"
+              },
               "safari_ios": [
                 {
                   "version_added": "13"

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -120,20 +120,12 @@
               "opera_android": "mirror",
               "safari": [
                 {
-                  "version_added": "13",
-                  "partial_implementation": true,
-                  "notes": "<code>local</code> is recognized but has no effect due to <a href='https://webkit.org/b/219324'>a bug</a>."
-                },
-                {
-                  "version_added": "5",
-                  "version_removed": "13"
+                  "version_added": "5"
                 }
               ],
               "safari_ios": [
                 {
-                  "version_added": "13",
-                  "partial_implementation": true,
-                  "notes": "<code>local</code> is recognized but has no effect due to <a href='https://webkit.org/b/219324'>a bug</a>."
+                  "version_added": "13"
                 },
                 {
                   "version_added": "4.2",

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -69,7 +69,11 @@
               "opera_android": "mirror",
               "safari": [
                 {
+                  "version_added": "15.4"
+                },
+                {
                   "version_added": "14",
+                  "version_removed": "15.4",
                   "partial_implementation": true,
                   "notes": "<code>local</code> is recognized but has no effect due to <a href='https://webkit.org/b/219324'>a bug</a>."
                 },
@@ -78,11 +82,16 @@
                   "version_removed": "14"
                 }
               ],
-              "safari_ios": {
-                "version_added": "5",
-                "partial_implementation": true,
-                "notes": "<code>fixed</code> is recognized but has no effect. See <a href='https://webkit.org/b/219324'>bug 219324</a>."
-              },
+              "safari_ios": [
+                {
+                  "version_added": "15.4"
+                },
+                {
+                  "version_added": "5",
+                  "partial_implementation": true,
+                  "notes": "<code>fixed</code> is recognized but has no effect. See <a href='https://webkit.org/b/219324'>bug 219324</a>."
+                }
+              ],
               "samsunginternet_android": "mirror",
               "webview_android": {
                 "version_added": "37"
@@ -118,12 +127,30 @@
                 "version_added": "10.5"
               },
               "opera_android": "mirror",
-              "safari": {
-                "version_added": "5"
-              },
+              "safari": [
+                {
+                  "version_added": "15.4"
+                },
+                {
+                  "version_added": "13",
+                  "version_removed": "15.4",
+                  "partial_implementation": true,
+                  "notes": "<code>local</code> is recognized but has no effect due to <a href='https://webkit.org/b/219324'>a bug</a>."
+                },
+                {
+                  "version_added": "5",
+                  "version_removed": "13"
+                }
+              ],
               "safari_ios": [
                 {
-                  "version_added": "13"
+                  "version_added": "15.4"
+                },
+                {
+                  "version_added": "13",
+                  "version_removed": "15.4",
+                  "partial_implementation": true,
+                  "notes": "<code>local</code> is recognized but has no effect due to <a href='https://webkit.org/b/219324'>a bug</a>."
                 },
                 {
                   "version_added": "4.2",

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -88,6 +88,7 @@
                 },
                 {
                   "version_added": "5",
+                  "version_removed": "15.4",
                   "partial_implementation": true,
                   "notes": "<code>fixed</code> is recognized but has no effect. See <a href='https://webkit.org/b/219324'>bug 219324</a>."
                 }

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -72,14 +72,14 @@
                   "version_added": "15.4"
                 },
                 {
+                  "version_added": "3.1",
+                  "version_removed": "14"
+                },
+                {
                   "version_added": "14",
                   "version_removed": "15.4",
                   "partial_implementation": true,
                   "notes": "<code>local</code> is recognized but has no effect due to <a href='https://webkit.org/b/219324'>a bug</a>."
-                },
-                {
-                  "version_added": "3.1",
-                  "version_removed": "14"
                 }
               ],
               "safari_ios": [
@@ -133,14 +133,14 @@
                   "version_added": "15.4"
                 },
                 {
+                  "version_added": "5",
+                  "version_removed": "13"
+                },
+                {
                   "version_added": "13",
                   "version_removed": "15.4",
                   "partial_implementation": true,
                   "notes": "<code>local</code> is recognized but has no effect due to <a href='https://webkit.org/b/219324'>a bug</a>."
-                },
-                {
-                  "version_added": "5",
-                  "version_removed": "13"
                 }
               ],
               "safari_ios": [
@@ -148,15 +148,15 @@
                   "version_added": "15.4"
                 },
                 {
+                  "version_added": "4.2",
+                  "version_removed": "13",
+                  "notes": "If <code>-webkit-overflow-scrolling: touch</code> is set, then <code>local</code> has no effect."
+                },
+                {
                   "version_added": "13",
                   "version_removed": "15.4",
                   "partial_implementation": true,
                   "notes": "<code>local</code> is recognized but has no effect due to <a href='https://webkit.org/b/219324'>a bug</a>."
-                },
-                {
-                  "version_added": "4.2",
-                  "version_removed": "13",
-                  "notes": "If <code>-webkit-overflow-scrolling: touch</code> is set, then <code>local</code> has no effect."
                 }
               ],
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
Removed mention of background-attachment: local bug. Fixes https://github.com/mdn/browser-compat-data/issues/18821

#### Summary

I've removed the mention of background-attachment: local not working on iOS. According to the [bug report](https://bugs.webkit.org/show_bug.cgi?id=219324) it has been fixed and merged. However I'm not exactly sure in which Safari version.

#### Test results and supporting details

I've tested this on an iPhone 12 Pro iOS16.2 and using BrowserStack iPhone 12 Pro iOS14. 
Using these examples: 
https://codepen.io/smashingmag/pen/ExRNxpd
https://codepen.io/bramus/pen/ExxgNrV

#### Related
[This is another bug](https://bugs.webkit.org/show_bug.cgi?id=181048) that has been fixed by the same fix.