### PR TITLE
Add Chrome version numbers for tabs webextensions API

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1226,7 +1226,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/ZoomSettings",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "79"
@@ -1248,14 +1248,14 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "43"
                 },
                 "edge": {
                   "version_added": "79"
                 },
                 "firefox": [
                   {
-                    "version_added": "107"
+                    "version_added": "110"
                   },
                   {
                     "version_added": "45",
@@ -1278,7 +1278,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "38"
                 },
                 "edge": {
                   "version_added": "79"
@@ -1301,7 +1301,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "38"
                 },
                 "edge": {
                   "version_added": "79"
@@ -1326,7 +1326,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/ZoomSettingsMode",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "79"
@@ -1350,7 +1350,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/ZoomSettingsScope",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "38"
               },
               "edge": {
                 "version_added": "79"
@@ -2163,7 +2163,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getZoomSettings",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "42"
               },
               "edge": {
                 "version_added": "79"


### PR DESCRIPTION
#### Summary

Fix up the version_added field for a couple properties

#### Test results and supporting details

https://web.archive.org/web/20150609090643/https://developer.chrome.com/extensions/tabs#method-getZoomSettings
https://web.archive.org/web/20150609090643/https://developer.chrome.com/extensions/tabs#type-ZoomSettings

#### Related issues

https://bugzilla.mozilla.org/show_bug.cgi?id=1772166
