### PR TITLE
FF109: CSS system-color add Mark, MarkText, ButtonBorder

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -1027,6 +1027,44 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "mark_marktext_buttonborder": {
+            "__compat": {
+              "description": "Mark, MarkText, ButtonBorder",
+              "spec_url": [
+                "https://w3c.github.io/csswg-drafts/css-color/#valdef-system-color-mark",
+                "https://w3c.github.io/csswg-drafts/css-color/#valdef-system-color-marktext",
+                "https://w3c.github.io/csswg-drafts/css-color/#valdef-system-color-buttonborder"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "109"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "transparent": {


### PR DESCRIPTION
FF109 adds support for new [`<system-color>`](https://developer.mozilla.org/en-US/docs/Web/CSS/system-color#mark) values `Mark`, `MarkText`, `ButtonBorder` in https://bugzilla.mozilla.org/show_bug.cgi?id=1638052

There is no support in Chrome according to https://bugs.chromium.org/p/chromium/issues/detail?id=1260079.

There is no evident of support in Safari et al.

Other docs work for this can be tracked in https://github.com/mdn/content/issues/23334