### PR TITLE
Set Brotli as supported on Safari iOS

### DIFF
--- a/http/headers/Content-Encoding.json
+++ b/http/headers/Content-Encoding.json
@@ -68,7 +68,7 @@
                 "notes": "Unsupported before macOS 10.13 High Sierra."
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "11"
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Set Brotli as supported on Safari iOS since version 11.

#### Test results and supporting details

See #12305

#### Related issues

Fix #12305
