### PR TITLE
Safari 16.2 is released

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -230,9 +230,16 @@
         "16.1": {
           "release_date": "2022-10-24",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_1-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "614.2.9"
+        },
+        "16.2": {
+          "release_date": "2022-12-13",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_2-release-notes",
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "614.3.9"
         }
       }
     }

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -239,7 +239,7 @@
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_2-release-notes",
           "status": "current",
           "engine": "WebKit",
-          "engine_version": "614.3.9"
+          "engine_version": "614.3.7"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -202,9 +202,16 @@
         "16.1": {
           "release_date": "2022-10-24",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_1-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "614.2.9"
+        },
+        "16.2": {
+          "release_date": "2022-12-13",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_2-release-notes",
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "614.3.9"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -211,7 +211,7 @@
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_2-release-notes",
           "status": "current",
           "engine": "WebKit",
-          "engine_version": "614.3.9"
+          "engine_version": "614.3.7"
         }
       }
     }


### PR DESCRIPTION
This PR adds Safari 16.2 to BCD, marking it as the current Safari version.  The release date comes from https://support.apple.com/en-us/HT201222.  Engine version comes from Safari's About panel.
