### PR TITLE
Update Safari versions for CSSFontFeatureValuesRule API

### DIFF
--- a/api/CSSFontFeatureValuesRule.json
+++ b/api/CSSFontFeatureValuesRule.json
@@ -19,7 +19,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "preview"
+            "version_added": "16.2"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -51,7 +51,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "16.2"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/CSSFontFeatureValuesRule.json
+++ b/api/CSSFontFeatureValuesRule.json
@@ -2,6 +2,7 @@
   "api": {
     "CSSFontFeatureValuesRule": {
       "__compat": {
+        "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts-4/#cssfontfeaturevaluesrule",
         "support": {
           "chrome": {
             "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `CSSFontFeatureValuesRule` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CSSFontFeatureValuesRule

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
