### PR TITLE
Update Safari versions for font-variant-alternates CSS property

### DIFF
--- a/css/properties/font-variant-alternates.json
+++ b/css/properties/font-variant-alternates.json
@@ -56,7 +56,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "16.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -90,7 +90,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "16.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -124,7 +124,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "16.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -158,7 +158,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "16.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -192,7 +192,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "16.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -226,7 +226,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "16.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `font-variant-alternates` CSS property, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.2).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/font-variant-alternates

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
