### PR TITLE
Set preview->false for features not in Safari 16.2

### DIFF
--- a/api/CSPViolationReportBody.json
+++ b/api/CSPViolationReportBody.json
@@ -25,7 +25,7 @@
             "version_added": "48"
           },
           "safari": {
-            "version_added": "preview"
+            "version_added": false
           },
           "safari_ios": "mirror",
           "samsunginternet_android": {
@@ -64,7 +64,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -104,7 +104,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -144,7 +144,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -184,7 +184,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -224,7 +224,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -264,7 +264,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -304,7 +304,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -344,7 +344,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -384,7 +384,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -424,7 +424,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -464,7 +464,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -502,7 +502,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {

--- a/api/CSSStyleSheet.json
+++ b/api/CSSStyleSheet.json
@@ -65,7 +65,7 @@
               "version_added": "47"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -374,7 +374,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -408,7 +408,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/CompressionStream.json
+++ b/api/CompressionStream.json
@@ -37,7 +37,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "preview"
+            "version_added": false
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -234,7 +234,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -274,7 +274,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/DecompressionStream.json
+++ b/api/DecompressionStream.json
@@ -37,7 +37,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "preview"
+            "version_added": false
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -234,7 +234,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -274,7 +274,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/Document.json
+++ b/api/Document.json
@@ -230,7 +230,7 @@
               "version_added": "50"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/EncodedVideoChunk.json
+++ b/api/EncodedVideoChunk.json
@@ -21,7 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "preview"
+            "version_added": false
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -55,7 +55,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -89,7 +89,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -123,7 +123,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -157,7 +157,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -191,7 +191,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -225,7 +225,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -509,7 +509,7 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/HTMLSlotElement.json
+++ b/api/HTMLSlotElement.json
@@ -54,7 +54,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -263,7 +263,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2063,7 +2063,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -4652,7 +4652,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -179,7 +179,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -287,7 +287,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -713,7 +713,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -785,7 +785,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/PerformanceServerTiming.json
+++ b/api/PerformanceServerTiming.json
@@ -21,7 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "preview"
+            "version_added": false
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -54,7 +54,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -88,7 +88,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -122,7 +122,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -156,7 +156,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/PermissionStatus.json
+++ b/api/PermissionStatus.json
@@ -58,7 +58,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/RTCIceTransport.json
+++ b/api/RTCIceTransport.json
@@ -312,7 +312,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -386,7 +386,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/Report.json
+++ b/api/Report.json
@@ -21,7 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "preview"
+            "version_added": false
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -54,7 +54,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -87,7 +87,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -121,7 +121,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -155,7 +155,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/ReportBody.json
+++ b/api/ReportBody.json
@@ -21,7 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "preview"
+            "version_added": false
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -53,7 +53,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/ReportingObserver.json
+++ b/api/ReportingObserver.json
@@ -21,7 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "preview"
+            "version_added": false
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -55,7 +55,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -127,7 +127,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -161,7 +161,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -195,7 +195,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/Screen.json
+++ b/api/Screen.json
@@ -530,7 +530,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/ScreenOrientation.json
+++ b/api/ScreenOrientation.json
@@ -21,7 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "preview"
+            "version_added": false
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -54,7 +54,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -88,7 +88,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -139,7 +139,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -173,7 +173,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -215,7 +215,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -90,7 +90,7 @@
               "version_added": "50"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -518,7 +518,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/VideoDecoder.json
+++ b/api/VideoDecoder.json
@@ -21,7 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "preview"
+            "version_added": false
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -55,7 +55,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -89,7 +89,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -123,7 +123,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -157,7 +157,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -191,7 +191,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -225,7 +225,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -259,7 +259,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -292,7 +292,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -326,7 +326,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -360,7 +360,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/VideoEncoder.json
+++ b/api/VideoEncoder.json
@@ -21,7 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "preview"
+            "version_added": false
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -55,7 +55,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -89,7 +89,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -123,7 +123,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -157,7 +157,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -191,7 +191,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -225,7 +225,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -258,7 +258,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -291,7 +291,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -325,7 +325,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -359,7 +359,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/VideoFrame.json
+++ b/api/VideoFrame.json
@@ -21,7 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "preview"
+            "version_added": false
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -55,7 +55,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -89,7 +89,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -123,7 +123,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -157,7 +157,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -191,7 +191,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -225,7 +225,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -259,7 +259,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -293,7 +293,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -326,7 +326,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -360,7 +360,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -394,7 +394,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -428,7 +428,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -462,7 +462,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -496,7 +496,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -530,7 +530,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/WakeLock.json
+++ b/api/WakeLock.json
@@ -21,7 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "preview"
+            "version_added": false
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -54,7 +54,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/WakeLockSentinel.json
+++ b/api/WakeLockSentinel.json
@@ -21,7 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "preview"
+            "version_added": false
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -54,7 +54,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -89,7 +89,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -123,7 +123,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -157,7 +157,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -520,7 +520,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR changes `preview` to `false` for features that were not released in Safari 16.2.  Results come from the mdn-bcd-collector project (v7.1.2) at https://mdn-bcd-collector.appspot.com.
