### PR TITLE
Update Safari versions for api.Document.securitypolicyviolation_event

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6274,7 +6274,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15.5"
+              "version_added": "15.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `securitypolicyviolation_event` member of the `Document` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.2).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Document/securitypolicyviolation_event

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
