### PR TITLE
Update Chromium versions for CSPViolationReportBody API

### DIFF
--- a/api/CSPViolationReportBody.json
+++ b/api/CSPViolationReportBody.json
@@ -6,7 +6,7 @@
         "spec_url": "https://w3c.github.io/webappsec-csp/#cspviolationreportbody",
         "support": {
           "chrome": {
-            "version_added": "74"
+            "version_added": false
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -18,19 +18,13 @@
             "version_added": false
           },
           "oculus": "mirror",
-          "opera": {
-            "version_added": "56"
-          },
-          "opera_android": {
-            "version_added": "48"
-          },
+          "opera": "mirror",
+          "opera_android": "mirror",
           "safari": {
             "version_added": "preview"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": {
-            "version_added": "10.0"
-          },
+          "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
         "status": {
@@ -45,7 +39,7 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-blockedurl",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -57,19 +51,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "56"
-            },
-            "opera_android": {
-              "version_added": "48"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "preview"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "10.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -85,7 +73,7 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-columnnumber",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -97,19 +85,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "56"
-            },
-            "opera_android": {
-              "version_added": "48"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "preview"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "10.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -125,7 +107,7 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-disposition",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -137,19 +119,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "56"
-            },
-            "opera_android": {
-              "version_added": "48"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "preview"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "10.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -165,7 +141,7 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-documenturl",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -177,19 +153,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "56"
-            },
-            "opera_android": {
-              "version_added": "48"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "preview"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "10.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -205,7 +175,7 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-effectivedirective",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -217,19 +187,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "56"
-            },
-            "opera_android": {
-              "version_added": "48"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "preview"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "10.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -245,7 +209,7 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-linenumber",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -257,19 +221,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "56"
-            },
-            "opera_android": {
-              "version_added": "48"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "preview"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "10.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -285,7 +243,7 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-originalpolicy",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -297,19 +255,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "56"
-            },
-            "opera_android": {
-              "version_added": "48"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "preview"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "10.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -325,7 +277,7 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-referrer",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -337,19 +289,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "56"
-            },
-            "opera_android": {
-              "version_added": "48"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "preview"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "10.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -365,7 +311,7 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-sample",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -377,19 +323,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "56"
-            },
-            "opera_android": {
-              "version_added": "48"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "preview"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "10.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -405,7 +345,7 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-sourcefile",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -417,19 +357,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "56"
-            },
-            "opera_android": {
-              "version_added": "48"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "preview"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "10.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -445,7 +379,7 @@
           "spec_url": "https://w3c.github.io/webappsec-csp/#dom-cspviolationreportbody-statuscode",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -457,19 +391,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "56"
-            },
-            "opera_android": {
-              "version_added": "48"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "preview"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "10.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
@@ -483,7 +411,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -495,19 +423,13 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "56"
-            },
-            "opera_android": {
-              "version_added": "48"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "preview"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "10.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `CSPViolationReportBody` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.2).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CSPViolationReportBody

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Note: this was originally set to "74" in #10925 based upon commit history.  However, while Chrome seems to have IDL for this feature, it's not exposed.
