### PR TITLE
Remove api.DOMMatrixReadOnly.transform from BCD

### DIFF
--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -1593,44 +1593,6 @@
           }
         }
       },
-      "transform": {
-        "__compat": {
-          "description": "<code>transform()</code>",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DOMMatrixReadOnly/transform",
-          "support": {
-            "chrome": {
-              "version_added": "61"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "33",
-              "notes": "Before Firefox 69, the <code>tx</code> and <code>ty</code> parameters were required; they are now correctly optional, each defaulting to a value of 0."
-            },
-            "firefox_android": {
-              "version_added": "33",
-              "notes": "Before Firefox for Android 79, the <code>tx</code> and <code>ty</code> parameters were required; they are now correctly optional, each defaulting to a value of 0."
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "11"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "transformPoint": {
         "__compat": {
           "description": "<code>transformPoint()</code>",


### PR DESCRIPTION
This PR removes the irrelevant `transform` member of the `DOMMatrixReadOnly` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features). The lack of current support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.2), even if the current BCD suggests support.
