### PR TITLE
Update Safari iOS version for api.Document.exitPointerLock

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -3189,7 +3189,9 @@
             "safari": {
               "version_added": "10.1"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `exitPointerLock` member of the `Document` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.2).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Document/exitPointerLock

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
