### PR TITLE
Remove api.Element.aria[Col/Row]IndexText from BCD

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -945,40 +945,6 @@
           }
         }
       },
-      "ariaColIndexText": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaColIndexText",
-          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariacolindextext",
-          "support": {
-            "chrome": {
-              "version_added": "81"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "12.1"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "ariaColSpan": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaColSpan",
@@ -1797,40 +1763,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaRowIndex",
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariarowindex",
-          "support": {
-            "chrome": {
-              "version_added": "81"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "12.1"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "ariaRowIndexText": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaRowIndexText",
-          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariarowindextext",
           "support": {
             "chrome": {
               "version_added": "81"


### PR DESCRIPTION
This PR removes the irrelevant `ariaColIndexText` and `ariaRowIndexText` members of the `Element` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features). The lack of current support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.2), even if the current BCD suggests support.
