### PR TITLE
Update WebView versions for api.GamepadHapticActuator.pulse

### DIFF
--- a/api/GamepadHapticActuator.json
+++ b/api/GamepadHapticActuator.json
@@ -141,9 +141,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "68"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR updates and corrects version values for WebView Android for the `pulse` member of the `GamepadHapticActuator` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.2).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/GamepadHapticActuator/pulse

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
