### PR TITLE
Update Chromium versions for api.HTMLMediaElement.sinkId

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2793,7 +2793,8 @@
               "version_added": "49"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": false,
+              "notes": "Not available due to <a href='https://crbug.com/648286'>a limitation in Android</a>."
             },
             "edge": {
               "version_added": "17"

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2792,7 +2792,9 @@
             "chrome": {
               "version_added": "49"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "17"
             },
@@ -2811,9 +2813,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `sinkId` member of the `HTMLMediaElement` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.2).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/HTMLMediaElement/sinkId

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
