### PR TITLE
Update Firefox versions for IDBIndex API

### DIFF
--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -297,7 +297,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "43"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
@@ -368,7 +368,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "43"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `IDBIndex` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.2).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/IDBIndex

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
