### PR TITLE
Update Chromium versions for api.MediaDevices.setCaptureHandleConfig

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -588,7 +588,9 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -82,7 +82,9 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -294,7 +296,9 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `setCaptureHandleConfig` member of the `MediaDevices` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.2).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/MediaDevices/setCaptureHandleConfig

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
