### PR TITLE
Remove api.MediaStreamTrackAudioSourceNode.mediaStreamTrack from BCD

### DIFF
--- a/api/MediaStreamTrackAudioSourceNode.json
+++ b/api/MediaStreamTrackAudioSourceNode.json
@@ -68,39 +68,6 @@
             "deprecated": false
           }
         }
-      },
-      "mediaStreamTrack": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrackAudioSourceNode/mediaStreamTrack",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "68"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
This PR removes the irrelevant `mediaStreamTrack` member of the `MediaStreamTrackAudioSourceNode` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features). The lack of current support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.2), even if the current BCD suggests support.
