### PR TITLE
Remove api.IDBIndex.locale/isAutoLocale from BCD

### DIFF
--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -287,39 +287,6 @@
           }
         }
       },
-      "isAutoLocale": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBIndex/isAutoLocale",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "43"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": false,
-            "deprecated": false
-          }
-        }
-      },
       "keyPath": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBIndex/keyPath",
@@ -354,39 +321,6 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "locale": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBIndex/locale",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "43"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": false,
             "deprecated": false
           }
         }


### PR DESCRIPTION
This PR removes the irrelevant `locale` and `isAutoLocale` members of the `IDBIndex` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features). The lack of current support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.2), even if the current BCD suggests support.  (See #18551.)
