### PR TITLE
Permissions - reorder permission strings together

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -36,7 +36,7 @@
           "deprecated": false
         }
       },
-      "accelerometer_permission": {
+      "permission_accelerometer": {
         "__compat": {
           "description": "<code>accelerometer</code> permission",
           "support": {
@@ -71,7 +71,7 @@
           }
         }
       },
-      "accessibility-events_permission": {
+      "permission_accessibility-events": {
         "__compat": {
           "description": "<code>accessibility-events</code> permission",
           "support": {
@@ -106,7 +106,7 @@
           }
         }
       },
-      "ambient-light-sensor_permission": {
+      "permission_ambient-light-sensor": {
         "__compat": {
           "description": "<code>ambient-light-sensor</code> permission",
           "support": {
@@ -141,7 +141,7 @@
           }
         }
       },
-      "background-sync_permission": {
+      "permission_background-sync": {
         "__compat": {
           "description": "<code>background-sync</code> permission",
           "support": {
@@ -176,7 +176,7 @@
           }
         }
       },
-      "camera_permission": {
+      "permission_camera": {
         "__compat": {
           "description": "<code>camera</code> permission",
           "support": {
@@ -211,7 +211,7 @@
           }
         }
       },
-      "clipboard-read_permission": {
+      "permission_clipboard-read": {
         "__compat": {
           "description": "<code>clipboard-read</code> permission",
           "support": {
@@ -246,7 +246,7 @@
           }
         }
       },
-      "clipboard-write_permission": {
+      "permission_clipboard-write": {
         "__compat": {
           "description": "<code>clipboard-write</code> permission",
           "support": {
@@ -281,7 +281,7 @@
           }
         }
       },
-      "geolocation_permission": {
+      "permission_geolocation": {
         "__compat": {
           "description": "<code>geolocation</code> permission",
           "support": {
@@ -316,7 +316,7 @@
           }
         }
       },
-      "gyroscope_permission": {
+      "permission_gyroscope": {
         "__compat": {
           "description": "<code>gyroscope</code> permission",
           "support": {
@@ -351,7 +351,7 @@
           }
         }
       },
-      "local-fonts_permission": {
+      "permission_local-fonts": {
         "__compat": {
           "description": "<code>local-fonts</code> permission",
           "support": {
@@ -388,7 +388,7 @@
           }
         }
       },
-      "magnetometer_permission": {
+      "permission_magnetometer": {
         "__compat": {
           "description": "<code>magnetometer</code> permission",
           "support": {
@@ -423,7 +423,7 @@
           }
         }
       },
-      "microphone_permission": {
+      "permission_microphone": {
         "__compat": {
           "description": "<code>microphone</code> permission",
           "support": {
@@ -458,7 +458,7 @@
           }
         }
       },
-      "midi_permission": {
+      "permission_midi": {
         "__compat": {
           "description": "<code>midi</code> permission",
           "support": {
@@ -493,7 +493,7 @@
           }
         }
       },
-      "notifications_permission": {
+      "permission_notifications": {
         "__compat": {
           "description": "<code>notifications</code> permission",
           "support": {
@@ -528,7 +528,7 @@
           }
         }
       },
-      "payment-handler_permission": {
+      "permission_payment-handler": {
         "__compat": {
           "description": "<code>payment-handler</code> permission",
           "support": {
@@ -563,7 +563,7 @@
           }
         }
       },
-      "persistent-storage_permission": {
+      "permission_persistent-storage": {
         "__compat": {
           "description": "<code>persistent-storage</code> permission",
           "support": {
@@ -598,7 +598,7 @@
           }
         }
       },
-      "push_permission": {
+      "permission_push": {
         "__compat": {
           "description": "<code>push</code> permission",
           "support": {
@@ -628,6 +628,41 @@
           },
           "status": {
             "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "permission_speaker-selection": {
+        "__compat": {
+          "description": "<code>speaker-selection</code> permission",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Permissions/speaker-selection",
+          "spec_url": "https://w3c.github.io/mediacapture-output/#dfn-speaker-selection",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "92"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -801,41 +836,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": true
-          }
-        }
-      },
-      "speaker-selection_permission": {
-        "__compat": {
-          "description": "<code>speaker-selection</code> permission",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Permissions/speaker-selection",
-          "spec_url": "https://w3c.github.io/mediacapture-output/#dfn-speaker-selection",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "92"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
           }
         }
       }


### PR DESCRIPTION
This prefixes rather than suffixes permission keys with `permission_` so that they will be grouped. Otherwise you end up with the case we have now where the permissions are interleaved with methods - see https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API#browser_compatibility

This is first part of work on https://github.com/mdn/content/issues/13003. We should also add spec links for each of these permissions, as they are defined in their own specs, but will leave that as a follow up.
