### PR TITLE
Adding `nth-col` and `nth-last-col` data

### DIFF
--- a/css/selectors/nth-col.json
+++ b/css/selectors/nth-col.json
@@ -1,0 +1,39 @@
+{
+  "css": {
+    "selectors": {
+      "nth-col": {
+        "__compat": {
+          "description": "<code>:nth-col()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:nth-col",
+          "spec_url": "https://w3c.github.io/csswg-drafts/selectors/#the-nth-col-pseudo",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/371323'>bug 371323</a>."
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/nth-last-col.json
+++ b/css/selectors/nth-last-col.json
@@ -1,0 +1,39 @@
+{
+  "css": {
+    "selectors": {
+      "nth-last-col": {
+        "__compat": {
+          "description": "<code>:nth-last-col()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:nth-last-col",
+          "spec_url": "https://w3c.github.io/csswg-drafts/selectors/#the-nth-last-col-pseudo",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/371323'>bug 371323</a>."
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Summary

Adds missing data for `:nth-col()` and `:nth-last-col()` pseudo-classes.

#### Test results and supporting details

These two selectors are in an identical situation to that of the [column combinator (`||`)](https://developer.mozilla.org/docs/Web/CSS/Column_combinator), i.e. no implementation by any browser yet but having a Firefox bug ([Bug 371323](https://bugzil.la/371323)).

#### Related issues

Fully fixes https://github.com/mdn/content/issues/23365.