### PR TITLE
Update Chromium versions for CSSTransition API

### DIFF
--- a/api/CSSTransition.json
+++ b/api/CSSTransition.json
@@ -6,12 +6,10 @@
         "spec_url": "https://w3c.github.io/csswg-drafts/css-transitions-2/#the-CSSTransition-interface",
         "support": {
           "chrome": {
-            "version_added": "78"
-          },
-          "chrome_android": "mirror",
-          "edge": {
             "version_added": "84"
           },
+          "chrome_android": "mirror",
+          "edge": "mirror",
           "firefox": {
             "version_added": "75"
           },


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `CSSTransition` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CSSTransition

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

---

This data was originally set to "78" in #6372.  This data had come from reading through the IDL and using commit history to determine when the feature was implemented (see https://github.com/mdn/browser-compat-data/pull/6372#discussion_r459623074).  Since Edge was set to "84" in #9190, it makes less sense to keep Chrome at "78".
