### PR TITLE
Update Chromium versions for ClipboardItem API

### DIFF
--- a/api/ClipboardItem.json
+++ b/api/ClipboardItem.json
@@ -6,7 +6,7 @@
         "spec_url": "https://w3c.github.io/clipboard-apis/#clipboarditem",
         "support": {
           "chrome": {
-            "version_added": "66"
+            "version_added": "76"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -98,7 +98,7 @@
           "spec_url": "https://w3c.github.io/clipboard-apis/#dom-clipboarditem-gettype",
           "support": {
             "chrome": {
-              "version_added": "66"
+              "version_added": "76"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -180,7 +180,7 @@
           "spec_url": "https://w3c.github.io/clipboard-apis/#dom-clipboarditem-types",
           "support": {
             "chrome": {
-              "version_added": "66"
+              "version_added": "76"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/ClipboardItem.json
+++ b/api/ClipboardItem.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "76"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": "84"
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": "87",
@@ -46,12 +48,28 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ClipboardItem/ClipboardItem",
           "spec_url": "https://w3c.github.io/clipboard-apis/#dom-clipboarditem-clipboarditem",
           "support": {
-            "chrome": {
-              "version_added": "76",
-              "partial_implementation": true,
-              "notes": "The <code>ClipboardItem</code> constructor only accepts a blob as the item data, but not strings or Promises that resolve to strings or blobs. See <a href='https://crbug.com/1014310'>bug 1014310</a>."
-            },
-            "chrome_android": "mirror",
+            "chrome": [
+              {
+                "version_added": "98"
+              },
+              {
+                "version_added": "76",
+                "version_removed": "98",
+                "partial_implementation": true,
+                "notes": "The <code>ClipboardItem</code> constructor only accepts a blob as the item data, but not strings or Promises that resolve to strings or blobs. See <a href='https://crbug.com/1014310'>bug 1014310</a>."
+              }
+            ],
+            "chrome_android": [
+              {
+                "version_added": "98"
+              },
+              {
+                "version_added": "84",
+                "version_removed": "98",
+                "partial_implementation": true,
+                "notes": "The <code>ClipboardItem</code> constructor only accepts a blob as the item data, but not strings or Promises that resolve to strings or blobs. See <a href='https://crbug.com/1014310'>bug 1014310</a>."
+              }
+            ],
             "edge": "mirror",
             "firefox": {
               "version_added": "87",
@@ -92,7 +110,9 @@
             "chrome": {
               "version_added": "76"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": "84"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "87",
@@ -133,7 +153,9 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": "84"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "87",
@@ -174,7 +196,9 @@
             "chrome": {
               "version_added": "76"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": "84"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "87",

--- a/api/ClipboardItem.json
+++ b/api/ClipboardItem.json
@@ -47,15 +47,11 @@
           "spec_url": "https://w3c.github.io/clipboard-apis/#dom-clipboarditem-clipboarditem",
           "support": {
             "chrome": {
-              "version_added": "66",
+              "version_added": "76",
               "partial_implementation": true,
               "notes": "The <code>ClipboardItem</code> constructor only accepts a blob as the item data, but not strings or Promises that resolve to strings or blobs. See <a href='https://crbug.com/1014310'>bug 1014310</a>."
             },
-            "chrome_android": {
-              "version_added": "66",
-              "partial_implementation": true,
-              "notes": "The <code>ClipboardItem</code> constructor only accepts a blob as the item data. Full implementation would also allow for a string or a Promise which resolves with either a string or blob. See <a href='https://crbug.com/1014310'>bug 1014310</a>."
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": "87",
@@ -78,11 +74,7 @@
               "version_added": "13.1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "9.0",
-              "partial_implementation": true,
-              "notes": "The <code>ClipboardItem</code> constructor only accepts a blob as the item data, but not strings or Promises that resolve to strings or blobs. See <a href='https://crbug.com/1014310'>bug 1014310</a>."
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `ClipboardItem` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/ClipboardItem

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
