### PR TITLE
Update Firefox versions for api.DOMPoint.fromPoint

### DIFF
--- a/api/DOMPoint.json
+++ b/api/DOMPoint.json
@@ -115,7 +115,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "31"
+              "version_added": "62"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `fromPoint` member of the `DOMPoint` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/DOMPoint/fromPoint

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
