### PR TITLE
Update Firefox versions for api.DedicatedWorkerGlobalScope.animationFrame

### DIFF
--- a/api/DedicatedWorkerGlobalScope.json
+++ b/api/DedicatedWorkerGlobalScope.json
@@ -54,7 +54,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "97"
+              "version_added": "99"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -345,7 +345,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "97"
+              "version_added": "99"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `cancelAnimationFrame` and `requestAnimationFrame` members of the `DedicatedWorkerGlobalScope` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used:
https://mdn-bcd-collector.gooborg.com/tests/api/DedicatedWorkerGlobalScope/cancelAnimationFrame
https://mdn-bcd-collector.gooborg.com/tests/api/DedicatedWorkerGlobalScope/requestAnimationFrame

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
