### PR TITLE
Update Chromium versions for api.ElementInternals.shadowRoot

### DIFF
--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -1670,7 +1670,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#dom-elementinternals-shadowroot",
           "support": {
             "chrome": {
-              "version_added": "77"
+              "version_added": "88"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `shadowRoot` member of the `ElementInternals` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/ElementInternals/shadowRoot

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
