### PR TITLE
Update Chromium versions for api.ExtendableEvent.ExtendableEvent

### DIFF
--- a/api/ExtendableEvent.json
+++ b/api/ExtendableEvent.json
@@ -46,7 +46,7 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#dom-extendableevent-extendableevent",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": "41"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `ExtendableEvent` member of the `ExtendableEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/ExtendableEvent/ExtendableEvent

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
