### PR TITLE
Update Chromium versions for api.FetchEvent.FetchEvent

### DIFF
--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -42,7 +42,7 @@
           "spec_url": "https://w3c.github.io/ServiceWorker/#dom-fetchevent-fetchevent",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": "44"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `FetchEvent` member of the `FetchEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/FetchEvent/FetchEvent

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
