### PR TITLE
Partially revert Firefox versions for referrerPolicy property

### DIFF
--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -664,7 +664,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "61"
+              "version_added": "50"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -582,7 +582,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "61"
+              "version_added": "50"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -708,7 +708,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "61"
+              "version_added": "50"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -821,7 +821,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "61"
+              "version_added": "50"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -195,7 +195,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "52"
+              "version_added": "61"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -195,7 +195,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "61"
+              "version_added": "52"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This reverts #17421 for all interfaces other than SVGAElement, based upon results from mdn-bcd-collector v7.1.3.  See the linked PR for more details.