### PR TITLE
Update Firefox versions for api.IDBIndex.getAllKeys

### DIFF
--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -220,13 +220,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "44",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.indexedDB.experimental"
-                }
-              ]
+              "version_added": "44"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -297,7 +291,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "43"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
@@ -326,7 +320,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#dom-idbindex-keypath",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "43"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -368,7 +362,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "43"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
@@ -397,7 +391,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#dom-idbindex-multientry",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "43"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -435,7 +429,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbindex-name①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "43"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -508,7 +502,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbindex-objectstore①",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "43"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -622,7 +616,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#dom-idbindex-unique",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "43"
             },
             "chrome_android": "mirror",
             "edge": {

--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -291,7 +291,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "43"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -320,7 +320,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#dom-idbindex-keypath",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "23"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -362,7 +362,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "43"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -391,7 +391,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#dom-idbindex-multientry",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "23"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -429,7 +429,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbindex-name①",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "23"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -502,7 +502,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbindex-objectstore①",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "23"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -616,7 +616,7 @@
           "spec_url": "https://w3c.github.io/IndexedDB/#dom-idbindex-unique",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "23"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `getAllKeys` member of the `IDBIndex` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/IDBIndex/getAllKeys

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
