### PR TITLE
Update Chromium versions for LaunchParams API

### DIFF
--- a/api/LaunchParams.json
+++ b/api/LaunchParams.json
@@ -5,7 +5,7 @@
         "spec_url": "https://wicg.github.io/web-app-launch/#launchparams-interface",
         "support": {
           "chrome": {
-            "version_added": "110"
+            "version_added": "102"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -37,7 +37,7 @@
           "spec_url": "https://wicg.github.io/web-app-launch/#ref-for-dom-launchparams-files-1",
           "support": {
             "chrome": {
-              "version_added": "110"
+              "version_added": "102"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `LaunchParams` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/LaunchParams

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
