### PR TITLE
Update Chromium versions for LaunchQueue API

### DIFF
--- a/api/LaunchQueue.json
+++ b/api/LaunchQueue.json
@@ -5,7 +5,7 @@
         "spec_url": "https://wicg.github.io/web-app-launch/#launchqueue-interface",
         "support": {
           "chrome": {
-            "version_added": "110"
+            "version_added": "102"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -37,7 +37,7 @@
           "spec_url": "https://wicg.github.io/web-app-launch/#dom-launchqueue-setconsumer",
           "support": {
             "chrome": {
-              "version_added": "110"
+              "version_added": "102"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `LaunchQueue` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/LaunchQueue

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
