### PR TITLE
Update Edge versions for MediaDeviceInfo API

### DIFF
--- a/api/MediaDeviceInfo.json
+++ b/api/MediaDeviceInfo.json
@@ -10,7 +10,7 @@
           },
           "chrome_android": "mirror",
           "edge": {
-            "version_added": "12"
+            "version_added": "14"
           },
           "firefox": {
             "version_added": "39"
@@ -45,7 +45,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "39"
@@ -81,7 +81,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "39",
@@ -118,7 +118,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "39"
@@ -154,7 +154,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "14"
             },
             "firefox": {
               "version_added": "39"


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `MediaDeviceInfo` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/MediaDeviceInfo

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
