### PR TITLE
Update Firefox versions for MediaDevices API

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -13,11 +13,9 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "33"
-          },
-          "firefox_android": {
             "version_added": "36"
           },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -433,7 +431,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": "42"
             },
             "firefox_android": {
               "version_added": "50"


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `MediaDevices` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/MediaDevices

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
