### PR TITLE
Update Chromium versions for api.MediaStreamTrack.contentHint

### DIFF
--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -150,7 +150,7 @@
           "spec_url": "https://w3c.github.io/mst-content-hint/#dom-mediastreamtrack-contenthint",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": "70"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `contentHint` member of the `MediaStreamTrack` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/MediaStreamTrack/contentHint

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
