### PR TITLE
Update Chromium versions for api.MediaStreamTrackEvent.MediaStreamTrackEvent

### DIFF
--- a/api/MediaStreamTrackEvent.json
+++ b/api/MediaStreamTrackEvent.json
@@ -42,7 +42,7 @@
           "spec_url": "https://w3c.github.io/mediacapture-main/#dom-mediastreamtrackevent-constructor",
           "support": {
             "chrome": {
-              "version_added": "26"
+              "version_added": "55"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `MediaStreamTrackEvent` member of the `MediaStreamTrackEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/MediaStreamTrackEvent/MediaStreamTrackEvent

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
