### PR TITLE
Update Firefox versions for api.MediaStreamTrackEvent.MediaStreamTrackEvent

### DIFF
--- a/api/MediaStreamTrackEvent.json
+++ b/api/MediaStreamTrackEvent.json
@@ -49,7 +49,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "50"
+              "version_added": "34"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `MediaStreamTrackEvent` member of the `MediaStreamTrackEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/MediaStreamTrackEvent/MediaStreamTrackEvent

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
