### PR TITLE
Update Safari versions for MerchantValidationEvent API

### DIFF
--- a/api/MerchantValidationEvent.json
+++ b/api/MerchantValidationEvent.json
@@ -28,7 +28,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "11.1"
+            "version_added": "12.1"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -101,7 +101,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -173,7 +173,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "12.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `MerchantValidationEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/MerchantValidationEvent

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
