### PR TITLE
Update Samsung Internet versions for NavigatorUAData API

### DIFF
--- a/api/NavigatorUAData.json
+++ b/api/NavigatorUAData.json
@@ -2,6 +2,7 @@
   "api": {
     "NavigatorUAData": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorUAData",
         "spec_url": "https://wicg.github.io/ua-client-hints/#navigatoruadata",
         "support": {
           "chrome": {
@@ -39,6 +40,7 @@
       },
       "brands": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorUAData/brands",
           "spec_url": "https://wicg.github.io/ua-client-hints/#dom-navigatoruadata-brands",
           "support": {
             "chrome": {
@@ -76,6 +78,7 @@
       },
       "getHighEntropyValues": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorUAData/getHighEntropyValues",
           "spec_url": "https://wicg.github.io/ua-client-hints/#dom-navigatoruadata-gethighentropyvalues",
           "support": {
             "chrome": {
@@ -113,6 +116,7 @@
       },
       "mobile": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorUAData/mobile",
           "spec_url": "https://wicg.github.io/ua-client-hints/#dom-navigatoruadata-mobile",
           "support": {
             "chrome": {
@@ -150,6 +154,7 @@
       },
       "platform": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorUAData/platform",
           "spec_url": "https://wicg.github.io/ua-client-hints/#dom-navigatoruadata-platform",
           "support": {
             "chrome": {
@@ -187,6 +192,7 @@
       },
       "toJSON": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorUAData/toJSON",
           "spec_url": "https://wicg.github.io/ua-client-hints/#dom-navigatoruadata-tojson",
           "support": {
             "chrome": {

--- a/api/NavigatorUAData.json
+++ b/api/NavigatorUAData.json
@@ -23,7 +23,9 @@
             "version_added": false
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": {
             "version_added": false,
             "notes": "See <a href='https://crbug.com/921655'>bug 921655</a>."
@@ -58,7 +60,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -93,7 +97,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -128,7 +134,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -163,7 +171,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -198,7 +208,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }


### PR DESCRIPTION
This PR updates and corrects version values for Samsung Internet for the `NavigatorUAData` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/NavigatorUAData

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
