### PR TITLE
Update Chromium versions for api.Notification.image

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -635,7 +635,7 @@
           "spec_url": "https://notifications.spec.whatwg.org/#image-resource",
           "support": {
             "chrome": {
-              "version_added": "53"
+              "version_added": "56"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `image` member of the `Notification` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Notification/image

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
