### PR TITLE
Update Firefox versions for Performance API

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -75,7 +75,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "41"
+              "version_added": "38"
             },
             "firefox_android": {
               "version_added": "42"
@@ -130,7 +130,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "41"
+              "version_added": "38"
             },
             "firefox_android": {
               "version_added": "42"
@@ -435,7 +435,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "41"
+              "version_added": "38"
             },
             "firefox_android": {
               "version_added": "42"
@@ -568,7 +568,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "41"
+              "version_added": "38"
             },
             "firefox_android": {
               "version_added": "42"


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `Performance` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Performance

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
