### PR TITLE
Update Firefox versions for api.PerformanceEntry.toJSON

### DIFF
--- a/api/PerformanceEntry.json
+++ b/api/PerformanceEntry.json
@@ -280,7 +280,7 @@
               "version_added": "16"
             },
             "firefox": {
-              "version_added": "35"
+              "version_added": "34"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `toJSON` member of the `PerformanceEntry` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/PerformanceEntry/toJSON

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
