### PR TITLE
Update Chromium versions for api.PerformanceMark.detail

### DIFF
--- a/api/PerformanceMark.json
+++ b/api/PerformanceMark.json
@@ -92,7 +92,7 @@
           "spec_url": "https://w3c.github.io/user-timing/#dom-performancemark-detail",
           "support": {
             "chrome": {
-              "version_added": "76"
+              "version_added": "78"
             },
             "chrome_android": "mirror",
             "deno": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `detail` member of the `PerformanceMark` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/PerformanceMark/detail

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
