### PR TITLE
Update Chromium versions for PerformanceResourceTiming API

### DIFF
--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -732,7 +732,7 @@
           "spec_url": "https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-tojson",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "45"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -804,7 +804,7 @@
           "spec_url": "https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-workerstart",
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": "46"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `PerformanceResourceTiming` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/PerformanceResourceTiming

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
