### PR TITLE
Update WebView versions for PeriodicSyncEvent API

### DIFF
--- a/api/PeriodicSyncEvent.json
+++ b/api/PeriodicSyncEvent.json
@@ -25,7 +25,9 @@
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": true,
@@ -59,7 +61,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,
@@ -93,7 +97,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,


### PR DESCRIPTION
This PR updates and corrects version values for WebView Android for the `PeriodicSyncEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).  The collector obtains results based upon the latest WebView version (to determine if it is supported), then version numbers are copied from Chrome Android.

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/PeriodicSyncEvent

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
