### PR TITLE
Update Firefox versions for PushSubscriptionOptions API

### DIFF
--- a/api/PushSubscriptionOptions.json
+++ b/api/PushSubscriptionOptions.json
@@ -13,11 +13,9 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "44"
-          },
-          "firefox_android": {
             "version_added": "48"
           },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -57,11 +55,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44"
-            },
-            "firefox_android": {
               "version_added": "48"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `PushSubscriptionOptions` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/PushSubscriptionOptions

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
