### PR TITLE
Add flag data for api.IDBIndex.[isAuto]locale

### DIFF
--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -291,7 +291,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "43"
+              "version_added": "43",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.indexedDB.experimental",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -362,7 +369,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "43"
+              "version_added": "43",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.indexedDB.experimental",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR adds the missing flag data for Firefox for the `locale` and `isAutoLocale` properties of the `IDBIndex` API, as mentioned in https://github.com/mdn/browser-compat-data/pull/18560#pullrequestreview-1240592712.
