### PR TITLE
Enable MathML and related features in Chrome 109

### DIFF
--- a/api/MathMLElement.json
+++ b/api/MathMLElement.json
@@ -5,16 +5,21 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MathMLElement",
         "spec_url": "https://w3c.github.io/mathml-core/#dom-mathmlelement",
         "support": {
-          "chrome": {
-            "version_added": "80",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#enable-experimental-web-platform-features",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
+          "chrome": [
+            {
+              "version_added": "109"
+            },
+            {
+              "version_added": "80",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            }
+          ],
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
@@ -43,16 +48,21 @@
       "blur": {
         "__compat": {
           "support": {
-            "chrome": {
-              "version_added": "80",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "80",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -82,16 +92,21 @@
       "dataset": {
         "__compat": {
           "support": {
-            "chrome": {
-              "version_added": "80",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "80",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -121,16 +136,21 @@
       "focus": {
         "__compat": {
           "support": {
-            "chrome": {
-              "version_added": "80",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "80",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -161,16 +181,21 @@
         "__compat": {
           "spec_url": "https://w3c.github.io/csswg-drafts/cssom/#dom-elementcssinlinestyle-style",
           "support": {
-            "chrome": {
-              "version_added": "80",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "80",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -200,16 +225,21 @@
       "tabIndex": {
         "__compat": {
           "support": {
-            "chrome": {
-              "version_added": "80",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "80",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -581,16 +581,21 @@
         "math": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "87",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "87",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/css/properties/font-family.json
+++ b/css/properties/font-family.json
@@ -50,16 +50,21 @@
           "__compat": {
             "description": "<code>math</code>",
             "support": {
-              "chrome": {
-                "version_added": "103",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "103",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/css/properties/font-size.json
+++ b/css/properties/font-size.json
@@ -46,16 +46,21 @@
           "__compat": {
             "description": "<code>math</code> keyword",
             "support": {
-              "chrome": {
-                "version_added": "87",
-                "impl_url": "https://crrev.com/c/2423843",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "87",
+                  "impl_url": "https://crrev.com/c/2423843",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/css/properties/math-depth.json
+++ b/css/properties/math-depth.json
@@ -6,16 +6,21 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/math-depth",
           "spec_url": "https://w3c.github.io/mathml-core/#the-math-script-level-property",
           "support": {
-            "chrome": {
-              "version_added": "87",
-              "impl_url": "https://crrev.com/c/2423843",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "87",
+                "impl_url": "https://crrev.com/c/2423843",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/css/properties/math-shift.json
+++ b/css/properties/math-shift.json
@@ -6,16 +6,21 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/math-shift",
           "spec_url": "https://w3c.github.io/mathml-core/#the-math-shift",
           "support": {
-            "chrome": {
-              "version_added": "87",
-              "impl_url": "https://crrev.com/c/2421662",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "87",
+                "impl_url": "https://crrev.com/c/2421662",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/css/properties/math-style.json
+++ b/css/properties/math-style.json
@@ -6,15 +6,20 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/math-style",
           "spec_url": "https://w3c.github.io/mathml-core/#the-math-style-property",
           "support": {
-            "chrome": {
-              "version_added": "83",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -42,7 +47,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -255,16 +255,21 @@
           "__compat": {
             "spec_url": "https://w3c.github.io/mathml-core/#new-text-transform-values",
             "support": {
-              "chrome": {
-                "version_added": "84",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "84",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/mathml/elements/maction.json
+++ b/mathml/elements/maction.json
@@ -6,18 +6,24 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/maction",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-maction",
           "support": {
-            "chrome": {
-              "version_added": "105",
-              "impl_url": "https://crrev.com/c/3720717",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ],
-              "notes": "This follows MathML Core: Only the first child is rendered while the others have their <code>display</code> set to <code>none</code>. <code>actiontype</code> and <code>selection</code> attributes are ignored."
-            },
+            "chrome": [
+              {
+                "version_added": "109",
+                "notes": "This follows MathML Core: Only the first child is rendered while the others have their <code>display</code> set to <code>none</code>. <code>actiontype</code> and <code>selection</code> attributes are ignored."
+              },
+              {
+                "version_added": "105",
+                "impl_url": "https://crrev.com/c/3720717",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "This follows MathML Core: Only the first child is rendered while the others have their <code>display</code> set to <code>none</code>. <code>actiontype</code> and <code>selection</code> attributes are ignored."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/mathml/elements/math.json
+++ b/mathml/elements/math.json
@@ -8,6 +8,9 @@
           "support": {
             "chrome": [
               {
+                "version_added": "109"
+              },
+              {
                 "version_added": "80",
                 "impl_url": "https://crbug.com/6606",
                 "flags": [
@@ -46,6 +49,9 @@
             },
             "oculus": "mirror",
             "opera": [
+              {
+                "version_added": "95"
+              },
               {
                 "version_added": "67",
                 "impl_url": "https://crbug.com/6606",
@@ -87,16 +93,21 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/math#attr-display",
             "support": {
-              "chrome": {
-                "version_added": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "83",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/mathml/elements/merror.json
+++ b/mathml/elements/merror.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/merror",
           "spec_url": "https://w3c.github.io/mathml-core/#error-message-merror",
           "support": {
-            "chrome": {
-              "version_added": "81",
-              "impl_url": "https://crrev.com/c/1913250",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "81",
+                "impl_url": "https://crrev.com/c/1913250",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/mathml/elements/mfrac.json
+++ b/mathml/elements/mfrac.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mfrac",
           "spec_url": "https://w3c.github.io/mathml-core/#fractions-mfrac",
           "support": {
-            "chrome": {
-              "version_added": "83",
-              "impl_url": "https://crrev.com/c/2041665",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "83",
+                "impl_url": "https://crrev.com/c/2041665",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -78,16 +83,21 @@
         "linethickness": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "83",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/mathml/elements/mi.json
+++ b/mathml/elements/mi.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mi",
           "spec_url": "https://w3c.github.io/mathml-core/#identifier-mi",
           "support": {
-            "chrome": {
-              "version_added": "87",
-              "impl_url": "https://crrev.com/c/2391150",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "87",
+                "impl_url": "https://crrev.com/c/2391150",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/mathml/elements/mmultiscripts.json
+++ b/mathml/elements/mmultiscripts.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mmultiscripts",
           "spec_url": "https://w3c.github.io/mathml-core/#prescripts-and-tensor-indices-mmultiscripts",
           "support": {
-            "chrome": {
-              "version_added": "86",
-              "impl_url": "https://crrev.com/c/2264334",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "86",
+                "impl_url": "https://crrev.com/c/2264334",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/mathml/elements/mn.json
+++ b/mathml/elements/mn.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mn",
           "spec_url": "https://w3c.github.io/mathml-core/#number-mn",
           "support": {
-            "chrome": {
-              "version_added": "87",
-              "impl_url": "https://crrev.com/c/2391150",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "87",
+                "impl_url": "https://crrev.com/c/2391150",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/mathml/elements/mo.json
+++ b/mathml/elements/mo.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mo",
           "spec_url": "https://w3c.github.io/mathml-core/#operator-fence-separator-or-accent-mo",
           "support": {
-            "chrome": {
-              "version_added": "95",
-              "impl_url": "https://crrev.com/c/3121110",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "95",
+                "impl_url": "https://crrev.com/c/3121110",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -77,16 +82,21 @@
         "lspace": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "87",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "87",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -118,16 +128,21 @@
         "maxsize": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "94",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "94",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -157,16 +172,21 @@
         "minsize": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "94",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "94",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -196,16 +216,21 @@
         "moveablelimits": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "87",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "87",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -304,16 +329,21 @@
         "rspace": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "87",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "87",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -345,16 +375,21 @@
         "stretchy": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "94",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "94",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -384,16 +419,21 @@
         "symmetric": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "94",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "94",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/mathml/elements/mover.json
+++ b/mathml/elements/mover.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mover",
           "spec_url": "https://w3c.github.io/mathml-core/#underscripts-and-overscripts-munder-mover-munderover",
           "support": {
-            "chrome": {
-              "version_added": "84",
-              "impl_url": "https://crrev.com/c/2119538",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "84",
+                "impl_url": "https://crrev.com/c/2119538",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -45,16 +50,21 @@
         "accent": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "87",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "87",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/mathml/elements/mpadded.json
+++ b/mathml/elements/mpadded.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mpadded",
           "spec_url": "https://w3c.github.io/mathml-core/#adjust-space-around-content-mpadded",
           "support": {
-            "chrome": {
-              "version_added": "86",
-              "impl_url": "https://crrev.com/c/2288388",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "86",
+                "impl_url": "https://crrev.com/c/2288388",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -45,17 +50,22 @@
         "depth": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "86",
-                "impl_url": "https://crrev.com/c/2288388",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "86",
+                  "impl_url": "https://crrev.com/c/2288388",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -85,17 +95,22 @@
         "height": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "86",
-                "impl_url": "https://crrev.com/c/2288388",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "86",
+                  "impl_url": "https://crrev.com/c/2288388",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -125,17 +140,22 @@
         "lspace": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "86",
-                "impl_url": "https://crrev.com/c/2288388",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "86",
+                  "impl_url": "https://crrev.com/c/2288388",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -333,17 +353,22 @@
         "voffset": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "86",
-                "impl_url": "https://crrev.com/c/2288388",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "86",
+                  "impl_url": "https://crrev.com/c/2288388",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -373,17 +398,22 @@
         "width": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "86",
-                "impl_url": "https://crrev.com/c/2288388",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "86",
+                  "impl_url": "https://crrev.com/c/2288388",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/mathml/elements/mphantom.json
+++ b/mathml/elements/mphantom.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mphantom",
           "spec_url": "https://w3c.github.io/mathml-core/#making-sub-expressions-invisible-mphantom",
           "support": {
-            "chrome": {
-              "version_added": "81",
-              "impl_url": "https://crrev.com/c/1913250",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "81",
+                "impl_url": "https://crrev.com/c/1913250",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/mathml/elements/mroot.json
+++ b/mathml/elements/mroot.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mroot",
           "spec_url": "https://w3c.github.io/mathml-core/#radicals-msqrt-mroot",
           "support": {
-            "chrome": {
-              "version_added": "86",
-              "impl_url": "https://crrev.com/c/2190671",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "86",
+                "impl_url": "https://crrev.com/c/2190671",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/mathml/elements/mrow.json
+++ b/mathml/elements/mrow.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mrow",
           "spec_url": "https://w3c.github.io/mathml-core/#horizontally-group-sub-expressions-mrow",
           "support": {
-            "chrome": {
-              "version_added": "81",
-              "impl_url": "https://crrev.com/c/1913250",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "81",
+                "impl_url": "https://crrev.com/c/1913250",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/mathml/elements/ms.json
+++ b/mathml/elements/ms.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/ms",
           "spec_url": "https://w3c.github.io/mathml-core/#string-literal-ms",
           "support": {
-            "chrome": {
-              "version_added": "87",
-              "impl_url": "https://crrev.com/c/2391150",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "87",
+                "impl_url": "https://crrev.com/c/2391150",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/mathml/elements/mspace.json
+++ b/mathml/elements/mspace.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mspace",
           "spec_url": "https://w3c.github.io/mathml-core/#space-mspace",
           "support": {
-            "chrome": {
-              "version_added": "81",
-              "impl_url": "https://crrev.com/c/1936251",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "81",
+                "impl_url": "https://crrev.com/c/1936251",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -45,16 +50,21 @@
         "depth": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "81",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "81",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -84,16 +94,21 @@
         "height": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "81",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "81",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -157,16 +172,21 @@
         "width": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "81",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "81",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/mathml/elements/msqrt.json
+++ b/mathml/elements/msqrt.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/msqrt",
           "spec_url": "https://w3c.github.io/mathml-core/#radicals-msqrt-mroot",
           "support": {
-            "chrome": {
-              "version_added": "86",
-              "impl_url": "https://crrev.com/c/2190671",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "86",
+                "impl_url": "https://crrev.com/c/2190671",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/mathml/elements/mstyle.json
+++ b/mathml/elements/mstyle.json
@@ -8,6 +8,9 @@
           "support": {
             "chrome": [
               {
+                "version_added": "109"
+              },
+              {
                 "version_added": "88",
                 "impl_url": "https://crrev.com/c/1908533",
                 "flags": [
@@ -73,8 +76,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mstyle#attr-background",
             "support": {
               "chrome": {
-                "version_added": "24",
-                "version_removed": "25"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -108,8 +110,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mstyle#attr-color",
             "support": {
               "chrome": {
-                "version_added": "24",
-                "version_removed": "25"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -143,8 +144,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mstyle#attr-fontsize",
             "support": {
               "chrome": {
-                "version_added": "24",
-                "version_removed": "25"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -178,8 +178,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mstyle#attr-fontstyle",
             "support": {
               "chrome": {
-                "version_added": "24",
-                "version_removed": "25"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -213,8 +212,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mstyle#attr-fontweight",
             "support": {
               "chrome": {
-                "version_added": "24",
-                "version_removed": "25"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/mathml/elements/msub.json
+++ b/mathml/elements/msub.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/msub",
           "spec_url": "https://w3c.github.io/mathml-core/#subscripts-and-superscripts-msub-msup-msubsup",
           "support": {
-            "chrome": {
-              "version_added": "84",
-              "impl_url": "https://crrev.com/c/2128081",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "84",
+                "impl_url": "https://crrev.com/c/2128081",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/mathml/elements/msubsup.json
+++ b/mathml/elements/msubsup.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/msubsup",
           "spec_url": "https://w3c.github.io/mathml-core/#subscripts-and-superscripts-msub-msup-msubsup",
           "support": {
-            "chrome": {
-              "version_added": "84",
-              "impl_url": "https://crrev.com/c/2128081",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "84",
+                "impl_url": "https://crrev.com/c/2128081",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/mathml/elements/msup.json
+++ b/mathml/elements/msup.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/msup",
           "spec_url": "https://w3c.github.io/mathml-core/#subscripts-and-superscripts-msub-msup-msubsup",
           "support": {
-            "chrome": {
-              "version_added": "84",
-              "impl_url": "https://crrev.com/c/2128081",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "84",
+                "impl_url": "https://crrev.com/c/2128081",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/mathml/elements/mtable.json
+++ b/mathml/elements/mtable.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mtable",
           "spec_url": "https://w3c.github.io/mathml-core/#table-or-matrix-mtable",
           "support": {
-            "chrome": {
-              "version_added": "104",
-              "impl_url": "https://crrev.com/c/3657309",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "104",
+                "impl_url": "https://crrev.com/c/3657309",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/mathml/elements/mtd.json
+++ b/mathml/elements/mtd.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mtd",
           "spec_url": "https://w3c.github.io/mathml-core/#entry-in-table-or-matrix-mtd",
           "support": {
-            "chrome": {
-              "version_added": "104",
-              "impl_url": "https://crrev.com/c/3657309",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "104",
+                "impl_url": "https://crrev.com/c/3657309",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/mathml/elements/mtext.json
+++ b/mathml/elements/mtext.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mtext",
           "spec_url": "https://w3c.github.io/mathml-core/#text-mtext",
           "support": {
-            "chrome": {
-              "version_added": "87",
-              "impl_url": "https://crrev.com/c/2391150",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "87",
+                "impl_url": "https://crrev.com/c/2391150",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/mathml/elements/mtr.json
+++ b/mathml/elements/mtr.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/mtr",
           "spec_url": "https://w3c.github.io/mathml-core/#row-in-table-or-matrix-mtr",
           "support": {
-            "chrome": {
-              "version_added": "104",
-              "impl_url": "https://crrev.com/c/3657309",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "104",
+                "impl_url": "https://crrev.com/c/3657309",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/mathml/elements/munder.json
+++ b/mathml/elements/munder.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/munder",
           "spec_url": "https://w3c.github.io/mathml-core/#underscripts-and-overscripts-munder-mover-munderover",
           "support": {
-            "chrome": {
-              "version_added": "84",
-              "impl_url": "https://crrev.com/c/2119538",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "84",
+                "impl_url": "https://crrev.com/c/2119538",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -45,16 +50,21 @@
         "accentunder": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "87",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "87",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/mathml/elements/munderover.json
+++ b/mathml/elements/munderover.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/munderover",
           "spec_url": "https://w3c.github.io/mathml-core/#underscripts-and-overscripts-munder-mover-munderover",
           "support": {
-            "chrome": {
-              "version_added": "84",
-              "impl_url": "https://crrev.com/c/2119538",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "84",
+                "impl_url": "https://crrev.com/c/2119538",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -45,16 +50,21 @@
         "accent": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "87",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "87",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -84,16 +94,21 @@
         "accentunder": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "87",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "87",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/mathml/elements/semantics.json
+++ b/mathml/elements/semantics.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Element/semantics",
           "spec_url": "https://w3c.github.io/mathml-core/#semantics-and-presentation",
           "support": {
-            "chrome": {
-              "version_added": "88",
-              "impl_url": "https://crrev.com/c/2467903",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "88",
+                "impl_url": "https://crrev.com/c/2467903",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/mathml/global_attributes.json
+++ b/mathml/global_attributes.json
@@ -6,17 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/dir",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-dir",
           "support": {
-            "chrome": {
-              "version_added": "80",
-              "impl_url": "https://crrev.com/c/1908533",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "80",
+                "impl_url": "https://crrev.com/c/1908533",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -53,17 +58,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/displaystyle",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-displaystyle",
           "support": {
-            "chrome": {
-              "version_added": "83",
-              "impl_url": "https://crrev.com/c/2105317",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "83",
+                "impl_url": "https://crrev.com/c/2105317",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -136,17 +146,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/mathbackground",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-mathbackground",
           "support": {
-            "chrome": {
-              "version_added": "80",
-              "impl_url": "https://crrev.com/c/1908533",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "80",
+                "impl_url": "https://crrev.com/c/1908533",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -186,17 +201,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/mathcolor",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-mathcolor",
           "support": {
-            "chrome": {
-              "version_added": "80",
-              "impl_url": "https://crrev.com/c/1908533",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "80",
+                "impl_url": "https://crrev.com/c/1908533",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -236,17 +256,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/mathsize",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-mathsize",
           "support": {
-            "chrome": {
-              "version_added": "80",
-              "impl_url": "https://crrev.com/c/1908533",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "80",
+                "impl_url": "https://crrev.com/c/1908533",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": [
@@ -392,19 +417,25 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/mathvariant",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-mathvariant",
           "support": {
-            "chrome": {
-              "version_added": "84",
-              "partial_implementation": true,
-              "notes": "The only value supported is 'normal'.",
-              "impl_url": "https://crrev.com/c/2161013",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109",
+                "notes": "The only value supported is 'normal'."
+              },
+              {
+                "version_added": "84",
+                "partial_implementation": true,
+                "notes": "The only value supported is 'normal'.",
+                "impl_url": "https://crrev.com/c/2161013",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -449,17 +480,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Global_attributes/scriptlevel",
           "spec_url": "https://w3c.github.io/mathml-core/#dfn-scriptlevel",
           "support": {
-            "chrome": {
-              "version_added": "88",
-              "impl_url": "https://crrev.com/c/2474780",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "109"
+              },
+              {
+                "version_added": "88",
+                "impl_url": "https://crrev.com/c/2474780",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/svg/attributes/conditional_processing.json
+++ b/svg/attributes/conditional_processing.json
@@ -38,17 +38,22 @@
             "__compat": {
               "description": "Recognizes MathML namespace",
               "support": {
-                "chrome": {
-                  "version_added": "81",
-                  "impl_url": "https://crrev.com/c/2007454",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-experimental-web-platform-features",
-                      "value_to_set": "Enabled"
-                    }
-                  ]
-                },
+                "chrome": [
+                  {
+                    "version_added": "109"
+                  },
+                  {
+                    "version_added": "81",
+                    "impl_url": "https://crrev.com/c/2007454",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "#enable-experimental-web-platform-features",
+                        "value_to_set": "Enabled"
+                      }
+                    ]
+                  }
+                ],
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION
#### Summary

Enable MathML and related features in Chrome 109

#### Test results and supporting details

See https://developer.chrome.com/blog/chrome-109-beta/#mathml
Chrome 109 is going to be released today.

#### Related issues

N/A