### PR TITLE
Update spec exception list

### DIFF
--- a/http/headers/Digest.json
+++ b/http/headers/Digest.json
@@ -4,7 +4,7 @@
       "Digest": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Digest",
-          "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers-05#section-3",
+          "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers#section-3",
           "support": {
             "chrome": {
               "version_added": null

--- a/http/headers/Expect-CT.json
+++ b/http/headers/Expect-CT.json
@@ -4,7 +4,7 @@
       "Expect-CT": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Expect-CT",
-          "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-expect-ct-08#section-2.1",
+          "spec_url": "https://www.rfc-editor.org/rfc/rfc9163#section-2.1",
           "support": {
             "chrome": {
               "version_added": "61",

--- a/http/headers/Want-Digest.json
+++ b/http/headers/Want-Digest.json
@@ -4,7 +4,7 @@
       "Want-Digest": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Want-Digest",
-          "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers-05#section-4",
+          "spec_url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers#section-4",
           "support": {
             "chrome": {
               "version_added": null

--- a/test/linter/test-spec-urls.ts
+++ b/test/linter/test-spec-urls.ts
@@ -19,10 +19,6 @@ const specsExceptions = [
   // Remove once Window.{clearImmediate,setImmediate} are irrelevant and removed
   'https://w3c.github.io/setImmediate/',
 
-  // Remove if supported in browser-specs https://github.com/w3c/browser-specs/issues/339
-  'https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers-05',
-  'https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-expect-ct-08',
-
   // Exception for April Fools' joke for "418 I'm a teapot"
   'https://www.rfc-editor.org/rfc/rfc2324',
 
@@ -34,14 +30,10 @@ const specsExceptions = [
   // Remove if this spec will be merged with the main WebAssembly spec
   'https://webassembly.github.io/threads/js-api/',
 
-  // Remove if https://github.com/w3c/webrtc-extensions/issues/108 is closed
+  // See https://github.com/w3c/browser-specs/issues/305
+  // Features with this URL need to be checked after some time
+  // if they have been integrated into a real spec
   'https://w3c.github.io/webrtc-extensions/',
-
-  // Remove when added to browser-specs
-  'https://w3c.github.io/csswg-drafts/css-color-6/',
-
-  // Remove if https://github.com/w3c/browser-specs/issues/730 is resolved
-  'https://w3c.github.io/csswg-drafts/css2',
 ];
 
 const allowedSpecURLs = [


### PR DESCRIPTION
This PR updates BCD's exception list for specs that aren't in browser-specs or web-specs.
See https://github.com/w3c/browser-specs/pull/817#issuecomment-1377207689 for details