### PR TITLE
Fix WebExtension mirroring warnings

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1228,9 +1228,7 @@
               "chrome": {
                 "version_added": "38"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "45"
               },
@@ -1250,9 +1248,7 @@
                 "chrome": {
                   "version_added": "43"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": [
                   {
                     "version_added": "110"
@@ -1280,9 +1276,7 @@
                 "chrome": {
                   "version_added": "38"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "45"
                 },
@@ -1303,9 +1297,7 @@
                 "chrome": {
                   "version_added": "38"
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "45"
                 },
@@ -1328,9 +1320,7 @@
               "chrome": {
                 "version_added": "38"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "45"
               },
@@ -1352,9 +1342,7 @@
               "chrome": {
                 "version_added": "38"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "45"
               },
@@ -2165,9 +2153,7 @@
               "chrome": {
                 "version_added": "42"
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "45"
               },


### PR DESCRIPTION
On every build I see: 

```
Mirroring - 7 problems (0 errors, 7 warnings):
[27](https://github.com/mdn/browser-compat-data/actions/runs/3883926419/jobs/6625808535#step:5:28)
 ✖ webextensions.api.tabs.ZoomSettings - Warning → Data for edge can be automatically mirrored, use "edge": "mirror" instead
[28](https://github.com/mdn/browser-compat-data/actions/runs/3883926419/jobs/6625808535#step:5:29)
   ◆ Tip: Run npm run fix to fix this problem automatically
[29](https://github.com/mdn/browser-compat-data/actions/runs/3883926419/jobs/6625808535#step:5:30)
 ✖ webextensions.api.tabs.ZoomSettings.defaultZoomFactor - Warning → Data for edge can be automatically mirrored, use "edge": "mirror" instead
[30](https://github.com/mdn/browser-compat-data/actions/runs/3883926419/jobs/6625808535#step:5:31)
   ◆ Tip: Run npm run fix to fix this problem automatically
[31](https://github.com/mdn/browser-compat-data/actions/runs/3883926419/jobs/6625808535#step:5:32)
 ✖ webextensions.api.tabs.ZoomSettings.mode - Warning → Data for edge can be automatically mirrored, use "edge": "mirror" instead
[32](https://github.com/mdn/browser-compat-data/actions/runs/3883926419/jobs/6625808535#step:5:33)
   ◆ Tip: Run npm run fix to fix this problem automatically
[33](https://github.com/mdn/browser-compat-data/actions/runs/3883926419/jobs/6625808535#step:5:34)
 ✖ webextensions.api.tabs.ZoomSettings.scope - Warning → Data for edge can be automatically mirrored, use "edge": "mirror" instead
[34](https://github.com/mdn/browser-compat-data/actions/runs/3883926419/jobs/6625808535#step:5:35)
   ◆ Tip: Run npm run fix to fix this problem automatically
[35](https://github.com/mdn/browser-compat-data/actions/runs/3883926419/jobs/6625808535#step:5:36)
 ✖ webextensions.api.tabs.ZoomSettingsMode - Warning → Data for edge can be automatically mirrored, use "edge": "mirror" instead
[36](https://github.com/mdn/browser-compat-data/actions/runs/3883926419/jobs/6625808535#step:5:37)
   ◆ Tip: Run npm run fix to fix this problem automatically
[37](https://github.com/mdn/browser-compat-data/actions/runs/3883926419/jobs/6625808535#step:5:38)
 ✖ webextensions.api.tabs.ZoomSettingsScope - Warning → Data for edge can be automatically mirrored, use "edge": "mirror" instead
[38](https://github.com/mdn/browser-compat-data/actions/runs/3883926419/jobs/6625808535#step:5:39)
   ◆ Tip: Run npm run fix to fix this problem automatically
[39](https://github.com/mdn/browser-compat-data/actions/runs/3883926419/jobs/6625808535#step:5:40)
 ✖ webextensions.api.tabs.getZoomSettings - Warning → Data for edge can be automatically mirrored, use "edge": "mirror" instead
[40](https://github.com/mdn/browser-compat-data/actions/runs/3883926419/jobs/6625808535#step:5:41)
   ◆ Tip: Run npm run fix to fix this problem automatically
```

This PR fixes that.