### PR TITLE
Make mirroring linter an error vs. a warning

### DIFF
--- a/test/linter/test-mirror.ts
+++ b/test/linter/test-mirror.ts
@@ -30,7 +30,7 @@ const checkMirroring = (
 
   for (const browser of browsersToCheck) {
     if (isMirrorEquivalent(supportData, browser)) {
-      logger.warning(
+      logger.error(
         chalk`Data for {bold ${browser}} can be automatically mirrored, use {bold "${browser}": "mirror"} instead`,
         { fixable: true },
       );


### PR DESCRIPTION
This PR converts the "mirrorable data" warning into an error as suggested in https://github.com/mdn/browser-compat-data/pull/18617#issuecomment-1378381044.
