### PR TITLE
Collector v7.1.3 changes (Jan. 11, 2023) [2020+ releases only]

### DIFF
--- a/api/CSSTransition.json
+++ b/api/CSSTransition.json
@@ -6,12 +6,10 @@
         "spec_url": "https://w3c.github.io/csswg-drafts/css-transitions-2/#the-CSSTransition-interface",
         "support": {
           "chrome": {
-            "version_added": "78"
-          },
-          "chrome_android": "mirror",
-          "edge": {
             "version_added": "84"
           },
+          "chrome_android": "mirror",
+          "edge": "mirror",
           "firefox": {
             "version_added": "75"
           },

--- a/api/DOMRectReadOnly.json
+++ b/api/DOMRectReadOnly.json
@@ -176,7 +176,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "3"
@@ -253,7 +253,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "3"
@@ -295,7 +295,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "3"
@@ -337,7 +337,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "3"
@@ -412,7 +412,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "3"
@@ -454,7 +454,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "3"

--- a/api/DataTransferItem.json
+++ b/api/DataTransferItem.json
@@ -273,7 +273,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤108"
             }
           },
           "status": {

--- a/api/DeviceMotionEventAcceleration.json
+++ b/api/DeviceMotionEventAcceleration.json
@@ -10,7 +10,7 @@
           },
           "chrome_android": "mirror",
           "edge": {
-            "version_added": "12"
+            "version_added": "18> ≤80"
           },
           "firefox": {
             "version_added": "6"
@@ -47,7 +47,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "6"
@@ -85,7 +85,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "6"
@@ -123,7 +123,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "6"

--- a/api/DeviceMotionEventRotationRate.json
+++ b/api/DeviceMotionEventRotationRate.json
@@ -10,7 +10,7 @@
           },
           "chrome_android": "mirror",
           "edge": {
-            "version_added": "12"
+            "version_added": "18> ≤80"
           },
           "firefox": {
             "version_added": "6"
@@ -47,7 +47,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "6"
@@ -85,7 +85,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "6"
@@ -123,7 +123,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "6"

--- a/api/Document.json
+++ b/api/Document.json
@@ -6282,7 +6282,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15.5"
+              "version_added": "15.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/DragEvent.json
+++ b/api/DragEvent.json
@@ -9,7 +9,7 @@
             "version_added": "3"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "≤108"
           },
           "edge": {
             "version_added": "12"
@@ -28,13 +28,15 @@
           },
           "opera_android": "mirror",
           "safari": {
-            "version_added": "3.1"
+            "version_added": "13.1> ≤14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "≤16.2"
           },
           "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "webview_android": {
+            "version_added": "≤108"
+          }
         },
         "status": {
           "experimental": false,
@@ -52,10 +54,10 @@
               "version_added": "46"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "≤108"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "3.5"
@@ -70,13 +72,15 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": "3.1"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤16.2"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": "≤108"
+            }
           },
           "status": {
             "experimental": false,
@@ -94,7 +98,7 @@
               "version_added": "46"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "≤108"
             },
             "edge": {
               "version_added": "12"
@@ -112,13 +116,15 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "3.1"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤16.2"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": "≤108"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/EXT_texture_compression_bptc.json
+++ b/api/EXT_texture_compression_bptc.json
@@ -33,7 +33,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "16.1"
+            "version_added": "16"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": {

--- a/api/EXT_texture_norm16.json
+++ b/api/EXT_texture_norm16.json
@@ -25,7 +25,7 @@
           },
           "opera_android": "mirror",
           "safari": {
-            "version_added": "16.1"
+            "version_added": "16"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -2364,10 +2364,14 @@
           "spec_url": "https://immersive-web.github.io/dom-overlays/#onbeforexrselect",
           "support": {
             "chrome": {
-              "version_added": "83"
+              "version_added": "83",
+              "version_removed": "90"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "83",
+              "version_removed": "90"
+            },
             "firefox": {
               "version_added": false
             },

--- a/api/Event.json
+++ b/api/Event.json
@@ -752,7 +752,10 @@
               "version_added": false,
               "notes": "Temporarily added in 63, removed in 64, briefly added in 65, then removed again while related compatibility issues are sorted out (see <a href='https://bugzil.la/1520756'>bug 1520756</a>)."
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "≤108",
+              "notes": "Temporarily added in 63, removed in 64, briefly added in 65, then removed again while related compatibility issues are sorted out (see <a href='https://bugzil.la/1520756'>bug 1520756</a>)."
+            },
             "ie": {
               "version_added": "6"
             },

--- a/api/FeaturePolicy.json
+++ b/api/FeaturePolicy.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FeaturePolicy",
         "support": {
           "chrome": {
-            "version_added": "74"
+            "version_added": "80"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -45,7 +45,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FeaturePolicy/allowedFeatures",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": "80"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -85,7 +85,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FeaturePolicy/allowsFeature",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": "80"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -125,7 +125,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FeaturePolicy/features",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": "80"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -165,7 +165,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/FeaturePolicy/getAllowlistForFeature",
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": "80"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/FileSystemSyncAccessHandle.json
+++ b/api/FileSystemSyncAccessHandle.json
@@ -9,7 +9,7 @@
             "version_added": "102"
           },
           "chrome_android": {
-            "version_added": "109"
+            "version_added": "≤108"
           },
           "edge": "mirror",
           "firefox": {
@@ -27,7 +27,9 @@
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "webview_android": {
+            "version_added": "≤108"
+          }
         },
         "status": {
           "experimental": false,
@@ -44,7 +46,7 @@
               "version_added": "102"
             },
             "chrome_android": {
-              "version_added": "109"
+              "version_added": "≤108"
             },
             "edge": "mirror",
             "firefox": {
@@ -62,7 +64,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": "≤108"
+            }
           },
           "status": {
             "experimental": false,
@@ -122,7 +126,7 @@
               "version_added": "102"
             },
             "chrome_android": {
-              "version_added": "109"
+              "version_added": "≤108"
             },
             "edge": "mirror",
             "firefox": {
@@ -140,7 +144,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": "≤108"
+            }
           },
           "status": {
             "experimental": false,
@@ -200,7 +206,7 @@
               "version_added": "102"
             },
             "chrome_android": {
-              "version_added": "109"
+              "version_added": "≤108"
             },
             "edge": "mirror",
             "firefox": {
@@ -218,7 +224,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": "≤108"
+            }
           },
           "status": {
             "experimental": false,
@@ -278,7 +286,7 @@
               "version_added": "102"
             },
             "chrome_android": {
-              "version_added": "109"
+              "version_added": "≤108"
             },
             "edge": "mirror",
             "firefox": {
@@ -296,7 +304,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": "≤108"
+            }
           },
           "status": {
             "experimental": false,
@@ -314,7 +324,7 @@
               "version_added": "102"
             },
             "chrome_android": {
-              "version_added": "109"
+              "version_added": "≤108"
             },
             "edge": "mirror",
             "firefox": {
@@ -332,7 +342,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": "≤108"
+            }
           },
           "status": {
             "experimental": false,
@@ -392,7 +404,7 @@
               "version_added": "102"
             },
             "chrome_android": {
-              "version_added": "109"
+              "version_added": "≤108"
             },
             "edge": "mirror",
             "firefox": {
@@ -410,7 +422,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": "≤108"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/FontFaceSetLoadEvent.json
+++ b/api/FontFaceSetLoadEvent.json
@@ -26,7 +26,7 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": false
+            "version_added": "≤108"
           }
         },
         "status": {
@@ -62,7 +62,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤108"
             }
           },
           "status": {
@@ -133,7 +133,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤108"
             }
           },
           "status": {

--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -556,7 +556,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤108"
             }
           },
           "status": {

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -143,7 +143,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤108"
             }
           },
           "status": {

--- a/api/GamepadHapticActuator.json
+++ b/api/GamepadHapticActuator.json
@@ -83,7 +83,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "15"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": false
@@ -154,7 +154,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "15"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": false

--- a/api/GeolocationPositionError.json
+++ b/api/GeolocationPositionError.json
@@ -123,10 +123,10 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "18> ≤80"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "72"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -140,7 +140,7 @@
               "version_added": "16"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -165,10 +165,10 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "18> ≤80"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "72"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -182,7 +182,7 @@
               "version_added": "16"
             },
             "safari": {
-              "version_added": "5"
+              "version_added": "13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -325,10 +325,12 @@
           "spec_url": "https://w3c.github.io/uievents/#event-type-beforeinput",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": "105"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "105"
+            },
             "firefox": {
               "version_added": "87"
             },

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -68,7 +68,7 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤108"
             }
           },
           "status": {

--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -419,7 +419,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "10"

--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -409,7 +409,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "10"

--- a/api/InstallEvent.json
+++ b/api/InstallEvent.json
@@ -9,7 +9,7 @@
           },
           "chrome_android": "mirror",
           "edge": {
-            "version_added": "17"
+            "version_added": "18> ≤80"
           },
           "firefox": {
             "version_added": "44"

--- a/api/LaunchParams.json
+++ b/api/LaunchParams.json
@@ -5,10 +5,12 @@
         "spec_url": "https://wicg.github.io/web-app-launch/#launchparams-interface",
         "support": {
           "chrome": {
-            "version_added": "110"
+            "version_added": "102"
           },
           "chrome_android": "mirror",
-          "edge": "mirror",
+          "edge": {
+            "version_added": "102"
+          },
           "firefox": {
             "version_added": false
           },
@@ -37,10 +39,12 @@
           "spec_url": "https://wicg.github.io/web-app-launch/#ref-for-dom-launchparams-files-1",
           "support": {
             "chrome": {
-              "version_added": "110"
+              "version_added": "102"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "102"
+            },
             "firefox": {
               "version_added": false
             },

--- a/api/LaunchQueue.json
+++ b/api/LaunchQueue.json
@@ -5,10 +5,12 @@
         "spec_url": "https://wicg.github.io/web-app-launch/#launchqueue-interface",
         "support": {
           "chrome": {
-            "version_added": "110"
+            "version_added": "102"
           },
           "chrome_android": "mirror",
-          "edge": "mirror",
+          "edge": {
+            "version_added": "102"
+          },
           "firefox": {
             "version_added": false
           },
@@ -37,10 +39,12 @@
           "spec_url": "https://wicg.github.io/web-app-launch/#dom-launchqueue-setconsumer",
           "support": {
             "chrome": {
-              "version_added": "110"
+              "version_added": "102"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "102"
+            },
             "firefox": {
               "version_added": false
             },

--- a/api/MIDIInput.json
+++ b/api/MIDIInput.json
@@ -90,7 +90,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤108"
             }
           },
           "status": {

--- a/api/MIDIMessageEvent.json
+++ b/api/MIDIMessageEvent.json
@@ -41,7 +41,7 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": false
+            "version_added": "≤108"
           }
         },
         "status": {
@@ -92,7 +92,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤108"
             }
           },
           "status": {
@@ -143,7 +143,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤108"
             }
           },
           "status": {

--- a/api/MIDIOutput.json
+++ b/api/MIDIOutput.json
@@ -41,7 +41,7 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": false
+            "version_added": "≤108"
           }
         },
         "status": {
@@ -141,7 +141,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤108"
             }
           },
           "status": {

--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -25,7 +25,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "15"
+            "version_added": "13.1> ≤14.1"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -61,7 +61,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -97,7 +97,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -133,7 +133,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -169,7 +169,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -205,7 +205,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -27,7 +27,7 @@
             "version_added": "12.1"
           },
           "safari": {
-            "version_added": "5.1"
+            "version_added": "13.1> ≤14.1"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -104,7 +104,7 @@
               "version_added": "12.1"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -181,7 +181,7 @@
               "version_added": "12.1"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -223,7 +223,7 @@
               "version_added": "12.1"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -266,7 +266,7 @@
               "version_added": "12.1"
             },
             "safari": {
-              "version_added": "5.1",
+              "version_added": "13.1> ≤14.1",
               "notes": "Before Safari 14, <code>MediaQueryList</code> is based on <code>EventTarget</code>, so you must use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
             },
             "safari_ios": "mirror",

--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -186,7 +186,7 @@
               "version_added": "44"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤108"
             },
             "ie": {
               "version_added": false

--- a/api/MediaStreamAudioDestinationNode.json
+++ b/api/MediaStreamAudioDestinationNode.json
@@ -10,7 +10,7 @@
           },
           "chrome_android": "mirror",
           "edge": {
-            "version_added": "18"
+            "version_added": "18> ≤80"
           },
           "firefox": {
             "version_added": "25"
@@ -82,7 +82,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "18"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "25"

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -87,7 +87,7 @@
               "version_added": "20"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "≤108"
             },
             "edge": {
               "version_added": "14"

--- a/api/OES_fbo_render_mipmap.json
+++ b/api/OES_fbo_render_mipmap.json
@@ -11,7 +11,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "71"
+            "version_added": "80"
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/OVR_multiview2.json
+++ b/api/OVR_multiview2.json
@@ -8,7 +8,8 @@
           "chrome": {
             "version_added": "93",
             "partial_implementation": true,
-            "notes": "Not supported on macOS."
+            "notes": "Not supported on macOS.",
+            "version_removed": "109"
           },
           "chrome_android": {
             "version_added": "93"
@@ -45,7 +46,8 @@
           "spec_url": "https://registry.khronos.org/webgl/extensions/OVR_multiview2/",
           "support": {
             "chrome": {
-              "version_added": "93"
+              "version_added": "93",
+              "version_removed": "109"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -684,13 +684,17 @@
           "spec_url": "https://wicg.github.io/performance-measure-memory/#ref-for-dom-performance-measureuseragentspecificmemory⑤",
           "support": {
             "chrome": {
-              "version_added": "89"
+              "version_added": "89",
+              "version_removed": "92"
             },
             "chrome_android": "mirror",
             "deno": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "89",
+              "version_removed": "92"
+            },
             "firefox": {
               "version_added": false
             },

--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -166,7 +166,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "17"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "45"
@@ -274,7 +274,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "17"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "45"
@@ -772,7 +772,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "17"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "45"

--- a/api/PictureInPictureEvent.json
+++ b/api/PictureInPictureEvent.json
@@ -108,12 +108,14 @@
           "spec_url": "https://w3c.github.io/picture-in-picture/#dom-pictureinpictureevent-pictureinpicturewindow",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "85"
             },
             "chrome_android": {
               "version_added": "105"
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "85"
+            },
             "firefox": {
               "version_added": false
             },
@@ -125,7 +127,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "13.1"
+              "version_added": "16"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -159,7 +159,7 @@
               "version_added": "16"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤16.2"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/api/PushMessageData.json
+++ b/api/PushMessageData.json
@@ -34,7 +34,7 @@
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": false,
+            "version_added": "≤108",
             "notes": "See <a href='https://crbug.com/421921'>bug 421921</a>."
           }
         },
@@ -78,7 +78,7 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤108"
             }
           },
           "status": {
@@ -122,7 +122,7 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤108"
             }
           },
           "status": {
@@ -166,7 +166,7 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤108"
             }
           },
           "status": {
@@ -210,7 +210,7 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤108"
             }
           },
           "status": {

--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -13,10 +13,13 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": false,
+            "version_added": "82",
             "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": "≤108",
+            "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
+          },
           "ie": {
             "version_added": false
           },
@@ -174,10 +177,13 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false,
+              "version_added": "82",
               "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "≤108",
+              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
+            },
             "ie": {
               "version_added": false
             },
@@ -220,10 +226,13 @@
               }
             ],
             "firefox": {
-              "version_added": false,
+              "version_added": "82",
               "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "≤108",
+              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
+            },
             "ie": {
               "version_added": false
             },

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -2720,7 +2720,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤16.2"
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -441,7 +441,7 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": "34"
+              "version_added": "82"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/RTCRtpTransceiver.json
+++ b/api/RTCRtpTransceiver.json
@@ -10,7 +10,7 @@
           },
           "chrome_android": "mirror",
           "edge": {
-            "version_added": "≤18"
+            "version_added": "18> ≤80"
           },
           "firefox": {
             "version_added": "59"

--- a/api/ReadableStreamDefaultController.json
+++ b/api/ReadableStreamDefaultController.json
@@ -22,7 +22,7 @@
           ],
           "edge": "mirror",
           "firefox": {
-            "version_added": "65"
+            "version_added": "100"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -71,7 +71,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "65"
+              "version_added": "100"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -111,7 +111,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "65"
+              "version_added": "100"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -151,7 +151,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "65"
+              "version_added": "100"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -191,7 +191,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "65"
+              "version_added": "100"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -22,7 +22,7 @@
           ],
           "edge": "mirror",
           "firefox": {
-            "version_added": "65"
+            "version_added": "100"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -72,7 +72,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "65"
+              "version_added": "100"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -112,7 +112,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "65"
+              "version_added": "100"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -152,7 +152,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "65"
+              "version_added": "100"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -192,7 +192,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "65"
+              "version_added": "100"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -232,7 +232,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "65"
+              "version_added": "100"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -367,7 +367,16 @@
               "alternative_name": "SVGLoad",
               "notes": "See <a href='https://bugzil.la/620002'>bug 620002</a> for implementation status of the standard <code>load</code> event."
             },
-            "firefox_android": "mirror",
+            "firefox_android": [
+              {
+                "version_added": "≤108"
+              },
+              {
+                "version_added": "4",
+                "alternative_name": "SVGLoad",
+                "notes": "See <a href='https://bugzil.la/620002'>bug 620002</a> for implementation status of the standard <code>load</code> event."
+              }
+            ],
             "ie": {
               "version_added": "9"
             },

--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -131,7 +131,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "1.5"

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -24,14 +24,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "83",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.security.sanitizer.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "82",
+            "version_removed": "83"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -216,14 +210,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "83",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.sanitizer.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "82",
+              "version_removed": "83"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -51,7 +51,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": "74"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -235,7 +235,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": "74"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -955,7 +955,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": "74"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/SpeechSynthesisErrorEvent.json
+++ b/api/SpeechSynthesisErrorEvent.json
@@ -10,7 +10,7 @@
           },
           "chrome_android": "mirror",
           "edge": {
-            "version_added": "≤18"
+            "version_added": "18> ≤80"
           },
           "firefox": {
             "version_added": "49"
@@ -29,7 +29,7 @@
             "version_added": false
           },
           "safari": {
-            "version_added": "7"
+            "version_added": "16"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": {
@@ -96,7 +96,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤18"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "49"
@@ -115,7 +115,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "16"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {

--- a/api/SpeechSynthesisEvent.json
+++ b/api/SpeechSynthesisEvent.json
@@ -160,9 +160,11 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "16"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.2"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
@@ -345,7 +347,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "16"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {

--- a/api/Touch.json
+++ b/api/Touch.json
@@ -10,7 +10,7 @@
           },
           "chrome_android": "mirror",
           "edge": {
-            "version_added": "≤18"
+            "version_added": "18> ≤80"
           },
           "firefox": [
             {
@@ -165,7 +165,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤18"
+              "version_added": "18> ≤80"
             },
             "firefox": [
               {
@@ -212,7 +212,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤18"
+              "version_added": "18> ≤80"
             },
             "firefox": [
               {
@@ -313,7 +313,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤18"
+              "version_added": "18> ≤80"
             },
             "firefox": [
               {
@@ -360,7 +360,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤18"
+              "version_added": "18> ≤80"
             },
             "firefox": [
               {
@@ -407,7 +407,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤18"
+              "version_added": "18> ≤80"
             },
             "firefox": [
               {
@@ -616,7 +616,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤18"
+              "version_added": "18> ≤80"
             },
             "firefox": [
               {
@@ -663,7 +663,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤18"
+              "version_added": "18> ≤80"
             },
             "firefox": [
               {
@@ -710,7 +710,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤18"
+              "version_added": "18> ≤80"
             },
             "firefox": [
               {

--- a/api/TouchList.json
+++ b/api/TouchList.json
@@ -10,7 +10,7 @@
           },
           "chrome_android": "mirror",
           "edge": {
-            "version_added": "≤18"
+            "version_added": "18> ≤80"
           },
           "firefox": [
             {
@@ -56,7 +56,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤18"
+              "version_added": "18> ≤80"
             },
             "firefox": [
               {
@@ -103,7 +103,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤18"
+              "version_added": "18> ≤80"
             },
             "firefox": [
               {

--- a/api/TransformStreamDefaultController.json
+++ b/api/TransformStreamDefaultController.json
@@ -6,7 +6,7 @@
         "spec_url": "https://streams.spec.whatwg.org/#ts-default-controller-class",
         "support": {
           "chrome": {
-            "version_added": "67"
+            "version_added": "105"
           },
           "chrome_android": "mirror",
           "deno": [
@@ -20,7 +20,9 @@
               "notes": "<code>TransformStreamDefaultController</code> is not exposed on the global scope."
             }
           ],
-          "edge": "mirror",
+          "edge": {
+            "version_added": "105"
+          },
           "firefox": {
             "version_added": "102"
           },
@@ -53,13 +55,15 @@
           "spec_url": "https://streams.spec.whatwg.org/#ts-default-controller-desired-size",
           "support": {
             "chrome": {
-              "version_added": "67"
+              "version_added": "105"
             },
             "chrome_android": "mirror",
             "deno": {
               "version_added": "1.0"
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "105"
+            },
             "firefox": {
               "version_added": "102"
             },
@@ -93,13 +97,15 @@
           "spec_url": "https://streams.spec.whatwg.org/#ts-default-controller-enqueue",
           "support": {
             "chrome": {
-              "version_added": "67"
+              "version_added": "105"
             },
             "chrome_android": "mirror",
             "deno": {
               "version_added": "1.0"
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "105"
+            },
             "firefox": {
               "version_added": "102"
             },
@@ -133,13 +139,15 @@
           "spec_url": "https://streams.spec.whatwg.org/#ts-default-controller-error",
           "support": {
             "chrome": {
-              "version_added": "67"
+              "version_added": "105"
             },
             "chrome_android": "mirror",
             "deno": {
               "version_added": "1.0"
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "105"
+            },
             "firefox": {
               "version_added": "102"
             },
@@ -173,13 +181,15 @@
           "spec_url": "https://streams.spec.whatwg.org/#ts-default-controller-terminate",
           "support": {
             "chrome": {
-              "version_added": "67"
+              "version_added": "105"
             },
             "chrome_android": "mirror",
             "deno": {
               "version_added": "1.0"
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "105"
+            },
             "firefox": {
               "version_added": "102"
             },

--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -102,7 +102,9 @@
             "safari": {
               "version_added": "preview"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.2"
+            },
             "samsunginternet_android": {
               "version_added": "2.0"
             },

--- a/api/UserActivation.json
+++ b/api/UserActivation.json
@@ -76,7 +76,9 @@
               "version_added": "97"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "18> ≤80"
+            },
             "firefox": {
               "version_added": false
             },

--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -6,7 +6,7 @@
         "spec_url": "https://w3c.github.io/media-playback-quality/#videoplaybackquality-interface",
         "support": {
           "chrome": {
-            "version_added": "23"
+            "version_added": "80"
           },
           "chrome_android": "mirror",
           "edge": {
@@ -88,7 +88,7 @@
           "spec_url": "https://w3c.github.io/media-playback-quality/#dom-videoplaybackquality-creationtime",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "80"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -129,7 +129,7 @@
           "spec_url": "https://w3c.github.io/media-playback-quality/#dom-videoplaybackquality-droppedvideoframes",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "80"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -210,7 +210,7 @@
           "spec_url": "https://w3c.github.io/media-playback-quality/#dom-videoplaybackquality-totalvideoframes",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": "80"
             },
             "chrome_android": "mirror",
             "edge": {

--- a/api/WEBGL_compressed_texture_astc.json
+++ b/api/WEBGL_compressed_texture_astc.json
@@ -6,10 +6,13 @@
         "spec_url": "https://registry.khronos.org/webgl/extensions/WEBGL_compressed_texture_astc/",
         "support": {
           "chrome": {
-            "version_added": "47"
+            "version_added": "93",
+            "version_removed": "109"
           },
           "chrome_android": "mirror",
-          "edge": "mirror",
+          "edge": {
+            "version_added": "93"
+          },
           "firefox": {
             "version_added": "53"
           },
@@ -21,9 +24,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "16.2"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "≤16.2"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -39,10 +44,13 @@
           "spec_url": "https://registry.khronos.org/webgl/extensions/WEBGL_compressed_texture_astc/",
           "support": {
             "chrome": {
-              "version_added": "47"
+              "version_added": "93",
+              "version_removed": "109"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "93"
+            },
             "firefox": {
               "version_added": "53"
             },
@@ -54,9 +62,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "16.2"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.2"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/WEBGL_compressed_texture_etc.json
+++ b/api/WEBGL_compressed_texture_etc.json
@@ -21,7 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "16.2"
           },
           "safari_ios": {
             "version_added": "14"

--- a/api/WEBGL_compressed_texture_etc1.json
+++ b/api/WEBGL_compressed_texture_etc1.json
@@ -23,7 +23,9 @@
           "safari": {
             "version_added": false
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "≤16.2"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },

--- a/api/WEBGL_compressed_texture_pvrtc.json
+++ b/api/WEBGL_compressed_texture_pvrtc.json
@@ -23,9 +23,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "16.2"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "≤16.2"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },

--- a/api/WEBGL_compressed_texture_s3tc_srgb.json
+++ b/api/WEBGL_compressed_texture_s3tc_srgb.json
@@ -25,7 +25,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "13.1> ≤14.1"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",

--- a/api/WEBGL_debug_shaders.json
+++ b/api/WEBGL_debug_shaders.json
@@ -21,7 +21,9 @@
             ],
             "notes": "The extension is activated by default to privileged contexts (chrome context)."
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": "≤108"
+          },
           "ie": {
             "version_added": false
           },
@@ -62,7 +64,9 @@
               ],
               "notes": "The extension is activated by default to privileged contexts (chrome context)."
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "≤108"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/WEBGL_multi_draw.json
+++ b/api/WEBGL_multi_draw.json
@@ -23,7 +23,7 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1> ≤15.1"
           },
           "safari_ios": {
             "version_added": "15"
@@ -60,7 +60,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1> ≤15.1"
             },
             "safari_ios": {
               "version_added": "15"
@@ -98,7 +98,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1> ≤15.1"
             },
             "safari_ios": {
               "version_added": "15"
@@ -136,7 +136,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1> ≤15.1"
             },
             "safari_ios": {
               "version_added": "15"
@@ -174,7 +174,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1> ≤15.1"
             },
             "safari_ios": {
               "version_added": "15"

--- a/api/WebGLQuery.json
+++ b/api/WebGLQuery.json
@@ -25,7 +25,9 @@
           "safari": {
             "version_added": "preview"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "≤16.2"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -4500,7 +4500,8 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1> ≤14.1",
+              "version_removed": "14.1> ≤15.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {

--- a/api/WebGLSampler.json
+++ b/api/WebGLSampler.json
@@ -25,7 +25,9 @@
           "safari": {
             "version_added": "preview"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "≤16.2"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },

--- a/api/WebGLSync.json
+++ b/api/WebGLSync.json
@@ -25,7 +25,9 @@
           "safari": {
             "version_added": "preview"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "≤16.2"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },

--- a/api/WebGLVertexArrayObjectOES.json
+++ b/api/WebGLVertexArrayObjectOES.json
@@ -25,7 +25,9 @@
           "safari": {
             "version_added": false
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "≤16.2"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },

--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -205,7 +205,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "100"
+                "version_added": "97"
               },
               {
                 "version_added": "97",
@@ -214,7 +214,16 @@
               }
             ],
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": [
+              {
+                "version_added": "97"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "100",
+                "alternative_name": "createSendStream"
+              }
+            ],
             "firefox": {
               "version_added": false
             },
@@ -311,7 +320,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "100"
+                "version_added": "97"
               },
               {
                 "version_added": "97",
@@ -320,7 +329,16 @@
               }
             ],
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": [
+              {
+                "version_added": "97"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "100",
+                "alternative_name": "receiveBidirectionalStreams"
+              }
+            ],
             "firefox": {
               "version_added": false
             },
@@ -351,7 +369,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "100"
+                "version_added": "97"
               },
               {
                 "version_added": "97",
@@ -360,7 +378,16 @@
               }
             ],
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": [
+              {
+                "version_added": "97"
+              },
+              {
+                "version_added": "97",
+                "version_removed": "100",
+                "alternative_name": "receiveStreams"
+              }
+            ],
             "firefox": {
               "version_added": false
             },

--- a/api/WebTransportBidirectionalStream.json
+++ b/api/WebTransportBidirectionalStream.json
@@ -6,7 +6,7 @@
         "support": {
           "chrome": [
             {
-              "version_added": "100"
+              "version_added": "97"
             },
             {
               "version_added": "97",
@@ -15,7 +15,16 @@
             }
           ],
           "chrome_android": "mirror",
-          "edge": "mirror",
+          "edge": [
+            {
+              "version_added": "97"
+            },
+            {
+              "version_added": "97",
+              "version_removed": "100",
+              "alternative_name": "BidirectionalStream"
+            }
+          ],
           "firefox": {
             "version_added": false
           },

--- a/api/Window.json
+++ b/api/Window.json
@@ -1790,7 +1790,7 @@
               "notes": "The <code>ongamepadconnected</code> event handler property is not supported. See <a href='https://webkit.org/b/223860'>bug 223860</a>."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤16.2"
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -1857,7 +1857,7 @@
               "notes": "The <code>ongamepaddisconnected</code> event handler property is not supported. See <a href='https://webkit.org/b/223860'>bug 223860</a>."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤16.2"
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -2328,10 +2328,12 @@
           "spec_url": "https://wicg.github.io/web-app-launch/#launchqueue-interface",
           "support": {
             "chrome": {
-              "version_added": "110"
+              "version_added": "102"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "102"
+            },
             "firefox": {
               "version_added": false
             },
@@ -3442,7 +3444,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/origin.html#origin-keyed-agent-clusters",
           "support": {
             "chrome": {
-              "version_added": "88"
+              "version_added": "90"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -5739,7 +5741,7 @@
               "notes": "See <a href='https://webkit.org/b/151885'>WebKit bug 151885</a> for possible future removal from Safari."
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤16.2"
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/api/WindowClient.json
+++ b/api/WindowClient.json
@@ -58,7 +58,7 @@
               "version_added": "16"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤16.2"
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -147,9 +147,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "14.1> ≤15.1"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.2"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -297,7 +297,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "3.5",
@@ -342,7 +342,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "16"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "32",
@@ -392,9 +392,11 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "96"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "≤108"
+            },
             "ie": {
               "version_added": false
             },

--- a/api/WritableStreamDefaultWriter.json
+++ b/api/WritableStreamDefaultWriter.json
@@ -79,9 +79,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "13.1> ≤14.1"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.2"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/XRFrame.json
+++ b/api/XRFrame.json
@@ -82,7 +82,9 @@
               "version_added": false
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "93"
+            },
             "firefox": {
               "version_added": false
             },
@@ -118,7 +120,9 @@
               "version_added": false
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "93"
+            },
             "firefox": {
               "version_added": false
             },
@@ -262,7 +266,9 @@
               "version_added": false
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "93"
+            },
             "firefox": {
               "version_added": false
             },

--- a/api/XRHand.json
+++ b/api/XRHand.json
@@ -9,7 +9,9 @@
             "version_added": false
           },
           "chrome_android": "mirror",
-          "edge": "mirror",
+          "edge": {
+            "version_added": "93"
+          },
           "firefox": {
             "version_added": false
           },

--- a/api/XRInputSource.json
+++ b/api/XRInputSource.json
@@ -122,7 +122,9 @@
               "version_added": false
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "93"
+            },
             "firefox": {
               "version_added": false
             },

--- a/api/XRJointPose.json
+++ b/api/XRJointPose.json
@@ -9,7 +9,9 @@
             "version_added": false
           },
           "chrome_android": "mirror",
-          "edge": "mirror",
+          "edge": {
+            "version_added": "93"
+          },
           "firefox": {
             "version_added": false
           },
@@ -44,7 +46,9 @@
               "version_added": false
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "93"
+            },
             "firefox": {
               "version_added": false
             },

--- a/api/XRJointSpace.json
+++ b/api/XRJointSpace.json
@@ -9,7 +9,9 @@
             "version_added": false
           },
           "chrome_android": "mirror",
-          "edge": "mirror",
+          "edge": {
+            "version_added": "93"
+          },
           "firefox": {
             "version_added": false
           },
@@ -44,7 +46,9 @@
               "version_added": false
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "93"
+            },
             "firefox": {
               "version_added": false
             },

--- a/api/XRSession.json
+++ b/api/XRSession.json
@@ -271,10 +271,12 @@
           "spec_url": "https://immersive-web.github.io/webxr-ar-module/#dom-xrsession-environmentblendmode",
           "support": {
             "chrome": {
-              "version_added": "79"
+              "version_added": "81"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "81"
+            },
             "firefox": {
               "version_added": false
             },

--- a/api/XRSystem.json
+++ b/api/XRSystem.json
@@ -5,12 +5,33 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSystem",
         "spec_url": "https://immersive-web.github.io/webxr/#xrsystem-interface",
         "support": {
-          "chrome": {
-            "alternative_name": "XR",
-            "version_added": "79"
-          },
-          "chrome_android": "mirror",
-          "edge": "mirror",
+          "chrome": [
+            {
+              "version_added": "83"
+            },
+            {
+              "alternative_name": "XR",
+              "version_added": "79"
+            }
+          ],
+          "chrome_android": [
+            {
+              "version_added": "≤108"
+            },
+            {
+              "alternative_name": "XR",
+              "version_added": "79"
+            }
+          ],
+          "edge": [
+            {
+              "version_added": "83"
+            },
+            {
+              "alternative_name": "XR",
+              "version_added": "79"
+            }
+          ],
           "firefox": {
             "version_added": false
           },
@@ -49,10 +70,12 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "79"
+              "version_added": "83"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "83"
+            },
             "firefox": {
               "version_added": false
             },
@@ -88,10 +111,12 @@
           "spec_url": "https://immersive-web.github.io/webxr/#dom-xrsystem-issessionsupported",
           "support": {
             "chrome": {
-              "version_added": "79"
+              "version_added": "83"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "83"
+            },
             "firefox": {
               "version_added": false
             },
@@ -127,10 +152,12 @@
           "spec_url": "https://immersive-web.github.io/webxr/#dom-xrsystem-requestsession",
           "support": {
             "chrome": {
-              "version_added": "79"
+              "version_added": "83"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "83"
+            },
             "firefox": {
               "version_added": false
             },

--- a/api/XRWebGLBinding.json
+++ b/api/XRWebGLBinding.json
@@ -26,7 +26,7 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": false
+            "version_added": "≤108"
           }
         },
         "status": {
@@ -62,7 +62,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤108"
             }
           },
           "status": {

--- a/css/properties/-webkit-mask-box-image.json
+++ b/css/properties/-webkit-mask-box-image.json
@@ -10,7 +10,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "18"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": false

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -79,7 +79,9 @@
                 "version_added": "83"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "84"
+              },
               "firefox": {
                 "version_added": "80"
               },
@@ -113,10 +115,10 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "84"
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "80"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -126,7 +128,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "3"
+                "version_added": "15.4"
               },
               "safari_ios": {
                 "version_added": "1"
@@ -150,7 +152,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "84"
               },
               "firefox": [
                 {
@@ -170,7 +172,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "3"
+                "version_added": "15.4"
               },
               "safari_ios": {
                 "version_added": "1"
@@ -193,7 +195,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "84"
               },
               "firefox": [
                 {
@@ -213,7 +215,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "3"
+                "version_added": "15.4"
               },
               "safari_ios": {
                 "version_added": "3"
@@ -236,10 +238,10 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "84"
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "80"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -249,7 +251,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "3"
+                "version_added": "15.4"
               },
               "safari_ios": {
                 "version_added": "1"

--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/backdrop-filter.json
+++ b/css/properties/backdrop-filter.json
@@ -11,7 +11,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "17"
+              "version_added": "18> ≤80"
             },
             "firefox": {
               "version_added": "103"

--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -171,10 +171,13 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "88",
                 "notes": "See <a href='https://bugzil.la/1107646'>bug 1107646</a>."
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108",
+                "notes": "See <a href='https://bugzil.la/1107646'>bug 1107646</a>."
+              },
               "ie": {
                 "version_added": false
               },
@@ -192,7 +195,17 @@
                   "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit. See <a href='https://webkit.org/b/160934'>bug 160934</a>."
                 }
               ],
-              "safari_ios": "mirror",
+              "safari_ios": [
+                {
+                  "version_added": "≤16.2"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "6",
+                  "partial_implementation": true,
+                  "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit. See <a href='https://webkit.org/b/160934'>bug 160934</a>."
+                }
+              ],
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/block-size.json
+++ b/css/properties/block-size.json
@@ -45,11 +45,24 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": "41"
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "41"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤108"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "41"
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/caption-side.json
+++ b/css/properties/caption-side.json
@@ -63,7 +63,9 @@
               "safari": {
                 "version_added": "preview"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.2"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/clear.json
+++ b/css/properties/clear.json
@@ -70,9 +70,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "14.1> ≤15.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.2"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -113,7 +113,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "7"
+                "version_added": "13.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -147,9 +147,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "13.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.2"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/color-scheme.json
+++ b/css/properties/color-scheme.json
@@ -41,12 +41,18 @@
               "chrome": {
                 "version_added": false
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "chrome_android": {
+                "version_added": "≤108"
               },
-              "firefox_android": "mirror",
+              "edge": {
+                "version_added": "81"
+              },
+              "firefox": {
+                "version_added": "96"
+              },
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -58,7 +64,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤108"
+              }
             },
             "status": {
               "experimental": false,
@@ -78,9 +86,11 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "96"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -93,7 +103,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {

--- a/css/properties/contain-intrinsic-height.json
+++ b/css/properties/contain-intrinsic-height.json
@@ -7,10 +7,12 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-sizing-4/#propdef-contain-intrinsic-height",
           "support": {
             "chrome": {
-              "version_added": "83"
+              "version_added": "95"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "95"
+            },
             "firefox": {
               "version_added": "107"
             },

--- a/css/properties/contain-intrinsic-width.json
+++ b/css/properties/contain-intrinsic-width.json
@@ -7,10 +7,12 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-sizing-4/#propdef-contain-intrinsic-width",
           "support": {
             "chrome": {
-              "version_added": "83"
+              "version_added": "95"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "95"
+            },
             "firefox": {
               "version_added": "107"
             },

--- a/css/properties/cursor.json
+++ b/css/properties/cursor.json
@@ -35,7 +35,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤108"
             }
           },
           "status": {
@@ -77,7 +77,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -120,7 +120,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -161,7 +161,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -204,7 +204,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -247,7 +247,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -290,7 +290,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -335,7 +335,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -378,7 +378,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -419,7 +419,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -460,7 +460,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -549,7 +549,7 @@
                 }
               ],
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -590,7 +590,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -631,7 +631,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -672,7 +672,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -715,7 +715,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -754,7 +754,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -797,7 +797,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -838,7 +838,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -879,7 +879,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -922,7 +922,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -963,7 +963,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -1004,7 +1004,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -1046,7 +1046,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -1086,7 +1086,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -1129,7 +1129,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -1170,7 +1170,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {
@@ -1247,7 +1247,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤108"
               }
             },
             "status": {

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -635,7 +635,7 @@
                 "version_added": "70"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤108"
               },
               "ie": {
                 "version_added": false

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -161,9 +161,11 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "preview"
+                "version_added": "15.4"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.2"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/float.json
+++ b/css/properties/float.json
@@ -70,9 +70,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "14.1> ≤15.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.2"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/font-size.json
+++ b/css/properties/font-size.json
@@ -152,7 +152,7 @@
                 "version_added": "70"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤108"
               },
               "ie": {
                 "version_added": false

--- a/css/properties/font-style.json
+++ b/css/properties/font-style.json
@@ -48,7 +48,9 @@
               "chrome": {
                 "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": "≤108"
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": "61"
@@ -63,9 +65,13 @@
               "safari": {
                 "version_added": "preview"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.2"
+              },
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤108"
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/forced-color-adjust.json
+++ b/css/properties/forced-color-adjust.json
@@ -10,7 +10,7 @@
               "version_added": "89"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "≤108"
             },
             "edge": [
               {
@@ -39,7 +39,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": "≤108"
+            }
           },
           "status": {
             "experimental": false,

--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -50,9 +50,11 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "94"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/properties/inline-size.json
+++ b/css/properties/inline-size.json
@@ -45,11 +45,24 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": "41"
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "41"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤108"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "41"
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -54,11 +54,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -91,11 +95,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -128,11 +136,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -243,11 +255,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -316,11 +332,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -420,8 +440,12 @@
               "chrome": {
                 "version_added": false
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤108"
+              },
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": "28"
               },
@@ -433,11 +457,15 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "14.1> ≤15.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.2"
+              },
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤108"
+              }
             },
             "status": {
               "experimental": false,
@@ -738,8 +766,12 @@
               "chrome": {
                 "version_added": false
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤108"
+              },
+              "edge": {
+                "version_added": "89"
+              },
               "firefox": {
                 "version_added": "33"
               },
@@ -755,7 +787,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤108"
+              }
             },
             "status": {
               "experimental": false,
@@ -771,8 +805,12 @@
               "chrome": {
                 "version_added": false
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤108"
+              },
+              "edge": {
+                "version_added": "89"
+              },
               "firefox": {
                 "version_added": "33"
               },
@@ -788,7 +826,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤108"
+              }
             },
             "status": {
               "experimental": false,
@@ -806,11 +846,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -843,11 +887,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -880,11 +928,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -917,11 +969,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -954,11 +1010,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -991,11 +1051,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -1032,7 +1096,15 @@
                 "version_added": "1",
                 "prefix": "-moz-"
               },
-              "firefox_android": "mirror",
+              "firefox_android": [
+                {
+                  "version_added": "≤108"
+                },
+                {
+                  "version_added": "4",
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -1062,11 +1134,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -1099,11 +1175,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -1140,7 +1220,15 @@
                 "version_added": "1",
                 "prefix": "-moz-"
               },
-              "firefox_android": "mirror",
+              "firefox_android": [
+                {
+                  "version_added": "≤108"
+                },
+                {
+                  "version_added": "4",
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -1170,11 +1258,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -1207,11 +1299,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -1244,11 +1340,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -1281,11 +1381,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -1318,11 +1422,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -1359,7 +1467,15 @@
                 "version_added": "1",
                 "prefix": "-moz-"
               },
-              "firefox_android": "mirror",
+              "firefox_android": [
+                {
+                  "version_added": "≤108"
+                },
+                {
+                  "version_added": "4",
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -1395,7 +1511,15 @@
                 "version_added": "1",
                 "prefix": "-moz-"
               },
-              "firefox_android": "mirror",
+              "firefox_android": [
+                {
+                  "version_added": "≤108"
+                },
+                {
+                  "version_added": "4",
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -1427,11 +1551,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -1462,8 +1590,12 @@
               "chrome": {
                 "version_added": false
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤108"
+              },
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": [
                 {
                   "version_added": "33",
@@ -1486,7 +1618,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤108"
+              }
             },
             "status": {
               "experimental": false,
@@ -1504,11 +1638,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -1659,7 +1797,15 @@
                 "version_added": "1",
                 "prefix": "-moz-"
               },
-              "firefox_android": "mirror",
+              "firefox_android": [
+                {
+                  "version_added": "≤108"
+                },
+                {
+                  "version_added": "4",
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -1693,7 +1839,15 @@
                 "version_added": "1",
                 "prefix": "-moz-"
               },
-              "firefox_android": "mirror",
+              "firefox_android": [
+                {
+                  "version_added": "≤108"
+                },
+                {
+                  "version_added": "4",
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -1820,8 +1974,12 @@
               "chrome": {
                 "version_added": false
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤108"
+              },
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": [
                 {
                   "version_added": "28"
@@ -1843,7 +2001,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤108"
+              }
             },
             "status": {
               "experimental": false,
@@ -1859,8 +2019,12 @@
               "chrome": {
                 "version_added": false
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤108"
+              },
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": [
                 {
                   "version_added": "28"
@@ -1882,7 +2046,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤108"
+              }
             },
             "status": {
               "experimental": false,
@@ -2293,11 +2459,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -2371,11 +2541,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -2558,11 +2732,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -2631,11 +2809,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -2704,11 +2886,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -2816,11 +3002,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -2888,7 +3078,9 @@
                 "version_added": "79"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": "39"
               },
@@ -2923,8 +3115,12 @@
               "chrome": {
                 "version_added": false
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤108"
+              },
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": "35"
               },
@@ -2940,7 +3136,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤108"
+              }
             },
             "status": {
               "experimental": false,
@@ -2956,8 +3154,12 @@
               "chrome": {
                 "version_added": false
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤108"
+              },
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": [
                 {
                   "version_added": "33"
@@ -2975,11 +3177,15 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "14.1> ≤15.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.2"
+              },
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤108"
+              }
             },
             "status": {
               "experimental": false,
@@ -3079,7 +3285,7 @@
                 "version_added": "33"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤108"
               },
               "ie": {
                 "version_added": false
@@ -3110,11 +3316,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -3144,11 +3354,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -3178,11 +3392,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -3212,11 +3430,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -3246,11 +3468,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -3469,11 +3695,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -3545,11 +3775,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -3625,7 +3859,15 @@
                 "prefix": "-moz-",
                 "version_added": "33"
               },
-              "firefox_android": "mirror",
+              "firefox_android": [
+                {
+                  "version_added": "≤108"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "33"
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/list-style.json
+++ b/css/properties/list-style.json
@@ -48,7 +48,9 @@
               "chrome": {
                 "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": "≤108"
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": "35"
@@ -65,7 +67,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤108"
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/margin-block-end.json
+++ b/css/properties/margin-block-end.json
@@ -10,7 +10,9 @@
               "version_added": "87"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "18> ≤80"
+            },
             "firefox": {
               "version_added": "41"
             },

--- a/css/properties/margin-block-start.json
+++ b/css/properties/margin-block-start.json
@@ -10,7 +10,9 @@
               "version_added": "87"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "18> ≤80"
+            },
             "firefox": {
               "version_added": "41"
             },

--- a/css/properties/margin-inline-end.json
+++ b/css/properties/margin-inline-end.json
@@ -16,7 +16,15 @@
               }
             ],
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": [
+              {
+                "version_added": "18> ≤80"
+              },
+              {
+                "version_added": "79",
+                "alternative_name": "-webkit-margin-end"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/margin-inline-start.json
+++ b/css/properties/margin-inline-start.json
@@ -16,7 +16,15 @@
               }
             ],
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": [
+              {
+                "version_added": "18> ≤80"
+              },
+              {
+                "version_added": "79",
+                "alternative_name": "-webkit-margin-start"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -59,7 +59,9 @@
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -103,14 +105,22 @@
               "opera_android": "mirror",
               "safari": [
                 {
-                  "version_added": "preview"
+                  "version_added": "15.4"
                 },
                 {
                   "prefix": "-webkit-",
                   "version_added": "4"
                 }
               ],
-              "safari_ios": "mirror",
+              "safari_ios": [
+                {
+                  "version_added": "≤16.2"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "3.2"
+                }
+              ],
               "samsunginternet_android": "mirror",
               "webview_android": {
                 "prefix": "-webkit-",
@@ -136,7 +146,9 @@
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },
@@ -170,7 +182,9 @@
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/properties/max-block-size.json
+++ b/css/properties/max-block-size.json
@@ -46,9 +46,11 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "94"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -59,13 +59,28 @@
               ],
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "partial_implementation": true,
-                "prefix": "-moz-",
-                "version_added": "3",
-                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "partial_implementation": true,
+                  "prefix": "-moz-",
+                  "version_added": "3",
+                  "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤108"
+                },
+                {
+                  "partial_implementation": true,
+                  "prefix": "-moz-",
+                  "version_added": "4",
+                  "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -49,11 +49,24 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": "41"
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "41"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤108"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "41"
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -57,13 +57,28 @@
                 "version_added": "46"
               },
               "edge": "mirror",
-              "firefox": {
-                "partial_implementation": true,
-                "prefix": "-moz-",
-                "version_added": "3",
-                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "partial_implementation": true,
+                  "prefix": "-moz-",
+                  "version_added": "3",
+                  "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤108"
+                },
+                {
+                  "partial_implementation": true,
+                  "prefix": "-moz-",
+                  "version_added": "4",
+                  "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/min-block-size.json
+++ b/css/properties/min-block-size.json
@@ -44,9 +44,11 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "94"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -97,12 +97,26 @@
                 "version_added": "46"
               },
               "edge": "mirror",
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": "3",
-                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "3",
+                  "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤108"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4",
+                  "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/min-inline-size.json
+++ b/css/properties/min-inline-size.json
@@ -43,11 +43,24 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": "41"
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "41"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤108"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "41"
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -109,12 +109,26 @@
                 "version_added": "46"
               },
               "edge": "mirror",
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": "3",
-                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "3",
+                  "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤108"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4",
+                  "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/offset-anchor.json
+++ b/css/properties/offset-anchor.json
@@ -24,7 +24,9 @@
             "safari": {
               "version_added": "preview"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.2"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/offset-distance.json
+++ b/css/properties/offset-distance.json
@@ -21,7 +21,7 @@
               "version_added": "72"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤108"
             },
             "ie": {
               "version_added": false
@@ -32,7 +32,9 @@
             "safari": {
               "version_added": "preview"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.2"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -87,7 +87,9 @@
               "safari": {
                 "version_added": "preview"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.2"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -127,7 +129,9 @@
               "safari": {
                 "version_added": "preview"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.2"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/offset-position.json
+++ b/css/properties/offset-position.json
@@ -26,7 +26,9 @@
             "safari": {
               "version_added": "preview"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.2"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/offset-rotate.json
+++ b/css/properties/offset-rotate.json
@@ -25,7 +25,7 @@
               "version_added": "72"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤108"
             },
             "ie": {
               "version_added": false
@@ -36,7 +36,9 @@
             "safari": {
               "version_added": "preview"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.2"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/offset.json
+++ b/css/properties/offset.json
@@ -21,7 +21,7 @@
               "version_added": "72"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤108"
             },
             "ie": {
               "version_added": false

--- a/css/properties/opacity.json
+++ b/css/properties/opacity.json
@@ -67,7 +67,7 @@
                 "version_added": "70"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤108"
               },
               "ie": {
                 "version_added": false
@@ -80,9 +80,11 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "preview"
+                "version_added": "13.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.2"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/overflow-anchor.json
+++ b/css/properties/overflow-anchor.json
@@ -15,7 +15,7 @@
               "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤108"
             },
             "ie": {
               "version_added": false

--- a/css/properties/overflow-block.json
+++ b/css/properties/overflow-block.json
@@ -15,7 +15,7 @@
               "version_added": "69"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤108"
             },
             "ie": {
               "version_added": false

--- a/css/properties/overflow-inline.json
+++ b/css/properties/overflow-inline.json
@@ -15,7 +15,7 @@
               "version_added": "69"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤108"
             },
             "ie": {
               "version_added": false

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -106,9 +106,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "13.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.2"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/overscroll-behavior-block.json
+++ b/css/properties/overscroll-behavior-block.json
@@ -15,7 +15,7 @@
               "version_added": "73"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤108"
             },
             "ie": {
               "version_added": false

--- a/css/properties/overscroll-behavior-inline.json
+++ b/css/properties/overscroll-behavior-inline.json
@@ -15,7 +15,7 @@
               "version_added": "73"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤108"
             },
             "ie": {
               "version_added": false

--- a/css/properties/padding-block-end.json
+++ b/css/properties/padding-block-end.json
@@ -10,7 +10,9 @@
               "version_added": "87"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "18> ≤80"
+            },
             "firefox": {
               "version_added": "41"
             },

--- a/css/properties/padding-block-start.json
+++ b/css/properties/padding-block-start.json
@@ -10,7 +10,9 @@
               "version_added": "87"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "18> ≤80"
+            },
             "firefox": {
               "version_added": "41"
             },

--- a/css/properties/padding-inline-end.json
+++ b/css/properties/padding-inline-end.json
@@ -16,7 +16,15 @@
               }
             ],
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": [
+              {
+                "version_added": "18> ≤80"
+              },
+              {
+                "version_added": "79",
+                "alternative_name": "-webkit-padding-end"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/padding-inline-start.json
+++ b/css/properties/padding-inline-start.json
@@ -16,7 +16,15 @@
               }
             ],
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": [
+              {
+                "version_added": "18> ≤80"
+              },
+              {
+                "version_added": "79",
+                "alternative_name": "-webkit-padding-start"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/page.json
+++ b/css/properties/page.json
@@ -24,7 +24,9 @@
             "safari": {
               "version_added": "preview"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.2"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/quotes.json
+++ b/css/properties/quotes.json
@@ -53,7 +53,7 @@
                 "version_added": "70"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤108"
               },
               "ie": {
                 "version_added": false,
@@ -66,10 +66,13 @@
                 "notes": "This value is not supported, but the default browser behavior is to choose appropriate quotes for the user's language setting"
               },
               "safari": {
-                "version_added": "preview",
+                "version_added": "13.1> ≤14.1",
                 "notes": "This value is not supported, but the default browser behavior is to choose appropriate quotes for the user's language setting"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.2",
+                "notes": "This value is not supported, but the default browser behavior is to choose appropriate quotes for the user's language setting"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/rotate.json
+++ b/css/properties/rotate.json
@@ -54,9 +54,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "13.1> ≤14.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.2"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/scroll-margin-block-end.json
+++ b/css/properties/scroll-margin-block-end.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "14.1> ≤15.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/scroll-margin-block-start.json
+++ b/css/properties/scroll-margin-block-start.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "14.1> ≤15.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/scroll-margin-block.json
+++ b/css/properties/scroll-margin-block.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "14.1> ≤15.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/scroll-margin-inline-end.json
+++ b/css/properties/scroll-margin-inline-end.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "14.1> ≤15.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/scroll-margin-inline-start.json
+++ b/css/properties/scroll-margin-inline-start.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "14.1> ≤15.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/scroll-margin-inline.json
+++ b/css/properties/scroll-margin-inline.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "14.1> ≤15.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/shape-image-threshold.json
+++ b/css/properties/shape-image-threshold.json
@@ -47,7 +47,7 @@
                 "version_added": "70"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤108"
               },
               "ie": {
                 "version_added": false

--- a/css/properties/tab-size.json
+++ b/css/properties/tab-size.json
@@ -74,7 +74,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "53"
+                "version_added": "90> ≤92"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -86,7 +86,9 @@
               "safari": {
                 "version_added": "preview"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.2"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": {
                 "version_added": "56"

--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -53,13 +53,29 @@
                 "prefix": "-webkit-",
                 "version_added": "1"
               },
-              "chrome_android": "mirror",
+              "chrome_android": [
+                {
+                  "version_added": "≤108"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "18"
+                }
+              ],
               "edge": "mirror",
               "firefox": {
                 "prefix": "-moz-",
                 "version_added": "1"
               },
-              "firefox_android": "mirror",
+              "firefox_android": [
+                {
+                  "version_added": "≤108"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -79,12 +95,29 @@
                   "version_added": "1"
                 }
               ],
-              "safari_ios": "mirror",
+              "safari_ios": [
+                {
+                  "version_added": "≤16.2"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1"
+                },
+                {
+                  "prefix": "-khtml-",
+                  "version_added": "1"
+                }
+              ],
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "prefix": "-webkit-",
-                "version_added": "37"
-              }
+              "webview_android": [
+                {
+                  "version_added": "≤108"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "37"
+                }
+              ]
             },
             "status": {
               "experimental": false,

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -43,7 +43,7 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "preview"
+                "version_added": "15.4"
               },
               {
                 "partial_implementation": true,

--- a/css/properties/text-decoration-skip-ink.json
+++ b/css/properties/text-decoration-skip-ink.json
@@ -15,7 +15,7 @@
               "version_added": "70"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤108"
             },
             "ie": {
               "version_added": false
@@ -53,7 +53,7 @@
                 "version_added": "75"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤108"
               },
               "ie": {
                 "version_added": false
@@ -62,9 +62,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "15.4"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.2"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/text-decoration-thickness.json
+++ b/css/properties/text-decoration-thickness.json
@@ -23,7 +23,7 @@
               "version_added": "70"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤108"
             },
             "ie": {
               "version_added": false
@@ -55,13 +55,17 @@
               "chrome": {
                 "version_added": false
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤108"
+              },
+              "edge": {
+                "version_added": "87"
+              },
               "firefox": {
                 "version_added": "74"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤108"
               },
               "ie": {
                 "version_added": false
@@ -74,7 +78,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤108"
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -49,7 +49,9 @@
               "chrome": {
                 "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": "≤108"
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": "1",
@@ -71,9 +73,13 @@
               "safari": {
                 "version_added": "preview"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.2"
+              },
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤108"
+              }
             },
             "status": {
               "experimental": false,
@@ -129,7 +135,7 @@
                 "version_added": "70"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤108"
               },
               "ie": {
                 "version_added": false

--- a/css/properties/text-emphasis-color.json
+++ b/css/properties/text-emphasis-color.json
@@ -44,10 +44,15 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "4.4"
-            }
+            "webview_android": [
+              {
+                "version_added": "≤108"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4.4"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/text-emphasis-position.json
+++ b/css/properties/text-emphasis-position.json
@@ -44,10 +44,15 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "4.4"
-            }
+            "webview_android": [
+              {
+                "version_added": "≤108"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4.4"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -63,7 +68,9 @@
                 "version_added": "62"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "99"
+              },
               "firefox": {
                 "version_added": "46"
               },

--- a/css/properties/text-emphasis-style.json
+++ b/css/properties/text-emphasis-style.json
@@ -44,10 +44,15 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "4.4"
-            }
+            "webview_android": [
+              {
+                "version_added": "≤108"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4.4"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/text-emphasis.json
+++ b/css/properties/text-emphasis.json
@@ -44,10 +44,15 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "4.4"
-            }
+            "webview_android": [
+              {
+                "version_added": "≤108"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4.4"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/text-orientation.json
+++ b/css/properties/text-orientation.json
@@ -61,8 +61,12 @@
               "chrome": {
                 "version_added": false
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤108"
+              },
+              "edge": {
+                "version_added": "18> ≤80"
+              },
               "firefox": {
                 "version_added": "44",
                 "notes": "<code>sideways-right</code> has become an alias of <code>sideways</code>."
@@ -75,11 +79,13 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "7"
+                "version_added": "13.1> ≤14.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤108"
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/text-size-adjust.json
+++ b/css/properties/text-size-adjust.json
@@ -64,7 +64,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "18> ≤80"
               },
               "firefox": {
                 "version_added": false

--- a/css/properties/text-underline-offset.json
+++ b/css/properties/text-underline-offset.json
@@ -15,7 +15,7 @@
               "version_added": "70"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤108"
             },
             "ie": {
               "version_added": false
@@ -45,13 +45,17 @@
               "chrome": {
                 "version_added": false
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤108"
+              },
+              "edge": {
+                "version_added": "87"
+              },
               "firefox": {
                 "version_added": "74"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤108"
               },
               "ie": {
                 "version_added": false
@@ -64,7 +68,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤108"
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -17,7 +17,7 @@
               "version_added": "74"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤108"
             },
             "ie": {
               "version_added": "6"
@@ -35,7 +35,7 @@
               }
             ],
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤16.2"
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -133,7 +133,7 @@
                 "version_added": "74"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤108"
               },
               "ie": {
                 "version_added": false
@@ -148,7 +148,9 @@
               "safari": {
                 "version_added": "preview"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.2"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -172,7 +174,7 @@
                 "version_added": "74"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤108"
               },
               "ie": {
                 "version_added": false
@@ -207,7 +209,7 @@
                 "version_added": "74"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤108"
               },
               "ie": {
                 "version_added": false
@@ -219,7 +221,7 @@
                 "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "≤16.2"
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"

--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -152,10 +152,15 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "prefix": "-webkit-",
-                "version_added": "3"
-              }
+              "webview_android": [
+                {
+                  "version_added": "≤108"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "3"
+                }
+              ]
             },
             "status": {
               "experimental": false,

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -116,7 +116,9 @@
               "chrome": {
                 "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": "≤108"
+              },
               "edge": {
                 "version_added": "12",
                 "version_removed": "79"
@@ -124,7 +126,9 @@
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤108"
+              },
               "ie": {
                 "version_added": "10"
               },
@@ -134,9 +138,13 @@
               "safari": {
                 "version_added": "preview"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.2"
+              },
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤108"
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -123,7 +123,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "18> ≤80"
               },
               "firefox": {
                 "version_added": "1"
@@ -198,7 +198,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "18> ≤80"
               },
               "firefox": [
                 {
@@ -243,7 +243,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "18> ≤80"
               },
               "firefox": {
                 "version_added": "1"

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -53,7 +53,7 @@
                 "version_added": "69"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤108"
               },
               "ie": {
                 "version_added": false

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -218,13 +218,17 @@
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-installerrorcause",
             "support": {
               "chrome": {
-                "version_added": "93"
+                "version_added": "93",
+                "version_removed": "94"
               },
               "chrome_android": "mirror",
               "deno": {
                 "version_added": "1.13"
               },
-              "edge": "mirror",
+              "edge": {
+                "version_added": "93",
+                "version_removed": "94"
+              },
               "firefox": {
                 "version_added": "91"
               },

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1540,7 +1540,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "13"
+                "version_added": "18> ≤80"
               },
               "firefox": {
                 "version_added": "49"
@@ -1664,7 +1664,7 @@
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "13"
+                "version_added": "18> ≤80"
               },
               "firefox": {
                 "version_added": "49"

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -15,7 +15,10 @@
             "deno": {
               "version_added": "1.0"
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "79",
+              "version_removed": "92"
+            },
             "firefox": {
               "version_added": "78"
             },
@@ -57,7 +60,10 @@
               "deno": {
                 "version_added": "1.0"
               },
-              "edge": "mirror",
+              "edge": {
+                "version_added": "79",
+                "version_removed": "92"
+              },
               "firefox": {
                 "version_added": "78"
               },
@@ -99,7 +105,10 @@
               "deno": {
                 "version_added": "1.0"
               },
-              "edge": "mirror",
+              "edge": {
+                "version_added": "79",
+                "version_removed": "92"
+              },
               "firefox": {
                 "version_added": "78"
               },
@@ -141,7 +150,10 @@
               "deno": {
                 "version_added": "1.0"
               },
-              "edge": "mirror",
+              "edge": {
+                "version_added": "79",
+                "version_removed": "92"
+              },
               "firefox": {
                 "version_added": "78"
               },

--- a/javascript/builtins/WebAssembly.json
+++ b/javascript/builtins/WebAssembly.json
@@ -71,7 +71,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "11"
+                "version_added": "13.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -157,7 +157,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "11"
+                "version_added": "13.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -243,7 +243,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "11"
+                "version_added": "13.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR contains all of the changes made by the [mdn-bcd-collector](https://github.com/GooborgStudios/mdn-bcd-collector) project, v7.1.3, on January 11, 2023.  This PR is intended to be used as a burndown list and should not be merged directly.  Unlike #18621, this PR only contains changes for 2020+ browser releases.

