### PR TITLE
Enable css lenght type lh for chrome

### DIFF
--- a/css/types/length.json
+++ b/css/types/length.json
@@ -267,8 +267,7 @@
             "description": "<code>lh</code> unit",
             "support": {
               "chrome": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/937104'>bug 937104</a>."
+                "version_added": "109"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/test/linter/test-obsolete.ts
+++ b/test/linter/test-obsolete.ts
@@ -129,7 +129,6 @@ export default {
     processData(logger, data);
   },
   exceptions: [
-    'css.types.length.lh',
     'css.types.length.rlh',
     'http.headers.Cache-Control.stale-if-error',
     'http.headers.Feature-Policy.layout-animations',


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Enable the css length unit "lh" for chrome. Referenced bug is also close (Nov 2022) and tested in chromium 109. 

#### Test results and supporting details

Bug was fixed https://crbug.com/937104
Implementation tested in chromium 109 (Did not work before in 108)

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
