### PR TITLE
Update Firefox versions for api.Selection.setBaseAndExtent

### DIFF
--- a/api/Selection.json
+++ b/api/Selection.json
@@ -980,7 +980,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "52"
+              "version_added": "53"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `setBaseAndExtent` member of the `Selection` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Selection/setBaseAndExtent

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
