### PR TITLE
Update Edge versions for api.TextTrack.id

### DIFF
--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -232,7 +232,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "18"
             },
             "firefox": {
               "version_added": "31"


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `id` member of the `TextTrack` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/TextTrack/id

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
