### PR TITLE
Update Chromium versions for api.UserActivation.isActive

### DIFF
--- a/api/UserActivation.json
+++ b/api/UserActivation.json
@@ -73,7 +73,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-useractivation-isactive",
           "support": {
             "chrome": {
-              "version_added": "97"
+              "version_added": "72"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `isActive` member of the `UserActivation` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/UserActivation/isActive

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
