### PR TITLE
Update Edge versions for api.TransitionEvent.TransitionEvent

### DIFF
--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -88,7 +88,9 @@
               "version_added": "27"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "14"
+            },
             "firefox": {
               "version_added": "23"
             },


### PR DESCRIPTION
This PR updates and corrects version values for Edge for the `TransitionEvent` member of the `TransitionEvent` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/TransitionEvent/TransitionEvent

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
