### PR TITLE
Update Firefox versions for api.URLSearchParams.forEach

### DIFF
--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -365,7 +365,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": "47"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `forEach` member of the `URLSearchParams` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/URLSearchParams/forEach

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
