### PR TITLE
Update Firefox versions for WEBGL_color_buffer_float API

### DIFF
--- a/api/WEBGL_color_buffer_float.json
+++ b/api/WEBGL_color_buffer_float.json
@@ -13,7 +13,7 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "30"
+            "version_added": "47"
           },
           "firefox_android": "mirror",
           "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `WEBGL_color_buffer_float` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/WEBGL_color_buffer_float

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
