### PR TITLE
Update Safari versions for WEBGL_compressed_texture_astc API

### DIFF
--- a/api/WEBGL_compressed_texture_astc.json
+++ b/api/WEBGL_compressed_texture_astc.json
@@ -21,7 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "16.2"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -54,7 +54,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "16.2"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `WEBGL_compressed_texture_astc` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/WEBGL_compressed_texture_astc

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
