### PR TITLE
Update Chromium versions for WebTransportBidirectionalStream API

### DIFF
--- a/api/WebTransportBidirectionalStream.json
+++ b/api/WebTransportBidirectionalStream.json
@@ -4,16 +4,9 @@
       "__compat": {
         "spec_url": "https://w3c.github.io/webtransport/#webtransportbidirectionalstream",
         "support": {
-          "chrome": [
-            {
-              "version_added": "100"
-            },
-            {
-              "version_added": "97",
-              "version_removed": "100",
-              "alternative_name": "BidirectionalStream"
-            }
-          ],
+          "chrome": {
+            "version_added": "97"
+          },
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `WebTransportBidirectionalStream` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/WebTransportBidirectionalStream

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

---

Note: the alternative names were removed from the data because I could not find any evidence of them in Chrome 97.  This data was added in #18209 but the author mentioned the data wasn't quite definitive so I believe it's purely incorrect.
