### PR TITLE
Update Chromium versions for api.Window.originAgentCluster

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3442,12 +3442,10 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/origin.html#origin-keyed-agent-clusters",
           "support": {
             "chrome": {
-              "version_added": "88"
-            },
-            "chrome_android": "mirror",
-            "edge": {
               "version_added": "90"
             },
+            "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -3456,20 +3454,14 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "76"
-            },
-            "opera_android": {
-              "version_added": "64"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "90"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `originAgentCluster` member of the `Window` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Window/originAgentCluster

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
