### PR TITLE
Update Chromium versions for Worklet API

### DIFF
--- a/api/Worklet.json
+++ b/api/Worklet.json
@@ -6,7 +6,7 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/worklets.html#worklets-worklet",
         "support": {
           "chrome": {
-            "version_added": "65"
+            "version_added": "66"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -39,7 +39,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/worklets.html#dom-worklet-addmodule-dev",
           "support": {
             "chrome": {
-              "version_added": "65"
+              "version_added": "66"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Worklet` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Worklet

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
