### PR TITLE
Update Chromium versions for api.Bluetooth.referringDevice

### DIFF
--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -193,11 +193,9 @@
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-referringdevice",
           "support": {
             "chrome": {
-              "version_added": "56"
-            },
-            "chrome_android": {
               "version_added": false
             },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `referringDevice` member of the `Bluetooth` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Bluetooth/referringDevice

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
