### PR TITLE
Remove api.Bluetooth.referringDevice from BCD

### DIFF
--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -187,42 +187,6 @@
           }
         }
       },
-      "referringDevice": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth/referringDevice",
-          "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-referringdevice",
-          "support": {
-            "chrome": {
-              "version_added": "56"
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "requestDevice": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth/requestDevice",


### PR DESCRIPTION
This PR removes the irrelevant `referringDevice` member of the `Bluetooth` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features). The lack of current support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3), even if the current BCD suggests support.
