### PR TITLE
XRSession.environmentBlendMode shipped in Chromium 81

### DIFF
--- a/api/XRSession.json
+++ b/api/XRSession.json
@@ -271,7 +271,7 @@
           "spec_url": "https://immersive-web.github.io/webxr-ar-module/#dom-xrsession-environmentblendmode",
           "support": {
             "chrome": {
-              "version_added": "79"
+              "version_added": "81"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
It's part of the AR module, so 81 is correct
https://chromestatus.com/feature/5450241148977152