### PR TITLE
New edge 109 browser data

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -241,7 +241,7 @@
         },
         "106": {
           "release_date": "2022-10-03",
-          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1060137034-october-3-2022",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1060137034-october-3-2022",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "106"
@@ -254,23 +254,30 @@
           "engine_version": "107"
         },
         "108": {
-          "release_date": "2022-12-05",
+          "release_date": "2022-12-06",
           "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1080146242-december-5-2022",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "108"
         },
         "109": {
           "release_date": "2023-01-12",
-          "status": "beta",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1090151849-january-12-2023",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "109"
         },
         "110": {
           "release_date": "2023-02-09",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "110"
+        },
+        "111": {
+          "release_date": "2023-03-09",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "111"
         }
       }
     }


### PR DESCRIPTION
#### Summary

Edge 109 was released yesterday. This PR contains the necessary changes to update the edge.json file on the repo.
