### PR TITLE
Chromium renamed XR to XRSystem in 83

### DIFF
--- a/api/XRSystem.json
+++ b/api/XRSystem.json
@@ -7,7 +7,7 @@
         "support": {
           "chrome": [
             {
-              "version_added": "82"
+              "version_added": "83"
             },
             {
               "alternative_name": "XR",

--- a/api/XRSystem.json
+++ b/api/XRSystem.json
@@ -11,7 +11,8 @@
             },
             {
               "alternative_name": "XR",
-              "version_added": "79"
+              "version_added": "79",
+              "version_removed": "83"
             }
           ],
           "chrome_android": "mirror",

--- a/api/XRSystem.json
+++ b/api/XRSystem.json
@@ -5,10 +5,15 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSystem",
         "spec_url": "https://immersive-web.github.io/webxr/#xrsystem-interface",
         "support": {
-          "chrome": {
-            "alternative_name": "XR",
-            "version_added": "79"
-          },
+          "chrome": [
+            {
+              "version_added": "82"
+            },
+            {
+              "alternative_name": "XR",
+              "version_added": "79"
+            }
+          ],
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
@@ -25,10 +30,7 @@
             "version_added": false
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": {
-            "alternative_name": "XR",
-            "version_added": "11.2"
-          },
+          "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false
           }
@@ -67,9 +69,7 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "11.2"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
             }
@@ -106,9 +106,7 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "11.2"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
             }
@@ -145,9 +143,7 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "11.2"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
             }


### PR DESCRIPTION
See https://bugs.chromium.org/p/chromium/issues/detail?id=1050600 and https://chromium.googlesource.com/chromium/src/+/d7a0292ca39f93d358b68ee703b0eb4fb4901022

I guess the same happened to Samsung so I think we should mirror. At least I don't see why not.