### PR TITLE
Fix support data for picture-in-picture in chromium-based-browsers

### DIFF
--- a/css/selectors/picture-in-picture.json
+++ b/css/selectors/picture-in-picture.json
@@ -8,7 +8,7 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/selectors/#pip-state",
           "support": {
             "chrome": {
-              "version_added": "76"
+              "version_added": "110"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

According to the Chrome roadmap (https://chromestatus.com/roadmap), `:picture-in-picture` pseudo class will be added in Chrome v110, but MDN states that it has already been added in Chrome v76.
Correct support data to Chrome v110 in line with the Chrome roadmap.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details
https://chromestatus.com/feature/6259534815297536

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
Fixes #18550 

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
