### PR TITLE
Add exceptions for extended HTTP status code

### DIFF
--- a/test/linter/test-spec-urls.ts
+++ b/test/linter/test-spec-urls.ts
@@ -21,6 +21,12 @@ const specsExceptions = [
 
   // Exception for April Fools' joke for "418 I'm a teapot"
   'https://www.rfc-editor.org/rfc/rfc2324',
+  
+  // Exceptions for RFCs for HTTP extension not directly implemented by browsers
+  // but useful for applications writers (like WebDAV)
+  'https://www.rfc-editor.org/rfc/rfc2518.html',
+  'https://www.rfc-editor.org/rfc/rfc5842.html',
+  'https://www.rfc-editor.org/rfc/rfc3229.html',
 
   // Unfortunately this doesn't produce a rendered spec, so it isn't in browser-specs
   // Remove if it is in the main ECMA spec

--- a/test/linter/test-spec-urls.ts
+++ b/test/linter/test-spec-urls.ts
@@ -21,7 +21,7 @@ const specsExceptions = [
 
   // Exception for April Fools' joke for "418 I'm a teapot"
   'https://www.rfc-editor.org/rfc/rfc2324',
-  
+
   // Exceptions for RFCs for HTTP extension not directly implemented by browsers
   // but useful for applications writers (like WebDAV)
   'https://www.rfc-editor.org/rfc/rfc2518.html',


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Added three RFC to the exceptions list for status code.

These IETF RFC are not in browser-specs because they are not implemented by browsers but by web applications connected to relevant servers (like WebDAV-compliant ones)

#### Test results and supporting details
N/A

#### Related issues

This will allow the specs to be displayed correctly on mdn after this content PR get merged: mdn/content#12601
