### PR TITLE
add entry for : css.at-rules.import.supports

### DIFF
--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -79,6 +79,29 @@
         "supports": {
           "__compat": {
             "description": "<code>supports([ <supports-condition> | <declaration> ])</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
             "status": {
               "experimental": false,
               "standard_track": true,

--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -75,6 +75,16 @@
               "deprecated": false
             }
           }
+        },
+        "supports": {
+          "__compat": {
+            "description": "<code>supports([ <supports-condition> | <declaration> ])</code>",
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

There is no indication on [the `@imports` docs](https://developer.mozilla.org/en-US/docs/Web/CSS/@import#browser_compatibility) that support conditions are not supported.
My intention is the have an entry in the browser support overview showing that `@import url(foo.css) supports(...)` is not supported by any browser at this time.

~~I was unsure how to express "not supported by any browser" in the JSON structure.
I've omitted the `support` field entirely.~~

#### Test results and supporting details

No browser supports `supports()` in `@import`.
Relevant WPT tests : https://wpt.fyi/results/css/css-cascade/import-conditions.html?label=master&label=experimental&aligned&view=subtest&q=import

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/12404

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
