### PR TITLE
Remove api.Document.registerElement from BCD

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5797,49 +5797,6 @@
           }
         }
       },
-      "registerElement": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/registerElement",
-          "support": {
-            "chrome": {
-              "version_added": "33",
-              "version_removed": "80"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": {
-              "version_added": "23",
-              "version_removed": "67"
-            },
-            "opera_android": {
-              "version_added": "24",
-              "version_removed": "57"
-            },
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "3.0",
-              "version_removed": "13.0"
-            },
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "releaseCapture": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/releaseCapture",


### PR DESCRIPTION
This PR removes the irrelevant `registerElement` member of the `Document` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features). The lack of current support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.3), even if the current BCD suggests support.
