### PR TITLE
Add compat data for the form and largeop attributes of the mo element

### DIFF
--- a/mathml/elements/mo.json
+++ b/mathml/elements/mo.json
@@ -79,6 +79,94 @@
             }
           }
         },
+        "form": {
+          "__compat": {
+            "support": {
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "87",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "8"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "largeop": {
+          "__compat": {
+            "support": {
+              "chrome": [
+                {
+                  "version_added": "109"
+                },
+                {
+                  "version_added": "88",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features",
+                      "value_to_set": "Enabled"
+                    }
+                  ]
+                }
+              ],
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "8"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "lspace": {
           "__compat": {
             "support": {


### PR DESCRIPTION
#### Summary

Add compat data for the form and largeop attributes of the mo element.

#### Test results and supporting details

It is assumed that largeop/form were in Gecko's MathML implementation before the initial release of Firefox.

largeop in chrome 88: https://chromiumdash.appspot.com/commit/128f42798a9b4a38af0c4091eeba10257f983050

largeop in Safari 8:
https://searchfox.org/wubkat/commit/2564e621dafa47d3a8d4efe12eb625e15a549311

form in chrome 87:
https://chromiumdash.appspot.com/commit/ebf91dd9f79a57164d54485cbd5434ca81d609f5

form in Safari 8:
https://searchfox.org/wubkat/commit/6beac8063b0254b04afbc1f464c425879d76ad5d

#### Related issues

https://github.com/mdn/content/issues/23669
https://github.com/mdn/content/pull/23769