### PR TITLE
Fix representation of permissions in webextensions.manifest.optional_permissions

### DIFF
--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -24,9 +24,9 @@
             }
           }
         },
-        "activeTab": {
+        "activeTab_permission": {
           "__compat": {
-            "description": "<code>activeTab</code>",
+            "description": "<code>activeTab</code> permission",
             "support": {
               "chrome": {
                 "version_added": false
@@ -46,9 +46,9 @@
             }
           }
         },
-        "background": {
+        "background_permission": {
           "__compat": {
-            "description": "<code>background</code>",
+            "description": "<code>background</code> permission",
             "support": {
               "chrome": {
                 "version_added": true
@@ -68,9 +68,9 @@
             }
           }
         },
-        "bookmarks": {
+        "bookmarks_permission": {
           "__compat": {
-            "description": "<code>bookmarks</code>",
+            "description": "<code>bookmarks</code> permission",
             "support": {
               "chrome": {
                 "version_added": true
@@ -92,9 +92,9 @@
             }
           }
         },
-        "browserSettings": {
+        "browserSettings_permission": {
           "__compat": {
-            "description": "<code>browserSettings</code>",
+            "description": "<code>browserSettings</code> permission",
             "support": {
               "chrome": {
                 "version_added": false
@@ -112,9 +112,9 @@
             }
           }
         },
-        "browsingData": {
+        "browsingData_permission": {
           "__compat": {
-            "description": "<code>browsingData</code>",
+            "description": "<code>browsingData</code> permission",
             "support": {
               "chrome": {
                 "version_added": false
@@ -134,9 +134,9 @@
             }
           }
         },
-        "clipboardRead": {
+        "clipboardRead_permission": {
           "__compat": {
-            "description": "<code>clipboardRead</code>",
+            "description": "<code>clipboardRead</code> permission",
             "support": {
               "chrome": {
                 "version_added": true
@@ -156,79 +156,9 @@
             }
           }
         },
-        "clipboardWrite": {
+        "clipboardWrite_permission": {
           "__compat": {
-            "description": "<code>clipboardWrite</code>",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": "79"
-              },
-              "firefox": {
-                "version_added": "55"
-              },
-              "firefox_android": "mirror",
-              "opera": "mirror",
-              "safari": {
-                "version_added": "14"
-              },
-              "safari_ios": {
-                "version_added": "15"
-              }
-            }
-          }
-        },
-        "contentSettings": {
-          "__compat": {
-            "description": "<code>contentSettings</code>",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": "79"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "opera": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror"
-            }
-          }
-        },
-        "contextMenus": {
-          "__compat": {
-            "description": "<code>contextMenus</code>",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": "79"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "opera": "mirror",
-              "safari": {
-                "version_added": "14"
-              },
-              "safari_ios": {
-                "version_added": false
-              }
-            }
-          }
-        },
-        "cookies": {
-          "__compat": {
-            "description": "<code>cookies</code>",
+            "description": "<code>clipboardWrite</code> permission",
             "support": {
               "chrome": {
                 "version_added": true
@@ -250,9 +180,9 @@
             }
           }
         },
-        "debugger": {
+        "contentSettings_permission": {
           "__compat": {
-            "description": "<code>debugger</code>",
+            "description": "<code>contentSettings</code> permission",
             "support": {
               "chrome": {
                 "version_added": true
@@ -272,9 +202,79 @@
             }
           }
         },
-        "downloads": {
+        "contextMenus_permission": {
           "__compat": {
-            "description": "<code>downloads</code>",
+            "description": "<code>contextMenus</code> permission",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": false
+              }
+            }
+          }
+        },
+        "cookies_permission": {
+          "__compat": {
+            "description": "<code>cookies</code> permission",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": "55"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": "14"
+              },
+              "safari_ios": {
+                "version_added": "15"
+              }
+            }
+          }
+        },
+        "debugger_permission": {
+          "__compat": {
+            "description": "<code>debugger</code> permission",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": {
+                "version_added": "79"
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "downloads_open_permission": {
+          "__compat": {
+            "description": "<code>downloads.open</code> permission",
             "support": {
               "chrome": {
                 "version_added": false
@@ -292,9 +292,9 @@
             }
           }
         },
-        "downloads_open": {
+        "downloads_permission": {
           "__compat": {
-            "description": "<code>downloads.open</code>",
+            "description": "<code>downloads</code> permission",
             "support": {
               "chrome": {
                 "version_added": false
@@ -312,9 +312,9 @@
             }
           }
         },
-        "find": {
+        "find_permission": {
           "__compat": {
-            "description": "<code>find</code>",
+            "description": "<code>find</code> permission",
             "support": {
               "chrome": {
                 "version_added": false
@@ -334,9 +334,9 @@
             }
           }
         },
-        "geolocation": {
+        "geolocation_permission": {
           "__compat": {
-            "description": "<code>geolocation</code>",
+            "description": "<code>geolocation</code> permission",
             "support": {
               "chrome": {
                 "version_added": false
@@ -354,9 +354,9 @@
             }
           }
         },
-        "history": {
+        "history_permission": {
           "__compat": {
-            "description": "<code>history</code>",
+            "description": "<code>history</code> permission",
             "support": {
               "chrome": {
                 "version_added": true
@@ -378,9 +378,9 @@
             }
           }
         },
-        "idle": {
+        "idle_permission": {
           "__compat": {
-            "description": "<code>idle</code>",
+            "description": "<code>idle</code> permission",
             "support": {
               "chrome": {
                 "version_added": true
@@ -400,9 +400,9 @@
             }
           }
         },
-        "management": {
+        "management_permission": {
           "__compat": {
-            "description": "<code>management</code>",
+            "description": "<code>management</code> permission",
             "support": {
               "chrome": {
                 "version_added": true
@@ -424,9 +424,9 @@
             }
           }
         },
-        "nativeMessaging": {
+        "nativeMessaging_permission": {
           "__compat": {
-            "description": "<code>nativeMessaging</code>",
+            "description": "<code>nativeMessaging</code> permission",
             "support": {
               "chrome": {
                 "version_added": false
@@ -448,9 +448,9 @@
             }
           }
         },
-        "notifications": {
+        "notifications_permission": {
           "__compat": {
-            "description": "<code>notifications</code>",
+            "description": "<code>notifications</code> permission",
             "support": {
               "chrome": {
                 "version_added": true
@@ -470,9 +470,9 @@
             }
           }
         },
-        "pageCapture": {
+        "pageCapture_permission": {
           "__compat": {
-            "description": "<code>pageCapture</code>",
+            "description": "<code>pageCapture</code> permission",
             "support": {
               "chrome": {
                 "version_added": true
@@ -492,9 +492,9 @@
             }
           }
         },
-        "pkcs11": {
+        "pkcs11_permission": {
           "__compat": {
-            "description": "<code>pkcs11</code>",
+            "description": "<code>pkcs11</code> permission",
             "support": {
               "chrome": {
                 "version_added": false
@@ -514,9 +514,9 @@
             }
           }
         },
-        "privacy": {
+        "privacy_permission": {
           "__compat": {
-            "description": "<code>privacy</code>",
+            "description": "<code>privacy</code> permission",
             "support": {
               "chrome": {
                 "version_added": true
@@ -538,9 +538,9 @@
             }
           }
         },
-        "proxy": {
+        "proxy_permission": {
           "__compat": {
-            "description": "<code>proxy</code>",
+            "description": "<code>proxy</code> permission",
             "support": {
               "chrome": {
                 "version_added": false
@@ -560,9 +560,9 @@
             }
           }
         },
-        "sessions": {
+        "sessions_permission": {
           "__compat": {
-            "description": "<code>sessions</code>",
+            "description": "<code>sessions</code> permission",
             "support": {
               "chrome": {
                 "version_added": false
@@ -582,9 +582,9 @@
             }
           }
         },
-        "tabHide": {
+        "tabHide_permission": {
           "__compat": {
-            "description": "<code>tabHide</code>",
+            "description": "<code>tabHide</code> permission",
             "support": {
               "chrome": {
                 "version_added": false
@@ -604,9 +604,9 @@
             }
           }
         },
-        "tabs": {
+        "tabs_permission": {
           "__compat": {
-            "description": "<code>tabs</code>",
+            "description": "<code>tabs</code> permission",
             "support": {
               "chrome": {
                 "version_added": true
@@ -628,9 +628,9 @@
             }
           }
         },
-        "topSites": {
+        "topSites_permission": {
           "__compat": {
-            "description": "<code>topSites</code>",
+            "description": "<code>topSites</code> permission",
             "support": {
               "chrome": {
                 "version_added": true
@@ -650,9 +650,9 @@
             }
           }
         },
-        "webNavigation": {
+        "webNavigation_permission": {
           "__compat": {
-            "description": "<code>webNavigation</code>",
+            "description": "<code>webNavigation</code> permission",
             "support": {
               "chrome": {
                 "version_added": true
@@ -674,9 +674,9 @@
             }
           }
         },
-        "webRequest": {
+        "webRequest_permission": {
           "__compat": {
-            "description": "<code>webRequest</code>",
+            "description": "<code>webRequest</code> permission",
             "support": {
               "chrome": {
                 "version_added": true
@@ -698,9 +698,9 @@
             }
           }
         },
-        "webRequestBlocking": {
+        "webRequestBlocking_permission": {
           "__compat": {
-            "description": "<code>webRequestBlocking</code>",
+            "description": "<code>webRequestBlocking</code> permission",
             "support": {
               "chrome": {
                 "version_added": true
@@ -720,9 +720,9 @@
             }
           }
         },
-        "webRequestFilterResponse": {
+        "webRequestFilterResponse_permission": {
           "__compat": {
-            "description": "<code>webRequestFilterResponse</code>",
+            "description": "<code>webRequestFilterResponse</code> permission",
             "support": {
               "chrome": {
                 "version_added": false
@@ -740,9 +740,9 @@
             }
           }
         },
-        "webRequestFilterResponse_serviceWorkerScript": {
+        "webRequestFilterResponse_serviceWorkerScript_permission": {
           "__compat": {
-            "description": "<code>webRequestFilterResponse.serviceWorkerScript</code>",
+            "description": "<code>webRequestFilterResponse.serviceWorkerScript</code> permission",
             "support": {
               "chrome": {
                 "version_added": false


### PR DESCRIPTION
This PR fixes the representation of the permissions within `webextensions.manifest.optional_permissions` to make it more clear that they are not properties.  This was inspired by #18680, where the PR had resolved the `webRequestFilterResponse.serviceWorkerScript` from being a `serviceWorkerScript` feature nested under `webRequestFilterResponse`, because it is not a `serviceWorkerScript` property of `webRequestFilterResponse`, but rather a separate string value of `webRequestFilterResponse.serviceWorkerScript`.  This PR attempts to resolve this confusion by suffixing all of the features with `_permission`.
