### PR TITLE
Add Chromium versions for api.Element.scrollLeft

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -7706,18 +7706,27 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/scrollLeft",
           "spec_url": "https://w3c.github.io/csswg-drafts/cssom-view/#dom-element-scrollleft",
           "support": {
-            "chrome": {
-              "version_added": "1",
-              "notes": "For right-to-left elements, this property uses 0-100 (most left to most right) instead of negative values. See <a href='https://crbug.com/721759'>bug 721759</a>."
-            },
+            "chrome": [
+              {
+                "version_added": "86"
+              },
+              {
+                "version_added": "1",
+                "version_removed": "86",
+                "notes": "For right-to-left elements, this property uses 0-100 (most left to most right) instead of negative values. See <a href='https://crbug.com/721759'>bug 721759</a>."
+              }
+            ],
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "12",
-              "notes": [
-                "From Edge 79, for right-to-left elements, this property uses 0-100 (most left to most right) instead of negative values. See <a href='https://crbug.com/721759'>bug 721759</a>.",
-                "Before Edge 79, for right-to-left elements, this property uses 100-0 (most left to most right) instead of negative values."
-              ]
-            },
+            "edge": [
+              {
+                "version_added": "86"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "86",
+                "notes": "For right-to-left elements, this property uses 0-100 (most left to most right) instead of negative values. See <a href='https://crbug.com/721759'>bug 721759</a>."
+              }
+            ],
             "firefox": {
               "version_added": "1"
             },


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `scrollLeft` member of the `Element` API, based upon manual testing.

Test Code Used: https://jsfiddle.net/gh9wycov/

This fixes #18465.
