### PR TITLE
Add Opera versions for api.Element.requestFullscreen.returns_promise

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -7007,12 +7007,8 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR adds real values for Opera and Opera Android for the `requestFullscreen.returns_promise` member of the `Element` API.  This should have been mirrored but wasn't, probably due to Chrome getting an update that introduced this change but Opera had not yet updated at the time.

Fixes #18420.
