### PR TITLE
Update Firefox Android versions for api.HTMLFormElement.formdata_event

### DIFF
--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -345,9 +345,7 @@
             "firefox": {
               "version_added": "72"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR corrects the values for Firefox Android for the `formdata_event` member of the `HTMLFormElement` API.  This was a case of Firefox Android not updated when version 79 was released.

Fixes #18695.
