### PR TITLE
Mark 'lh' and 'rlh' units as standard compliant

### DIFF
--- a/css/types/length.json
+++ b/css/types/length.json
@@ -265,6 +265,7 @@
         "lh": {
           "__compat": {
             "description": "<code>lh</code> unit",
+            "spec_url": "https://www.w3.org/TR/css-values-4/#lh",
             "support": {
               "chrome": {
                 "version_added": "109"
@@ -290,7 +291,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -342,6 +343,7 @@
         "rlh": {
           "__compat": {
             "description": "<code>rlh</code> unit",
+            "spec_url": "https://www.w3.org/TR/css-values-4/#rlh",
             "support": {
               "chrome": {
                 "version_added": false,
@@ -368,7 +370,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -291,7 +291,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }
@@ -369,7 +369,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -290,7 +290,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -368,7 +368,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/test/linter/test-obsolete.ts
+++ b/test/linter/test-obsolete.ts
@@ -129,7 +129,6 @@ export default {
     processData(logger, data);
   },
   exceptions: [
-    'css.types.length.rlh',
     'http.headers.Cache-Control.stale-if-error',
     'http.headers.Feature-Policy.layout-animations',
     'http.headers.Feature-Policy.legacy-image-formats',


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

'lh' and 'rlh' are part of the CSS Values and Units Module Level 4 draft just like small, large, and dynamic viewport units.

They should therefor also be marked as following the standard track
Both lengths were added as [supported in Chromium 109 in a previous PR](https://github.com/mdn/browser-compat-data/pull/18624)

#### Test results and supporting details

https://www.w3.org/TR/css-values-4/#lh
https://www.w3.org/TR/css-values-4/#rlh
