### PR TITLE
Ensure that `alternative_name` can't just be `prefix`ed

### DIFF
--- a/test/linter/test-prefix.ts
+++ b/test/linter/test-prefix.ts
@@ -11,11 +11,13 @@ import { CompatStatement, Identifier } from '../../types/types.js';
  *
  * @param {Identifier} data The data to test
  * @param {string} category The category the data belongs to
+ * @param {string} feature The full feature path
  * @param {Logger} logger The logger to output errors to
  */
 const processData = (
   data: CompatStatement,
   category: string,
+  feature: string,
   logger: Logger,
 ): void => {
   let prefixes: string[] = [];
@@ -44,6 +46,8 @@ const processData = (
     return;
   }
 
+  const featureName = feature.split('.')[-1];
+
   for (const support of Object.values(data.support)) {
     const supportStatements = Array.isArray(support) ? support : [support];
 
@@ -64,6 +68,17 @@ const processData = (
           chalk`Prefix is set to {bold ${statement.prefix}}, which is invalid for ${category}`,
         );
       }
+      if (
+        statement.alternative_name &&
+        statement.alternative_name.endsWith(featureName)
+      ) {
+        logger.error(
+          chalk`Use {bold "prefix": "${statement.alternative_name.replace(
+            featureName,
+            '',
+          )}"} instead of {bold "alternative_name": "statement.alternative_name"}`,
+        );
+      }
     }
   }
 };
@@ -78,7 +93,7 @@ export default {
    * @param {Logger} logger The logger to output errors to
    * @param {LinterData} root The data to test
    */
-  check: (logger: Logger, { data, path: { category } }: LinterData) => {
-    processData(data, category, logger);
+  check: (logger: Logger, { data, path: { category, full } }: LinterData) => {
+    processData(data, category, full, logger);
   },
 } as Linter;


### PR DESCRIPTION
This PR updates the linter to ensure that an `alternative_name` cannot simply be a `prefix`.  For example, if a statement has `"alternative_name": "webkitfoobar"`, the linter will require `"prefix": "webkit"` in its place.
