### PR TITLE
Fix spec URL for css.types.image.linear-gradient

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -328,7 +328,7 @@
             "__compat": {
               "description": "<code>linear-gradient()</code>",
               "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/gradient/linear-gradient",
-              "spec_url": "https://w3c.github.io/csswg-drafts/css-images/#linear-gradients",
+              "spec_url": "https://w3c.github.io/csswg-drafts/css-images-4/#linear-gradients",
               "support": {
                 "chrome": [
                   {


### PR DESCRIPTION
This PR fixes #18674 by pointing to the Level 4 spec rather than the Level 3 spec.
