### PR TITLE
Rename "logical nullish assignment" to "nullish coalescing assignment"

### DIFF
--- a/javascript/operators/nullish_coalescing_assignment.json
+++ b/javascript/operators/nullish_coalescing_assignment.json
@@ -1,9 +1,9 @@
 {
   "javascript": {
     "operators": {
-      "logical_nullish_assignment": {
+      "nullish_coalescing_assignment": {
         "__compat": {
-          "description": "Logical nullish assignment (<code>x ??= y</code>)",
+          "description": "Nullish coalescing assignment (<code>x ??= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Logical_nullish_assignment",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
           "support": {


### PR DESCRIPTION
This PR fixes the name for the `logical nullish assignment` operator and changes it to the `nullish coalescing assignment` operator following the content change.  Fixes #18558.
