### PR TITLE
Add Firefox versions for webextensions.manifest/manifest_version.v3

### DIFF
--- a/webextensions/manifest/manifest_version.json
+++ b/webextensions/manifest/manifest_version.json
@@ -80,7 +80,7 @@
                 "version_added": false
               },
               "firefox": {
-                "version_added": false
+                "version_added": "109"
               },
               "firefox_android": "mirror",
               "opera": {


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `v3` member of the `manifest/manifest_version` Webextensions feature.  This fixes #18702, which is where the data comes from.
