### PR TITLE
Update Safari versions for css.selectors.user-valid/user-invalid

### DIFF
--- a/css/selectors/user-invalid.json
+++ b/css/selectors/user-invalid.json
@@ -30,7 +30,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
+              "version_added": "preview",
               "notes": "See <a href='https://webkit.org/b/222267'>bug 222267</a>."
             },
             "safari_ios": "mirror",

--- a/css/selectors/user-valid.json
+++ b/css/selectors/user-valid.json
@@ -30,7 +30,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
+              "version_added": "preview",
               "notes": "See <a href='https://webkit.org/b/222267'>bug 222267</a>."
             },
             "safari_ios": "mirror",


### PR DESCRIPTION
This PR updates the versions for the `:user-valid` and `:user-invalid` selectors based on manual testing.  This fixes #18656.
