### PR TITLE
Add Safari versions for css.at-rules.media.resolution

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1378,8 +1378,7 @@
                 }
               ],
               "safari": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/78087'>bug 78087</a>."
+                "version_added": "16"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `resolution` member of the `media` CSS @rule.  The data comes from Can I Use: https://caniuse.com/css-media-resolution.  Fixes #18645.
