### PR TITLE
update css.properties.text-decoration.text-decoration-thickness

### DIFF
--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -128,9 +128,7 @@
               "firefox": {
                 "version_added": "70"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -146,7 +144,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

The `text-decoration-thickness` sub feature of the `text-decoration` shorthand is part of [css-text-decor-4](https://www.w3.org/TR/css-text-decor-4/#text-decoration-property).
`standard_track` should be true.

I also saw no reason why `firefox_android` wasn't set to `mirror`.

#### Test results and supporting details

/

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

/

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
