### PR TITLE
CSS Custom Highlight API follow-ups

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -875,7 +875,7 @@
       },
       "highlights": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api-1/#dom-css-highlights",
+          "spec_url": "https://www.w3.org/TR/css-highlight-api-1/#dom-css-highlights",
           "support": {
             "chrome": {
               "version_added": "105"
@@ -900,7 +900,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/CSS.json
+++ b/api/CSS.json
@@ -875,7 +875,7 @@
       },
       "highlights": {
         "__compat": {
-          "spec_url": "https://www.w3.org/TR/css-highlight-api-1/#dom-css-highlights",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api-1/#dom-css-highlights",
           "support": {
             "chrome": {
               "version_added": "105"
@@ -900,7 +900,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Highlight.json
+++ b/api/Highlight.json
@@ -2,7 +2,7 @@
   "api": {
     "Highlight": {
       "__compat": {
-        "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api-1/#highlight",
+        "spec_url": "https://www.w3.org/TR/css-highlight-api-1/#highlight",
         "support": {
           "chrome": {
             "version_added": "105"
@@ -27,7 +27,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -35,7 +35,7 @@
       "Highlight": {
         "__compat": {
           "description": "<code>Highlight()</code> constructor",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api-1/#dom-highlight-highlight",
+          "spec_url": "https://www.w3.org/TR/css-highlight-api-1/#dom-highlight-highlight",
           "support": {
             "chrome": {
               "version_added": "105"
@@ -60,7 +60,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -92,7 +92,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -124,7 +124,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -156,7 +156,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -188,7 +188,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -220,7 +220,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -252,7 +252,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -284,7 +284,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -292,7 +292,7 @@
       },
       "priority": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api-1/#dom-highlight-priority",
+          "spec_url": "https://www.w3.org/TR/css-highlight-api-1/#dom-highlight-priority",
           "support": {
             "chrome": {
               "version_added": "105"
@@ -317,7 +317,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -349,7 +349,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -357,7 +357,7 @@
       },
       "type": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api-1/#dom-highlight-type",
+          "spec_url": "https://www.w3.org/TR/css-highlight-api-1/#enumdef-highlighttype",
           "support": {
             "chrome": {
               "version_added": "105"
@@ -382,7 +382,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -414,7 +414,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -446,7 +446,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Highlight.json
+++ b/api/Highlight.json
@@ -2,7 +2,7 @@
   "api": {
     "Highlight": {
       "__compat": {
-        "spec_url": "https://www.w3.org/TR/css-highlight-api-1/#highlight",
+        "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api-1/#highlight",
         "support": {
           "chrome": {
             "version_added": "105"
@@ -27,7 +27,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }
@@ -35,7 +35,7 @@
       "Highlight": {
         "__compat": {
           "description": "<code>Highlight()</code> constructor",
-          "spec_url": "https://www.w3.org/TR/css-highlight-api-1/#dom-highlight-highlight",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api-1/#dom-highlight-highlight",
           "support": {
             "chrome": {
               "version_added": "105"
@@ -60,7 +60,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -92,7 +92,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -124,7 +124,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -156,7 +156,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -188,7 +188,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -220,7 +220,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -252,7 +252,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -284,7 +284,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -292,7 +292,7 @@
       },
       "priority": {
         "__compat": {
-          "spec_url": "https://www.w3.org/TR/css-highlight-api-1/#dom-highlight-priority",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api-1/#dom-highlight-priority",
           "support": {
             "chrome": {
               "version_added": "105"
@@ -317,7 +317,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -349,7 +349,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -357,7 +357,7 @@
       },
       "type": {
         "__compat": {
-          "spec_url": "https://www.w3.org/TR/css-highlight-api-1/#enumdef-highlighttype",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api-1/#enumdef-highlighttype",
           "support": {
             "chrome": {
               "version_added": "105"
@@ -382,7 +382,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -414,7 +414,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -446,7 +446,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HighlightRegistry.json
+++ b/api/HighlightRegistry.json
@@ -2,7 +2,7 @@
   "api": {
     "HighlightRegistry": {
       "__compat": {
-        "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api-1/#highlightregistry",
+        "spec_url": "https://www.w3.org/TR/css-highlight-api-1/#highlight-registry",
         "support": {
           "chrome": {
             "version_added": "105"
@@ -27,7 +27,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -58,7 +58,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -90,7 +90,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -122,7 +122,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -154,7 +154,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -186,7 +186,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -218,7 +218,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -250,7 +250,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -282,7 +282,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -314,7 +314,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -346,7 +346,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -378,7 +378,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HighlightRegistry.json
+++ b/api/HighlightRegistry.json
@@ -2,7 +2,7 @@
   "api": {
     "HighlightRegistry": {
       "__compat": {
-        "spec_url": "https://www.w3.org/TR/css-highlight-api-1/#highlight-registry",
+        "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api-1/#highlight-registry",
         "support": {
           "chrome": {
             "version_added": "105"
@@ -27,7 +27,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }
@@ -58,7 +58,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -90,7 +90,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -122,7 +122,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -154,7 +154,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -186,7 +186,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -218,7 +218,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -250,7 +250,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -282,7 +282,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -314,7 +314,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -346,7 +346,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -378,7 +378,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/selectors/highlight.json
+++ b/css/selectors/highlight.json
@@ -12,11 +12,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": false
-              }
-            ],
+            "firefox": {
+              "version_added": false
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/css/selectors/highlight.json
+++ b/css/selectors/highlight.json
@@ -1,0 +1,43 @@
+{
+  "css": {
+    "selectors": {
+      "highlight": {
+        "__compat": {
+          "description": "<code>::highlight()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::highlight",
+          "spec_url": "https://www.w3.org/TR/css-highlight-api-1/#custom-highlight-pseudo",
+          "support": {
+            "chrome": {
+              "version_added": "105"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": [
+              {
+                "version_added": false
+              }
+            ],
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/highlight.json
+++ b/css/selectors/highlight.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>::highlight()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::highlight",
-          "spec_url": "https://www.w3.org/TR/css-highlight-api-1/#custom-highlight-pseudo",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api-1/#custom-highlight-pseudo",
           "support": {
             "chrome": {
               "version_added": "105"
@@ -30,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
#### Summary

* Marked API as non-experimental: the API shipped on-by-default in Chromium-based browsers. I don't believe we're in the experimental phase anymore where browsers are waiting for feedback (although the API is still off-by-default in Safari).
* Added the missing `::highlight()` pseudo-element, which comes with this API.
* Changed the spec URLs to use the www.w3.org server instead.