### PR TITLE
FF110 Nightly supports StorageManager.getDirectory() - OPFS

### DIFF
--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -101,6 +101,7 @@
       },
       "getDirectory": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/StorageManager/getDirectory",
           "spec_url": "https://fs.spec.whatwg.org/#dom-storagemanager-getdirectory",
           "support": {
             "chrome": {
@@ -110,9 +111,21 @@
               "version_added": "109"
             },
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "97",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.fs.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
FF supports OPFS by default in nightly from FF110 - see https://bugzilla.mozilla.org/show_bug.cgi?id=1785123. In practice this means that the `navigator.storage.getDirectory()` method is implemented, hence this change.

The preference for the feature was actually introduced in FF97 (tested using browserstack).

Other docs work for the feature can be tracked in https://github.com/mdn/content/issues/23688

FYI @queengooborg 