### PR TITLE
FF110 Permission API midi permission

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -461,6 +461,7 @@
       "permission_midi": {
         "__compat": {
           "description": "<code>midi</code> permission",
+          "spec_url": "https://webaudio.github.io/web-midi-api/#permissions-integration",
           "support": {
             "chrome": {
               "version_added": "43"
@@ -468,7 +469,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "110"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -487,7 +488,7 @@
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
FF110 adds support for querying the Permissions API midi permission in https://bugzilla.mozilla.org/show_bug.cgi?id=1437171.

This allows users to query for midi permission support using code like: `navigator.permissions.query({ name: "midi" })` or `navigator.permissions.query({ name: "midi", sysex: true })`, where previously an exception would be thrown.

This PR just adds the supported version and sets this as no-longer experimental. I also added spec link, though this is not yet shown anywhere on MDN. 

Other docs work for this can be tracked in https://github.com/mdn/content/issues/23680

FYI @queengooborg 