### PR TITLE
Document Firefox and Safari behavior wrt createConicGradient

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -410,7 +410,8 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "90",
-              "notes": "The gradient starts from a line going vertically up from the center, like the equivalent CSS function."
+              "notes": "Implements an older version of the specification. The gradient starts from a line going vertically up from the center, like the equivalent CSS function.",
+              "partial_implementation": true
             },
             "firefox_android": "mirror",
             "ie": {
@@ -421,7 +422,8 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "15",
-              "notes": "The gradient starts from a line going vertically up from the center, like the equivalent CSS function."
+              "notes": "Implements an older version of the specification. The gradient starts from a line going vertically up from the center, like the equivalent CSS function.",
+              "partial_implementation": true
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -408,11 +408,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "90",
-              "notes": "Implements an older version of the specification. The gradient starts from a line going vertically up from the center, like the equivalent CSS function.",
-              "partial_implementation": true
-            },
+            "firefox": [
+              {
+                "version_added": "112"
+              },
+              {
+                "version_added": "90",
+                "notes": "Implements an older version of the specification. The gradient starts from a line going vertically up from the center, like the equivalent CSS function.",
+                "partial_implementation": true
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -420,11 +425,16 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "15",
-              "notes": "Implements an older version of the specification. The gradient starts from a line going vertically up from the center, like the equivalent CSS function.",
-              "partial_implementation": true
-            },
+            "safari": [
+              {
+                "version_added": "16.4"
+              },
+              {
+                "version_added": "15",
+                "notes": "Implements an older version of the specification. The gradient starts from a line going vertically up from the center, like the equivalent CSS function.",
+                "partial_implementation": true
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -427,7 +427,7 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "16.4"
+                "version_added": "16.1"
               },
               {
                 "version_added": "15",

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -409,7 +409,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "90"
+              "version_added": "90",
+              "notes": "The gradient starts from a line going vertically up from the center, like the equivalent CSS function."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -419,7 +420,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "15",
+              "notes": "The gradient starts from a line going vertically up from the center, like the equivalent CSS function."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
See https://github.com/mdn/content/pull/22363 - when gradients are created using [`CanvasRenderingContext2D.createConicGradient()`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/createConicGradient) Firefox and Safari start the gradient at 12 o'clock, but the standard now expects them to start at 3 o'clock, like the other Canvas APIs.

2 questions:
- I'm not sure the wording here is the best. Maybe "12 o'clock" would be better?
- per https://github.com/mdn/content/pull/22363#issuecomment-1324388656, it looks like Safari has updated to the standard, but AFAICT this isn't in a released version yet. But I'm hoping someone can tell me if I have to do something else here.