### PR TITLE
Safari 16.3 is released

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -237,9 +237,16 @@
         "16.2": {
           "release_date": "2022-12-13",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_2-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "614.3.7"
+        },
+        "16.3": {
+          "release_date": "2023-01-23",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_3-release-notes",
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "614.4.6"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -209,9 +209,16 @@
         "16.2": {
           "release_date": "2022-12-13",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_2-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "614.3.7"
+        },
+        "16.3": {
+          "release_date": "2023-01-23",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_3-release-notes",
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "614.4.6"
         }
       }
     }


### PR DESCRIPTION
This PR adds Safari 16.3 to BCD following its release yesterday.
