### PR TITLE
icons.json: mirrored Opera and Edge to Chrome

### DIFF
--- a/webextensions/manifest/icons.json
+++ b/webextensions/manifest/icons.json
@@ -9,16 +9,12 @@
               "version_added": true,
               "notes": "Chrome does not support SVG format for icons. It is recommended to use PNG images."
             },
-            "edge": {
-              "version_added": "14"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "48"
             },
             "firefox_android": "mirror",
-            "opera": {
-              "version_added": true
-            },
+            "opera": "mirror",
             "safari": {
               "version_added": "14",
               "notes": "SVG icons are not supported."


### PR DESCRIPTION
#### Summary

Since SVG icons are [not supported in Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=29683) they are not supported in derivatives like Edge and Opera.
I was asked to update these browsers data to "mirror" in change request to corresponding MDN page update: https://github.com/mdn/content/pull/22845

#### Test results and supporting details

Unfortunatelly I did not tested my changes.

#### Related issues

It is related to https://github.com/mdn/content/pull/22845
