### PR TITLE
Add missing api.CSSKeyframesRule.length feature

### DIFF
--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -303,6 +303,41 @@
           }
         }
       },
+      "length": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-animations/#dom-csskeyframesrule-length",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "109"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSKeyframesRule/name",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `length` member of the CSSKeyframesRule API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.4).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CSSKeyframesRule/length

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
