### PR TITLE
Add missing Prerendering Revamped spec features

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -5377,9 +5377,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": "≤72"
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },

--- a/api/Document.json
+++ b/api/Document.json
@@ -5359,6 +5359,41 @@
           }
         }
       },
+      "prerendering": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/nav-speculation/prerendering.html#dom-document-prerendering",
+          "support": {
+            "chrome": {
+              "version_added": "108"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": "≤72"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "queryCommandEnabled": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/queryCommandEnabled",

--- a/api/PerformanceNavigationTiming.json
+++ b/api/PerformanceNavigationTiming.json
@@ -42,7 +42,7 @@
           "spec_url": "https://wicg.github.io/nav-speculation/prerendering.html#dom-performancenavigationtiming-activationstart",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "108"
             },
             "chrome_android": {
               "version_added": "57"


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `prerendering` and `prerenderingchange_event` members of the Document API, as well as the `activationStart` member of the PerformanceNavigationTiming API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.4).

Tests Used:
https://mdn-bcd-collector.gooborg.com/tests/api/Document/prerendering
https://mdn-bcd-collector.gooborg.com/tests/api/Document/prerenderingchange_event
https://mdn-bcd-collector.gooborg.com/tests/api/PerformanceNavigationTiming/activationStart

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
