### PR TITLE
Opera Android 73 is released

### DIFF
--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -407,9 +407,15 @@
         "72": {
           "release_date": "2022-10-21",
           "release_notes": "https://blogs.opera.com/mobile/2022/10/ofa-72/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "106"
+        },
+        "73": {
+          "release_date": "2023-01-17",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "108"
         }
       }
     }


### PR DESCRIPTION
This PR adds Opera Android 73 and marks it as the current Opera Android release.  Release date comes from UpToDown, engine version comes from user agent string.
