### PR TITLE
Add missing api.MathMLElement.attributeStyleMap feature

### DIFF
--- a/api/MathMLElement.json
+++ b/api/MathMLElement.json
@@ -45,6 +45,41 @@
           "deprecated": false
         }
       },
+      "attributeStyleMap": {
+        "__compat": {
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-elementcssinlinestyle-attributestylemap",
+          "support": {
+            "chrome": {
+              "version_added": "109"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "blur": {
         "__compat": {
           "support": {


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `attributeStyleMap` member of the MathMLElement API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.4).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/MathMLElement/attributeStyleMap

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
