### PR TITLE
Revert "releases(108): Fx 108 support for 'effective-directive' and 'status-code' props"

### DIFF
--- a/api/CSPViolationReportBody.json
+++ b/api/CSPViolationReportBody.json
@@ -11,7 +11,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "63"
+            "version_added": false
           },
           "firefox_android": "mirror",
           "ie": {
@@ -210,7 +210,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "108"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
@@ -450,7 +450,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "108"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
Reverts mdn/browser-compat-data#18557

For more information, see https://github.com/mdn/browser-compat-data/issues/18710