### PR TITLE
Fx(110): 'unsafe-hashes' CSP keyword is enabled

### DIFF
--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -1307,8 +1307,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1343950'>bug 1343950</a>."
+                "version_added": "110"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
Fx 110 enables `'unsafe-hashes'` which allows for hashing event handlers, style attributes and `javascript:` navigations (`<a href="javascript:alert('Hello!')"></a>`)

__Parent issue:__
- [ ] https://github.com/mdn/content/issues/23679

__Related pull requests:__
- [x] https://github.com/mdn/content/pull/23930 

__Bugzilla bugs:__
- https://bugzilla.mozilla.org/show_bug.cgi?id=1343950