### PR TITLE
Add missing api.Window.getDigitalGoodsService feature

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -2019,6 +2019,43 @@
           }
         }
       },
+      "getDigitalGoodsService": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/digital-goods/#getdigitalgoodsservice-method",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "101"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getScreenDetails": {
         "__compat": {
           "spec_url": "https://w3c.github.io/window-placement/#api-window-getScreenDetails-method",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `getDigitalGoodsService` member of the Window API, populating the results using data from ChromeStatus at https://chromestatus.com/feature/5339955595313152.
