### PR TITLE
Update Chromium, Safari versions for `Element.animate()` `options.pseudoElement`

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -407,17 +407,22 @@
             "description": "<code>options.pseudoElement</code> parameter",
             "spec_url": "https://w3c.github.io/csswg-drafts/web-animations-1/#dom-keyframeeffectoptions-pseudoelement",
             "support": {
-              "chrome": {
-                "version_added": "81",
-                "partial_implementation": true,
-                "notes": "A valid animation object is returned but the targeted pseudoelement is not visually animated.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features"
-                  }
-                ]
-              },
+              "chrome": [
+                {
+                  "version_added": "84"
+                },
+                {
+                  "version_added": "81",
+                  "partial_implementation": true,
+                  "notes": "A valid animation object is returned but the targeted pseudoelement is not visually animated.",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features"
+                    }
+                  ]
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -440,7 +445,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/api/Element.json
+++ b/api/Element.json
@@ -438,7 +438,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Record that `Element.animate()`'s `pseudoElement` option is supported in Chrome as of version 84.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

This was part of the [Web Animations API feature](https://chromestatus.com/feature/5126405660606464), listed as shipping in Chrome 84.

According to the [tracking bug](https://bugs.chromium.org/p/chromium/issues/detail?id=978551), support was enabled by default in [9cdcb10](https://chromium.googlesource.com/chromium/src/+/9cdcb106b0bcfee75cf3e94576fd48c055cc4bd6), which landed in [84.0.4129.0](https://storage.googleapis.com/chromium-find-releases-static/9cd.html#9cdcb106b0bcfee75cf3e94576fd48c055cc4bd6).

I don't have a chromium 84 install, but this feature definitely works in chromium 109, if that's worth anything; and @rururux [reported it working in chrome 92](https://github.com/mdn/browser-compat-data/issues/11811).

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Closes #11811.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
