### PR TITLE
Update Chromium versions for AudioParam API

### DIFF
--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -190,7 +190,7 @@
               "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "18",
+              "version_added": "25",
               "partial_implementation": true,
               "notes": "This sets the target volume at the specified time, but it doesn’t ramp to it, causing this function to behave like <code>setValueAtTime()</code>."
             },
@@ -215,9 +215,7 @@
               "version_added": "6"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "1.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"
             }
@@ -238,7 +236,7 @@
               "version_added": "24"
             },
             "chrome_android": {
-              "version_added": "18",
+              "version_added": "25",
               "partial_implementation": true,
               "notes": "This sets the target volume at the specified time, but it doesn’t ramp to it, causing this function to behave like <code>setValueAtTime()</code>."
             },
@@ -263,9 +261,7 @@
               "version_added": "6"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "1.0"
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"
             }

--- a/api/AudioParam.json
+++ b/api/AudioParam.json
@@ -6,7 +6,7 @@
         "spec_url": "https://webaudio.github.io/web-audio-api/#AudioParam",
         "support": {
           "chrome": {
-            "version_added": "14"
+            "version_added": "24"
           },
           "chrome_android": "mirror",
           "edge": {
@@ -111,7 +111,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audioparam-cancelscheduledvalues",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "24"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -149,7 +149,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audioparam-defaultvalue",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "24"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -187,7 +187,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audioparam-exponentialramptovalueattime",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "18",
@@ -235,7 +235,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audioparam-linearramptovalueattime",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "24"
             },
             "chrome_android": {
               "version_added": "18",
@@ -351,7 +351,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audioparam-settargetattime",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "24"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -389,7 +389,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audioparam-setvalueattime",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "24"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -427,7 +427,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audioparam-setvaluecurveattime",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "24"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -465,7 +465,7 @@
           "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audioparam-value",
           "support": {
             "chrome": {
-              "version_added": "14"
+              "version_added": "24"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `AudioParam` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.5).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/AudioParam

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

---

Note: although the `AudioParam` API was introduced all the way back in [late 2010](https://source.chromium.org/chromium/chromium/src/+/1e8047393acec1d927b8aeb56fbbf7ebf5d84aa2:third_party/WebKit/WebCore/webaudio/AudioParam.idl;dlc=368be040da67709e2023171654ed89436a351085), this was never usable until `GainNode` and similar was introduced.