### PR TITLE
Update Chromium versions for api.Bluetooth.requestDevice

### DIFF
--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -193,7 +193,7 @@
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-requestdevice",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "57"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `requestDevice` member of the `Bluetooth` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.5).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Bluetooth/requestDevice

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
