### PR TITLE
Update Chromium versions for BluetoothRemoteGATTCharacteristic API

### DIFF
--- a/api/BluetoothRemoteGATTCharacteristic.json
+++ b/api/BluetoothRemoteGATTCharacteristic.json
@@ -115,7 +115,7 @@
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-getdescriptor",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "57"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -151,7 +151,7 @@
           "spec_url": "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-getdescriptors",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "57"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `BluetoothRemoteGATTCharacteristic` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.5).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/BluetoothRemoteGATTCharacteristic

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
