### PR TITLE
Update Safari versions for api.CanvasRenderingContext2D.drawImage.ImageBitmap_source_image

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -764,8 +764,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/149990'>bug 149990</a>."
+                "version_added": "15"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `drawImage.ImageBitmap_source_image` member of the `CanvasRenderingContext2D` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.5).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CanvasRenderingContext2D/drawImage.ImageBitmap_source_image

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

---

Note: I don't actually have a Safari 15 VM to test with, but the collector found support in 14.1> ≤15.1.  Since `ImageBitmap` was implemented in Safari 15, I went with "15" as the version number for this.
