### PR TITLE
Add data for `Element.animate()` `options.timeline`

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -445,6 +445,40 @@
               "deprecated": false
             }
           }
+        },
+        "options_timeline_parameter": {
+          "__compat": {
+            "description": "<code>options.timeline</code> parameter",
+            "spec_url": "https://w3c.github.io/csswg-drafts/web-animations-1/#dom-keyframeanimationoptions-timeline",
+            "support": {
+              "chrome": {
+                "version_added": "85"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "16"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "animationcancel_event": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Adds support data for the `timeline` property of the `options` parameter of `Element.animate()`.

Firefox does not support this option. Chromium does, likely since version 85. Safari likely does, since version 16.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

Manually tested in Firefox 111 and Chromium 109. A simple test case is:

```js
console.assert(
  document.body.animate([], { timeline: new DocumentTimeline() }).timeline !== document.timeline
);
```

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Chromium support was added in [d393163](https://chromium.googlesource.com/chromium/src/+/d3931637492464d7781d2699c3c549c8f845aec6), which released in [Chromium 85](https://storage.googleapis.com/chromium-find-releases-static/d39.html#d3931637492464d7781d2699c3c549c8f845aec6).

Safari support was added in https://github.com/WebKit/WebKit/commit/1a2775d4de27be9e08d6c54a5d7ae03abc315168, included in WebKit since 614.1.6, which is Safari 16.

I don't have a setup to test Safari 16 or any additional browsers at the moment; the `"mirror"` entries are pure speculation, since the linter disallows `null`. I apologize if that makes this PR not useful.