### PR TITLE
Update Opera versions for FileSystemDirectoryEntry API

### DIFF
--- a/api/FileSystemDirectoryEntry.json
+++ b/api/FileSystemDirectoryEntry.json
@@ -19,9 +19,7 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": {
-            "version_added": false
-          },
+          "opera_android": "mirror",
           "safari": {
             "version_added": "11.1"
           },
@@ -58,9 +56,7 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "11.1"
             },
@@ -99,9 +95,7 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "11.1"
             },
@@ -140,9 +134,7 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "11.1"
             },
@@ -181,9 +173,7 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `FileSystemDirectoryEntry` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v7.1.5).  The collector obtains results based upon Opera Desktop 12.16 and 15, as well as the latest version of Opera Desktop and Opera Android.  Version numbers are then copied for Blink-based Opera versions from Chrome Desktop and Android respectively.

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/FileSystemDirectoryEntry

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
