### PR TITLE
Fix Firefox compatibility data for the Link HTTP header

### DIFF
--- a/http/headers/Link.json
+++ b/http/headers/Link.json
@@ -12,7 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/http/headers/Link.json
+++ b/http/headers/Link.json
@@ -12,7 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": null
+              "version_added": true
             },
             "firefox_android": "mirror",
             "ie": {

--- a/http/headers/Link.json
+++ b/http/headers/Link.json
@@ -29,7 +29,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
Support was added to Gecko 0.9 (predates Firefox) by [bug 3248](https://bugzilla.mozilla.org/show_bug.cgi?id=3248).