### PR TITLE
Add Opera versions for api.BarProp.visible.returns_popup

### DIFF
--- a/api/BarProp.json
+++ b/api/BarProp.json
@@ -95,12 +95,8 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR adds real values for Opera and Opera Android for the `visible.returns_popup` member of the `BarProp` API.  I'm guessing that Opera was set to `false` because a corresponding Opera release wasn't out when the data was added, so this PR sets it to mirror from Chrome.
