### PR TITLE
Add Chromium versions for api.CanMakePaymentEvent.modifiers

### DIFF
--- a/api/CanMakePaymentEvent.json
+++ b/api/CanMakePaymentEvent.json
@@ -114,12 +114,8 @@
               "version_added": "70",
               "version_removed": "111"
             },
-            "chrome_android": {
-              "version_added": "70"
-            },
-            "edge": {
-              "version_added": "79"
-            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -128,9 +124,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "57"
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `modifiers` member of the `CanMakePaymentEvent` API.  The other Chromium browsers should be mirrored, but are not for whatever reason.  This corrects it by setting the other browsers to mirror.
