### PR TITLE
FF110 Navigator.getAutoplayPolicy() behind pref/nightly

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -946,6 +946,52 @@
           }
         }
       },
+      "getAutoplayPolicy": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/getAutoplayPolicy",
+          "spec_url": "https://www.w3.org/TR/autoplay-detection/#dom-navigator-getautoplaypolicy",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "110",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.media.autoplay-policy-detection.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getBattery": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/getBattery",


### PR DESCRIPTION
FF110 adds support for `Navigator.getAutoplayPolicy()` in https://bugzilla.mozilla.org/show_bug.cgi?id=1773551 in nightly (otherwise behind a pref)

Other docs work can be tracked in https://github.com/mdn/content/issues/23676