### PR TITLE
Revert "Add CHIPs data additions"

### DIFF
--- a/api/CookieStore.json
+++ b/api/CookieStore.json
@@ -105,39 +105,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "partitioned_option": {
-          "__compat": {
-            "description": "<code>partitioned</code> option",
-            "support": {
-              "chrome": {
-                "version_added": "109"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": false
-            }
-          }
         }
       },
       "get": {
@@ -171,39 +138,6 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "partitioned_return_property": {
-          "__compat": {
-            "description": "<code>partitioned</code> in return value",
-            "support": {
-              "chrome": {
-                "version_added": "109"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": false
-            }
           }
         }
       },
@@ -239,39 +173,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "partitioned_return_property": {
-          "__compat": {
-            "description": "<code>partitioned</code> in return value",
-            "support": {
-              "chrome": {
-                "version_added": "109"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": false
-            }
-          }
         }
       },
       "set": {
@@ -305,39 +206,6 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "partitioned_option": {
-          "__compat": {
-            "description": "<code>partitioned</code> option",
-            "support": {
-              "chrome": {
-                "version_added": "109"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": false
-            }
           }
         }
       }

--- a/http/headers/Set-Cookie.json
+++ b/http/headers/Set-Cookie.json
@@ -114,39 +114,6 @@
             }
           }
         },
-        "Partitioned": {
-          "__compat": {
-            "description": "<code>Partitioned</code>",
-            "support": {
-              "chrome": {
-                "version_added": "109"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "SameSite": {
           "__compat": {
             "description": "<code>SameSite</code>",


### PR DESCRIPTION
Reverts mdn/browser-compat-data#18591.

When looking deeper into the code for https://cr2.kungfoo.net/cookies/v2/ in an attempt to reverse engineer test code for the collector, I had realized that what I thought was functional code was actually just names set by the server, and did not actually reflect partitioning.  The "Opt-out of partitioned cookies" button does nothing in the example.  Additionally, in my test code, I find that the `partitioned` option is completely ignored:

```js
var accessed = false;
cookieStore.set({name: 'foo', value: 'bar', partitioned: {
  get: function () {
    accessed = true;
    return true;
  }
}}).then(() => {
  console.log(accessed);
});
// > false
```

Additionally, the [ChromeStatus feature's](https://chromestatus.com/feature/5179189105786880) linked bug is [set to "Assigned (Open)", not "Fixed (Closed)"](https://crbug.com/1225444).

CC @chrisdavidmills