### PR TITLE
Fx(109): 'unsafe-hashes' CSP keyword is enabled

### DIFF
--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -1307,7 +1307,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "110"
+                "version_added": "109"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
`'unsafe-hashes'` enabled in 109, see https://github.com/mdn/browser-compat-data/pull/18759#issuecomment-1407372232

CCing @evilpie 