### PR TITLE
CSSImportRule.layerName: add link to MDN

### DIFF
--- a/api/CSSImportRule.json
+++ b/api/CSSImportRule.json
@@ -81,7 +81,7 @@
       },
       "layerName": {
         "__compat": {
-          "mdn_url": "https:/developer.mozilla.org/docs/Web/API/CSSImportRule/layerName",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSImportRule/layerName",
           "spec_url": "https://w3c.github.io/csswg-drafts/css-cascade-5/#dom-cssimportrule-layername",
           "support": {
             "chrome": {

--- a/api/CSSImportRule.json
+++ b/api/CSSImportRule.json
@@ -81,6 +81,7 @@
       },
       "layerName": {
         "__compat": {
+          "mdn_url": "https:/developer.mozilla.org/docs/Web/API/CSSImportRule/layerName",
           "spec_url": "https://w3c.github.io/csswg-drafts/css-cascade-5/#dom-cssimportrule-layername",
           "support": {
             "chrome": {


### PR DESCRIPTION
This missing page is being created in the following mdn/content PR: https://github.com/mdn/content/pull/24014

