### PR TITLE
Fix names of constructor features for Temporal API objects

### DIFF
--- a/javascript/builtins/Temporal/Calendar.json
+++ b/javascript/builtins/Temporal/Calendar.json
@@ -39,10 +39,10 @@
               "deprecated": false
             }
           },
-          "constructor": {
+          "Calendar": {
             "__compat": {
               "description": "Temporal.Calendar constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Calendar/Calendar",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-calendar-constructor",
               "support": {
                 "chrome": {

--- a/javascript/builtins/Temporal/Duration.json
+++ b/javascript/builtins/Temporal/Duration.json
@@ -39,6 +39,44 @@
               "deprecated": false
             }
           },
+          "Duration": {
+            "__compat": {
+              "description": "Temporal.Duration constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration/Duration",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-duration-constructor",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "preview"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "abs": {
             "__compat": {
               "description": "Temporal.Duration.abs()",
@@ -158,44 +196,6 @@
               "description": "Temporal.Duration.compare()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/duration/compare",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.duration.compare",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "preview"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "constructor": {
-            "__compat": {
-              "description": "Temporal.Duration constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Duration/constructor",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-duration-constructor",
               "support": {
                 "chrome": {
                   "version_added": false

--- a/javascript/builtins/Temporal/Instant.json
+++ b/javascript/builtins/Temporal/Instant.json
@@ -39,6 +39,44 @@
               "deprecated": false
             }
           },
+          "Instant": {
+            "__compat": {
+              "description": "Temporal.Instant constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/Instant",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-instant-objects",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "preview"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "add": {
             "__compat": {
               "description": "Temporal.Instant.add()",
@@ -103,44 +141,6 @@
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "constructor": {
-            "__compat": {
-              "description": "Temporal.Instant constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/instant/constructor",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-instant-objects",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "preview"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/javascript/builtins/Temporal/PlainDate.json
+++ b/javascript/builtins/Temporal/PlainDate.json
@@ -39,6 +39,44 @@
               "deprecated": false
             }
           },
+          "PlainDate": {
+            "__compat": {
+              "description": "Temporal.PlainDate constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/PlainDate",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plaindate-constructor",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "add": {
             "__compat": {
               "description": "Temporal.PlainDate.add()",
@@ -120,44 +158,6 @@
               "description": "Temporal.PlainDate.compare()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindate/compare",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindate.compare",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "constructor": {
-            "__compat": {
-              "description": "Temporal.PlainDate constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDate/constructor",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plaindate-constructor",
               "support": {
                 "chrome": {
                   "version_added": false

--- a/javascript/builtins/Temporal/PlainDateTime.json
+++ b/javascript/builtins/Temporal/PlainDateTime.json
@@ -39,6 +39,44 @@
               "deprecated": false
             }
           },
+          "PlainDateTime": {
+            "__compat": {
+              "description": "Temporal.PlainDateTime constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/PlainDateTime",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plaindatetime-constructor",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "add": {
             "__compat": {
               "description": "Temporal.PlainDateTime.add()",
@@ -120,44 +158,6 @@
               "description": "Temporal.PlainDateTime.compare()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaindatetime/compare",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.compare",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "constructor": {
-            "__compat": {
-              "description": "Temporal.PlainDateTime constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainDateTime/constructor",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plaindatetime-constructor",
               "support": {
                 "chrome": {
                   "version_added": false

--- a/javascript/builtins/Temporal/PlainMonthDay.json
+++ b/javascript/builtins/Temporal/PlainMonthDay.json
@@ -39,11 +39,11 @@
               "deprecated": false
             }
           },
-          "calendar": {
+          "PlainMonthDay": {
             "__compat": {
-              "description": "Temporal.PlainMonthDay.calendar",
-              "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/calendar",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.calendar",
+              "description": "Temporal.PlainMonthDay constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainMonthDay/PlainMonthDay",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plainmonthday-constructor",
               "support": {
                 "chrome": {
                   "version_added": false
@@ -77,11 +77,11 @@
               }
             }
           },
-          "constructor": {
+          "calendar": {
             "__compat": {
-              "description": "Temporal.PlainMonthDay constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainMonthDay/constructor",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plainmonthday-constructor",
+              "description": "Temporal.PlainMonthDay.calendar",
+              "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainmonthday/calendar",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-get-temporal.plainmonthday.prototype.calendar",
               "support": {
                 "chrome": {
                   "version_added": false

--- a/javascript/builtins/Temporal/PlainTime.json
+++ b/javascript/builtins/Temporal/PlainTime.json
@@ -39,6 +39,44 @@
               "deprecated": false
             }
           },
+          "PlainTime": {
+            "__compat": {
+              "description": "Temporal.PlainTime constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainTime/PlainTime",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaintime-constructor",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "preview"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "add": {
             "__compat": {
               "description": "Temporal.PlainTime.add()",
@@ -119,44 +157,6 @@
             "__compat": {
               "description": "Temporal.PlainTime.compare()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plaintime/compare",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "preview"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "constructor": {
-            "__compat": {
-              "description": "Temporal.PlainTime constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainTime/constructor",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-properties-of-the-temporal-plaintime-constructor",
               "support": {
                 "chrome": {
                   "version_added": false

--- a/javascript/builtins/Temporal/PlainYearMonth.json
+++ b/javascript/builtins/Temporal/PlainYearMonth.json
@@ -39,6 +39,44 @@
               "deprecated": false
             }
           },
+          "PlainYearMonth": {
+            "__compat": {
+              "description": "Temporal.PlainYearMonth constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/PlainYearMonth",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plainyearmonth-constructor",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "add": {
             "__compat": {
               "description": "Temporal.PlainYearMonth.add()",
@@ -120,44 +158,6 @@
               "description": "Temporal.PlainYearMonth.compare()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/plainyearmonth/compare",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.compare",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "constructor": {
-            "__compat": {
-              "description": "Temporal.PlainYearMonth constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/PlainYearMonth/constructor",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-plainyearmonth-constructor",
               "support": {
                 "chrome": {
                   "version_added": false

--- a/javascript/builtins/Temporal/TimeZone.json
+++ b/javascript/builtins/Temporal/TimeZone.json
@@ -39,10 +39,10 @@
               "deprecated": false
             }
           },
-          "constructor": {
+          "TimeZone": {
             "__compat": {
               "description": "Temporal.TimeZone constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/TimeZone/constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/TimeZone/TimeZone",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-timezone-constructor",
               "support": {
                 "chrome": {

--- a/javascript/builtins/Temporal/ZonedDateTime.json
+++ b/javascript/builtins/Temporal/ZonedDateTime.json
@@ -39,6 +39,44 @@
               "deprecated": false
             }
           },
+          "ZonedDateTime": {
+            "__compat": {
+              "description": "Temporal.ZonedDateTime constructor",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/ZonedDateTime",
+              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-zoneddatetime-objects",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "add": {
             "__compat": {
               "description": "Temporal.ZonedDateTime.add()",
@@ -120,44 +158,6 @@
               "description": "Temporal.ZonedDateTime.compare()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/zoneddatetime/compare",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.zoneddatetime.compare",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          },
-          "constructor": {
-            "__compat": {
-              "description": "Temporal.ZonedDateTime constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime/constructor",
-              "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-zoneddatetime-objects",
               "support": {
                 "chrome": {
                   "version_added": false


### PR DESCRIPTION
This PR fixes the names of the constructor features for the Temporal JavaScript API.  These were inappropriately named `constructor`.
