### PR TITLE
Add support of EXT_texture_norm16 WebGL Extension for Edge

### DIFF
--- a/api/EXT_texture_norm16.json
+++ b/api/EXT_texture_norm16.json
@@ -9,9 +9,7 @@
             "version_added": "87"
           },
           "chrome_android": "mirror",
-          "edge": {
-            "version_added": false
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": false
           },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Edge seems to support the WebGL Extension EXT_texture_norm16 just like Chrome does.

#### Test results and supporting details
I tested via https://webglreport.com/?v=2 on (Edge Version 109).

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Thanks a lot @Elchi3 for suggesting the "mirror" approach for this fix.
