### PR TITLE
FF110 supports ContentVisibilityAutoStateChangedEvent

### DIFF
--- a/api/ContentVisibilityAutoStateChangedEvent.json
+++ b/api/ContentVisibilityAutoStateChangedEvent.json
@@ -11,7 +11,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "110"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -28,7 +28,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -45,7 +45,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "110"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -62,7 +62,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -79,7 +79,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "110"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -96,7 +96,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Element.json
+++ b/api/Element.json
@@ -3164,7 +3164,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "110"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3181,7 +3181,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
FF110 adds support for `ContentVisibilityAutoStateChangedEvent` object and the associated event `contentvisibilityautostatechanged_event` in https://bugzilla.mozilla.org/show_bug.cgi?id=1798485

As this means two browsers support the feature, it is also no longer experimental.

Other docs work can be tracked in https://github.com/mdn/content/issues/23687

FYI @queengooborg 