### PR TITLE
relnote(Fx110): CSS container queries enabled by default in Fx110

### DIFF
--- a/css/at-rules/container.json
+++ b/css/at-rules/container.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "110"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/container-name.json
+++ b/css/properties/container-name.json
@@ -12,7 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "110"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/container-type.json
+++ b/css/properties/container-type.json
@@ -12,7 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "110"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/container.json
+++ b/css/properties/container.json
@@ -12,7 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "110"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -160,14 +160,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.container-queries.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "110"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
CSS (size) container queries enabled by default in Fx 110.

__Related issues and pull requests:__
- Parent issue https://github.com/mdn/content/issues/23683
- [x] Relnote https://github.com/mdn/content/pull/24105
- [x] Experimental flag addition: https://github.com/mdn/browser-compat-data/pull/18379
