### PR TITLE
last baseline data

### DIFF
--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -197,9 +197,7 @@
                   "version_added": "108"
                 },
                 "chrome_android": "mirror",
-                "edge": {
-                  "version_added": "mirror"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "52"
                 },
@@ -208,22 +206,14 @@
                   "version_added": false
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": "mirror"
-                },
-                "opera_android": {
-                  "version_added": "mirror"
-                },
+                "opera": "mirror",
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": "16.2"
                 },
                 "safari_ios": "mirror",
-                "samsunginternet_android": {
-                  "version_added": "mirror"
-                },
-                "webview_android": {
-                  "version_added": "mirror"
-                }
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
               },
               "status": {
                 "experimental": false,

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -194,17 +194,11 @@
               "description": "<code>last baseline</code>",
               "support": {
                 "chrome": {
-                  "version_added": "59",
-                  "version_removed": "86",
-                  "partial_implementation": true,
-                  "notes": "This value is recognized, but has no effect. See <a href='https://crbug.com/885175'>bug 885175</a>."
+                  "version_added": "108"
                 },
                 "chrome_android": "mirror",
                 "edge": {
-                  "version_added": "≤79",
-                  "version_removed": "86",
-                  "partial_implementation": true,
-                  "notes": "This value is recognized, but has no effect. See <a href='https://crbug.com/885175'>bug 885175</a>."
+                  "version_added": "mirror"
                 },
                 "firefox": {
                   "version_added": "52"
@@ -215,22 +209,20 @@
                 },
                 "oculus": "mirror",
                 "opera": {
-                  "version_added": "46"
+                  "version_added": "mirror"
                 },
                 "opera_android": {
-                  "version_added": "43"
+                  "version_added": "mirror"
                 },
                 "safari": {
-                  "version_added": "11",
-                  "partial_implementation": true,
-                  "notes": "This value is recognized, but has no effect. See <a href='https://webkit.org/b/235005'>bug 235005</a>."
+                  "version_added": "16.2"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": {
-                  "version_added": "7.0"
+                  "version_added": "mirror"
                 },
                 "webview_android": {
-                  "version_added": "59"
+                  "version_added": "mirror"
                 }
               },
               "status": {

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -204,9 +204,7 @@
                   "version_added": "108"
                 },
                 "chrome_android": "mirror",
-                "edge": {
-                  "version_added": "mirror"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "52"
                 },
@@ -215,22 +213,14 @@
                   "version_added": false
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": "mirror"
-                },
-                "opera_android": {
-                  "version_added": "mirror"
-                },
+                "opera": "mirror",
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": "16.2"
                 },
                 "safari_ios": "mirror",
-                "samsunginternet_android": {
-                  "version_added": "mirror"
-                },
-                "webview_android": {
-                  "version_added": "mirror"
-                }
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
               },
               "status": {
                 "experimental": false,

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -201,17 +201,11 @@
               "description": "<code>last baseline</code>",
               "support": {
                 "chrome": {
-                  "version_added": "59",
-                  "version_removed": "86",
-                  "partial_implementation": true,
-                  "notes": "This value is recognized, but has no effect. See <a href='https://crbug.com/885175'>bug 885175</a>."
+                  "version_added": "108"
                 },
                 "chrome_android": "mirror",
                 "edge": {
-                  "version_added": "≤79",
-                  "version_removed": "86",
-                  "partial_implementation": true,
-                  "notes": "This value is recognized, but has no effect. See <a href='https://crbug.com/885175'>bug 885175</a>."
+                  "version_added": "mirror"
                 },
                 "firefox": {
                   "version_added": "52"
@@ -222,22 +216,20 @@
                 },
                 "oculus": "mirror",
                 "opera": {
-                  "version_added": "44"
+                  "version_added": "mirror"
                 },
                 "opera_android": {
-                  "version_added": "43"
+                  "version_added": "mirror"
                 },
                 "safari": {
-                  "version_added": "11",
-                  "partial_implementation": true,
-                  "notes": "This value is recognized, but has no effect. See <a href='https://webkit.org/b/235005'>bug 235005</a>."
+                  "version_added": "16.2"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": {
-                  "version_added": "7.0"
+                  "version_added": "mirror"
                 },
                 "webview_android": {
-                  "version_added": "57"
+                  "version_added": "mirror"
                 }
               },
               "status": {


### PR DESCRIPTION
The `last baseline` alignment value is now implemented in all three engines. The data was a bit unwieldy as it represented the fact that for a time the value was parsed but didn't do anything in Chrome and Safari. I have just removed that information, but let me know if you want it back.

I've tested this: https://codepen.io/rachelandrew/pen/MWBKPrR/1ec83980993b3d01d160f9438fbfca4e 

- Safari release notes: https://developer.apple.com/documentation/safari-release-notes/safari-16_2-release-notes
- Chrome Status: https://chromestatus.com/feature/5093352798683136
