### PR TITLE
Update Opera release version to 95

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -718,19 +718,26 @@
         "94": {
           "release_date": "2022-12-15",
           "release_notes": "https://blogs.opera.com/desktop/2022/12/opera-94-stable/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "108"
         },
         "95": {
-          "status": "beta",
+          "release_date": "2023-02-01",
+          "release_notes": "https://blogs.opera.com/desktop/2023/02/opera-95-stable/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "109"
         },
         "96": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "110"
+        },
+        "97": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "111"
         }
       }
     }


### PR DESCRIPTION
#### Summary

Update Opera release to 95, released on Feb 1st using chromium 109, see https://blogs.opera.com/desktop/2023/02/opera-95-stable/

Also increment beta/nighly versions, although I'm not sure when they are actually released/provided (https://www.opera.com/download still provides 95 and 96 for beta and developer versions respectively).

#### Test results and supporting details

Reading the blog post.

#### Related issues

Android version was updated in https://github.com/mdn/browser-compat-data/pull/18746
