### PR TITLE
Add more Chrome & Firefox version numbers for tabs webextensions API

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1809,15 +1809,7 @@
               "firefox_android": {
                 "version_added": false
               },
-              "opera": {
-                "version_added": "41",
-                "notes": [
-                  "Only accepts a single tab ID as a parameter, not an array.",
-                  "The tab ID argument is optional: if it is omitted, the browser discards the least important tab.",
-                  "The callback is passed a <code>Tab</code> object representing the tab that was discarded.",
-                  "Tabs whose document contains a <a href='https://developer.mozilla.org/docs/Web/API/BeforeUnloadEvent'><code>beforeunload</code></a> listener that displays a prompt will be discarded."
-                ]
-              },
+              "opera": "mirror",
               "safari": {
                 "version_added": false
               },

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -10,7 +10,7 @@
                 "version_added": "46"
               },
               "edge": {
-                "version_added": "79"
+                "version_added": "mirror"
               },
               "firefox": {
                 "version_added": "47"
@@ -38,7 +38,7 @@
                 "version_added": "46"
               },
               "edge": {
-                "version_added": "79"
+                "version_added": "mirror"
               },
               "firefox": {
                 "version_added": "47"
@@ -749,7 +749,7 @@
                   "version_added": "16"
                 },
                 "edge": {
-                  "version_added": "79"
+                  "version_added": "mirror"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -985,7 +985,7 @@
                   "version_added": "5"
                 },
                 "edge": {
-                  "version_added": "79"
+                  "version_added": "mirror"
                 },
                 "firefox": {
                   "version_added": "45"
@@ -1422,7 +1422,7 @@
                 "version_added": "5"
               },
               "edge": {
-                "version_added": "79"
+                "version_added": "mirror"
               },
               "firefox": {
                 "version_added": "45"
@@ -1658,7 +1658,7 @@
                     "version_added": "9"
                   },
                   "edge": {
-                    "version_added": "79"
+                    "version_added": "mirror"
                   },
                   "firefox": {
                     "version_added": "45"
@@ -1683,7 +1683,7 @@
                     "version_added": "5"
                   },
                   "edge": {
-                    "version_added": "79"
+                    "version_added": "mirror"
                   },
                   "firefox": {
                     "version_added": false
@@ -1847,7 +1847,7 @@
                 "version_added": "23"
               },
               "edge": {
-                "version_added": "79"
+                "version_added": "mirror"
               },
               "firefox": {
                 "version_added": "47"
@@ -1889,10 +1889,10 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "5"
+                  "version_added": "23"
                 },
                 "edge": {
-                  "version_added": "79"
+                  "version_added": "mirror"
                 },
                 "firefox": {
                   "version_added": "47"
@@ -2052,7 +2052,7 @@
                 "version_added": "5"
               },
               "edge": {
-                "version_added": "79"
+                "version_added": "mirror"
               },
               "firefox": {
                 "version_added": false

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1001,9 +1001,6 @@
                   "version_added": "15"
                 }
               }
-            },
-            "status": {
-              "deprecated": true
             }
           },
           "sessionId": {

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -9,9 +9,7 @@
               "chrome": {
                 "version_added": "46"
               },
-              "edge": {
-                "version_added": "mirror"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "47"
               },
@@ -37,9 +35,7 @@
               "chrome": {
                 "version_added": "46"
               },
-              "edge": {
-                "version_added": "mirror"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "47"
               },
@@ -748,9 +744,7 @@
                 "chrome": {
                   "version_added": "16"
                 },
-                "edge": {
-                  "version_added": "mirror"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "45"
                 },
@@ -984,9 +978,7 @@
                 "chrome": {
                   "version_added": "5"
                 },
-                "edge": {
-                  "version_added": "mirror"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "45"
                 },
@@ -1421,9 +1413,7 @@
               "chrome": {
                 "version_added": "5"
               },
-              "edge": {
-                "version_added": "mirror"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "45"
               },
@@ -1657,9 +1647,7 @@
                   "chrome": {
                     "version_added": "9"
                   },
-                  "edge": {
-                    "version_added": "mirror"
-                  },
+                  "edge": "mirror",
                   "firefox": {
                     "version_added": "45"
                   },
@@ -1682,9 +1670,7 @@
                   "chrome": {
                     "version_added": "5"
                   },
-                  "edge": {
-                    "version_added": "mirror"
-                  },
+                  "edge": "mirror",
                   "firefox": {
                     "version_added": false
                   },
@@ -1824,7 +1810,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": "mirror",
+                "version_added": "41",
                 "notes": [
                   "Only accepts a single tab ID as a parameter, not an array.",
                   "The tab ID argument is optional: if it is omitted, the browser discards the least important tab.",
@@ -1846,9 +1832,7 @@
               "chrome": {
                 "version_added": "23"
               },
-              "edge": {
-                "version_added": "mirror"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "47"
               },
@@ -1891,9 +1875,7 @@
                 "chrome": {
                   "version_added": "23"
                 },
-                "edge": {
-                  "version_added": "mirror"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "47"
                 },
@@ -2051,9 +2033,7 @@
               "chrome": {
                 "version_added": "5"
               },
-              "edge": {
-                "version_added": "mirror"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -7,7 +7,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/MutedInfo",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "46"
               },
               "edge": {
                 "version_added": "79"
@@ -35,7 +35,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/MutedInfoReason",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "46"
               },
               "edge": {
                 "version_added": "79"
@@ -564,7 +564,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/TAB_ID_NONE",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "46"
               },
               "edge": {
                 "version_added": "14"
@@ -590,7 +590,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "16"
                 },
                 "edge": {
                   "version_added": "14"
@@ -700,7 +700,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "5"
                 },
                 "edge": {
                   "version_added": "14"
@@ -746,7 +746,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "16"
                 },
                 "edge": {
                   "version_added": "79"
@@ -772,7 +772,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "5"
                 },
                 "edge": {
                   "version_added": "14"
@@ -797,7 +797,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "16"
                 },
                 "edge": {
                   "alternative_name": "inPrivate",
@@ -823,7 +823,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "5"
                 },
                 "edge": {
                   "version_added": "14"
@@ -957,7 +957,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "9"
                 },
                 "edge": {
                   "version_added": "14"
@@ -982,7 +982,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "5"
                 },
                 "edge": {
                   "version_added": "79"
@@ -1001,6 +1001,9 @@
                   "version_added": "15"
                 }
               }
+            },
+            "status": {
+              "deprecated": true
             }
           },
           "sessionId": {
@@ -1011,7 +1014,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": true
+                  "version_added": "52"
                 },
                 "firefox_android": {
                   "version_added": false
@@ -1028,7 +1031,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "5"
                 },
                 "edge": {
                   "version_added": "14"
@@ -1074,7 +1077,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "5"
                 },
                 "edge": {
                   "version_added": "14"
@@ -1099,7 +1102,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "5"
                 },
                 "edge": {
                   "version_added": "14"
@@ -1147,7 +1150,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "5"
                 },
                 "edge": {
                   "version_added": "14"
@@ -1174,7 +1177,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/TabStatus",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "5"
               },
               "edge": {
                 "version_added": "14"
@@ -1385,7 +1388,7 @@
             "support": {
               "chrome": {
                 "notes": "The default file format is 'jpeg'.",
-                "version_added": true
+                "version_added": "5"
               },
               "edge": {
                 "version_added": "15"
@@ -1419,7 +1422,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/connect",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "5"
               },
               "edge": {
                 "version_added": "79"
@@ -1474,7 +1477,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/create",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "5"
               },
               "edge": {
                 "version_added": "14"
@@ -1499,7 +1502,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "5"
                   },
                   "edge": {
                     "version_added": "14"
@@ -1567,7 +1570,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "5"
                   },
                   "edge": {
                     "version_added": "14"
@@ -1655,7 +1658,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "9"
                   },
                   "edge": {
                     "version_added": "79"
@@ -1680,7 +1683,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "5"
                   },
                   "edge": {
                     "version_added": "79"
@@ -1720,7 +1723,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "5"
                   },
                   "edge": {
                     "notes": "If the <code>url</code> has the 'ms-browser-extension://' protocol it is mistakenly considered a relative URL and the prefix is added redundantly, causing tab to fail loading.",
@@ -1748,7 +1751,7 @@
               "__compat": {
                 "support": {
                   "chrome": {
-                    "version_added": true
+                    "version_added": "5"
                   },
                   "edge": {
                     "version_added": "14"
@@ -1776,7 +1779,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/detectLanguage",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "5"
               },
               "edge": {
                 "version_added": "14"
@@ -1824,7 +1827,7 @@
                 "version_added": false
               },
               "opera": {
-                "version_added": true,
+                "version_added": "mirror",
                 "notes": [
                   "Only accepts a single tab ID as a parameter, not an array.",
                   "The tab ID argument is optional: if it is omitted, the browser discards the least important tab.",
@@ -1844,7 +1847,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/duplicate",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "23"
               },
               "edge": {
                 "version_added": "79"
@@ -1889,7 +1892,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "5"
                 },
                 "edge": {
                   "version_added": "79"
@@ -1916,7 +1919,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/executeScript",
             "support": {
               "chrome": {
-                "version_added": true,
+                "version_added": "5",
                 "notes": [
                   "Extensions can't inject scripts into their own pages using this API.",
                   "Available for use in Manifest V2 only."
@@ -2023,7 +2026,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/get",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "5"
               },
               "edge": {
                 "version_added": "14"
@@ -2049,7 +2052,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getAllInWindow",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "5"
               },
               "edge": {
                 "version_added": "79"
@@ -2073,7 +2076,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getCurrent",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "6"
               },
               "edge": {
                 "version_added": "14"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

A few apis are missing correct values for the `version_added` field.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://web.archive.org/web/20090918121259/http://code.google.com/chrome/extensions/tabs.html
https://web.archive.org/web/20160701175838if_/https://developer.chrome.com/extensions/tabs#type-MutedInfo
https://web.archive.org/web/20160701175838if_/https://developer.chrome.com/extensions/tabs#properties
https://web.archive.org/web/20160701175838if_/https://developer.chrome.com/extensions/tabs#property-Tab-active
https://web.archive.org/web/20160701175838if_/https://developer.chrome.com/extensions/tabs#property-Tab-highlighted
https://web.archive.org/web/20160701175838if_/https://developer.chrome.com/extensions/tabs#method-duplicate
https://web.archive.org/web/20180706052022/https://developer.chrome.com/extensions/whats_new
In this snapshot from Nov 22, 2011, there is no incognito property: https://web.archive.org/web/20111122231840/http://code.google.com/chrome/extensions/tabs.html
In this snapshot from Nov 30, 2011, the incognito property is present: https://web.archive.org/web/20111130085758/http://code.google.com/chrome/extensions/tabs.html
So I reason that the property was added in version 16 (stable release 2011-12-13).
sessionId in Firefox: https://searchfox.org/mozilla-central/rev/b303437fafc9d962e93f2322711355da25ed2a26/browser/components/extensions/ext-utils.js#708