### PR TITLE
FF110 ReadableStream is Async Iterable

### DIFF
--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -94,7 +94,7 @@
       },
       "async_iterable": {
         "__compat": {
-          "description": "Async iterable (supports <code>for await (const chunk of readableStream) {}</code>.",
+          "description": "Async iterable (<code>@@asyncIterator</code>)</code>",
           "spec_url": "https://streams.spec.whatwg.org/#rs-asynciterator",
           "support": {
             "chrome": {

--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -92,6 +92,46 @@
           }
         }
       },
+      "async_iterable": {
+        "__compat": {
+          "description": "Async iterable (supports <code>for await (const chunk of readableStream) {}</code>.",
+          "spec_url": "https://streams.spec.whatwg.org/#rs-asynciterator",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "110"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "cancel": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStream/cancel",


### PR DESCRIPTION
FF110 makes [ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) an async iterable in https://bugzilla.mozilla.org/show_bug.cgi?id=1734244. 

This means that you can iterate over a stream using the following construct:

```js
for await (const chunk of stream.values({ preventCancel: true })) { ... }
```

This is not supported in [chrome](https://bugs.chromium.org/p/chromium/issues/detail?id=929585) or [safari](https://bugs.webkit.org/show_bug.cgi?id=194379). Something similar appears to be in Nodejs and Deno, but not clear if that is "spec compliant". For now putting false.

Other docs for this can be tracked in https://github.com/mdn/content/issues/23678