### PR TITLE
FF110 RTCRtpEncodingParameters.active and RTCPeerConnection.addTransceiver() with sendEncodings

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -698,8 +698,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "notes": "<code>sendEncodings</code> is not yet implemented in Firefox. See <a href='https://bugzil.la/1396918'>bug 1396918</a>."
+                "version_added": "110"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/api/RTCRtpEncodingParameters.json
+++ b/api/RTCRtpEncodingParameters.json
@@ -47,7 +47,7 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "110"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF110 was brought up to spec around setting/getting parameters in https://bugzilla.mozilla.org/show_bug.cgi?id=1401592,  I'm splitting into bits because the code is a little complicated to review.

This PR covers:
- `RTCRtpEncodingParameters.active` 
- `RTCPeerConnection.addTransceiver()` supports `sendEncodings()` in init

Other docs work can be tracked in #23677