### PR TITLE
RTCRtpEncodingParameters.rid note is wrong

### DIFF
--- a/api/RTCRtpEncodingParameters.json
+++ b/api/RTCRtpEncodingParameters.json
@@ -98,7 +98,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -253,8 +253,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "46",
-              "notes": "The standard version of this property is <a href='https://developer.mozilla.org/docs/Web/API/RTCRtpCodecParameters/rid'><code>RTCRtpCodecParameters.rid</code></a>."
+              "version_added": "46"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -272,7 +271,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
`RTCRtpEncodingParameters` fixes
- `dtx` is marked as standard track, but is not in the standard.
-  `rid` had a note indicating "standard version in `RTCRtpCodecParameters`. Actually this is just in an undocumented parent class `RTCRtpCodingParameters`. That class has no independent existence so doesn't need docs, and this note isn't needed.
  - This is also "standard" so marked it as such.
  
 `fec`, `rtx`, `srcc` are all correctly marked as "non-standard". No docs on them, so not sure what value they add.

This is part of cleanup for https://github.com/mdn/content/issues/23677