### PR TITLE
color-gamut is supported in FF110

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -259,7 +259,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "110"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
Support for @media query's color-gamut has been added in Firefox 110 via https://bugzilla.mozilla.org/show_bug.cgi?id=1422237

MDN page: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/color-gamut

#### Related issues

Doc issue tracker: https://github.com/mdn/content/issues/23681