### PR TITLE
Chrome 111 supports the “of S” syntax in `:nth-child`

### DIFF
--- a/css/selectors/nth-child.json
+++ b/css/selectors/nth-child.json
@@ -83,8 +83,7 @@
             "description": "<code>of &lt;selector&gt;</code> syntax",
             "support": {
               "chrome": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/304163'>bug 304163</a>."
+                "version_added": "111"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
_(👋 Hi, Chrome DevRel here!)_

#### Summary

Chrome 111 supports the “of S” syntax in `:nth-child`

#### Test results and supporting details

- Chrome Platform Status: https://chromestatus.com/feature/5144225077788672
- Tracking Bug: https://bugs.chromium.org/p/chromium/issues/detail?id=304163
- Intent To Ship: https://groups.google.com/a/chromium.org/g/blink-dev/c/6zLouMDG4Eg

Note that the Chrome Platform Status currently reads “In developer trial (Behind a flag)”. This is incorrect and will get updated once the owner of the feature gets online. The last commit mentioned in the bug at https://bugs.chromium.org/p/chromium/issues/detail?id=304163#c40 confirms the feature is enabled by default. See https://chromium.googlesource.com/chromium/src/+/2fe97d46718cd42384ac6f3d507e33fb4b0f3045%5E%21/#F0 for the actual commit contents.
