### PR TITLE
shadowroot to shadowrootmode

### DIFF
--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -43,7 +43,7 @@
         "shadowrootmode": {
           "__compat": {
             "support": {
-              "chrome": [ 
+              "chrome": [
                 {
                   "version_added": "111"
                 },

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -44,15 +44,15 @@
           "__compat": {
             "support": {
               "chrome": [ 
-              {
-                "version_added": "111"
-              },
-              {
-                "version_added": "90",
-                "version_removed": "111",
-                "alternative_name": "shadowroot"
-              }
-            ],
+                {
+                  "version_added": "111"
+                },
+                {
+                  "version_added": "90",
+                  "version_removed": "111",
+                  "alternative_name": "shadowroot"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -40,12 +40,19 @@
             "deprecated": false
           }
         },
-        "shadowroot": {
+        "shadowrootmode": {
           "__compat": {
             "support": {
-              "chrome": {
-                "version_added": "90"
+              "chrome": [ 
+              {
+                "version_added": "111"
               },
+              {
+                "version_added": "90",
+                "version_removed": "111",
+                "alternative_name": "shadowroot"
+              }
+            ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -70,7 +77,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
In Chrome 111 the `shadowroot` attribute for `<template>` has been renamed to `shadowrootmode` to match the updated spec.

I've updated BCD here, making `shadowroot` an alternative name, and I'll add updating the docs to our worklist.

https://chromestatus.com/feature/5161240576393216