### PR TITLE
Add Firefox versions for api.SVGElement.autofocus

### DIFF
--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -86,7 +86,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "78",
+              "partial_implementation": true,
+              "notes": "Only supported on <code>SVGGraphicsElement</code>."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -85,11 +85,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "78",
-              "partial_implementation": true,
-              "notes": "Only supported on <code>SVGGraphicsElement</code>."
-            },
+            "firefox": [
+              {
+                "version_added": "110"
+              },
+              {
+                "version_added": "78",
+                "partial_implementation": true,
+                "notes": "Only supported on <code>SVGGraphicsElement</code>."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR adds real values for Firefox and Firefox Android for the `autofocus` member of the `SVGElement` API.  This fixes #18843.
