### PR TITLE
Add Chromium versions for api.WebGLRenderingContext.canvas

### DIFF
--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -817,7 +817,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "69"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -839,7 +839,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `canvas` member of the `WebGLRenderingContext` API, based upon manual testing.

Test Code Used: https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/canvas#offscreen_canvas

Fixes #18752.
