### PR TITLE
Chrome 111 supports the CSS trig functions

### DIFF
--- a/css/types/acos.json
+++ b/css/types/acos.json
@@ -8,7 +8,7 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-values/#trig-funcs",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "111"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/types/asin.json
+++ b/css/types/asin.json
@@ -8,7 +8,7 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-values/#trig-funcs",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "111"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/types/atan.json
+++ b/css/types/atan.json
@@ -8,7 +8,7 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-values/#trig-funcs",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "111"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/types/atan2.json
+++ b/css/types/atan2.json
@@ -8,7 +8,7 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-values/#trig-funcs",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "111"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/types/cos.json
+++ b/css/types/cos.json
@@ -8,7 +8,7 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-values/#trig-funcs",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "111"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/types/sin.json
+++ b/css/types/sin.json
@@ -8,7 +8,7 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-values/#trig-funcs",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "111"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/types/tan.json
+++ b/css/types/tan.json
@@ -8,7 +8,7 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-values/#trig-funcs",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "111"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
_(👋 Hi, Chrome DevRel here!)_

#### Summary

Chrome 111 supports the CSS trig functions `sin()`, `cos()`, `tan()`, `asin()`, `acos()`, `atan()`, and `atan2()`

#### Test results and supporting details

- ChromeStatus: https://chromestatus.com/feature/5165381072191488
- Intent to Ship: https://groups.google.com/a/chromium.org/g/blink-dev/c/UiUVU722BbU/m/vQJy-qdpDAAJ
- Tracking Bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1190444
