### PR TITLE
Organize sandbox attribute values; add missing sandbox values

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -642,9 +642,7 @@
               "chrome": {
                 "version_added": "4"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -657,9 +655,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "5"
               },

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -672,305 +672,531 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        },
-        "sandbox-allow-downloads": {
-          "__compat": {
-            "description": "<code>sandbox=\"allow-downloads\"</code>",
-            "support": {
-              "chrome": {
-                "version_added": "83"
+          },
+          "allow-downloads": {
+            "__compat": {
+              "description": "<code>sandbox=\"allow-downloads\"</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "83"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "82"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "82"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "sandbox-allow-modals": {
-          "__compat": {
-            "description": "<code>sandbox=\"allow-modals\"</code>",
-            "support": {
-              "chrome": {
-                "version_added": "46"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "49"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "sandbox-allow-popups": {
-          "__compat": {
-            "description": "<code>sandbox=\"allow-popups\"</code>",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤18"
-              },
-              "firefox": {
-                "version_added": "28"
-              },
-              "firefox_android": {
-                "version_added": "27"
-              },
-              "ie": {
-                "version_added": null
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "sandbox-allow-popups-to-escape-sandbox": {
-          "__compat": {
-            "description": "<code>sandbox=\"allow-popups-to-escape-sandbox\"</code>",
-            "support": {
-              "chrome": {
-                "version_added": "46"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "49"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": {
-                "version_added": "32"
-              },
-              "opera_android": {
-                "version_added": "32"
-              },
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "sandbox-allow-presentation": {
-          "__compat": {
-            "description": "<code>sandbox=\"allow-presentation\"</code>",
-            "support": {
-              "chrome": {
-                "version_added": "53"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "50"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": null
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": false
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
             }
-          }
-        },
-        "sandbox-allow-same-origin": {
-          "__compat": {
-            "description": "<code>sandbox=\"allow-same-origin\"</code>",
-            "support": {
-              "chrome": {
-                "version_added": true,
-                "notes": "Chrome 70 and earlier block script execution without <code>allow-scripts</code>, even if <code>allow-same-origin</code> is set. For example, any bound handlers for click events of nodes inside an iframe throw an error for blocked script execution."
+          },
+          "allow-downloads-without-user-activation": {
+            "__compat": {
+              "description": "<code>sandbox=\"allow-downloads-without-user-activation\"</code>",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
               },
-              "chrome_android": {
-                "version_added": true
-              },
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": true
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": true
-              },
-              "oculus": "mirror",
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": true,
-                "notes": "Safari blocks script execution without <code>allow-scripts</code> even if <code>allow-same-origin</code> is set. For example, any bound handlers for click events of nodes inside an iframe throw an error for blocked script execution."
-              },
-              "safari_ios": {
-                "version_added": true
-              },
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
-          }
-        },
-        "sandbox-allow-storage-access-by-user-activation": {
-          "__compat": {
-            "description": "<code>sandbox=\"allow-storage-access-by-user-activation\"</code>",
-            "support": {
-              "chrome": {
-                "version_added": false
+          },
+          "allow-forms": {
+            "__compat": {
+              "description": "<code>sandbox=\"allow-forms\"</code>",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "65",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.storage_access.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "11.1"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": false,
-              "deprecated": false
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
-          }
-        },
-        "sandbox-allow-top-navigation-by-user-activation": {
-          "__compat": {
-            "description": "<code>sandbox=\"allow-top-navigation-by-user-activation\"</code>",
-            "support": {
-              "chrome": {
-                "version_added": "58"
+          },
+          "allow-modals": {
+            "__compat": {
+              "description": "<code>sandbox=\"allow-modals\"</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "46"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "49"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "79"
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "allow-orientation-lock": {
+            "__compat": {
+              "description": "<code>sandbox=\"allow-orientation-lock\"</code>",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
               },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "allow-pointer-lock": {
+            "__compat": {
+              "description": "<code>sandbox=\"allow-pointer-lock\"</code>",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
               },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "11.1",
-                "notes": "Not initially available in 11.1, but added in sub-version 13605.1.33.1.2."
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "allow-popups": {
+            "__compat": {
+              "description": "<code>sandbox=\"allow-popups\"</code>",
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "chrome_android": "mirror",
+                "edge": {
+                  "version_added": "≤18"
+                },
+                "firefox": {
+                  "version_added": "28"
+                },
+                "firefox_android": {
+                  "version_added": "27"
+                },
+                "ie": {
+                  "version_added": null
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": {
+                  "version_added": null
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
               },
-              "safari_ios": {
-                "version_added": null
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "allow-popups-to-escape-sandbox": {
+            "__compat": {
+              "description": "<code>sandbox=\"allow-popups-to-escape-sandbox\"</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "46"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "49"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": {
+                  "version_added": "32"
+                },
+                "opera_android": {
+                  "version_added": "32"
+                },
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
               },
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "allow-presentation": {
+            "__compat": {
+              "description": "<code>sandbox=\"allow-presentation\"</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "53"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "50"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": {
+                  "version_added": false
+                }
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "allow-same-origin": {
+            "__compat": {
+              "description": "<code>sandbox=\"allow-same-origin\"</code>",
+              "support": {
+                "chrome": {
+                  "version_added": true,
+                  "notes": "Chrome 70 and earlier block script execution without <code>allow-scripts</code>, even if <code>allow-same-origin</code> is set. For example, any bound handlers for click events of nodes inside an iframe throw an error for blocked script execution."
+                },
+                "chrome_android": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": true
+                },
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": true
+                },
+                "oculus": "mirror",
+                "opera": {
+                  "version_added": true
+                },
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": true,
+                  "notes": "Safari blocks script execution without <code>allow-scripts</code> even if <code>allow-same-origin</code> is set. For example, any bound handlers for click events of nodes inside an iframe throw an error for blocked script execution."
+                },
+                "safari_ios": {
+                  "version_added": true
+                },
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "allow-scripts": {
+            "__compat": {
+              "description": "<code>sandbox=\"allow-scripts\"</code>",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "allow-storage-access-by-user-activation": {
+            "__compat": {
+              "description": "<code>sandbox=\"allow-storage-access-by-user-activation\"</code>",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "65",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.storage_access.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "11.1"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": false,
+                "deprecated": false
+              }
+            }
+          },
+          "allow-top-navigation": {
+            "__compat": {
+              "description": "<code>sandbox=\"allow-top-navigation\"</code>",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "allow-top-navigation-by-user-activation": {
+            "__compat": {
+              "description": "<code>sandbox=\"allow-top-navigation-by-user-activation\"</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "58"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "79"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "11.1"
+                },
+                "safari_ios": {
+                  "version_added": null
+                },
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "allow-top-navigation-to-custom-protocols": {
+            "__compat": {
+              "description": "<code>sandbox=\"allow-top-navigation-to-custom-protocols\"</code>",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": null
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         },

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -672,6 +672,7 @@
           "allow-downloads": {
             "__compat": {
               "description": "<code>sandbox=\"allow-downloads\"</code>",
+              "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-downloads",
               "support": {
                 "chrome": {
                   "version_added": "83"
@@ -730,14 +731,15 @@
               },
               "status": {
                 "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+                "standard_track": false,
+                "deprecated": true
               }
             }
           },
           "allow-forms": {
             "__compat": {
               "description": "<code>sandbox=\"allow-forms\"</code>",
+              "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-forms",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -771,6 +773,7 @@
           "allow-modals": {
             "__compat": {
               "description": "<code>sandbox=\"allow-modals\"</code>",
+              "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-modals",
               "support": {
                 "chrome": {
                   "version_added": "46"
@@ -804,6 +807,7 @@
           "allow-orientation-lock": {
             "__compat": {
               "description": "<code>sandbox=\"allow-orientation-lock\"</code>",
+              "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-orientation-lock",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -837,6 +841,7 @@
           "allow-pointer-lock": {
             "__compat": {
               "description": "<code>sandbox=\"allow-pointer-lock\"</code>",
+              "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-pointer-lock",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -870,6 +875,7 @@
           "allow-popups": {
             "__compat": {
               "description": "<code>sandbox=\"allow-popups\"</code>",
+              "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-popups",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -909,6 +915,7 @@
           "allow-popups-to-escape-sandbox": {
             "__compat": {
               "description": "<code>sandbox=\"allow-popups-to-escape-sandbox\"</code>",
+              "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-popups-to-escape-sandbox",
               "support": {
                 "chrome": {
                   "version_added": "46"
@@ -946,6 +953,7 @@
           "allow-presentation": {
             "__compat": {
               "description": "<code>sandbox=\"allow-presentation\"</code>",
+              "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-presentation",
               "support": {
                 "chrome": {
                   "version_added": "53"
@@ -981,6 +989,7 @@
           "allow-same-origin": {
             "__compat": {
               "description": "<code>sandbox=\"allow-same-origin\"</code>",
+              "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-same-origin",
               "support": {
                 "chrome": {
                   "version_added": true,
@@ -1024,6 +1033,7 @@
           "allow-scripts": {
             "__compat": {
               "description": "<code>sandbox=\"allow-scripts\"</code>",
+              "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-scripts",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -1097,6 +1107,7 @@
           "allow-top-navigation": {
             "__compat": {
               "description": "<code>sandbox=\"allow-top-navigation\"</code>",
+              "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-top-navigation",
               "support": {
                 "chrome": {
                   "version_added": null
@@ -1130,6 +1141,7 @@
           "allow-top-navigation-by-user-activation": {
             "__compat": {
               "description": "<code>sandbox=\"allow-top-navigation-by-user-activation\"</code>",
+              "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-top-navigation-by-user-activation",
               "support": {
                 "chrome": {
                   "version_added": "58"
@@ -1165,6 +1177,7 @@
           "allow-top-navigation-to-custom-protocols": {
             "__compat": {
               "description": "<code>sandbox=\"allow-top-navigation-to-custom-protocols\"</code>",
+              "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-top-navigation-to-custom-protocols",
               "support": {
                 "chrome": {
                   "version_added": null


### PR DESCRIPTION
This PR organizes the `sandbox` attribute values of the `iframe` HTML element, as well as adds the missing attribute values.  Fixes #1208.
