### PR TITLE
FF CSS content-visibility behind pref

### DIFF
--- a/api/ContentVisibilityAutoStateChangeEvent.json
+++ b/api/ContentVisibilityAutoStateChangeEvent.json
@@ -11,7 +11,14 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "110"
+            "version_added": "110",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "layout.css.content-visibility.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/ContentVisibilityAutoStateChangeEvent.json
+++ b/api/ContentVisibilityAutoStateChangeEvent.json
@@ -35,7 +35,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }

--- a/api/ContentVisibilityAutoStateChangeEvent.json
+++ b/api/ContentVisibilityAutoStateChangeEvent.json
@@ -52,7 +52,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "110"
+              "version_added": "110",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.content-visibility.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -86,7 +93,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "110"
+              "version_added": "110",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.content-visibility.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -3188,7 +3188,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Element.json
+++ b/api/Element.json
@@ -3164,7 +3164,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "110"
+              "version_added": "110",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.content-visibility.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/content-visibility.json
+++ b/css/properties/content-visibility.json
@@ -36,7 +36,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/content-visibility.json
+++ b/css/properties/content-visibility.json
@@ -12,7 +12,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "109"
+              "version_added": "109",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.content-visibility.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
Fixes #18849

This updates `content-visibility` and the associated change event behind the preference `layout.css.content-visibility.enabled`, as reported in #18849 (and tested).
That makes the APIs experimental too, as are only implemented in Chromium on release builds by default.

This affects:
- https://github.com/mdn/content/issues/23687
- https://github.com/mdn/content/issues/22736
- #18848
