### PR TITLE
Add <form rel> browser support data

### DIFF
--- a/html/elements/form.json
+++ b/html/elements/form.json
@@ -349,6 +349,53 @@
             }
           }
         },
+        "rel": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "target": {
           "__compat": {
             "support": {

--- a/html/elements/form.json
+++ b/html/elements/form.json
@@ -353,7 +353,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "107"
+                "version_added": "108"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/html/elements/form.json
+++ b/html/elements/form.json
@@ -353,41 +353,26 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "107"
               },
-              "chrome_android": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "111"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15.4"
               },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": {
-                "version_added": false
-              },
-              "webview_android": {
-                "version_added": false
-              }
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
This PR is a reprise of #9130. Since then, all major browsers started supporting `<form rel>` attribute.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
Tested with Safari for iOS 15.4, Firefox 111a1, Chrome 110.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
* Safari
  * https://github.com/WebKit/WebKit/commit/a644f4f84dbfc94edf09759b1fd8619941dd41e8 
  * https://github.com/WebKit/WebKit/commit/82c4eeb93f2e140bf710266110410c66e9bc817d
* Firefox 
  * https://bugzilla.mozilla.org/show_bug.cgi?id=1509346 
  * https://www.mozilla.org/en-US/firefox/111.0a1/releasenotes/
* Chrome 
  * https://chromestatus.com/feature/5139812343349248
  * https://developer.chrome.com/blog/new-in-chrome-107/

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->
See more details at #9130.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
