### PR TITLE
Add missing subfeatures to webextensions.api.webRequest.ResourceType

### DIFF
--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -334,11 +334,53 @@
               }
             }
           },
+          "image": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "44"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "imageset": {
             "__compat": {
               "support": {
                 "chrome": {
                   "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "main_frame": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "44"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -376,6 +418,27 @@
               }
             }
           },
+          "object": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "44"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "object_subrequest": {
             "__compat": {
               "support": {
@@ -388,6 +451,27 @@
                   "notes": "Requests have been reported as <code>object_subrequest</code> before, but the type was missing in the <code>ResourceType</code> object before Firefox 55."
                 },
                 "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "other": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "44"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
                 "opera": "mirror",
                 "safari": {
                   "version_added": false
@@ -423,6 +507,27 @@
               }
             }
           },
+          "script": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "44"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "speculative": {
             "__compat": {
               "support": {
@@ -434,6 +539,48 @@
                   "version_added": "63"
                 },
                 "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "stylesheet": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "44"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "sub_frame": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "44"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
                 "opera": "mirror",
                 "safari": {
                   "version_added": false
@@ -511,6 +658,27 @@
               "support": {
                 "chrome": {
                   "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "xmlhttprequest": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "44"
                 },
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION
This PR adds the missing features for the `webRequest.ResourceType` webextensions API.  Fixes #1655.

(Note: all version numbers are speculative and are not confirmed.)
