### PR TITLE
New Edge 110 release information

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -248,7 +248,7 @@
         },
         "107": {
           "release_date": "2022-10-27",
-          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1070141824-october-27-2022",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1070141824-october-27-2022",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "107"
@@ -263,21 +263,28 @@
         "109": {
           "release_date": "2023-01-12",
           "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1090151849-january-12-2023",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "109"
         },
         "110": {
           "release_date": "2023-02-09",
-          "status": "beta",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1100158741-february-9-2023",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "110"
         },
         "111": {
           "release_date": "2023-03-09",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "111"
+        },
+        "112": {
+          "release_date": "2023-04-06",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "112"
         }
       }
     }


### PR DESCRIPTION
#### Summary

Edge 110 is out since yesterday. Here is the corresponding change to the edge.json file.
