### PR TITLE
Add NodeJS v12.6.0 to browser data

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -188,6 +188,13 @@
           "engine": "V8",
           "engine_version": "7.5"
         },
+        "12.6.0": {
+          "release_date": "2019-07-03",
+          "release_notes": "https://nodejs.org/en/blog/release/v12.6.0/",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "7.5"
+        },
         "12.9.0": {
           "release_date": "2019-08-20",
           "release_notes": "https://nodejs.org/en/blog/release/v12.9.0/",


### PR DESCRIPTION
This PR adds NodeJS v12.6.0 to the browser data.  This will unblock #18737.
