### PR TITLE
Add a note regarding backgrounds applied to `<thead>` elements

### DIFF
--- a/html/elements/thead.json
+++ b/html/elements/thead.json
@@ -28,7 +28,8 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": true,
+              "notes": "Backgrounds applied to <code>&lt;thead&gt;</code> elements will be applied to each table cell, rather than the entire header. To mimic the behavior of other browsers, set the <code>background-attachment</code> CSS property to <code>fixed</code>."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR adds a note regarding backgrounds applied to `<thead>` elements.  Fixes #5753.
