### PR TITLE
Add Chromium versions for svg.elements.title.tooltip_display

### DIFF
--- a/svg/elements/title.json
+++ b/svg/elements/title.json
@@ -66,7 +66,9 @@
               "safari": {
                 "version_added": "3"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "3"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/svg/elements/title.json
+++ b/svg/elements/title.json
@@ -49,7 +49,7 @@
             "description": "Tooltip display",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -64,7 +64,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": "3"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `tooltip_display` member of the `title` SVG element, based upon manual testing.

Test Code Used: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/title

Fixes #5893.
