### PR TITLE
Add ranged values for Chrome

### DIFF
--- a/test/linter/test-versions.ts
+++ b/test/linter/test-versions.ts
@@ -21,6 +21,7 @@ const { browsers } = bcd;
 const validBrowserVersions: { [browser: string]: string[] } = {};
 
 const VERSION_RANGE_BROWSERS: { [browser: string]: string[] } = {
+  chrome: ['≤15', '≤37'],
   edge: ['≤18', '≤79'],
   ie: ['≤6', '≤11'],
   opera: ['≤12.1', '≤15'],


### PR DESCRIPTION
This PR adds ranged values of ≤15 and ≤37 to Chrome.  These are the lowest versions available on BrowserStack and SauceLabs.
