### PR TITLE
Add versions for svg.attributes.presentation.vector-effect

### DIFF
--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -2104,7 +2104,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": null
+                "version_added": "15"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -2099,7 +2099,7 @@
             "spec_url": "https://svgwg.org/svg2-draft/coords.html#VectorEffects",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "12"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -2114,7 +2114,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": "5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR adds real values for Chrome, Safari and Firefox for the `vector-effect` member of the `presentation` SVG attributes.  The data comes from https://caniuse.com/vector-effect, and the Chrome version was guesstimated based upon engine version.  (I don't have access to my older VMs at the moment.)  Fixes #6022.
