### PR TITLE
Add compatibility data for scripting.ExecutionWorld

### DIFF
--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -2,6 +2,64 @@
   "webextensions": {
     "api": {
       "scripting": {
+        "ExecutionWorld": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting/ExecutionWorld",
+            "support": {
+              "chrome": {
+                "version_added": "102"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "102"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": "mirror"
+            }
+          },
+          "ISOLATED": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "102"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "102"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "15.4"
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "MAIN": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "102"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "15.4"
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          }
+        },
         "InjectionTarget": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting/InjectionTarget",
@@ -62,6 +120,25 @@
                 "safari_ios": "mirror"
               }
             }
+          },
+          "world": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "102"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
           }
         },
         "executeScript": {
@@ -106,7 +183,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "88"
+                  "version_added": "95"
                 },
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Fixes the incorrect and incomplete BCD for the "world" parameter of the scripting.executeScript API.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

References:

- "world" support introduced in Chrome 102 per https://chromium.googlesource.com/chromium/src/+/e5ad3451c17b21341b0b9019b074801c44c92c9f

- "world" + "ISOLATED" introduced in Firefox per https://bugzilla.mozilla.org/show_bug.cgi?id=1759932 While that bug was fixed in 100, the underlying feature was not available until it was enabled in MV2 - https://bugzilla.mozilla.org/show_bug.cgi?id=1766615

  "MAIN" not supported yet in Firefox, part of https://bugzilla.mozilla.org/show_bug.cgi?id=1736575


#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Related to https://github.com/mdn/content/pull/24316 and https://github.com/mdn/content/issues/22493

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
