### PR TITLE
Correct supported Firefox versions of scripting API

### DIFF
--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -12,7 +12,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "101"
+                "version_added": "102"
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -33,7 +33,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "101"
+                "version_added": "102"
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -51,8 +51,11 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "101",
-                  "notes": "Prior to Firefox 105, <code>true</code>, to indicate a script is persistent, was not supported."
+                  "version_added": "102",
+                  "notes": [
+                    "Since Firefox 105, this option is optional and accepts any boolean value.",
+                    "Prior to Firefox 105, this option was required and only accepted the <code>false</code> value."
+                  ]
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -73,7 +76,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "101"
+                "version_added": "102"
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -91,7 +94,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "101"
+                  "version_added": "102"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -110,7 +113,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "101",
+                  "version_added": "102",
                   "notes": "Only supports <code>ISOLATED</code>, not <code>MAIN</code>."
                 },
                 "firefox_android": "mirror",
@@ -132,7 +135,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "101"
+                "version_added": "102"
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -152,7 +155,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "101"
+                "version_added": "102"
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -170,7 +173,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "101"
+                  "version_added": "102"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -191,7 +194,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "101"
+                "version_added": "102"
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -211,7 +214,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "101"
+                "version_added": "102"
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -229,7 +232,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "101"
+                  "version_added": "102"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -250,7 +253,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "101"
+                "version_added": "102"
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -258,26 +261,6 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
-            }
-          },
-          "persistAcrossSessions": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "88"
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "101",
-                  "notes": "Only <code>false</code> is supported. Support for <code>true</code> will be introduced in <a href='https://bugzil.la/1751436'>bug 1751436</a>."
-                },
-                "firefox_android": "mirror",
-                "opera": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror"
-              }
             }
           }
         },
@@ -290,7 +273,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "101"
+                "version_added": "102"
               },
               "firefox_android": "mirror",
               "opera": "mirror",


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

The first release with support for the scripting API is 102, not 101. This PR fixes that.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

The first release with support for the scripting API is 102 - by https://bugzilla.mozilla.org/show_bug.cgi?id=1766615

The implementations landed before, but restricted to MV3, whose support was not enabled until Firefox 109 -
https://bugzilla.mozilla.org/show_bug.cgi?id=1801291

Also fixed the compat note for the persistAcrossSessions flag, whose implementation completed in
https://bugzilla.mozilla.org/show_bug.cgi?id=1751436

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

I already used the correct Firefox version in missing properties documented in #18878 .

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
