### PR TITLE
Update ping-other-repos workflow

### DIFF
--- a/.github/workflows/ping-other-repos.yml
+++ b/.github/workflows/ping-other-repos.yml
@@ -1,4 +1,12 @@
 name: Ping other repos
+# This workflow exists for this use case: When another repo wants to take
+# some action each time an MDN PR is merged and a change is pushed to the
+# MDN main branch. For example, other repos that pull in content directly
+# from MDN as part of their own builds might want to automatically re-run
+# their repo build scripts each time a change is pushed to MDN upstream.
+#
+# https://github.com/mdn/content/blob/main/.github/workflows/ping-other-repos.yml
+# has the MDN content equivalent of this workflow.
 
 on:
   push:
@@ -11,11 +19,15 @@ permissions:
 jobs:
   ping:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    # Don't run in forks, or when Dependabot merges a PR.
+    if: |
+      github.repository == 'mdn/content' &&
+      github.triggering_actor != 'dependabot[bot]'
     steps:
-      - name: Repository Dispatch
+      - name: Ping w3c/mdn-spec-links
+        # This is one of many possible repos we can ping. When adding other
+        # repos, you can follow this w3c/mdn-spec-links one as an example.
         uses: peter-evans/repository-dispatch@v2
-        if: ${{ github.repository == 'mdn/browser-compat-data' }}
         with:
           token: ${{ secrets.SIDESHOWBARKER }}
           repository: w3c/mdn-spec-links


### PR DESCRIPTION
This PR updates the `ping-other-repos` workflow to include comments and formatting just like what `mdn/content` has.
