### PR TITLE
Remove erroneous note from css.properties.background-clip.text

### DIFF
--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -168,7 +168,7 @@
               "chrome": {
                 "version_added": "3",
                 "partial_implementation": true,
-                "notes": "This value is supported with the prefixed version of the property only."
+                "notes": "The <code>text</code> value is only supported by <code>-webkit-background-clip</code> (and not by <code>background-clip</code>)."
               },
               "chrome_android": "mirror",
               "edge": [
@@ -198,7 +198,7 @@
                 {
                   "version_added": "4",
                   "partial_implementation": true,
-                  "notes": "This value is supported with the prefixed version of the property only."
+                  "notes": "The <code>text</code> value is only supported by <code>-webkit-background-clip</code> (and not by <code>background-clip</code>)."
                 }
               ],
               "safari_ios": "mirror",

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -168,10 +168,7 @@
               "chrome": {
                 "version_added": "3",
                 "partial_implementation": true,
-                "notes": [
-                  "This value is supported with the prefixed version of the property only.",
-                  "According to the <a href='https://webkit.org/blog/164/background-clip-text/'>WebKit blog</a>, text decorations or shadows are not included in the clipping."
-                ]
+                "notes": "This value is supported with the prefixed version of the property only."
               },
               "chrome_android": "mirror",
               "edge": [
@@ -201,22 +198,12 @@
                 {
                   "version_added": "4",
                   "partial_implementation": true,
-                  "notes": [
-                    "This value is supported with the prefixed version of the property only.",
-                    "According to the <a href='https://webkit.org/blog/164/background-clip-text/'>WebKit blog</a>, text decorations or shadows are not included in the clipping."
-                  ]
+                  "notes": "This value is supported with the prefixed version of the property only."
                 }
               ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37",
-                "partial_implementation": true,
-                "notes": [
-                  "This value is supported with the prefixed version of the property only.",
-                  "According to the <a href='https://webkit.org/blog/164/background-clip-text/'>WebKit blog</a>, text decorations or shadows are not included in the clipping."
-                ]
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
This PR fixes #18884 by removing an incorrect note.  The note claims that text decorations and shadows aren't accounted by the property, but the blog it links to says the _exact opposite._
