### PR TITLE
Update subfeatures for css.properties.hyphens

### DIFF
--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -8,35 +8,21 @@
           "support": {
             "chrome": [
               {
-                "partial_implementation": true,
-                "version_added": "55",
-                "notes": "<code>auto</code> value is only supported on macOS and Android and for languages the OS provides hyphenation for."
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "13",
-                "notes": "Only <code>-webkit-hyphens: none</code> is supported."
-              }
-            ],
-            "chrome_android": [
-              {
                 "version_added": "55"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "18"
+                "version_added": "13"
               }
             ],
+            "chrome_android": "mirror",
             "edge": [
               {
-                "partial_implementation": true,
-                "version_added": "79",
-                "notes": "<code>auto</code> value is only supported on macOS and Android and for languages the OS provides hyphenation for."
+                "version_added": "79"
               },
               {
                 "prefix": "-webkit-",
-                "version_added": "79",
-                "notes": "Only <code>-webkit-hyphens: none</code> is supported."
+                "version_added": "79"
               },
               {
                 "prefix": "-ms-",
@@ -52,8 +38,7 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "6",
-                "notes": "Automatic hyphenation only works for languages with hyphenation dictionaries that are integrated into Firefox."
+                "version_added": "6"
               }
             ],
             "firefox_android": "mirror",
@@ -64,14 +49,8 @@
               "notes": "Only works if the specified language is the same as the language of the underlying OS."
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "44",
-              "partial_implementation": true,
-              "notes": "<code>auto</code> value is only supported on macOS and Android."
-            },
-            "opera_android": {
-              "version_added": "43"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "prefix": "-webkit-",
               "version_added": "5.1"
@@ -81,15 +60,7 @@
               "version_added": "4.2"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "55"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "4"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -97,7 +68,51 @@
             "deprecated": false
           }
         },
-        "afrikaans": {
+        "auto_value": {
+          "__compat": {
+            "description": "Support for the <code>auto</code> value",
+            "support": {
+              "chrome": [
+                {
+                  "version_added": "88"
+                },
+                {
+                  "version_added": "55",
+                  "partial_implementation": true,
+                  "notes": "Only supported on macOS."
+                }
+              ],
+              "chrome_android": {
+                "version_added": "55"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "6"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "5.1"
+              },
+              "safari_ios": {
+                "version_added": "4.2"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_afrikaans": {
           "__compat": {
             "description": "Hyphenation dictionary for Afrikaans (af, af-*)",
             "support": {
@@ -130,7 +145,7 @@
             }
           }
         },
-        "bosnian": {
+        "language_bosnian": {
           "__compat": {
             "description": "Hyphenation dictionary for Bosnian, Serbian, and Serbo-Croatian (sh, sh-*, sr, sr-*, bs, bs-*)",
             "support": {
@@ -163,7 +178,7 @@
             }
           }
         },
-        "bulgarian": {
+        "language_bulgarian": {
           "__compat": {
             "description": "Hyphenation dictionary for Bulgarian (bg, bg-*)",
             "support": {
@@ -196,7 +211,7 @@
             }
           }
         },
-        "catalan": {
+        "language_catalan": {
           "__compat": {
             "description": "Hyphenation dictionary for Catalan (ca, ca-*)",
             "support": {
@@ -229,7 +244,7 @@
             }
           }
         },
-        "croatian": {
+        "language_croatian": {
           "__compat": {
             "description": "Hyphenation dictionary for Croatian (hr, hr-*)",
             "support": {
@@ -262,7 +277,7 @@
             }
           }
         },
-        "czech": {
+        "language_czech": {
           "__compat": {
             "description": "Hyphenation dictionary for Czech (cs, cs-*)",
             "support": {
@@ -295,7 +310,7 @@
             }
           }
         },
-        "danish": {
+        "language_danish": {
           "__compat": {
             "description": "Hyphenation dictionary for Danish (da, da-*)",
             "support": {
@@ -328,7 +343,7 @@
             }
           }
         },
-        "dutch": {
+        "language_dutch": {
           "__compat": {
             "description": "Hyphenation dictionary for Dutch (nl, nl-*)",
             "support": {
@@ -361,7 +376,7 @@
             }
           }
         },
-        "english": {
+        "language_english": {
           "__compat": {
             "description": "Hyphenation dictionary for English (en, en-*)",
             "support": {
@@ -402,7 +417,7 @@
             }
           }
         },
-        "esperanto": {
+        "language_esperanto": {
           "__compat": {
             "description": "Hyphenation dictionary for Esperanto (eo, eo-*)",
             "support": {
@@ -435,7 +450,7 @@
             }
           }
         },
-        "estonian": {
+        "language_estonian": {
           "__compat": {
             "description": "Hyphenation dictionary for Estonian (et, et-*)",
             "support": {
@@ -468,7 +483,7 @@
             }
           }
         },
-        "finish": {
+        "language_finish": {
           "__compat": {
             "description": "Hyphenation dictionary for Finnish (fi, fi-*)",
             "support": {
@@ -501,7 +516,7 @@
             }
           }
         },
-        "french": {
+        "language_french": {
           "__compat": {
             "description": "Hyphenation dictionary for French (fr, fr-*)",
             "support": {
@@ -534,7 +549,7 @@
             }
           }
         },
-        "galician": {
+        "language_galician": {
           "__compat": {
             "description": "Hyphenation dictionary for Galician (gl, gl-*)",
             "support": {
@@ -567,7 +582,7 @@
             }
           }
         },
-        "german_reformed_orthography": {
+        "language_german_reformed_orthography": {
           "__compat": {
             "description": "Hyphenation dictionary for German, Reformed Orthography of 1996 (de, de-1996, de-DE, de-AT, de-*)",
             "support": {
@@ -600,7 +615,7 @@
             }
           }
         },
-        "german_swiss_orthography": {
+        "language_german_swiss_orthography": {
           "__compat": {
             "description": "Hyphenation dictionary for German, Swiss Orthography (de-CH, de-CH-*)",
             "support": {
@@ -633,7 +648,7 @@
             }
           }
         },
-        "german_traditional_orthography": {
+        "language_german_traditional_orthography": {
           "__compat": {
             "description": "Hyphenation dictionary for German, Traditional Orthography of 1901 (de-1901, de-AT-1901, de-DE-1901)",
             "support": {
@@ -666,7 +681,7 @@
             }
           }
         },
-        "hungarian": {
+        "language_hungarian": {
           "__compat": {
             "description": "Hyphenation dictionary for Hungarian (hu, hu-*)",
             "support": {
@@ -699,7 +714,7 @@
             }
           }
         },
-        "icelandic": {
+        "language_icelandic": {
           "__compat": {
             "description": "Hyphenation dictionary for Icelandic (is, is-*)",
             "support": {
@@ -732,7 +747,7 @@
             }
           }
         },
-        "interlingua": {
+        "language_interlingua": {
           "__compat": {
             "description": "Hyphenation dictionary for Interlingua (ia, ia-*)",
             "support": {
@@ -765,7 +780,7 @@
             }
           }
         },
-        "italian": {
+        "language_italian": {
           "__compat": {
             "description": "Hyphenation dictionary for Italian (it, it-*)",
             "support": {
@@ -798,7 +813,7 @@
             }
           }
         },
-        "kurmanji": {
+        "language_kurmanji": {
           "__compat": {
             "description": "Hyphenation dictionary for Kurmanji (kmr, kmr-*)",
             "support": {
@@ -831,7 +846,7 @@
             }
           }
         },
-        "latin": {
+        "language_latin": {
           "__compat": {
             "description": "Hyphenation dictionary for Latin (la, la-*)",
             "support": {
@@ -864,7 +879,7 @@
             }
           }
         },
-        "lithuanian": {
+        "language_lithuanian": {
           "__compat": {
             "description": "Hyphenation dictionary for Lithuanian (lt, lt-*)",
             "support": {
@@ -897,7 +912,7 @@
             }
           }
         },
-        "mongolian": {
+        "language_mongolian": {
           "__compat": {
             "description": "Hyphenation dictionary for Mongolian (mn, mn-*)",
             "support": {
@@ -930,7 +945,7 @@
             }
           }
         },
-        "norwegian_nn": {
+        "language_norwegian_nn": {
           "__compat": {
             "description": "Hyphenation dictionary for Norwegian (Nynorsk) (nn, nn-*)",
             "support": {
@@ -965,7 +980,7 @@
             }
           }
         },
-        "norwegian_no": {
+        "language_norwegian_no": {
           "__compat": {
             "description": "Hyphenation dictionary for Norwegian (Bokmål) (no, no-*, nb, nb-*)",
             "support": {
@@ -998,7 +1013,7 @@
             }
           }
         },
-        "polish": {
+        "language_polish": {
           "__compat": {
             "description": "Hyphenation dictionary for Polish (pl, pl-*)",
             "support": {
@@ -1031,7 +1046,7 @@
             }
           }
         },
-        "portuguese": {
+        "language_portuguese": {
           "__compat": {
             "description": "Hyphenation dictionary for Portuguese (pt, pt-*)",
             "support": {
@@ -1064,7 +1079,7 @@
             }
           }
         },
-        "portuguese_brazilian": {
+        "language_portuguese_brazilian": {
           "__compat": {
             "description": "Hyphenation dictionary for Brazilian Portuguese (pt-BR)",
             "support": {
@@ -1098,7 +1113,7 @@
             }
           }
         },
-        "russian": {
+        "language_russian": {
           "__compat": {
             "description": "Hyphenation dictionary for Russian (ru, ru-*)",
             "support": {
@@ -1131,7 +1146,7 @@
             }
           }
         },
-        "slovenian": {
+        "language_slovenian": {
           "__compat": {
             "description": "Hyphenation dictionary for Slovenian (sl, sl-*)",
             "support": {
@@ -1164,7 +1179,7 @@
             }
           }
         },
-        "spanish": {
+        "language_spanish": {
           "__compat": {
             "description": "Hyphenation dictionary for Spanish (es, es-*)",
             "support": {
@@ -1197,7 +1212,7 @@
             }
           }
         },
-        "swedish": {
+        "language_swedish": {
           "__compat": {
             "description": "Hyphenation dictionary for Swedish (sv, sv-*)",
             "support": {
@@ -1230,7 +1245,7 @@
             }
           }
         },
-        "turkish": {
+        "language_turkish": {
           "__compat": {
             "description": "Hyphenation dictionary for Turkish (tr, tr-*)",
             "support": {
@@ -1263,7 +1278,7 @@
             }
           }
         },
-        "ukrainian": {
+        "language_ukrainian": {
           "__compat": {
             "description": "Hyphenation dictionary for Ukrainian (uk, uk-*)",
             "support": {
@@ -1296,7 +1311,7 @@
             }
           }
         },
-        "upper_sorbian": {
+        "language_upper_sorbian": {
           "__compat": {
             "description": "Hyphenation dictionary for Upper Sorbian (hsb, hsb-*)",
             "support": {
@@ -1329,7 +1344,7 @@
             }
           }
         },
-        "welsh": {
+        "language_welsh": {
           "__compat": {
             "description": "Hyphenation dictionary for Welsh (cy, cy-*)",
             "support": {


### PR DESCRIPTION
This PR updates the subfeatures for the `hyphens` CSS property in two ways:

- Adds an `auto_value` property, moving the data from notes to this property (fixes #8809)
- Prefixes all languages with `language_` to keep them together in sorting whilst adding a bit more description to the keys
