### PR TITLE
Update notes for api.MediaDevices.getDisplayMedia

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -147,7 +147,7 @@
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/487935'>bug 487935</a>."
+              "notes": "From Chrome Android 72 to 88, this method was exposed, but always failed with <code>NotAllowedError</code>. See <a href='https://crbug.com/487935'>bug 487935</a>."
             },
             "edge": [
               {
@@ -172,7 +172,7 @@
             ],
             "firefox_android": {
               "version_added": false,
-              "notes": "API is available, but will always fail with <code>NotAllowedError</code>."
+              "notes": "From Firefox Android 66 to 79, this method was exposed, but always failed with <code>NotAllowedError</code>."
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates the notes for `MediaDevices.getDisplayMedia()` to better reflect the history of the method on Android, should we ever use automated testing to determine their support.  Fixes #8821.
