### PR TITLE
Add Safari versions for html.elements.input.type_range.tick_marks

### DIFF
--- a/html/elements/input/range.json
+++ b/html/elements/input/range.json
@@ -80,7 +80,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "12.1"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `type_range.tick_marks` member of the `input` HTML element, based upon manual testing.

Test Code Used: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#adding_tick_marks

FIxes #9867.