### PR TITLE
Add Safari versions for css.types.image.gradient.radial-gradient.at

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -734,7 +734,7 @@
                     }
                   ],
                   "safari": {
-                    "version_added": false
+                    "version_added": "7"
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `gradient.radial-gradient.at` member of the `image` CSS type, based upon manual testing.

Test Code Used: `background: radial-gradient(ellipse at top, #e66465, transparent), radial-gradient(ellipse at bottom, #4d9f0c, transparent);`

Fixes #10015.
