### PR TITLE
Add Safari versions for css.properties.tab-size.length

### DIFF
--- a/css/properties/tab-size.json
+++ b/css/properties/tab-size.json
@@ -84,7 +84,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "13.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `length` member of the `tab-size` CSS property.  The data comes from https://caniuse.com/css3-tabsize.  Fixes #10642.
