### PR TITLE
Add Chromium versions for css.properties.list-style-type.disclosure-closed/disclosure-open

### DIFF
--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -736,7 +736,7 @@
             "description": "<code>disclosure-closed</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "89"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -769,7 +769,7 @@
             "description": "<code>disclosure-open</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "89"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR adds real values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `disclosure-closed/disclosure-open` members of the `list-style-type` CSS property.  This fixes #11131, which is where the data comes from.
