### PR TITLE
Add Safari versions for css.properties.gap.multicol_context

### DIFF
--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -223,7 +223,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "14.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR adds real values for Safari (Desktop and iOS/iPadOS) for the `multicol_context` member of the `gap` CSS property.  This PR fixes #11165, which is where the data comes from.
