### PR TITLE
Add note regarding Windows key not being meta key in KeyboardEvent

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -1046,7 +1046,8 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1.5"
+              "version_added": "1.5",
+              "notes": "Since Firefox 48, the Windows key is no longer treated as a <code>meta</code> key."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR adds a note stating that the Windows key is no longer treated as the meta key starting with Firefox 48.  Fixes #11537.
