### PR TITLE
Add partial support for input type color list attribute in FF110

### DIFF
--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -107,8 +107,7 @@
                   "notes": "See <a href='https://bugzil.la/1805397'>bug 1805397</a> for the status of support for the list attribute in Firefox."
                 }
                 "ie": {
-                  "version_added": false,
-                  "notes":
+                  "version_added": false
                 },
                 "oculus": "mirror",
                 "opera": {

--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -62,10 +62,7 @@
                   "version_added": false,
                   "notes": "See <a href='https://bugzil.la/960989'>bug 960989</a> for the status of support for the <code>autocomplete</code> attribute in Firefox."
                 },
-                "firefox_android": {
-                  "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/960984'>bug 960984</a> for the status of support for the <code>list</code> attribute in Firefox."
-                },
+                "firefox_android": "mirror",
                 "ie": {
                   "version_added": false
                 },
@@ -101,12 +98,17 @@
                   "version_added": "14"
                 },
                 "firefox": {
-                  "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/960984'>bug 960984</a> for the status of support for the <code>list</code> attribute in Firefox."
+                  "version_added": "110",
+                  "partial_implementation": true,
+                  "notes": "The <code>list</code> attribute is supported in Firefox for Windows and Linux. See <a href='https://bugzil.la/960984'>bug 960984</a>."
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugzil.la/1805397'>bug 1805397</a> for the status of support for the list attribute in Firefox."
+                }
                 "ie": {
-                  "version_added": false
+                  "version_added": false,
+                  "notes":
                 },
                 "oculus": "mirror",
                 "opera": {

--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -105,7 +105,7 @@
                 "firefox_android": {
                   "version_added": false,
                   "notes": "See <a href='https://bugzil.la/1805397'>bug 1805397</a> for the status of support for the list attribute in Firefox."
-                }
+                },
                 "ie": {
                   "version_added": false
                 },


### PR DESCRIPTION
Support for `list` attribute of `<input type="color">` element has been added in Firefox 110 via https://bugzilla.mozilla.org/show_bug.cgi?id=960984.

However, this fix only adds support in Firefox on Windows and Linux.

The implementation on Android and macOS is still pending (https://bugzilla.mozilla.org/show_bug.cgi?id=1805397).

This pull request makes the following changes:
- For the ["type_color.list" entry in the BCD table](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#browser_compatibility):
  - adds partial implementation flag with link to the bug 960984 for "firefox". The note also calls out the current support in Windows and Linux only.
  - replaces `"mirror"` with `"version_added": false` for "firefox_android" and adds link to the related bug (1805397).

    I am hoping this would be the way to reflect the current support. 

- For the ["type_color.autocomplete" entry in the BCD table](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#browser_compatibility):
  - fixes the entry for "firefox_android" because it was pointing to the `list` attribute. 

### Related
MDN page: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#browser_compatibility

Doc issue tracker: https://github.com/mdn/content/issues/23684