### PR TITLE
FF111 OPFS Released

### DIFF
--- a/api/StorageManager.json
+++ b/api/StorageManager.json
@@ -111,21 +111,9 @@
               "version_added": "109"
             },
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "97",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.fs.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "111"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
FF111 turns on the `dom.fs.enabled` preference in https://bugzilla.mozilla.org/show_bug.cgi?id=1811001 (in FF110 this was added in #18723)

Other docs work for this can be tracked in #24388

FYI @queengooborg Dunno if you want to hold off on merging this since FF110 just came out, and FF111 isn't released until next month.