### PR TITLE
FF99 Remove pref media.peerconnection.rtpsourcesapi.enable

### DIFF
--- a/api/RTCRtpContributingSource.json
+++ b/api/RTCRtpContributingSource.json
@@ -13,7 +13,7 @@
             "version_added": "≤79"
           },
           "firefox": {
-            "version_added": "99"
+            "version_added": "59"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -50,7 +50,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "99"
+              "version_added": "59"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -86,7 +86,7 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "99"
+              "version_added": "59"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -126,7 +126,7 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "99",
+              "version_added": "59",
               "notes": "Starting in version 60, the <code>timestamp</code> is correctly computed based on the window's <code>Performance</code> time, rather than <code>Date.getTime()</code>."
             },
             "firefox_android": "mirror",

--- a/api/RTCRtpContributingSource.json
+++ b/api/RTCRtpContributingSource.json
@@ -13,14 +13,7 @@
             "version_added": "≤79"
           },
           "firefox": {
-            "version_added": "59",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "media.peerconnection.rtpsourcesapi.enable",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "99"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -57,14 +50,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.peerconnection.rtpsourcesapi.enable",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "99"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -100,14 +86,7 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.peerconnection.rtpsourcesapi.enable",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "99"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -147,14 +126,7 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.peerconnection.rtpsourcesapi.enable",
-                  "value_to_set": "true"
-                }
-              ],
+              "version_added": "99",
               "notes": "Starting in version 60, the <code>timestamp</code> is correctly computed based on the window's <code>Performance</code> time, rather than <code>Date.getTime()</code>."
             },
             "firefox_android": "mirror",

--- a/api/RTCRtpSynchronizationSource.json
+++ b/api/RTCRtpSynchronizationSource.json
@@ -11,14 +11,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "59",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "media.peerconnection.rtpsourcesapi.enable",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "99"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -50,14 +43,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "59",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "media.peerconnection.rtpsourcesapi.enable",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "99"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/RTCRtpSynchronizationSource.json
+++ b/api/RTCRtpSynchronizationSource.json
@@ -11,7 +11,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "99"
+            "version_added": "59"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -43,7 +43,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "99"
+              "version_added": "59"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF99 lost the config option `media.peerconnection.rtpsourcesapi.enable` https://bugzilla.mozilla.org/show_bug.cgi?id=1749802 

But I bisected and this showed that this was ALWAYS set true - ie. the preference was pointless. Checked later and earlier versions.

Discovered while looking into https://github.com/mdn/content/issues/24397