### PR TITLE
Fix MDN URL for keyword transparent

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -1070,7 +1070,7 @@
         "transparent": {
           "__compat": {
             "description": "<code>transparent</code> keyword",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value#transparent",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/named-color#transparent",
             "spec_url": "https://w3c.github.io/csswg-drafts/css-color/#transparent-color",
             "support": {
               "chrome": {


### PR DESCRIPTION
We moved it last year as part of our INTEROP2022 work.