### PR TITLE
fix(workflows): correct the target repo

### DIFF
--- a/.github/workflows/ping-other-repos.yml
+++ b/.github/workflows/ping-other-repos.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     # Don't run in forks, or when Dependabot merges a PR.
     if: |
-      github.repository == 'mdn/content' &&
+      github.repository == 'mdn/browser-compat-data' &&
       github.triggering_actor != 'dependabot[bot]'
     steps:
       - name: Ping w3c/mdn-spec-links


### PR DESCRIPTION
#### Summary

We should ping another repo when push commits to main branch of this repo, not mdn/content.
