### PR TITLE
Add mdn_url for DocumentFragment.getElementById

### DIFF
--- a/api/DocumentFragment.json
+++ b/api/DocumentFragment.json
@@ -224,6 +224,7 @@
       },
       "getElementById": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentFragment/getElementById",
           "spec_url": "https://dom.spec.whatwg.org/#dom-nonelementparentnode-getelementbyid",
           "support": {
             "chrome": {


### PR DESCRIPTION
We are adding this missing page in mdn/content#24449.

This links it from bcd.