### PR TITLE
Add mdn_url for FetchEvent.handled

### DIFF
--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -110,6 +110,7 @@
       },
       "handled": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FetchEvent/handled",
           "spec_url": "https://w3c.github.io/ServiceWorker/#dom-fetchevent-handled",
           "support": {
             "chrome": {


### PR DESCRIPTION
`Fetch.handled` is added to MDN in https://github.com/mdn/content/pull/24479