### PR TITLE
RemovalOptions.cookieStoreId is supported on Firefox for Android

### DIFF
--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -303,7 +303,8 @@
                   "version_added": "84"
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "84",
+                  "notes": "This option is currently limited to the <code>firefox-default</code> and <code>firefox-private</code> values."
                 },
                 "opera": "mirror",
                 "safari": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
While the option might not be doing much, it is definitely a supported property in `RemovalOptions` (and it might be already working with private browsing mode).

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
