### PR TITLE
Fix browser.browserSettings for Firefox for Android

### DIFF
--- a/webextensions/api/browserSettings.json
+++ b/webextensions/api/browserSettings.json
@@ -75,9 +75,7 @@
               "firefox": {
                 "version_added": "91"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
                 "version_added": false
@@ -118,9 +116,7 @@
                 "version_added": "72",
                 "notes": "From version 88, this setting is read-only (see <a href='https://bugzil.la/1626365'>bug 1626365</a>)."
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
                 "version_added": false
@@ -323,9 +319,7 @@
               "firefox": {
                 "version_added": "72"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
                 "version_added": false
@@ -385,9 +379,7 @@
               "firefox": {
                 "version_added": "75"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
                 "version_added": false
@@ -407,9 +399,7 @@
               "firefox": {
                 "version_added": "75"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

All but `closeTabsByDoubleClick` are supported in Android since they have been implemented at the same time as Desktop.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
