### PR TITLE
Update fetchpriority to match final spec

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -397,7 +397,7 @@
       "fetchPriority": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLImageElement/fetchPriority",
-          "spec_url": "https://wicg.github.io/priority-hints/#img",
+          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-fetchpriority",
           "support": {
             "chrome": [
               {
@@ -429,7 +429,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -237,7 +237,7 @@
       "fetchPriority": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/fetchPriority",
-          "spec_url": "https://wicg.github.io/priority-hints/#link",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-link-fetchpriority",
           "support": {
             "chrome": [
               {
@@ -269,7 +269,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -270,7 +270,7 @@
       },
       "fetchPriority": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/priority-hints/#script",
+          "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#attr-script-fetchpriority",
           "support": {
             "chrome": [
               {
@@ -302,7 +302,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Request.json
+++ b/api/Request.json
@@ -1068,7 +1068,7 @@
       },
       "priority": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/priority-hints/#fetch-integration",
+          "spec_url": "https://fetch.spec.whatwg.org/#dom-requestinit-priority",
           "support": {
             "chrome": {
               "version_added": "101"
@@ -1098,7 +1098,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -302,40 +302,6 @@
             }
           }
         },
-        "fetchpriority": {
-          "__compat": {
-            "spec_url": "https://wicg.github.io/priority-hints/#iframe",
-            "support": {
-              "chrome": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/1345601'>bug 1345601</a>."
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "frameborder": {
           "__compat": {
             "support": {

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -249,7 +249,7 @@
         },
         "fetchpriority": {
           "__compat": {
-            "spec_url": "https://wicg.github.io/priority-hints/#img",
+            "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-fetchpriority",
             "support": {
               "chrome": {
                 "version_added": "101"
@@ -276,7 +276,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -163,7 +163,7 @@
         },
         "fetchpriority": {
           "__compat": {
-            "spec_url": "https://wicg.github.io/priority-hints/#link",
+            "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-link-fetchpriority",
             "support": {
               "chrome": {
                 "version_added": "101"
@@ -190,7 +190,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -165,7 +165,7 @@
         },
         "fetchpriority": {
           "__compat": {
-            "spec_url": "https://wicg.github.io/priority-hints/#script",
+            "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#attr-script-fetchpriority",
             "support": {
               "chrome": {
                 "version_added": "101"
@@ -192,7 +192,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
#### Summary

This updates the `fetchpriority` HTML attribute and `priority` fetch option to match the final spec.

#### Test results and supporting details

Here is the [HTML spec PR](https://github.com/whatwg/html/pull/8470) and the [Fetch spec PR](https://github.com/whatwg/fetch/pull/1523).

The browser support matrix hasn't changed, it is just no longer experimental and the spec documenting them has changed.

