### PR TITLE
Add subfeature for the type of `click`, `auxclick`, `contextmenu` events

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2812,6 +2812,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "type_pointerevent": {
+          "__compat": {
+            "description": "Is a <code>PointerEvent</code>",
+            "support": {
+              "chrome": {
+                "version_added": "92"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "clientHeight": {
@@ -3261,6 +3294,39 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "type_pointerevent": {
+          "__compat": {
+            "description": "Is a <code>PointerEvent</code>",
+            "support": {
+              "chrome": {
+                "version_added": "92"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/Element.json
+++ b/api/Element.json
@@ -2285,6 +2285,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "type_pointerevent": {
+          "__compat": {
+            "description": "Is a <code>PointerEvent</code>",
+            "support": {
+              "chrome": {
+                "version_added": "92"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "before": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -2296,7 +2296,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1675847'>bug 1675847</a>."
               },
               "firefox_android": "mirror",
               "ie": {
@@ -2306,7 +2307,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/218665'>bug 218665</a>."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -2823,7 +2825,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1675847'>bug 1675847</a>."
               },
               "firefox_android": "mirror",
               "ie": {
@@ -2833,7 +2836,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/218665'>bug 218665</a>."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -3306,7 +3310,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1675847'>bug 1675847</a>."
               },
               "firefox_android": "mirror",
               "ie": {
@@ -3316,7 +3321,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "notes": "See <a href='https://webkit.org/b/218665'>bug 218665</a>."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Adds compat data describing whether `click`, `auxclick`, and `contextmenu` events are `MouseEvent`s or `PointerEvent`s.

The spec changed the type of these events from `MouseEvent` to `PointerEvent` in w3c/pointerevents#317.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

[Chromium feature page](https://chromestatus.com/feature/5670732015075328).

[Webkit tracking bug](https://webkit.org/b/218665).

[Firefox tracking bug](https://bugzil.la/1675847).