### PR TITLE
Update Firefox versions for api.AudioContext.AudioContext.options_latencyHint_parameter

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -165,7 +165,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "61"
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
@@ -175,7 +175,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
+                "version_added": "13.1> ≤14.1",
                 "notes": "See <a href='https://webkit.org/b/214258'>bug 214258</a>."
               },
               "safari_ios": "mirror",

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -175,7 +175,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "13.1> ≤14.1",
+                "version_added": false,
                 "notes": "See <a href='https://webkit.org/b/214258'>bug 214258</a>."
               },
               "safari_ios": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `AudioContext.options_latencyHint_parameter` member of the `AudioContext` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/AudioContext/AudioContext.options_latencyHint_parameter

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
