### PR TITLE
Update Safari versions for api.AudioContext.AudioContext.options_latencyHint_parameter

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -175,8 +175,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/214258'>bug 214258</a>."
+                "version_added": "14.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `AudioContext.options_latencyHint_parameter` member of the `AudioContext` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/AudioContext/AudioContext.options_latencyHint_parameter

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

---

Note: "14.1" is guesstimated from the collector's report of "13.1> ≤14.1", as I don't have access to Safari 14.0 at the moment.
