### PR TITLE
update spec link for `contentvisibilityautostatechange` event to refer to W3C specs mirror on GitHub Pages

### DIFF
--- a/api/ContentVisibilityAutoStateChangeEvent.json
+++ b/api/ContentVisibilityAutoStateChangeEvent.json
@@ -44,7 +44,7 @@
         "__compat": {
           "description": "<code>ContentVisibilityAutoStateChangeEvent()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ContentVisibilityAutoStateChangedEvent/ContentVisibilityAutoStateChangedEvent",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-contain-2/#contentvisibilityautostatechangeevent",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-contain-2/#dom-contentvisibilityautostatechangeevent-contentvisibilityautostatechangeevent",
           "support": {
             "chrome": {
               "version_added": "108"

--- a/api/ContentVisibilityAutoStateChangeEvent.json
+++ b/api/ContentVisibilityAutoStateChangeEvent.json
@@ -3,7 +3,7 @@
     "ContentVisibilityAutoStateChangeEvent": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ContentVisibilityAutoStateChangedEvent",
-        "spec_url": "https://www.w3.org/TR/css-contain-2/#content-visibility-auto-state-changed",
+        "spec_url": "https://w3c.github.io/csswg-drafts/css-contain-2/#content-visibility-auto-state-change",
         "support": {
           "chrome": {
             "version_added": "108"
@@ -44,7 +44,7 @@
         "__compat": {
           "description": "<code>ContentVisibilityAutoStateChangeEvent()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ContentVisibilityAutoStateChangedEvent/ContentVisibilityAutoStateChangedEvent",
-          "spec_url": "https://www.w3.org/TR/css-contain-2/#dom-contentvisibilityautostatechangedevent-contentvisibilityautostatechangedevent",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-contain-2/#contentvisibilityautostatechangeevent",
           "support": {
             "chrome": {
               "version_added": "108"
@@ -85,7 +85,7 @@
       "skipped": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ContentVisibilityAutoStateChangedEvent/skipped",
-          "spec_url": "https://www.w3.org/TR/css-contain-2/#dom-contentvisibilityautostatechangedevent-skipped",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-contain-2/#dom-contentvisibilityautostatechangeevent-skipped",
           "support": {
             "chrome": {
               "version_added": "108"

--- a/api/Element.json
+++ b/api/Element.json
@@ -3156,7 +3156,7 @@
         "__compat": {
           "description": "<code>contentvisibilityautostatechange</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/contentvisibilityautostatechanged_event",
-          "spec_url": "https://www.w3.org/TR/css-contain-2/#content-visibility-auto-state-changed",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-contain-2/#content-visibility-auto-state-change",
           "support": {
             "chrome": {
               "version_added": "108"


### PR DESCRIPTION

#### Summary

This is a followup for https://github.com/mdn/browser-compat-data/pull/18848

The CSSWG updaed the css-contain-2 editors' draft to incorporate name change I raised
https://github.com/mdn/browser-compat-data/issues/18847
https://github.com/w3c/csswg-drafts/pull/8413

The TR/contain-2 version updates less than Editors' drafts on GH. So I switched to the GH Pages link.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
