### PR TITLE
update link to MDN `ContentVisibilityAutoStateChangeEvent` pages

### DIFF
--- a/api/ContentVisibilityAutoStateChangeEvent.json
+++ b/api/ContentVisibilityAutoStateChangeEvent.json
@@ -2,7 +2,7 @@
   "api": {
     "ContentVisibilityAutoStateChangeEvent": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ContentVisibilityAutoStateChangedEvent",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/ContentVisibilityAutoStateChangeEvent",
         "spec_url": "https://w3c.github.io/csswg-drafts/css-contain-2/#content-visibility-auto-state-change",
         "support": {
           "chrome": {
@@ -43,7 +43,7 @@
       "ContentVisibilityAutoStateChangeEvent": {
         "__compat": {
           "description": "<code>ContentVisibilityAutoStateChangeEvent()</code> constructor",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ContentVisibilityAutoStateChangedEvent/ContentVisibilityAutoStateChangedEvent",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ContentVisibilityAutoStateChangeEvent/ContentVisibilityAutoStateChangeEvent",
           "spec_url": "https://w3c.github.io/csswg-drafts/css-contain-2/#dom-contentvisibilityautostatechangeevent-contentvisibilityautostatechangeevent",
           "support": {
             "chrome": {
@@ -84,7 +84,7 @@
       },
       "skipped": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ContentVisibilityAutoStateChangedEvent/skipped",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ContentVisibilityAutoStateChangeEvent/skipped",
           "spec_url": "https://w3c.github.io/csswg-drafts/css-contain-2/#dom-contentvisibilityautostatechangeevent-skipped",
           "support": {
             "chrome": {


### PR DESCRIPTION
#### Summary

This is a followup for https://github.com/mdn/browser-compat-data/pull/18848

Now MDN has updated their pages to use the past tense event names.
https://github.com/mdn/content/pull/24263

This updates links to those "d"-less pages.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
