### PR TITLE
Fix `browsingData.removeHistory()` for Firefox for Android

### DIFF
--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -595,8 +595,7 @@
                 "version_added": "53"
               },
               "firefox_android": {
-                "notes": "See <a href='https://bugzil.la/1363010'>bug 1363010</a>. Before Firefox for Android 79, <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browsingData/remove'><code>browser.history.remove(options, {history:true})</code></a> can be used instead.",
-                "version_added": false
+                "version_added": "85"
               },
               "opera": "mirror",
               "safari": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
[Bug 1363010](https://bugzilla.mozilla.org/show_bug.cgi?id=1363010) was closed as a duplicate of [Bug 1625233](https://bugzilla.mozilla.org/show_bug.cgi?id=1625233), which added Android support for the `browsingData` APIs in Firefox 85.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
