### PR TITLE
NodeList - spec link for forEach and @@iterator

### DIFF
--- a/api/NodeList.json
+++ b/api/NodeList.json
@@ -77,7 +77,7 @@
       "forEach": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NodeList/forEach",
-          "spec_url": "https://webidl.spec.whatwg.org/#idl-iterable",
+          "spec_url": "https://dom.spec.whatwg.org/#interface-nodelist",
           "support": {
             "chrome": {
               "version_added": "51"
@@ -262,7 +262,8 @@
       },
       "@@iterator": {
         "__compat": {
-          "spec_url": "https://webidl.spec.whatwg.org/#idl-iterable",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator",
+          "spec_url": "https://dom.spec.whatwg.org/#interface-nodelist",
           "support": {
             "chrome": {
               "version_added": "51"

--- a/api/NodeList.json
+++ b/api/NodeList.json
@@ -77,6 +77,7 @@
       "forEach": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/NodeList/forEach",
+          "spec_url": "https://webidl.spec.whatwg.org/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "51"
@@ -261,6 +262,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "spec_url": "https://webidl.spec.whatwg.org/#idl-iterable",
           "support": {
             "chrome": {
               "version_added": "51"


### PR DESCRIPTION
[`NodeList.forEach`](https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach#specifications) has no spec, which is a bit ugly in the docs. The reason is that `forEach` and `@@iterator` are implied because NodeList is and iterable.

There is literally nowhere to link to in NodeList in the spec https://dom.spec.whatwg.org/#nodelist to point to iterable. We could link to NodeList itself but that would look like a typo.

So my proposal is that we link to the Web IDL spec for both of these: https://webidl.spec.whatwg.org/#idl-iterable - see the text:

> n the ECMAScript language binding, an interface that is iterable will have entries, forEach, keys, values, and [@@iterator](https://tc39.es/ecma262/#sec-well-known-symbols) properties on its [interface prototype object](https://webidl.spec.whatwg.org/#dfn-interface-prototype-object).

OK? FYI @wbamberg @queengooborg @Josh-Cena 

Fixes https://github.com/mdn/content/issues/24653