### PR TITLE
Add Safari 16.4 for macOS and iOS as browsers

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -247,6 +247,12 @@
           "status": "current",
           "engine": "WebKit",
           "engine_version": "614.4.6"
+        },
+        "16.4": {
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes",
+          "status": "beta",
+          "engine": "WebKit",
+          "engine_version": "615"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -219,6 +219,12 @@
           "status": "current",
           "engine": "WebKit",
           "engine_version": "614.4.6"
+        },
+        "16.4": {
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes",
+          "status": "beta",
+          "engine": "WebKit",
+          "engine_version": "615"
         }
       }
     }


### PR DESCRIPTION
Per @queengooborg's request, split from #18963.