### PR TITLE
autocapitalize and translate attributes are supported in FF111

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -194,14 +194,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "83",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.forms.autocapitalize",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "111"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1991,7 +1984,6 @@
       },
       "translate": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/translate",
           "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#dom-translate",
           "support": {
             "chrome": {
@@ -2000,7 +1992,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "111"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -48,14 +48,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "83",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.forms.autocapitalize",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "111"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1480,7 +1473,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "111"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
`autocapitalize` attribute is fully supported in FF111
Bug tracker: https://bugzilla.mozilla.org/show_bug.cgi?id=1692007
MDN page: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize#browser_compatibility
Doc issue tracker: https://github.com/mdn/content/issues/24401

`translate` attribute attribute is supported in FF111
Bug tracker: https://bugzilla.mozilla.org/show_bug.cgi?id=1418449
MDN page: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/translate#browser_compatibility
Doc issue tracker: https://github.com/mdn/content/issues/24394