### PR TITLE
runtime.onSuspend implemented in Firefox

### DIFF
--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -977,7 +977,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "100"
               },
               "firefox_android": "mirror",
               "opera": "mirror",

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -957,7 +957,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "100"
+                "version_added": "100",
+                "notes": "This event does not fire until Firefox 106, when event pages are available."
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -977,7 +978,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "100"
+                "version_added": "100",
+                "notes": "This event does not fire until Firefox 106, when event pages are available."
               },
               "firefox_android": "mirror",
               "opera": "mirror",

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -957,7 +957,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "100"
               },
               "firefox_android": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
#### Summary

runtime.onSuspend was implemented in Firefox 100.

#### Test results and supporting details

See [Bug 1753850](https://bugzilla.mozilla.org/show_bug.cgi?id=1753850)


