### PR TITLE
Remove api.Element.show_event from BCD

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -8439,41 +8439,6 @@
           }
         }
       },
-      "show_event": {
-        "__compat": {
-          "description": "<code>show</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/show_event",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "8",
-              "version_removed": "85"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "slot": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/slot",


### PR DESCRIPTION
This PR removes the irrelevant `show_event` member of the `Element` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features). The lack of current support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.0.0), even if the current BCD suggests support.
