### PR TITLE
Remove api.HTMLMenuElement.label from BCD

### DIFF
--- a/api/HTMLMenuElement.json
+++ b/api/HTMLMenuElement.json
@@ -83,44 +83,6 @@
           }
         }
       },
-      "label": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMenuElement/label",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "8",
-              "version_removed": "85"
-            },
-            "firefox_android": {
-              "version_added": "8",
-              "version_removed": "85",
-              "notes": "Nested menus are not supported."
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "type": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMenuElement/type",


### PR DESCRIPTION
This PR removes the irrelevant `label` member of the `HTMLMenuElement` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines.md#removal-of-irrelevant-features). The lack of current support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.0.0), even if the current BCD suggests support.
