### PR TITLE
Update Firefox Android versions for api.CSSKeyframesRule.length

### DIFF
--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -315,9 +315,7 @@
             "firefox": {
               "version_added": "109"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox Android for the `length` member of the `CSSKeyframesRule` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CSSKeyframesRule/length

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
