### PR TITLE
Update Chromium versions for api.CredentialsContainer.get.identity_option

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -112,7 +112,7 @@
             "spec_url": "https://fedidcg.github.io/FedCM/#dom-credentialrequestoptions-identity",
             "support": {
               "chrome": {
-                "version_added": "108"
+                "version_added": "105"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `get.identity_option` member of the `CredentialsContainer` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.0.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CredentialsContainer/get.identity_option

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
