### PR TITLE
Firefox does not expose `browser.dom`

### DIFF
--- a/webextensions/api/dom.json
+++ b/webextensions/api/dom.json
@@ -11,7 +11,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "63"
+                "version_added": false,
+                "notes": "Use <code>element.openOrClosedShadowRoot</code>, available since Firefox 63."
               },
               "firefox_android": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

See: https://github.com/mdn/browser-compat-data/pull/17707#discussion_r963972701

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
