### PR TITLE
Mirror Opera Android for js.builtins.Error.options_cause_param

### DIFF
--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -195,9 +195,7 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": {
-                  "version_added": false
-                },
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": "15"
                 },


### PR DESCRIPTION
Fix https://github.com/mdn/browser-compat-data/issues/16782