### PR TITLE
Add session.storage support for Safari 16.4

### DIFF
--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -363,7 +363,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/session",
             "support": {
               "chrome": {
-                "version_added": "102"
+                "version_added": "102",
                 "notes": "Before version 112, storage quota limits were 1MB."
               },
               "edge": "mirror",

--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -364,6 +364,7 @@
             "support": {
               "chrome": {
                 "version_added": "102"
+                "notes": "Before version 112, storage quota limits were 1MB.",
               },
               "edge": "mirror",
               "firefox": {
@@ -372,8 +373,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": "16.4",
-                "notes": "Maximum allowed storage is 10MB."
+                "version_added": "16.4"
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -372,7 +372,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4",
+                "notes": "Maximum allowed storage is 10MB."
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -364,7 +364,7 @@
             "support": {
               "chrome": {
                 "version_added": "102"
-                "notes": "Before version 112, storage quota limits were 1MB.",
+                "notes": "Before version 112, storage quota limits were 1MB."
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
#### Summary

Adds support for session.storage for Safari 16.4 with a note about a 10MB maximum.

#### Test results and supporting details

See [Safari 16.4 Beta Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes#Safari-Extensions).