### PR TITLE
Add Safari 16.4 support for RegisteredContentScripts

### DIFF
--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -96,7 +96,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": 16.4,
+                "version_added": "16.4",
                 "notes": "Available for use in Manifest V2 or later."
               },
               "safari_ios": "mirror"

--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -96,7 +96,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": 16.4,
+                "notes": "Available for use in Manifest V2 or later."
               },
               "safari_ios": "mirror"
             }
@@ -118,7 +119,8 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "16.4",
+                  "notes": "Available for use in Manifest V2 or later."
                 },
                 "safari_ios": "mirror"
               }
@@ -217,7 +219,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4",
+                "notes": "Available for use in Manifest V2 or later."
               },
               "safari_ios": "mirror"
             }
@@ -276,7 +279,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4",
+                "notes": "Available for use in Manifest V2 or later."
               },
               "safari_ios": "mirror"
             }
@@ -335,7 +339,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4",
+                "notes": "Available for use in Manifest V2 or later."
               },
               "safari_ios": "mirror"
             }


### PR DESCRIPTION
#### Summary

Adds Safari 16.4 support for RegisteredContentScripts.

#### Test results and supporting details

See [Safari 16.4 Beta Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes#Safari-Extensions).