### PR TITLE
Samsung Internet 20.0 is released

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -249,9 +249,15 @@
         },
         "19.1": {
           "release_date": "2022-11-08",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "102"
+        },
+        "20.0": {
+          "release_date": "2023-02-10",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "106"
         }
       }
     }


### PR DESCRIPTION
This PR marks Samsung Internet 20.0 as the current version of Samsung Internet.  The date comes from [UpToDown](https://internet.en.uptodown.com/android), whereas the Chrome version comes from the user agent string.
