### PR TITLE
Add missing features for CSSContainerRule API

### DIFF
--- a/api/CSSContainerRule.json
+++ b/api/CSSContainerRule.json
@@ -35,7 +35,7 @@
       },
       "containerName": {
         "__compat": {
-          "spec_url": "https://drafts.csswg.org/css-contain-3/#dom-csscontainerrule-containername",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-contain-3/#dom-csscontainerrule-containername",
           "support": {
             "chrome": {
               "version_added": false
@@ -68,7 +68,7 @@
       },
       "containerQuery": {
         "__compat": {
-          "spec_url": "https://drafts.csswg.org/css-contain-3/#dom-csscontainerrule-containerquery",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-contain-3/#dom-csscontainerrule-containerquery",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/CSSContainerRule.json
+++ b/api/CSSContainerRule.json
@@ -32,6 +32,72 @@
           "standard_track": true,
           "deprecated": false
         }
+      },
+      "containerName": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-contain-3/#dom-csscontainerrule-containername",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "110"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "containerQuery": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-contain-3/#dom-csscontainerrule-containerquery",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "110"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing features of the CSSContainerRule API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.0.1).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CSSContainerRule

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
