### PR TITLE
Update Safari iOS versions for EXT_texture_compression_bptc API

### DIFF
--- a/api/EXT_texture_compression_bptc.json
+++ b/api/EXT_texture_compression_bptc.json
@@ -35,7 +35,9 @@
           "safari": {
             "version_added": "16.1"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": false
+          },
           "samsunginternet_android": {
             "version_added": false
           },


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `EXT_texture_compression_bptc` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.0.1).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/EXT_texture_compression_bptc

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
