### PR TITLE
Add version ranges for pre-2020 browser releases

### DIFF
--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -318,24 +318,34 @@ Note: many data categories no longer allow for `version_removed` to be set to `t
 
 For certain browsers, ranged versions are allowed as it is sometimes impractical to find out in which early version of a browser a feature shipped. Ranged versions should be used sparingly and only when it is impossible to find out the version number a feature initially shipped in. The following ranged version values are allowed:
 
+- Chrome
+  - "≤15" (the earliest version testable in BrowserStack)
+  - "≤37" (the earliest version testable in SauceLabs)
+  - "≤80" (the first version released in 2020)
 - Edge
-  - "≤18" (the last EdgeHTML-based Edge and possibly earlier)
-  - "≤79" (the first Chromium-based Edge and possibly in EdgeHTML-based Edge)
+  - "≤18" (the last EdgeHTML-based Edge)
+  - "≤79" (the first Chromium-based Edge)
+  - "≤80" (the first version released in 2020)
 - Internet Explorer
-  - "≤6" (the earliest IE version testable in BrowserStack and possibly earlier)
-  - "≤11" (the last IE version and possibly earlier)
+  - "≤6" (the earliest version testable in BrowserStack)
+  - "≤11" (the last IE version)
 - Opera
-  - "≤12.1" (the last Presto-based Opera and possibly earlier)
-  - "≤15" (the first Chromium-based Opera and possibly in Presto-based Opera)
+  - "≤12.1" (the last Presto-based Opera)
+  - "≤15" (the first Chromium-based Opera)
+  - "≤66" (the first version released in 2020)
 - Opera Android
-  - "≤12.1" (the last Presto-based Opera and possibly earlier)
-  - "≤14" (the first Chromium-based Opera and possibly in Presto-based Opera)
+  - "≤12.1" (the last Presto-based Opera)
+  - "≤14" (the first Chromium-based Opera)
+  - "≤56" (the first version released in 2020)
 - Safari
-  - "≤4" (the earliest Safari version testable in BrowserStack and possibly earlier)
+  - "≤4" (the earliest version testable in BrowserStack)
+  - "≤13.1" (the first version released in 2020)
 - Safari iOS
-  - "≤3" (the earliest Safari iOS version testable in BrowserStack and possibly earlier)
+  - "≤3" (the earliest version testable in BrowserStack)
+  - "≤13.4" (the first version released in 2020)
 - WebView Android
-  - "≤37" (the first Chrome-based WebView and possibly previous Android versions)
+  - "≤37" (the first Chrome-based WebView)
+  - "≤80" (the first version released in 2020)
 
 For example, the statement below means, "supported in at least version 37 and possibly in earlier versions as well".
 

--- a/test/linter/test-versions.ts
+++ b/test/linter/test-versions.ts
@@ -21,14 +21,15 @@ const { browsers } = bcd;
 const validBrowserVersions: { [browser: string]: string[] } = {};
 
 const VERSION_RANGE_BROWSERS: { [browser: string]: string[] } = {
-  chrome: ['≤15', '≤37'],
-  edge: ['≤18', '≤79'],
+  chrome: ['≤15', '≤37', '≤80'],
+  edge: ['≤18', '≤79', '≤80'],
+  firefox: ['≤72'],
   ie: ['≤6', '≤11'],
-  opera: ['≤12.1', '≤15'],
-  opera_android: ['≤12.1', '≤14'],
-  safari: ['≤4'],
-  safari_ios: ['≤3'],
-  webview_android: ['≤37'],
+  opera: ['≤12.1', '≤15', '≤66'],
+  opera_android: ['≤12.1', '≤14', '≤56'],
+  safari: ['≤4', '≤13.1'],
+  safari_ios: ['≤3', '≤13.4'],
+  webview_android: ['≤37', '≤80'],
 };
 
 const browserTips: { [browser: string]: string } = {


### PR DESCRIPTION
This PR adds version ranges for all of the pre-2020 browser releases.
