### PR TITLE
Allow ranges for any browser version

### DIFF
--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -316,7 +316,7 @@ Note: many data categories no longer allow for `version_removed` to be set to `t
 
 ### Ranged versions
 
-Ranged versions are allowed as it is sometimes impractical to find out in which early version of a browser a feature shipped. Ranged versions should be used sparingly and only when it is impossible to find out the version number a feature initially shipped in.
+Ranged versions are allowed as it is sometimes impractical to find out in which early version of a browser a feature shipped. Ranged versions should be used sparingly and only when an excessive amount of work if needed to find out the version number a feature initially shipped in.
 
 For example, the statement below means, "supported in at least version 37 and possibly in earlier versions as well".
 

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -316,26 +316,7 @@ Note: many data categories no longer allow for `version_removed` to be set to `t
 
 ### Ranged versions
 
-For certain browsers, ranged versions are allowed as it is sometimes impractical to find out in which early version of a browser a feature shipped. Ranged versions should be used sparingly and only when it is impossible to find out the version number a feature initially shipped in. The following ranged version values are allowed:
-
-- Edge
-  - "≤18" (the last EdgeHTML-based Edge and possibly earlier)
-  - "≤79" (the first Chromium-based Edge and possibly in EdgeHTML-based Edge)
-- Internet Explorer
-  - "≤6" (the earliest IE version testable in BrowserStack and possibly earlier)
-  - "≤11" (the last IE version and possibly earlier)
-- Opera
-  - "≤12.1" (the last Presto-based Opera and possibly earlier)
-  - "≤15" (the first Chromium-based Opera and possibly in Presto-based Opera)
-- Opera Android
-  - "≤12.1" (the last Presto-based Opera and possibly earlier)
-  - "≤14" (the first Chromium-based Opera and possibly in Presto-based Opera)
-- Safari
-  - "≤4" (the earliest Safari version testable in BrowserStack and possibly earlier)
-- Safari iOS
-  - "≤3" (the earliest Safari iOS version testable in BrowserStack and possibly earlier)
-- WebView Android
-  - "≤37" (the first Chrome-based WebView and possibly previous Android versions)
+Ranged versions are allowed as it is sometimes impractical to find out in which early version of a browser a feature shipped. Ranged versions should be used sparingly and only when it is impossible to find out the version number a feature initially shipped in.
 
 For example, the statement below means, "supported in at least version 37 and possibly in earlier versions as well".
 


### PR DESCRIPTION
This PR is an alternate to #19013 that allows _any_ browser version to be a range.  Fixes #6247, closes #19013, closes #19146.