### PR TITLE
relnote(Fx111): context-fill and context-stroke values supported in SVG fill and stroke attribs

### DIFF
--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -504,7 +504,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": null
+                "version_added": "3"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1616,7 +1616,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": null
+                "version_added": "3"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -525,6 +525,40 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "context-fill": {
+            "__compat": {
+              "description": "<code>context-fill</code>",
+              "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "111"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": null
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "fill-opacity": {
@@ -1602,6 +1636,40 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "context-stroke": {
+            "__compat": {
+              "description": "<code>context-stroke</code>",
+              "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint",
+              "support": {
+                "chrome": {
+                  "version_added": null
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "111"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": null
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": null
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         },


### PR DESCRIPTION
__Background:__
SVG elements can use `stroke="context-stroke" fill="context-fill"` in Fx 111

__Related issues and bugs:__
- [ ] parent issue https://github.com/mdn/content/issues/24399
- [x] content https://github.com/mdn/content/pull/24837

__Bugzilla:__
- https://bugzilla.mozilla.org/show_bug.cgi?id=752638