### PR TITLE
Add support for ES module workers in Firefox nightly

### DIFF
--- a/api/Worker.json
+++ b/api/Worker.json
@@ -160,8 +160,15 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1247687'>bug 1247687</a>"
+                "version_added": "111",
+                "notes": "Available only in Nightly builds. See <a href='https://bugzil.la/1247687'>bug 1247687</a>",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.moduleScripts.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
#### Summary

Firefox Nightly 111 supports ES6 module workers.

#### Test results and supporting details

Manually tested to confirm.
Feature implementation bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1247687
Feature shipping bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1812591

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
