### PR TITLE
Update api.SVGStyleElement.sheet on iOS

### DIFF
--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -162,9 +162,7 @@
             "safari": {
               "version_added": "16.4"
             },
-            "safari_ios": {
-              "version_added": "1"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
The Safari value got changed in #18963, but not the iOS value. This is an oversight.

This attribute got added in https://github.com/WebKit/WebKit/commit/737ccae0f4676feb85291509f4691a2235658104.

Its prior, incorrect documentation, dates from the big _mixins removal, which was wrong as WebKit didn't previously implement this as a mixin.