### PR TITLE
relnote(Fx111): color(), lab(), lch(), oklab(), oklch() support

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -53,7 +53,14 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "111",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.more_color_4.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "ie": {
@@ -446,7 +453,14 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "111",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.more_color_4.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "ie": {
@@ -481,7 +495,14 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "111",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.more_color_4.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "ie": {
@@ -597,7 +618,14 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "111",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.more_color_4.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "ie": {
@@ -632,7 +660,14 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "111",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.more_color_4.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
CSS color functions enabled behind a pref (`layout.css.more_color_4.enabled`) in Fx 111

__Additions:__
* color() 
* lab()
* lch()
* oklab()
* oklch() 

__Related issues and pull requests:__
- Parent issue https://github.com/mdn/content/issues/24395

__Bugzilla:__
- `color()` https://bugzilla.mozilla.org/show_bug.cgi?id=1128204
- `lab()`, `lch()`, `oklab()`, `oklch()` https://bugzilla.mozilla.org/show_bug.cgi?id=1352757
