### PR TITLE
Update X-Frame-Options spec link

### DIFF
--- a/http/headers/X-Frame-Options.json
+++ b/http/headers/X-Frame-Options.json
@@ -4,7 +4,7 @@
       "X-Frame-Options": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/X-Frame-Options",
-          "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-x-frame-options-header",
+          "spec_url": "https://html.spec.whatwg.org/multipage/document-lifecycle.html#the-x-frame-options-header",
           "support": {
             "chrome": {
               "version_added": "4"


### PR DESCRIPTION
#### Summary

Spec link for the X-Frame-Options HTTP header is wrong (outdated). I have fixed the link.

#### Test results and supporting details

Cf. [the current link target](https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-x-frame-options-header) and the [updated target](https://html.spec.whatwg.org/multipage/document-lifecycle.html#the-x-frame-options-header)
