### PR TITLE
Ff111 implements workers modules

### DIFF
--- a/api/Worker.json
+++ b/api/Worker.json
@@ -160,8 +160,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1247687'>bug 1247687</a>"
+                "version_added": "111"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -176,7 +175,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "15"
+                "version_added": "15",
+                "notes": [
+                  "Nested workers supported from version 15.5.",
+                  "Script loading in nested workers supported from version 16.4"
+                ]
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -175,11 +175,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "15",
-                "notes": [
-                  "Nested workers supported from version 15.5.",
-                  "Script loading in nested workers supported from version 16.4"
-                ]
+                "version_added": "15"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -159,9 +159,25 @@
                 "version_added": "1.0"
               },
               "edge": "mirror",
-              "firefox": {
-                "version_added": "111"
-              },
+              "firefox": [
+                {
+                  "version_added": "preview",
+                  "partial_implementation": true,
+                  "notes": "Does not support dynamic import. See <a href='https://bugzil.la/1540913'>bug 1540913</a>"
+                },
+                {
+                  "version_added": "111",
+                  "partial_implementation": true,
+                  "notes": "Does not support dynamic import. See <a href='https://bugzil.la/1540913'>bug 1540913</a>",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.workers.modules.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1336,8 +1336,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1247687'>bug 1247687</a>."
+                "version_added": "111"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1335,9 +1335,21 @@
                 "version_added": "1.0"
               },
               "edge": "mirror",
-              "firefox": {
-                "version_added": "111"
-              },
+              "firefox": [
+                {
+                  "version_added": "preview"
+                },
+                {
+                  "version_added": "111",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.workers.modules.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false


### PR DESCRIPTION
FF111 supports module loading from workers in https://bugzilla.mozilla.org/show_bug.cgi?id=1247687
This updates the existing support statements. 

Other docs work for this can be tracked in https://github.com/mdn/content/issues/24402