### PR TITLE
Add compatibility note about Safari's support for nested workers

### DIFF
--- a/api/Worker.json
+++ b/api/Worker.json
@@ -176,7 +176,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "15"
+                "version_added": "15",
+                "notes": [
+                  "Nested workers supported from version 15.5",
+                  "Script loading in nested workers supported from version 16.4"
+                ]
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -178,8 +178,8 @@
               "safari": {
                 "version_added": "15",
                 "notes": [
-                  "Nested workers supported from version 15.5",
-                  "Script loading in nested workers supported from version 16.4"
+                  "Nested workers support was introduced in Safari 15.5.",
+                  "Script loading in nested workers was introduced in Safari 16.4."
                 ]
               },
               "safari_ios": "mirror",

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1347,12 +1347,8 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "15"
               },


### PR DESCRIPTION
There is a note in [`Worker`](https://developer.mozilla.org/en-US/docs/Web/API/Worker):

![image](https://user-images.githubusercontent.com/5368500/222626129-56f4d4a3-581f-4ba9-82a1-56ba5db6ca72.png)

Following the bug you start to see support for nested workers in 15.5 - https://webkit.org/blog/13338/release-notes-for-safari-technology-preview-155/ and in 16.4 it looks like there were some other fixes that are relevant: https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes
There _might_ be more, but they are definitely supported in 15.5 and looks like it might be pretty much full support now.

Anyway, I have added this information as notes. Not sure if this is "correct enough". Should I make the original entry a partial implementation and have a separate "full support" entry at 15.5?

FYI @queengooborg 

This fell out of work in https://github.com/mdn/content/issues/24402

- [ ] Once this goes in, remove that note above