### PR TITLE
Update Chromium and Opera versions for Cookie and Set-Cookie headers

### DIFF
--- a/http/headers/Cookie.json
+++ b/http/headers/Cookie.json
@@ -7,7 +7,7 @@
           "spec_url": "https://httpwg.org/specs/rfc6265.html#cookie",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {

--- a/http/headers/Set-Cookie.json
+++ b/http/headers/Set-Cookie.json
@@ -7,7 +7,7 @@
           "spec_url": "https://httpwg.org/specs/rfc6265.html#sane-set-cookie",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -21,7 +21,9 @@
               "version_added": true
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": "≤12.1"
+            },
             "opera_android": "mirror",
             "safari": {
               "version_added": true


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `Cookie` and `Set-Cookie` headers.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Tested using https://www.browserling.com/ Chrome on version 1 and Opera on version 10.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
