### PR TITLE
FF does not support dynamic module import in workers

### DIFF
--- a/javascript/operators/import.json
+++ b/javascript/operators/import.json
@@ -54,6 +54,60 @@
             "deprecated": false
           }
         },
+        "worker_support": {
+          "__compat": {
+            "description": "Available in workers",
+            "support": {
+              "chrome": {
+                "version_added": "63"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.0",
+                "notes": "Bundled Deno applications (using `deno compile`) do not support dynamic imports"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1540913'>bug 1540913</a>"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": [
+                {
+                  "version_added": "13.2.0",
+                  "notes": "Dynamic <code>import</code> can be used in either CommonJS or ES module files, to import either CommonJS or ES module files. See Node's <a href='https://nodejs.org/api/esm.html#esm_import_expressions'>ECMAScript Modules documentation</a> for more details."
+                },
+                {
+                  "version_added": "12.0.0",
+                  "flags": [
+                    {
+                      "name": "--experimental-modules",
+                      "type": "runtime_flag"
+                    }
+                  ],
+                  "notes": "Dynamic <code>import</code> can be used in either CommonJS or ES module files, to import either CommonJS or ES module files. See Node's <a href='https://nodejs.org/api/esm.html#esm_import_expressions'>ECMAScript Modules documentation</a> for more details."
+                }
+              ],
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "11.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "options_parameter": {
           "__compat": {
             "description": "The <code>options</code> parameter",

--- a/javascript/operators/import.json
+++ b/javascript/operators/import.json
@@ -59,12 +59,11 @@
             "description": "Available in workers",
             "support": {
               "chrome": {
-                "version_added": "63"
+                "version_added": "80"
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": "1.0",
-                "notes": "Bundled Deno applications (using `deno compile`) do not support dynamic imports"
+                "version_added": "1.0"
               },
               "edge": "mirror",
               "firefox": {
@@ -75,27 +74,14 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "13.2.0",
-                  "notes": "Dynamic <code>import</code> can be used in either CommonJS or ES module files, to import either CommonJS or ES module files. See Node's <a href='https://nodejs.org/api/esm.html#esm_import_expressions'>ECMAScript Modules documentation</a> for more details."
-                },
-                {
-                  "version_added": "12.0.0",
-                  "flags": [
-                    {
-                      "name": "--experimental-modules",
-                      "type": "runtime_flag"
-                    }
-                  ],
-                  "notes": "Dynamic <code>import</code> can be used in either CommonJS or ES module files, to import either CommonJS or ES module files. See Node's <a href='https://nodejs.org/api/esm.html#esm_import_expressions'>ECMAScript Modules documentation</a> for more details."
-                }
-              ],
+              "nodejs": {
+                "version_added": false
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "11.1"
+                "version_added": "15"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
Firefox does not support dynamic module imports in workers - see https://bugzilla.mozilla.org/show_bug.cgi?id=1540913 (and discussion in  https://github.com/mdn/browser-compat-data/pull/19044 ).

This adds a worker support feature to `import()` and sets FF to false with a bug link.

EDITED The rest was copied from the worker support for static imports. 

Can you advise on a WPT test that I run to test dynamic import support for the other platforms (and are you aware of any others that do not have this support)?

This follows on from work in https://github.com/mdn/content/issues/24402
