### PR TITLE
Add type to the manifest background key

### DIFF
--- a/webextensions/manifest/background.json
+++ b/webextensions/manifest/background.json
@@ -151,13 +151,11 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true,
-                "notes": "When set to <code>module </code>, includes service workers as ES modules."
+                "version_added": true
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "112",
-                "notes": "When set to <code>module </code>, includes background scripts as ES modules."
+                "version_added": "112"
               },
               "firefox_android": "mirror",
               "opera": "mirror",

--- a/webextensions/manifest/background.json
+++ b/webextensions/manifest/background.json
@@ -162,7 +162,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4"
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/manifest/background.json
+++ b/webextensions/manifest/background.json
@@ -146,6 +146,27 @@
               "safari_ios": "mirror"
             }
           }
+        },
+        "type": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true,
+                "notes": "When set to <code>module </code>, includes service workers as ES modules."
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "112",
+                "notes": "When set to <code>module </code>, includes background scripts as ES modules."
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
- [x] Review Apple release notes to determine when or if included in Safari

#### Summary

Adds the `"type"` property to the `"background"` manifest key.

#### Related issues

Addresses the documentation requirements for [Bug 1811443](https://bugzilla.mozilla.org/show_bug.cgi?id=1811443).

Related MDN in changes in https://github.com/mdn/content/pull/25094.
