### PR TITLE
FF111 fetch() remove Authorization header on cross origin redirects

### DIFF
--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -100,6 +100,43 @@
           }
         }
       },
+      "authorization_removed_cross_origin": {
+        "__compat": {
+          "description": "<code>Authorization</code> header removed from cross-origin redirects",
+          "spec_url": "https://fetch.spec.whatwg.org/#http-redirect-fetch",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "111"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "blob_data_support": {
         "__compat": {
           "description": "Support for blob: and data:",


### PR DESCRIPTION
FF111 strips the `Authorization` header added by developers from cross-origin redirects - see https://bugzilla.mozilla.org/show_bug.cgi?id=1802086. This adds a feature to the `fetch()` entry.

This was tested with https://wpt.live/fetch/api/credentials/authentication-redirection.any.worker.htm - the first test should show that the header is not stripped from a normal response, the second that it is not stripped from a same-origin redirect, and the third that it is from a cross-origin redirect.

Note that Safari is "accidentally" compliant in 15.4 because it strips the authorization header in both cases. Safari 16.1 on browserstack does the "right thing" for all cases. So I have indicated Safari 16.1 because it more closely reflects the expected behaviour with this header on redirect.

I could not test deno so have set to false. Probably that is right given how recent this is.

Other docs info here: https://github.com/mdn/content/issues/22533