### PR TITLE
Chrome 111: Add oklch(), oklab(), lch(), lab() support

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -477,7 +477,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -519,7 +519,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -642,7 +642,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -684,7 +684,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -448,7 +448,7 @@
             "spec_url": "https://w3c.github.io/csswg-drafts/css-color/#lab-colors",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "111"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -490,7 +490,7 @@
             "spec_url": "https://w3c.github.io/csswg-drafts/css-color/#lab-colors",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "111"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -613,7 +613,7 @@
             "spec_url": "https://w3c.github.io/csswg-drafts/css-color/#ok-lab",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "111"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -655,7 +655,7 @@
             "spec_url": "https://w3c.github.io/csswg-drafts/css-color/#ok-lab",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "111"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 111 implements CSS Color 4 with `oklch()`, `oklab()`, `lch()`, and `lab()`. [Changelog](https://developer.chrome.com/blog/new-in-chrome-111/#css-color-level4)

I also removed `Experimental` flag because CI [told me](https://github.com/mdn/browser-compat-data/actions/runs/4359619533/jobs/7621601320).

#### Test results and supporting details

[WPT results](https://wpt.fyi/results/css/css-color?label=master&label=experimental&aligned=&view=subtest&q=oklch)

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes #19067

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
