### PR TITLE
Updates chrome to version 111

### DIFF
--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -100,6 +100,43 @@
           }
         }
       },
+      "authorization_removed_cross_origin": {
+        "__compat": {
+          "description": "<code>Authorization</code> header removed from cross-origin redirects",
+          "spec_url": "https://fetch.spec.whatwg.org/#http-redirect-fetch",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "111"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "blob_data_support": {
         "__compat": {
           "description": "Support for blob: and data:",

--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -789,12 +789,6 @@
           "status": "nightly",
           "engine": "Blink",
           "engine_version": "113"
-        },
-        "114": {
-          "release_date": "2023-05-30",
-          "status": "nightly",
-          "engine": "Blink",
-          "engine_version": "114"
         }
       }
     }

--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -767,21 +767,34 @@
         "110": {
           "release_date": "2023-02-07",
           "release_notes": "https://chromereleases.googleblog.com/2023/02/stable-channel-update-for-desktop.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "110"
         },
         "111": {
-          "release_date": "2023-03-01",
-          "status": "beta",
+          "release_date": "2023-03-07",
+          "release_notes": "https://chromereleases.googleblog.com/2023/03/stable-channel-update-for-desktop.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "111"
         },
         "112": {
-          "release_date": "2023-03-29",
-          "status": "nightly",
+          "release_date": "2023-04-04",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "112"
+        },
+        "113": {
+          "release_date": "2023-05-02",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "113"
+        },
+        "114": {
+          "release_date": "2023-05-30",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "114"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -603,21 +603,34 @@
         "110": {
           "release_date": "2023-02-07",
           "release_notes": "https://chromereleases.googleblog.com/2023/02/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "110"
         },
         "111": {
-          "release_date": "2023-03-01",
-          "status": "beta",
+          "release_date": "2023-03-07",
+          "release_notes": "https://chromereleases.googleblog.com/2023/03/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "111"
         },
         "112": {
-          "release_date": "2023-03-29",
-          "status": "nightly",
+          "release_date": "2023-04-04",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "112"
+        },
+        "113": {
+          "release_date": "2023-05-02",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "113"
+        },
+        "114": {
+          "release_date": "2023-05-30",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "114"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -625,12 +625,6 @@
           "status": "nightly",
           "engine": "Blink",
           "engine_version": "113"
-        },
-        "114": {
-          "release_date": "2023-05-30",
-          "status": "nightly",
-          "engine": "Blink",
-          "engine_version": "114"
         }
       }
     }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -567,21 +567,34 @@
         "110": {
           "release_date": "2023-02-07",
           "release_notes": "https://chromereleases.googleblog.com/2023/02/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "110"
         },
         "111": {
           "release_date": "2023-03-01",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2023/03/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "111"
         },
         "112": {
-          "release_date": "2023-03-29",
-          "status": "nightly",
+          "release_date": "2023-04-04",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "112"
+        },
+        "113": {
+          "release_date": "2023-05-02",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "113"
+        },
+        "114": {
+          "release_date": "2023-05-30",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "114"
         }
       }
     }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -589,12 +589,6 @@
           "status": "nightly",
           "engine": "Blink",
           "engine_version": "113"
-        },
-        "114": {
-          "release_date": "2023-05-30",
-          "status": "nightly",
-          "engine": "Blink",
-          "engine_version": "114"
         }
       }
     }


### PR DESCRIPTION
Hi all! 

This PR updates Chrome to version 111.

And according to https://chromiumdash.appspot.com/schedule, also includes the new release dates.