### PR TITLE
Update Chromium versions for api.AudioContext.AudioContext.options_latencyHint_parameter

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -160,7 +160,7 @@
             "spec_url": "https://webaudio.github.io/web-audio-api/#dom-audiocontextoptions-latencyhint",
             "support": {
               "chrome": {
-                "version_added": "60"
+                "version_added": "58"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `AudioContext.options_latencyHint_parameter` member of the `AudioContext` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.0.1).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/AudioContext/AudioContext.options_latencyHint_parameter

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
