### PR TITLE
Update Chromium versions for api.Clients.matchAll.options_includeUncontrolled_parameter

### DIFF
--- a/api/Clients.json
+++ b/api/Clients.json
@@ -162,7 +162,7 @@
             "spec_url": "https://w3c.github.io/ServiceWorker/#dom-clientqueryoptions-includeuncontrolled",
             "support": {
               "chrome": {
-                "version_added": "47",
+                "version_added": "42",
                 "notes": "<code>Client</code> objects returned in most recent focus order."
               },
               "chrome_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `matchAll.options_includeUncontrolled_parameter` member of the `Clients` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.0.1).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Clients/matchAll/options_includeUncontrolled_parameter

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
