### PR TITLE
Opera 96 is released

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -730,14 +730,21 @@
           "engine_version": "109"
         },
         "96": {
-          "status": "beta",
+          "release_date": "2023-02-22",
+          "release_notes": "https://blogs.opera.com/desktop/2023/02/opera-96-0-4693-20-stable-initial/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "110"
         },
         "97": {
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "111"
+        },
+        "98": {
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "112"
         }
       }
     }

--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -725,7 +725,7 @@
         "95": {
           "release_date": "2023-02-01",
           "release_notes": "https://blogs.opera.com/desktop/2023/02/opera-95-stable/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "109"
         },


### PR DESCRIPTION
This PR marks Opera 96 as the current version of Opera Desktop.
