### PR TITLE
Add missing api.DOMTokenList.toString feature

### DIFF
--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -658,7 +658,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "3.6"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -646,6 +646,45 @@
           }
         }
       },
+      "toString": {
+        "__compat": {
+          "spec_url": "https://dom.spec.whatwg.org/#DOMTokenList-stringification-behavior",
+          "support": {
+            "chrome": {
+              "version_added": "8"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "3.5"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "5.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "trim_whitespace": {
         "__compat": {
           "description": "Trims whitespace",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `toString` member of the DOMTokenList API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.1.1).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/DOMTokenList/toString

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
