### PR TITLE
FF111 XMLHttpRequest/HTTP channel - strip Authorization  on cross-origin redirect

### DIFF
--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -220,6 +220,43 @@
           }
         }
       },
+      "authorization_removed_cross_origin": {
+        "__compat": {
+          "description": "<code>Authorization</code> header removed from cross-origin redirects",
+          "spec_url": "https://fetch.spec.whatwg.org/#http-redirect-fetch",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "111"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "error_event": {
         "__compat": {
           "description": "<code>error</code> event",

--- a/http/headers/Authorization.json
+++ b/http/headers/Authorization.json
@@ -287,6 +287,43 @@
               "deprecated": false
             }
           }
+        },
+        "authorization_removed_cross_origin": {
+          "__compat": {
+            "description": "<code>Authorization</code> header removed from cross-origin redirects",
+            "spec_url": "https://fetch.spec.whatwg.org/#http-redirect-fetch",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "111"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "16.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/http/headers/Authorization.json
+++ b/http/headers/Authorization.json
@@ -297,9 +297,6 @@
                 "version_added": false
               },
               "chrome_android": "mirror",
-              "deno": {
-                "version_added": false
-              },
               "edge": "mirror",
               "firefox": {
                 "version_added": "111"


### PR DESCRIPTION
FF111 strips the `Authorization` header added by developers from cross-origin redirects in fetch(), XMLHttpRequest, and more generally theHTTP channel - see: https://bugzilla.mozilla.org/show_bug.cgi?id=1802086. 

The `fetch()` changes were done in #19064 . This duplicates the exactly the same info for XMLHttpRequest and `Authorization`. That makes sense because these build on fetch(), as per response in https://github.com/mdn/content/issues/22533#issuecomment-1458256595
.

Other docs work for this can be tracked in https://github.com/mdn/content/issues/22533