### PR TITLE
Add missing api.XRSession.enabledFeatures feature

### DIFF
--- a/api/XRSession.json
+++ b/api/XRSession.json
@@ -184,6 +184,45 @@
           }
         }
       },
+      "enabledFeatures": {
+        "__compat": {
+          "spec_url": "https://immersive-web.github.io/webxr/#dom-xrsession-enabledfeatures",
+          "support": {
+            "chrome": {
+              "version_added": "111"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": false
+            },
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "end": {
         "__compat": {
           "description": "<code>end()</code>",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser.  This particular PR adds the missing `enabledFeatures` member of the XRSession API, populating the results using data from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.1.1).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/XRSession/enabledFeatures

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
