### PR TITLE
Update Chromium versions for CSSFontFeatureValuesRule API

### DIFF
--- a/api/CSSFontFeatureValuesRule.json
+++ b/api/CSSFontFeatureValuesRule.json
@@ -5,7 +5,7 @@
         "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts-4/#cssfontfeaturevaluesrule",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "111"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -37,7 +37,7 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts-4/#dom-cssfontfeaturevaluesrule-fontfamily",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "111"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `CSSFontFeatureValuesRule` API, based upon results from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.1.1).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CSSFontFeatureValuesRule

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._
