### PR TITLE
Add mdn_url for members of MutationEvent

### DIFF
--- a/api/MutationEvent.json
+++ b/api/MutationEvent.json
@@ -41,6 +41,7 @@
       },
       "attrChange": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationEvent/attrChange",
           "spec_url": "https://w3c.github.io/uievents/#dom-mutationevent-attrchange",
           "support": {
             "chrome": {
@@ -80,6 +81,7 @@
       },
       "attrName": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationEvent/attrName",
           "spec_url": "https://w3c.github.io/uievents/#dom-mutationevent-attrname",
           "support": {
             "chrome": {
@@ -119,6 +121,7 @@
       },
       "initMutationEvent": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationEvent/initMutationEvent",
           "spec_url": "https://w3c.github.io/uievents/#dom-mutationevent-initmutationevent",
           "support": {
             "chrome": {
@@ -158,6 +161,7 @@
       },
       "newValue": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationEvent/newValue",
           "spec_url": "https://w3c.github.io/uievents/#dom-mutationevent-newvalue",
           "support": {
             "chrome": {
@@ -197,6 +201,7 @@
       },
       "prevValue": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationEvent/prevValue",
           "spec_url": "https://w3c.github.io/uievents/#dom-mutationevent-prevvalue",
           "support": {
             "chrome": {
@@ -236,6 +241,7 @@
       },
       "relatedNode": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MutationEvent/relatedNode",
           "spec_url": "https://w3c.github.io/uievents/#dom-mutationevent-relatednode",
           "support": {
             "chrome": {


### PR DESCRIPTION
We add these missing pages in mdn/content#25251. This PR adds the missing `mdn_url` field.