### PR TITLE
Add FormData constructor submitter parameter

### DIFF
--- a/api/FormData.json
+++ b/api/FormData.json
@@ -97,6 +97,42 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "submitter": {
+          "__compat": {
+            "description": "<code>submitter</code> parameter",
+            "support": {
+              "chrome": {
+                "version_added": "112"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "111"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "16.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "worker_support": {


### PR DESCRIPTION
#### Summary

Add data for the new submitter parameter to the FormData constructor (FF 111, Chrome 112, Safari 16.4)

#### Test results and supporting details

Here's what it looks like on the FormData constructor MDN page (goes with [this PR](https://github.com/mdn/content/pull/23950)):

![compat](https://user-images.githubusercontent.com/109489/224574441-c718cdae-1e8c-46a0-a057-11297599cda1.png)

Although it's experimental as of 2023-03-12, it will be live in Firefox on 2023-03-14 and Chrome on 2023-04-04.

Spec: https://xhr.spec.whatwg.org/#interface-formdata
Firefox: [Issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1812696), [Implementation](https://phabricator.services.mozilla.com/D167576)
Chrome: [Issue](https://bugs.chromium.org/p/chromium/issues/detail?id=1410542), [Implementation](https://chromium.googlesource.com/chromium/src/+/df5176aa228dc06e693a799d595ee95d68dcab0d), [Feature entry](https://chromestatus.com/feature/5066604734316544)
Safari: [Issue](https://bugs.webkit.org/show_bug.cgi?id=251220), [Implementation](https://github.com/WebKit/WebKit/commit/136a23f12bae93a6dd2c9f93565aa6da6efdfef5), [Release notes](https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes)

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

MDN Content Issue: https://github.com/mdn/content/issues/23917
MDN Content PR: https://github.com/mdn/content/pull/23950

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
