### PR TITLE
Fix Opera Android version of border-radius properties

### DIFF
--- a/css/properties/border-end-end-radius.json
+++ b/css/properties/border-end-end-radius.json
@@ -20,9 +20,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15"
             },

--- a/css/properties/border-end-start-radius.json
+++ b/css/properties/border-end-start-radius.json
@@ -20,9 +20,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15"
             },

--- a/css/properties/border-start-end-radius.json
+++ b/css/properties/border-start-end-radius.json
@@ -20,9 +20,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15"
             },

--- a/css/properties/border-start-start-radius.json
+++ b/css/properties/border-start-start-radius.json
@@ -20,9 +20,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15"
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Opera Android supports `border-start-start-radius`, `border-start-end-radius`, `border-end-start-radius` and `border-end-end-radius` starting with version 63 (chromium 89)
