### PR TITLE
Update Firefox data for api.CSSPageRule.selectorText

### DIFF
--- a/api/CSSPageRule.json
+++ b/api/CSSPageRule.json
@@ -54,7 +54,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "110"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `selectorText` member of the `CSSPageRule` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.1.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CSSPageRule/selectorText
