### PR TITLE
Update Chromium data for api.CSPViolationReportBody.toJSON

### DIFF
--- a/api/CSPViolationReportBody.json
+++ b/api/CSPViolationReportBody.json
@@ -483,7 +483,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "74"
+              "version_added": "80"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `toJSON` member of the `CSPViolationReportBody` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.1.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CSPViolationReportBody/toJSON
