### PR TITLE
Update Edge data for CanvasRenderingContext2D API

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -331,7 +331,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤18"
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "31"
@@ -900,7 +900,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤18"
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "31"
@@ -1635,7 +1635,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤18"
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "31"
@@ -2832,7 +2832,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤18"
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "31"


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `CanvasRenderingContext2D` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.1.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CanvasRenderingContext2D
