### PR TITLE
Opera Android 74 is released

### DIFF
--- a/api/FileSystemFileHandle.json
+++ b/api/FileSystemFileHandle.json
@@ -56,7 +56,9 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": "15.2"
             },

--- a/api/FileSystemHandle.json
+++ b/api/FileSystemHandle.json
@@ -240,7 +240,9 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },

--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -413,9 +413,15 @@
         },
         "73": {
           "release_date": "2023-01-17",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "108"
+        },
+        "74": {
+          "release_date": "2023-03-13",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "110"
         }
       }
     }

--- a/mathml/elements/math.json
+++ b/mathml/elements/math.json
@@ -70,12 +70,17 @@
                 "notes": "Only supported in XHTML documents."
               }
             ],
-            "opera_android": {
-              "version_added": "10.1",
-              "version_removed": "14",
-              "partial_implementation": true,
-              "notes": "Only supported in XHTML documents."
-            },
+            "opera_android": [
+              {
+                "version_added": "74"
+              },
+              {
+                "version_added": "10.1",
+                "version_removed": "14",
+                "partial_implementation": true,
+                "notes": "Only supported in XHTML documents."
+              }
+            ],
             "safari": {
               "version_added": "5.1"
             },


### PR DESCRIPTION
This PR marks Opera Android 74 as released.  Release date comes from the Play Store, and Chrome version comes from the user agent string.
