### PR TITLE
Update Chromium data for api.Element.animate.options_pseudoElement_parameter

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -407,22 +407,11 @@
             "description": "<code>options.pseudoElement</code> parameter",
             "spec_url": "https://w3c.github.io/csswg-drafts/web-animations-1/#dom-keyframeeffectoptions-pseudoelement",
             "support": {
-              "chrome": [
-                {
-                  "version_added": "84"
-                },
-                {
-                  "version_added": "81",
-                  "partial_implementation": true,
-                  "notes": "A valid animation object is returned but the targeted pseudoelement is not visually animated.",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-experimental-web-platform-features"
-                    }
-                  ]
-                }
-              ],
+              "chrome": {
+                "version_added": "81",
+                "partial_implementation": true,
+                "notes": "A valid animation object is returned but the targeted pseudoelement is not visually animated."
+              },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `animate.options_pseudoElement_parameter` member of the `Element` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.1.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Element/animate/options_pseudoElement_parameter
