### PR TITLE
Update Chromium data for api.Element.requestFullscreen.returns_promise

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -7161,7 +7161,7 @@
             "description": "Returns a <code>Promise</code>",
             "support": {
               "chrome": {
-                "version_added": "69"
+                "version_added": "71"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `requestFullscreen.returns_promise` member of the `Element` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.1.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Element/requestFullscreen/returns_promise
