### PR TITLE
Update Safari data for api.Element.scrollIntoView.options_parameter

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -7814,7 +7814,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "14"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `scrollIntoView.options_parameter` member of the `Element` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.1.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Element/scrollIntoView/options_parameter

Additional Notes: "14" was guesstimated from "13.1> ≤14.1", as I don't currently have access to Safari 14.
