### PR TITLE
Update Chromium data for api.HTMLCanvasElement.getContext.bitmaprenderer_context

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -191,7 +191,7 @@
             "description": "<code>bitmaprenderer</code> context",
             "support": {
               "chrome": {
-                "version_added": "56"
+                "version_added": "66"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -224,7 +224,7 @@
               "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-imagebitmaprenderingcontextsettings-alpha",
               "support": {
                 "chrome": {
-                  "version_added": "56"
+                  "version_added": "66"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",

--- a/api/ImageBitmapRenderingContext.json
+++ b/api/ImageBitmapRenderingContext.json
@@ -6,7 +6,7 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#the-imagebitmaprenderingcontext-interface",
         "support": {
           "chrome": {
-            "version_added": "56"
+            "version_added": "66"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -38,7 +38,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-imagebitmaprenderingcontext-canvas-dev",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "66"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -72,7 +72,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-imagebitmaprenderingcontext-transferfromimagebitmap-dev",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": "66"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `getContext.bitmaprenderer_context` member of the `HTMLCanvasElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.1.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/HTMLCanvasElement/getContext/bitmaprenderer_context
