### PR TITLE
Update Safari data for api.HTMLCanvasElement.getContext.bitmaprenderer_context

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -239,7 +239,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "11.1"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -206,7 +206,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "11.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `getContext.bitmaprenderer_context` member of the `HTMLCanvasElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.1.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/HTMLCanvasElement/getContext/bitmaprenderer_context
