### PR TITLE
Add data for prefers-reduced-transparency media query

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1293,6 +1293,49 @@
             }
           }
         },
+        "prefers-reduced-transparency": {
+          "__compat": {
+            "description": "<code>prefers-reduced-transparency</code> media feature",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@media/prefers-reduced-transparency",
+            "spec_url": "https://w3c.github.io/csswg-drafts/mediaqueries-5/#prefers-reduced-transparency",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "113",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.prefers-reduced-transparency.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "impl_url": "https://bugzil.la/1736914"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "range_syntax": {
           "__compat": {
             "description": "Range syntax from Media Queries Level 4",


### PR DESCRIPTION
#### Summary

Added data for the `prefers-reduced-transparency` media query as Firefox now supports in 113 behind a pref.

#### Test results and supporting details

New WPT tests: https://github.com/web-platform-tests/wpt/blob/master/css/mediaqueries/prefers-reduced-transparency.html

Gecko bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1736914
WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=175497 (unimplemented)
Blink bug: Does not exist currently
