### PR TITLE
Fixed edge 108 release notes (now archived)

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -255,7 +255,7 @@
         },
         "108": {
           "release_date": "2022-12-06",
-          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1080146242-december-5-2022",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1080146242-december-5-2022",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "108"


### PR DESCRIPTION
#### Summary

Edge 111 is out, and the edge.json was just updated in BCD. This PR is a quick follow-up to fix the 108 release note links. Release note links get updated when releases are too old (they move to an archive page instead).
