### PR TITLE
Update Firefox data for api.CSSKeyframesRule.appendRule

### DIFF
--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -122,11 +122,11 @@
             },
             "firefox": [
               {
-                "version_added": "22"
+                "version_added": "21"
               },
               {
                 "version_added": "5",
-                "version_removed": "22",
+                "version_removed": "21",
                 "alternative_name": "insertRule"
               }
             ],


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `appendRule` member of the `CSSKeyframesRule` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.1.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CSSKeyframesRule/appendRule
