### PR TITLE
Update Firefox data for CSSPageRule API

### DIFF
--- a/api/CSSPageRule.json
+++ b/api/CSSPageRule.json
@@ -13,7 +13,7 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "1"
+            "version_added": "19"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -96,7 +96,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "12"
+              "version_added": "19"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `CSSPageRule` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.1.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CSSPageRule

Additional Notes: The `@page` rule itself (at `css.at-rules.page`) states Firefox 19 as well, so Firefox 1 and 12 doesn't seem accurate.
