### PR TITLE
Update Firefox data for CloseEvent API

### DIFF
--- a/api/CloseEvent.json
+++ b/api/CloseEvent.json
@@ -16,14 +16,14 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "8",
+            "version_added": "4",
             "notes": [
               "Before Firefox 12, the close code <code>CLOSE_NORMAL</code> was used when the channel was closed due to an unexpected error or unspecified error condition.",
               "Before Firefox 8, the <code>WebSocket</code> close event was sent to the listener as a simple event."
             ]
           },
           "firefox_android": {
-            "version_added": "8"
+            "version_added": "4"
           },
           "ie": {
             "version_added": "10"
@@ -194,7 +194,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "8"
+              "version_added": "4"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `CloseEvent` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.1.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CloseEvent
