### PR TITLE
Allow ranged values for any browser release two+ years old

### DIFF
--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -314,28 +314,9 @@ Examples:
 
 Note: many data categories no longer allow for `version_removed` to be set to `true`, as we are working to [improve the quality of the compatibility data](https://github.com/mdn/browser-compat-data/issues/3555).
 
-### Ranged versions
+### Ranged versions (≤)
 
-For certain browsers, ranged versions are allowed as it is sometimes impractical to find out in which early version of a browser a feature shipped. Ranged versions should be used sparingly and only when it is impossible to find out the version number a feature initially shipped in. The following ranged version values are allowed:
-
-- Edge
-  - "≤18" (the last EdgeHTML-based Edge and possibly earlier)
-  - "≤79" (the first Chromium-based Edge and possibly in EdgeHTML-based Edge)
-- Internet Explorer
-  - "≤6" (the earliest IE version testable in BrowserStack and possibly earlier)
-  - "≤11" (the last IE version and possibly earlier)
-- Opera
-  - "≤12.1" (the last Presto-based Opera and possibly earlier)
-  - "≤15" (the first Chromium-based Opera and possibly in Presto-based Opera)
-- Opera Android
-  - "≤12.1" (the last Presto-based Opera and possibly earlier)
-  - "≤14" (the first Chromium-based Opera and possibly in Presto-based Opera)
-- Safari
-  - "≤4" (the earliest Safari version testable in BrowserStack and possibly earlier)
-- Safari iOS
-  - "≤3" (the earliest Safari iOS version testable in BrowserStack and possibly earlier)
-- WebView Android
-  - "≤37" (the first Chrome-based WebView and possibly previous Android versions)
+For certain browser versions, ranged versions (also called "ranged values") are allowed as it is sometimes impractical to find out in which early version of a browser a feature shipped. Ranged versions are a way to include some version data in BCD, while also stating the version number may not be accurate. These values state that the feature has been confirmed to be supported in at least a certain version of the browser, but may have been added in an earlier release. Ranged versions are indicated by the `Less Than or Equal To (U+2264)` (`≤`) symbol before the version number.
 
 For example, the statement below means, "supported in at least version 37 and possibly in earlier versions as well".
 
@@ -344,6 +325,8 @@ For example, the statement below means, "supported in at least version 37 and po
   "version_added": "≤37"
 }
 ```
+
+Ranged versions should be used sparingly and only when it is impossible or highly impractical to find out the version number a feature initially shipped in. Ranged versions are allowed for browser releases dating back two years or earlier. Contributors are encouraged to eliminate ranged versions and replace them with exact version numbers whenever possible.
 
 #### `prefix`
 

--- a/test/linter/test-versions.ts
+++ b/test/linter/test-versions.ts
@@ -18,18 +18,8 @@ import {
 import bcd from '../../index.js';
 const { browsers } = bcd;
 
-const validBrowserVersions: { [browser: string]: string[] } = {};
-
-const VERSION_RANGE_BROWSERS: { [browser: string]: string[] } = {
-  chrome: ['≤15', '≤37'],
-  edge: ['≤18', '≤79'],
-  ie: ['≤6', '≤11'],
-  opera: ['≤12.1', '≤15'],
-  opera_android: ['≤12.1', '≤14'],
-  safari: ['≤4'],
-  safari_ios: ['≤3'],
-  webview_android: ['≤37'],
-};
+const twoYearsAgo = new Date();
+twoYearsAgo.setFullYear(twoYearsAgo.getFullYear() - 2);
 
 const browserTips: { [browser: string]: string } = {
   nodejs:
@@ -39,16 +29,6 @@ const browserTips: { [browser: string]: string } = {
   opera_android:
     'Blink editions of Opera Android and Opera desktop were the Chrome version number minus 13, up until Opera Android 43 when they began skipping Chrome versions. Please double-check browsers/opera_android.json to make sure you are using the correct versions.',
 };
-
-for (const browser of Object.keys(browsers) as BrowserName[]) {
-  validBrowserVersions[browser] = Object.keys(browsers[browser].releases);
-  if (VERSION_RANGE_BROWSERS[browser]) {
-    validBrowserVersions[browser].push(...VERSION_RANGE_BROWSERS[browser]);
-  }
-  if (browsers[browser].preview_name) {
-    validBrowserVersions[browser].push('preview');
-  }
-}
 
 const realValuesTargetBrowsers = [
   'chrome',
@@ -90,7 +70,12 @@ const isValidVersion = (
   version: VersionValue,
 ): boolean => {
   if (typeof version === 'string') {
-    return validBrowserVersions[browser].includes(version);
+    if (version === 'preview') {
+      return !!browsers[browser].preview_name;
+    }
+    return Object.keys(browsers[browser].releases).includes(
+      version.replace('≤', ''),
+    );
   } else if (
     realValuesRequired[category].includes(browser) &&
     version !== false
@@ -159,90 +144,102 @@ const checkVersions = (
   ) as BrowserName[];
 
   for (const browser of browsersToCheck) {
-    if (validBrowserVersions[browser]) {
-      const supportStatement: InternalSupportStatement | undefined =
-        supportData[browser];
+    const supportStatement: InternalSupportStatement | undefined =
+      supportData[browser];
 
-      if (!supportStatement) {
-        if (realValuesRequired[category].includes(browser)) {
-          logger.error(chalk`{red {bold ${browser}} must be defined}`);
+    if (!supportStatement) {
+      if (realValuesRequired[category].includes(browser)) {
+        logger.error(chalk`{red {bold ${browser}} must be defined}`);
+      }
+
+      continue;
+    }
+
+    for (const statement of Array.isArray(supportStatement)
+      ? supportStatement
+      : [supportStatement]) {
+      if (statement === 'mirror') {
+        // If the data is to be mirrored, make sure it is mirrorable
+        if (!browsers[browser].upstream) {
+          logger.error(
+            chalk`{bold ${browser}} is set to mirror, however {bold ${browser}} does not have an upstream browser.`,
+          );
         }
-
         continue;
       }
 
-      for (const statement of Array.isArray(supportStatement)
-        ? supportStatement
-        : [supportStatement]) {
-        if (statement === 'mirror') {
-          // If the data is to be mirrored, make sure it is mirrorable
-          if (!browsers[browser].upstream) {
-            logger.error(
-              chalk`{bold ${browser}} is set to mirror, however {bold ${browser}} does not have an upstream browser.`,
-            );
-          }
+      for (const property of ['version_added', 'version_removed']) {
+        const version = statement[property];
+        if (property == 'version_removed' && version === undefined) {
+          // Undefined is allowed for version_removed
           continue;
         }
-
-        for (const property of ['version_added', 'version_removed']) {
-          const version = statement[property];
-          if (property == 'version_removed' && version === undefined) {
-            // Undefined is allowed for version_removed
-            continue;
-          }
-          if (!isValidVersion(browser, category, version)) {
-            logger.error(
-              chalk`{bold ${property}: "${version}"} is {bold NOT} a valid version number for {bold ${browser}}\n    Valid {bold ${browser}} versions are: ${validBrowserVersions[
-                browser
-              ].join(', ')}`,
-              { tip: browserTips[browser] },
-            );
-          }
-        }
-
-        if ('version_added' in statement && 'version_removed' in statement) {
-          if (statement.version_added === statement.version_removed) {
-            logger.error(
-              chalk`{bold version_added: "${statement.version_added}"} must not be the same as {bold version_removed} for {bold ${browser}}`,
-            );
-          }
-          if (
-            typeof statement.version_added === 'string' &&
-            typeof statement.version_removed === 'string' &&
-            addedBeforeRemoved(statement) === false
-          ) {
-            logger.error(
-              chalk`{bold version_removed: "${statement.version_removed}"} must be greater than {bold version_added: "${statement.version_added}"}`,
-            );
-          }
-        }
-
-        if ('flags' in statement && !browsers[browser].accepts_flags) {
+        if (!isValidVersion(browser, category, version)) {
           logger.error(
-            chalk`This browser ({bold ${browser}}) does not support flags, so support cannot be behind a flag for this feature.`,
+            chalk`{bold ${property}: "${version}"} is {bold NOT} a valid version number for {bold ${browser}}\n    Valid {bold ${browser}} versions are: ${Object.keys(
+              browsers[browser],
+            ).join(', ')}`,
+            { tip: browserTips[browser] },
           );
         }
 
-        if (statement.version_added === false) {
+        if (typeof version === 'string' && version.includes('≤')) {
+          const releaseData =
+            browsers[browser].releases[version.replace('≤', '')];
           if (
-            Object.keys(statement).some(
-              (k) => !['version_added', 'notes', 'impl_url'].includes(k),
-            )
+            !releaseData ||
+            !releaseData.release_date ||
+            new Date(releaseData.release_date) > twoYearsAgo
           ) {
             logger.error(
-              chalk`The data for ({bold ${browser}}) says no support, but contains additional properties that suggest support.`,
+              chalk`{bold ${property}: "${version}"} is {bold NOT} a valid version number for {bold ${browser}}\n    Ranged values are only allowed for browser versions released two years or older. Ranged values are also not allowed for browser versions without a known release date.}`,
             );
           }
         }
+      }
 
+      if ('version_added' in statement && 'version_removed' in statement) {
+        if (statement.version_added === statement.version_removed) {
+          logger.error(
+            chalk`{bold version_added: "${statement.version_added}"} must not be the same as {bold version_removed} for {bold ${browser}}`,
+          );
+        }
         if (
-          Array.isArray(supportStatement) &&
-          statement.version_added === false
+          typeof statement.version_added === 'string' &&
+          typeof statement.version_removed === 'string' &&
+          addedBeforeRemoved(statement) === false
         ) {
           logger.error(
-            chalk`{bold ${browser}} cannot have a {bold version_added: false} in an array of statements.`,
+            chalk`{bold version_removed: "${statement.version_removed}"} must be greater than {bold version_added: "${statement.version_added}"}`,
           );
         }
+      }
+
+      if ('flags' in statement && !browsers[browser].accepts_flags) {
+        logger.error(
+          chalk`This browser ({bold ${browser}}) does not support flags, so support cannot be behind a flag for this feature.`,
+        );
+      }
+
+      if (statement.version_added === false) {
+        if (
+          Object.keys(statement).some(
+            (k) => !['version_added', 'notes', 'impl_url'].includes(k),
+          )
+        ) {
+          logger.error(
+            chalk`The data for ({bold ${browser}}) says no support, but contains additional properties that suggest support.`,
+          );
+        }
+      }
+
+      if (
+        Array.isArray(supportStatement) &&
+        statement.version_added === false
+      ) {
+        logger.error(
+          chalk`{bold ${browser}} cannot have a {bold version_added: false} in an array of statements.`,
+        );
       }
     }
   }


### PR DESCRIPTION
This PR is an alternative solution to #19013 and #19014 that allows ranged values for _any_ browser release dating back two years ago or older.  Closes #19013, closes #19014.  This was discussed as a potential solution during the last BCD meeting.

CC @ddbeck
