### PR TITLE
Fx110: flag name change for scroll-timeline shorthand and longhand properties

### DIFF
--- a/css/properties/scroll-timeline-axis.json
+++ b/css/properties/scroll-timeline-axis.json
@@ -13,21 +13,21 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "103",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.scroll-linked-animations.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "110",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "layout.css.scroll-driven-animations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "103",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-linked-animations.enabled",
                     "value_to_set": "true"
                   }
                 ]

--- a/css/properties/scroll-timeline-axis.json
+++ b/css/properties/scroll-timeline-axis.json
@@ -11,16 +11,28 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "103",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.scroll-linked-animations.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "103",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-linked-animations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "110",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-driven-animations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/css/properties/scroll-timeline-name.json
+++ b/css/properties/scroll-timeline-name.json
@@ -13,21 +13,21 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "103",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.scroll-linked-animations.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "110",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "layout.css.scroll-driven-animations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "103",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-linked-animations.enabled",
                     "value_to_set": "true"
                   }
                 ]

--- a/css/properties/scroll-timeline-name.json
+++ b/css/properties/scroll-timeline-name.json
@@ -11,16 +11,28 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "103",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.scroll-linked-animations.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "103",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-linked-animations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "110",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-driven-animations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/css/properties/scroll-timeline.json
+++ b/css/properties/scroll-timeline.json
@@ -13,21 +13,21 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "103",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.scroll-linked-animations.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
                 "version_added": "110",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "layout.css.scroll-driven-animations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "103",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-linked-animations.enabled",
                     "value_to_set": "true"
                   }
                 ]

--- a/css/properties/scroll-timeline.json
+++ b/css/properties/scroll-timeline.json
@@ -11,16 +11,28 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "103",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.scroll-linked-animations.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "103",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-linked-animations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "110",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-driven-animations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
#### Summary

The shorthand and longhand properties, [scroll-timeline](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-timeline), [scroll-timeline-name](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-timeline-name),
    [scroll-timeline-axis](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-timeline-axis), are still behind a preference but the flag name was changed in Fx110 because of the change in spec. 

Flag name before: `layout.css.scroll-linked-animations.enabled`
Flag name now: `layout.css.scroll-driven-animations.enabled`

via https://bugzilla.mozilla.org/show_bug.cgi?id=1807685

#### Related doc issues and bugs

(The flag name was changed in Fx110 but other changes requiring content updates happened in Fx111.)

- Fx111 Doc issue tracker: https://github.com/mdn/content/issues/24396 (bugzilla: [1804573](https://bugzilla.mozilla.org/show_bug.cgi?id=1804573))
- Spec: https://w3c.github.io/csswg-drafts/scroll-animations/#scroll-timeline-shorthand

#### Related issue

This PR partly (the Firefox part) fixes the issue https://github.com/mdn/browser-compat-data/issues/19086. Awaiting more information about the version in which support was added in Chrome and Edge. I'll probably open a separate PR for updating Chrome info in BCD.

