### PR TITLE
Fix Chrome 1-15 data for SVG element APIs

### DIFF
--- a/api/SVGAnimateElement.json
+++ b/api/SVGAnimateElement.json
@@ -6,7 +6,7 @@
         "spec_url": "https://svgwg.org/specs/animations/#InterfaceSVGAnimateElement",
         "support": {
           "chrome": {
-            "version_added": "1"
+            "version_added": "2"
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/SVGAnimateTransformElement.json
+++ b/api/SVGAnimateTransformElement.json
@@ -6,7 +6,7 @@
         "spec_url": "https://svgwg.org/specs/animations/#InterfaceSVGAnimateTransformElement",
         "support": {
           "chrome": {
-            "version_added": "1"
+            "version_added": "2"
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/SVGAnimatedBoolean.json
+++ b/api/SVGAnimatedBoolean.json
@@ -6,7 +6,7 @@
         "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedBoolean",
         "support": {
           "chrome": {
-            "version_added": "5"
+            "version_added": "6"
           },
           "chrome_android": "mirror",
           "edge": {

--- a/api/SVGAnimatedInteger.json
+++ b/api/SVGAnimatedInteger.json
@@ -6,7 +6,7 @@
         "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedInteger",
         "support": {
           "chrome": {
-            "version_added": "5"
+            "version_added": "6"
           },
           "chrome_android": "mirror",
           "edge": {

--- a/api/SVGAnimatedNumberList.json
+++ b/api/SVGAnimatedNumberList.json
@@ -6,7 +6,7 @@
         "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedNumberList",
         "support": {
           "chrome": {
-            "version_added": "5"
+            "version_added": "6"
           },
           "chrome_android": "mirror",
           "edge": {

--- a/api/SVGAnimationElement.json
+++ b/api/SVGAnimationElement.json
@@ -6,7 +6,7 @@
         "spec_url": "https://svgwg.org/specs/animations/#InterfaceSVGAnimationElement",
         "support": {
           "chrome": {
-            "version_added": "1"
+            "version_added": "2"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -45,7 +45,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "2"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -83,7 +83,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "2"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -174,7 +174,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "2"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -212,7 +212,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "2"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -303,7 +303,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "2"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -341,7 +341,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "2"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -379,7 +379,7 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "2"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -471,7 +471,7 @@
           "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__requiredExtensions",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "2"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -512,7 +512,7 @@
           "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "2"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -554,7 +554,7 @@
           "spec_url": "https://svgwg.org/specs/animations/#__svg__SVGAnimationElement__targetElement",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "2"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/SVGNumberList.json
+++ b/api/SVGNumberList.json
@@ -6,7 +6,7 @@
         "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGNumberList",
         "support": {
           "chrome": {
-            "version_added": "5"
+            "version_added": "6"
           },
           "chrome_android": "mirror",
           "edge": {

--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -769,7 +769,7 @@
           "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__getElementById",
           "support": {
             "chrome": {
-              "version_added": "6"
+              "version_added": "7"
             },
             "chrome_android": "mirror",
             "edge": {

--- a/api/SVGSetElement.json
+++ b/api/SVGSetElement.json
@@ -6,7 +6,7 @@
         "spec_url": "https://svgwg.org/specs/animations/#InterfaceSVGSetElement",
         "support": {
           "chrome": {
-            "version_added": "1"
+            "version_added": "2"
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/svg/elements/set.json
+++ b/svg/elements/set.json
@@ -7,7 +7,7 @@
           "spec_url": "https://svgwg.org/specs/animations/#SetElement",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "2"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -46,7 +46,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": "2"
               },
               "chrome_android": "mirror",
               "edge": {


### PR DESCRIPTION
I recently overhauled all of my Chrome VMs to replace the Chromium builds with official Chrome releases, which affects Chrome 1-15 results submitted to the collector. This PR is a cherry-pick of #19145 that updates the SVG element interfaces.

Note: the data for the `<set>` SVG element was originally copied over from the API data (see #9510).  It has been re-copied in this PR.