### PR TITLE
Update firefox to version 111

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -795,28 +795,28 @@
         "110": {
           "release_date": "2023-02-14",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/110",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "110"
         },
         "111": {
           "release_date": "2023-03-14",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/111",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "111"
         },
         "112": {
           "release_date": "2023-04-11",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/112",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "112"
         },
         "113": {
           "release_date": "2023-05-09",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/113",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "113"
         },

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -662,28 +662,28 @@
         "110": {
           "release_date": "2023-02-14",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/110",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "110"
         },
         "111": {
           "release_date": "2023-03-14",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/111",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "111"
         },
         "112": {
           "release_date": "2023-04-11",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/112",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "112"
         },
         "113": {
           "release_date": "2023-05-09",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/113",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "113"
         },


### PR DESCRIPTION
#### Summary

This PR updates Firefox to version 111

* https://www.mozilla.org/en-US/firefox/111.0/releasenotes/
* https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/111
