### PR TITLE
FF112 navigator.getAutoplayPolicy() enabled on release

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -956,21 +956,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "110",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.media.autoplay-policy-detection.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "112"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
FF112 enables `navigator.getAutoplayPolicy()` by default in https://bugzilla.mozilla.org/show_bug.cgi?id=1812189
This removes the pref and changes the preview version to 112.

Related docs work can be tracked in https://github.com/mdn/content/issues/25362