### PR TITLE
FF112 supports roundRect() on Canvas2D

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2370,7 +2370,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "112"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -1760,7 +1760,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "112"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Path2D.json
+++ b/api/Path2D.json
@@ -432,7 +432,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "112"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF112 supports [CanvasRenderingContext2D/roundRect()](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/roundRect#result) in https://bugzilla.mozilla.org/show_bug.cgi?id=1756175

This applies to the same method in OffscreenCanvas2d and path2D. The offscreen support wasn't obvious from the issue (to me) but is obvious when you run the offscreen path roundrect tests in FF111 vs FF112 http://wpt.live/html/canvas/offscreen/path-objects/

Other docs work can be tracked in https://github.com/mdn/content/issues/25359