### PR TITLE
Update SVG element data from the corresponding APIs

### DIFF
--- a/svg/elements/animateMotion.json
+++ b/svg/elements/animateMotion.json
@@ -7,26 +7,28 @@
           "spec_url": "https://svgwg.org/specs/animations/#AnimateMotionElement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "19"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "4"
             },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": "≤12.1"
+            },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "6"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/svg/elements/animateTransform.json
+++ b/svg/elements/animateTransform.json
@@ -7,28 +7,32 @@
           "spec_url": "https://svgwg.org/specs/animations/#AnimateTransformElement",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "2"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "4"
             },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": "≤12.1"
+            },
             "opera_android": {
-              "version_added": null
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": null
+              "version_added": "3"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "1"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/svg/elements/set.json
+++ b/svg/elements/set.json
@@ -25,7 +25,7 @@
               "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
               "version_added": "3"


### PR DESCRIPTION
This copies some version numbers from the corresponding SVG*Element
interfaces. It's always possible the markup was supported before the
APIs, but this is too far back in time to warrant investigation.