### PR TITLE
Add note about `navigator.doNotTrack` return value in Firefox

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -838,7 +838,10 @@
             },
             "firefox": {
               "version_added": "9",
-              "notes": "In Firefox, <code>navigator.doNotTrack</code> returns <code>\"unspecified\"</code> instead of <code>null</code>. Before Firefox 32, <code>navigator.doNotTrack</code> would report values of <code>\"yes\"</code> and <code>\"no\"</code> rather than <code>\"1\"</code> and <code>\"0\"</code>."
+              "notes": [
+                "In Firefox, <code>navigator.doNotTrack</code> returns <code>\"unspecified\"</code> instead of <code>null</code>.",
+                "Before Firefox 32, <code>navigator.doNotTrack</code> would report values of <code>\"yes\"</code> and <code>\"no\"</code> rather than <code>\"1\"</code> and <code>\"0\"</code>."
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -838,7 +838,7 @@
             },
             "firefox": {
               "version_added": "9",
-              "notes": "Before Firefox 32, <code>navigator.doNotTrack</code> would report values of <code>yes</code> and <code>no</code> rather than <code>1</code> and <code>0</code>."
+              "notes": "In Firefox, <code>navigator.doNotTrack</code> returns <code>\"unspecified\"</code> instead of <code>null</code>. Before Firefox 32, <code>navigator.doNotTrack</code> would report values of <code>\"yes\"</code> and <code>\"no\"</code> rather than <code>\"1\"</code> and <code>\"0\"</code>."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
#### Summary

This PR adds a note about `navigator.doNotTrack` behaving differently than the specification in Firefox.

#### Related issues

See discussion in: https://github.com/mdn/content/pull/25310#discussion_r1136345176

Related PR in `mdn/content`: https://github.com/mdn/content/pull/25446