### PR TITLE
CSSContainerRule - chromiums appear to mirror - edge 111

### DIFF
--- a/api/CSSContainerRule.json
+++ b/api/CSSContainerRule.json
@@ -41,9 +41,7 @@
               "version_added": "111"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "110"
             },
@@ -52,9 +50,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false
@@ -80,9 +76,7 @@
               "version_added": "111"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "110"
             },
@@ -91,9 +85,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false

--- a/api/CSSContainerRule.json
+++ b/api/CSSContainerRule.json
@@ -50,7 +50,9 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": false
+            },
             "opera_android": "mirror",
             "safari": {
               "version_added": false
@@ -85,7 +87,9 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": false
+            },
             "opera_android": "mirror",
             "safari": {
               "version_added": false


### PR DESCRIPTION
Ran `CSSContainerRule` test code and found that edge 111 does appear to mirror the containerQuery and containerName properties of `CSSContainerRule`.

BUT, only in the 111 latest on browserstack - the beta and dev do not show these values. This also works on my local testing.

![image](https://user-images.githubusercontent.com/5368500/226511252-da165e3a-5439-4654-99dd-1f35937bd22b.png)

However opera in 96/97 with corresponding engine 96=111 does not appear to support this feature. I have no idea why it would not though!

FYI @queengooborg 


Related docs work in https://github.com/mdn/content/issues/25398