### PR TITLE
added the version added for inert for Firefox 112

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1246,7 +1246,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "112"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -809,7 +809,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "112"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
#### Summary

Added the version added for the inert Global_attribute and HTMLElement Web API

#### Test results and supporting details

N/A

#### Related issues

[Bugzilla bug 1764263](https://bugzilla.mozilla.org/show_bug.cgi?id=1764263)
[Content Issue 25356](https://github.com/mdn/content/issues/25356)
Content PR - Coming soon
Release Notes PR - Coming soon