### PR TITLE
Add missing features for api.Document.contains

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -1284,6 +1284,44 @@
           }
         }
       },
+      "contains": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "16"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "6"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "contentType": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/contentType",

--- a/api/Document.json
+++ b/api/Document.json
@@ -1286,6 +1286,7 @@
       },
       "contains": {
         "__compat": {
+          "spec_url": "https://dom.spec.whatwg.org/#dom-node-contains",
           "support": {
             "chrome": {
               "version_added": "16"


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing features of the `contains` member of the `Document` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.1.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Document/contains
