### PR TITLE
Add missing mdn_url in CSSLayerBlockRule.json

### DIFF
--- a/api/CSSLayerBlockRule.json
+++ b/api/CSSLayerBlockRule.json
@@ -2,6 +2,7 @@
   "api": {
     "CSSLayerBlockRule": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSLayerBlockRule",
         "spec_url": "https://w3c.github.io/csswg-drafts/css-cascade-5/#csslayerblockrule",
         "support": {
           "chrome": {
@@ -34,6 +35,7 @@
       },
       "name": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSLayerBlockRule/name",
           "spec_url": "https://w3c.github.io/csswg-drafts/css-cascade-5/#dom-csslayerblockrule-name",
           "support": {
             "chrome": {


### PR DESCRIPTION
We added these two pages on MDN earlier this Quarter.