### PR TITLE
Add missing mdn_url entries in CSSLayerStatementRule.json

### DIFF
--- a/api/CSSLayerStatementRule.json
+++ b/api/CSSLayerStatementRule.json
@@ -2,6 +2,7 @@
   "api": {
     "CSSLayerStatementRule": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSLayerStatementRule",
         "spec_url": "https://w3c.github.io/csswg-drafts/css-cascade-5/#csslayerstatementrule",
         "support": {
           "chrome": {
@@ -34,6 +35,7 @@
       },
       "nameList": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSLayerStatementRule/nameList",
           "spec_url": "https://w3c.github.io/csswg-drafts/css-cascade-5/#dom-csslayerstatementrule-namelist",
           "support": {
             "chrome": {


### PR DESCRIPTION
We created these two pages on MDN earlier this Quarter.