### PR TITLE
Update Firefox data for api.Clipboard.readText

### DIFF
--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -135,7 +135,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "63",
+              "version_added": false,
               "notes": "Firefox only supports reading the clipboard in browser extensions, using the <code>\"clipboardRead\"</code> extension permission."
             },
             "firefox_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `readText` member of the `Clipboard` API. Other
