### PR TITLE
Add missing mdn_urls in CSSContainerRule.json

### DIFF
--- a/api/CSSContainerRule.json
+++ b/api/CSSContainerRule.json
@@ -35,6 +35,7 @@
       },
       "containerName": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSContainerRule/containerName",
           "spec_url": "https://w3c.github.io/csswg-drafts/css-contain-3/#dom-csscontainerrule-containername",
           "support": {
             "chrome": {
@@ -72,6 +73,7 @@
       },
       "containerQuery": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSContainerRule/containerQuery",
           "spec_url": "https://w3c.github.io/csswg-drafts/css-contain-3/#dom-csscontainerrule-containerquery",
           "support": {
             "chrome": {


### PR DESCRIPTION
Hamish added them in https://github.com/mdn/content/pull/25493.