### PR TITLE
Add missing mdn_url in PerformanceTiming.json

### DIFF
--- a/api/PerformanceTiming.json
+++ b/api/PerformanceTiming.json
@@ -800,6 +800,7 @@
       },
       "toJSON": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceTiming/toJSON",
           "spec_url": "https://w3c.github.io/navigation-timing/#dom-performancetiming-tojson",
           "support": {
             "chrome": {


### PR DESCRIPTION
There was one missing in this interface.