### PR TITLE
Add missing mdn_url in PaymentResponse.json

### DIFF
--- a/api/PaymentResponse.json
+++ b/api/PaymentResponse.json
@@ -626,6 +626,7 @@
       "toJSON": {
         "__compat": {
           "description": "<code>toJSON()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentResponse/toJSON",
           "support": {
             "chrome": {
               "version_added": "60"


### PR DESCRIPTION
This missing page got added earlier this Quarter.