### PR TITLE
Update Chrome versions for scroll-timeline shorthand and longhand properties

### DIFF
--- a/css/properties/scroll-timeline-axis.json
+++ b/css/properties/scroll-timeline-axis.json
@@ -19,18 +19,8 @@
                 ]
               },
               {
-                "version_added": "107",
+                "version_added": "108",
                 "notes": "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "88",
                 "flags": [
                   {
                     "type": "preference",
@@ -44,7 +34,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "110",
+                "version_added": "111",
                 "notes": "The syntax of the shorthand property uses the fixed order of name and then the axis.",
                 "flags": [
                   {

--- a/css/properties/scroll-timeline-axis.json
+++ b/css/properties/scroll-timeline-axis.json
@@ -9,9 +9,7 @@
             "chrome": [
               {
                 "version_added": "111",
-                "notes": [
-                  "The syntax of the shorthand property `scroll-timeline` uses the fixed order of name and then the axis."
-                ],
+                "notes": "The syntax of the shorthand property `scroll-timeline` uses the fixed order of name and then the axis.",
                 "flags": [
                   {
                     "type": "preference",
@@ -22,9 +20,7 @@
               },
               {
                 "version_added": "107",
-                "notes": [
-                  "The `@scroll-timeline` at rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`."
-                ],
+                "notes": "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
                 "flags": [
                   {
                     "type": "preference",
@@ -60,7 +56,7 @@
               },
               {
                 "version_added": "103",
-                "notes": "The `@scroll-timeline` at rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
+                "notes": "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/scroll-timeline-axis.json
+++ b/css/properties/scroll-timeline-axis.json
@@ -6,14 +6,50 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-timeline-axis",
           "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations/#propdef-scroll-timeline-axis",
           "support": {
-            "chrome": {
-              "version_added": false
-            },
+            "chrome": [
+              {
+                "version_added": "111",
+                "notes": [
+                  "The syntax of the shorthand property `scroll-timeline` uses the fixed order of name and then the axis."
+                ],
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "107",
+                "notes": [
+                  "The `@scroll-timeline` at rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`."
+                ],
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "88",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": [
               {
                 "version_added": "110",
+                "notes": "The syntax of the shorthand property uses the fixed order of name and then the axis.",
                 "flags": [
                   {
                     "type": "preference",
@@ -24,6 +60,7 @@
               },
               {
                 "version_added": "103",
+                "notes": "The `@scroll-timeline` at rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/scroll-timeline-name.json
+++ b/css/properties/scroll-timeline-name.json
@@ -6,14 +6,50 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-timeline-name",
           "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations/#scroll-timeline-name",
           "support": {
-            "chrome": {
-              "version_added": false
-            },
+            "chrome": [
+              {
+                "version_added": "111",
+                "notes": [
+                  "The syntax of the shorthand property `scroll-timeline` uses the fixed order of name and then the axis."
+                ],
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "107",
+                "notes": [
+                  "The `@scroll-timeline` at rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`."
+                ],
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "88",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": [
               {
                 "version_added": "110",
+                "notes": "The syntax of the shorthand property uses the fixed order of name and then the axis.",
                 "flags": [
                   {
                     "type": "preference",
@@ -24,6 +60,7 @@
               },
               {
                 "version_added": "103",
+                "notes": "The `@scroll-timeline` at rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/scroll-timeline-name.json
+++ b/css/properties/scroll-timeline-name.json
@@ -19,18 +19,8 @@
                 ]
               },
               {
-                "version_added": "107",
+                "version_added": "108",
                 "notes": "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "88",
                 "flags": [
                   {
                     "type": "preference",
@@ -44,7 +34,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "110",
+                "version_added": "111",
                 "notes": "The syntax of the shorthand property uses the fixed order of name and then the axis.",
                 "flags": [
                   {

--- a/css/properties/scroll-timeline-name.json
+++ b/css/properties/scroll-timeline-name.json
@@ -9,9 +9,7 @@
             "chrome": [
               {
                 "version_added": "111",
-                "notes": [
-                  "The syntax of the shorthand property `scroll-timeline` uses the fixed order of name and then the axis."
-                ],
+                "notes": "The syntax of the shorthand property `scroll-timeline` uses the fixed order of name and then the axis.",
                 "flags": [
                   {
                     "type": "preference",
@@ -22,9 +20,7 @@
               },
               {
                 "version_added": "107",
-                "notes": [
-                  "The `@scroll-timeline` at rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`."
-                ],
+                "notes": "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
                 "flags": [
                   {
                     "type": "preference",
@@ -60,7 +56,7 @@
               },
               {
                 "version_added": "103",
-                "notes": "The `@scroll-timeline` at rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
+                "notes": "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/scroll-timeline.json
+++ b/css/properties/scroll-timeline.json
@@ -19,18 +19,8 @@
                 ]
               },
               {
-                "version_added": "107",
+                "version_added": "108",
                 "notes": "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "88",
                 "flags": [
                   {
                     "type": "preference",
@@ -44,7 +34,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "110",
+                "version_added": "111",
                 "notes": "The syntax of the shorthand property uses the fixed order of name and then the axis.",
                 "flags": [
                   {

--- a/css/properties/scroll-timeline.json
+++ b/css/properties/scroll-timeline.json
@@ -6,14 +6,50 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-timeline",
           "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations/#scroll-timeline-shorthand",
           "support": {
-            "chrome": {
-              "version_added": false
-            },
+            "chrome": [
+              {
+                "version_added": "111",
+                "notes": [
+                  "The syntax of the shorthand property `scroll-timeline` uses the fixed order of name and then the axis."
+                ],
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "107",
+                "notes": [
+                  "The `@scroll-timeline` at rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`."
+                ],
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "88",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": [
               {
                 "version_added": "110",
+                "notes": "The syntax of the shorthand property uses the fixed order of name and then the axis.",
                 "flags": [
                   {
                     "type": "preference",
@@ -24,6 +60,7 @@
               },
               {
                 "version_added": "103",
+                "notes": "The `@scroll-timeline` at rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
                 "flags": [
                   {
                     "type": "preference",

--- a/css/properties/scroll-timeline.json
+++ b/css/properties/scroll-timeline.json
@@ -9,9 +9,7 @@
             "chrome": [
               {
                 "version_added": "111",
-                "notes": [
-                  "The syntax of the shorthand property `scroll-timeline` uses the fixed order of name and then the axis."
-                ],
+                "notes": "The syntax of the shorthand property `scroll-timeline` uses the fixed order of name and then the axis.",
                 "flags": [
                   {
                     "type": "preference",
@@ -22,9 +20,7 @@
               },
               {
                 "version_added": "107",
-                "notes": [
-                  "The `@scroll-timeline` at rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`."
-                ],
+                "notes": "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
                 "flags": [
                   {
                     "type": "preference",
@@ -60,7 +56,7 @@
               },
               {
                 "version_added": "103",
-                "notes": "The `@scroll-timeline` at rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
+                "notes": "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
                 "flags": [
                   {
                     "type": "preference",


### PR DESCRIPTION
### Summary

This pull request is a follow up to https://github.com/mdn/browser-compat-data/pull/19148 for adding to the browser compat table chrome versions in which support was added for `scroll-timeline` shorthand and longhand properties.

Accordingly, this pull request also makes minor updates to the Firefox entries to add notes to explain the changes that  happened in those versions.

All the properties in both Chrome and Firefox are still behind the experimental flag/preference.

### Chrome version support
Source for information for Chrome versions: https://github.com/mdn/content/pull/25105#issuecomment-1472584987

version 111: https://bugs.chromium.org/p/chromium/issues/detail?id=1357795
version 107: https://bugs.chromium.org/p/chromium/issues/detail?id=1317765
version 88: https://bugs.chromium.org/p/chromium/issues/detail?id=1074052#c35

### Note
I do not have any explicit information about support in Edge.

### Related issue
Doc issue tracker: https://github.com/mdn/content/issues/24396


