### PR TITLE
Update Opera Android data for FileSystem APIs

### DIFF
--- a/api/FileSystemDirectoryEntry.json
+++ b/api/FileSystemDirectoryEntry.json
@@ -19,9 +19,7 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": {
-            "version_added": false
-          },
+          "opera_android": "mirror",
           "safari": {
             "version_added": "11.1"
           },
@@ -58,9 +56,7 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "11.1"
             },
@@ -99,9 +95,7 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "11.1"
             },
@@ -140,9 +134,7 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "11.1"
             },
@@ -181,9 +173,7 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },

--- a/api/FileSystemDirectoryHandle.json
+++ b/api/FileSystemDirectoryHandle.json
@@ -19,9 +19,7 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": {
-            "version_added": false
-          },
+          "opera_android": "mirror",
           "safari": {
             "version_added": "15.2"
           },
@@ -56,9 +54,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15.2"
             },
@@ -94,9 +90,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15.2"
             },
@@ -132,9 +126,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15.2"
             },
@@ -170,9 +162,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15.2"
             },
@@ -208,9 +198,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15.2"
             },
@@ -246,9 +234,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15.2"
             },
@@ -284,9 +270,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15.2"
             },
@@ -321,9 +305,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "16.4"
             },

--- a/api/FileSystemDirectoryReader.json
+++ b/api/FileSystemDirectoryReader.json
@@ -21,9 +21,7 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": {
-            "version_added": false
-          },
+          "opera_android": "mirror",
           "safari": {
             "version_added": "11.1"
           },
@@ -58,9 +56,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "11.1"
             },

--- a/api/FileSystemEntry.json
+++ b/api/FileSystemEntry.json
@@ -21,9 +21,7 @@
           "opera": {
             "version_added": false
           },
-          "opera_android": {
-            "version_added": false
-          },
+          "opera_android": "mirror",
           "safari": {
             "version_added": "11.1"
           },
@@ -59,9 +57,7 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
@@ -99,9 +95,7 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "11.1"
             },
@@ -139,9 +133,7 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "11.1"
             },
@@ -178,9 +170,7 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
@@ -218,9 +208,7 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "11.1"
             },
@@ -258,9 +246,7 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "11.1"
             },
@@ -298,9 +284,7 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "11.1"
             },
@@ -337,9 +321,7 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
@@ -377,9 +359,7 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "11.1"
             },
@@ -416,9 +396,7 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
@@ -455,9 +433,7 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },

--- a/api/FileSystemFileEntry.json
+++ b/api/FileSystemFileEntry.json
@@ -21,9 +21,7 @@
           "opera": {
             "version_added": false
           },
-          "opera_android": {
-            "version_added": false
-          },
+          "opera_android": "mirror",
           "safari": {
             "version_added": "11.1"
           },
@@ -61,9 +59,7 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
@@ -101,9 +97,7 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "11.1"
             },

--- a/api/FileSystemFileHandle.json
+++ b/api/FileSystemFileHandle.json
@@ -19,9 +19,7 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": {
-            "version_added": false
-          },
+          "opera_android": "mirror",
           "safari": {
             "version_added": "15.2"
           },
@@ -56,9 +54,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15.2"
             },
@@ -92,9 +88,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
@@ -130,9 +124,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15.2"
             },

--- a/api/FileSystemHandle.json
+++ b/api/FileSystemHandle.json
@@ -19,9 +19,7 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": {
-            "version_added": false
-          },
+          "opera_android": "mirror",
           "safari": {
             "version_added": "15.2"
           },
@@ -56,9 +54,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15.2"
             },
@@ -94,9 +90,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15.2"
             },
@@ -165,9 +159,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "15.2"
             },
@@ -203,9 +195,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
@@ -240,9 +230,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
@@ -278,9 +266,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Opera Android for the `FileSystem*` APIs. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v8.2.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used:
https://mdn-bcd-collector.gooborg.com/tests/api/FileSystemDirectoryEntry
https://mdn-bcd-collector.gooborg.com/tests/api/FileSystemDirectoryHandle
https://mdn-bcd-collector.gooborg.com/tests/api/FileSystemDirectoryReader
https://mdn-bcd-collector.gooborg.com/tests/api/FileSystemEntry
https://mdn-bcd-collector.gooborg.com/tests/api/FileSystemFileEntry
https://mdn-bcd-collector.gooborg.com/tests/api/FileSystemFileHandle
https://mdn-bcd-collector.gooborg.com/tests/api/FileSystemHandle
