### PR TITLE
Add missing mdn_url in XSLTProcessor.json

### DIFF
--- a/api/XSLTProcessor.json
+++ b/api/XSLTProcessor.json
@@ -44,6 +44,7 @@
       "XSLTProcessor": {
         "__compat": {
           "description": "<code>XSLTProcessor()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XSLTProcessor/XSLTProcessor",
           "spec_url": "https://dom.spec.whatwg.org/#dom-xsltprocessor-xsltprocessor",
           "support": {
             "chrome": {


### PR DESCRIPTION
This page got added on MDN yesterday.