### PR TITLE
amaric -> amharic

### DIFF
--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -84,7 +84,7 @@
         },
         "amharic": {
           "__compat": {
-            "description": "<code>amaric</code>",
+            "description": "<code>amharic</code>",
             "support": {
               "chrome": {
                 "version_added": "6",
@@ -121,7 +121,7 @@
         },
         "amharic-abegede": {
           "__compat": {
-            "description": "<code>amaric-abegede</code>",
+            "description": "<code>amharic-abegede</code>",
             "support": {
               "chrome": {
                 "version_added": "6",


### PR DESCRIPTION
Fix #19200

Note the ID is correct! Only the description had the typo.