### PR TITLE
Add path() to browser compat table of shape-outside property

### DIFF
--- a/css/properties/shape-outside.json
+++ b/css/properties/shape-outside.json
@@ -179,29 +179,13 @@
             "spec_url": "https://w3c.github.io/csswg-drafts/css-shapes/#funcdef-basic-shape-path",
             "support": {
               "chrome": {
-                "version_added": "46",
-                "partial_implementation": true,
-                "notes": "Only supported on the <code>offset-path</code> property."
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "97",
-                  "partial_implementation": true,
-                  "notes": "Only supported on the <code>d</code> SVG presentation attribute and the <code>clip-path</code> and <code>offset-path</code> CSS properties. Not supported on the <code>shape-outside</code> CSS property."
-                },
-                {
-                  "version_added": "71",
-                  "partial_implementation": true,
-                  "notes": "Only supported on the <code>clip-path</code> and <code>offset-path</code> properties."
-                },
-                {
-                  "version_added": "63",
-                  "partial_implementation": true,
-                  "notes": "Only supported on the <code>offset-path</code> property."
-                }
-              ],
+              "firefox": {
+                "version_added": false
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/css/properties/shape-outside.json
+++ b/css/properties/shape-outside.json
@@ -172,6 +172,57 @@
             }
           }
         },
+        "path": {
+          "__compat": {
+            "description": "<code>path()</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/path",
+            "spec_url": "https://w3c.github.io/csswg-drafts/css-shapes/#funcdef-basic-shape-path",
+            "support": {
+              "chrome": {
+                "version_added": "46",
+                "partial_implementation": true,
+                "notes": "Only supported on the <code>offset-path</code> property."
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": [
+                {
+                  "version_added": "97",
+                  "partial_implementation": true,
+                  "notes": "Only supported on the <code>d</code> SVG presentation attribute and the <code>clip-path</code> and <code>offset-path</code> CSS properties. Not supported on the <code>shape-outside</code> CSS property."
+                },
+                {
+                  "version_added": "71",
+                  "partial_implementation": true,
+                  "notes": "Only supported on the <code>clip-path</code> and <code>offset-path</code> properties."
+                },
+                {
+                  "version_added": "63",
+                  "partial_implementation": true,
+                  "notes": "Only supported on the <code>offset-path</code> property."
+                }
+              ],
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "polygon": {
           "__compat": {
             "description": "<code>polygon()</code>",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

Fixes https://github.com/mdn/browser-compat-data/issues/19228

#### Summary

This is an extension of the fix in https://github.com/mdn/content/pull/25588.

The `path()` entry is missing in the browser compat table for the [`shape-outside`](https://developer.mozilla.org/en-US/docs/Web/CSS/shape-outside#browser_compatibility) property.

#### Supporting details

The information for `path()` is copied from the browser compat on the [basic-shape](https://developer.mozilla.org/en-US/docs/Web/CSS/basic-shape#browser_compatibility) page.
Source: https://github.com/mdn/browser-compat-data/blob/6b29afce285316f9ab233729777550898781d848/css/types/basic-shape.json#L177-L227).

#### Related issues

https://github.com/mdn/content/issues/9703
