### PR TITLE
Remove Window.devicelight_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -974,60 +974,6 @@
           }
         }
       },
-      "devicelight_event": {
-        "__compat": {
-          "description": "<code>devicelight</code> event",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": {
-              "version_added": "13",
-              "version_removed": "79"
-            },
-            "firefox": [
-              {
-                "version_added": "22",
-                "version_removed": "61",
-                "notes": "Not supported for MacBook with Touch Bar and Windows 7 (see <a href='https://bugzil.la/754199'>bug 754199</a>)."
-              },
-              {
-                "version_added": "62",
-                "version_removed": "89",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "device.sensors.ambientLight.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": {
-              "version_added": "15",
-              "version_removed": "61"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "devicemotion_event": {
         "__compat": {
           "description": "<code>devicemotion</code> event",


### PR DESCRIPTION
Not documented on MDN + removed from any implementation for 2 years.