### PR TITLE
Add missing mdn_url for Document.rootElement

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6131,6 +6131,7 @@
       },
       "rootElement": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/rootElement",
           "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGDocument__rootElement",
           "support": {
             "chrome": {


### PR DESCRIPTION
This page exists for a long time.