### PR TITLE
Remove spec_urls for ShadowRoot.element(s)FromPoint

### DIFF
--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -170,7 +170,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }
@@ -210,7 +210,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": false,
             "deprecated": false
           }

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -140,7 +140,6 @@
       "elementFromPoint": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/elementFromPoint",
-          "spec_url": "https://w3c.github.io/csswg-drafts/cssom-view/#dom-document-elementfrompoint",
           "support": {
             "chrome": {
               "version_added": "53",
@@ -171,8 +170,8 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
-            "standard_track": true,
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }
@@ -180,7 +179,6 @@
       "elementsFromPoint": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/elementsFromPoint",
-          "spec_url": "https://w3c.github.io/csswg-drafts/cssom-view/#dom-document-elementsfrompoint",
           "support": {
             "chrome": {
               "version_added": "53",
@@ -212,8 +210,8 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
-            "standard_track": true,
+            "experimental": true,
+            "standard_track": false,
             "deprecated": false
           }
         }


### PR DESCRIPTION
-  `ShadowRoot.elementFromPoint()` and `ShadowRoot.elementsFromPoint()` were added to the collector as custom, non-standard IDL in response to https://github.com/w3c/csswg-drafts/issues/5886.
    In that PR, GitHub user @Haprog links to the old version of the W3C Shadow DOM spec, which contains these methods defined on a DocumentOrShadowRoot interface mixin: https://www.w3.org/TR/2017/WD-shadow-dom-20170905/#extensions-to-the-documentorshadowroot-mixin

- The very next version now just says “Shadow DOM specification is being incorporated into to the DOM specification, HTML specification, CSS Scoping Module Level 1, UI Events specification, and other relevant specifications.”

 - It seems that these features were moved over to the CSSOM View spec at first glance…  https://drafts.csswg.org/cssom-view/#extensions-to-the-document-interface

- …but the members have been defined much earlier in the spec: see https://www.w3.org/TR/2008/WD-cssom-view-20080222/#the-documentview-interface and https://www.w3.org/TR/2013/WD-cssom-view-20131217/#extensions-to-the-document-interface

TL:DR, the features on ShadowRoot seem to have originally been a standard feature, but has since been dropped and are no longer standard, yet browsers still implement the older IDL.