### PR TITLE
FF113 supports dynamic import behind pref

### DIFF
--- a/javascript/operators/import.json
+++ b/javascript/operators/import.json
@@ -67,8 +67,14 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1540913'>bug 1540913</a>"
+                "version_added": "113",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.workers.modules.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
FF113 adds support for dynamic import behind pref - see https://bugzilla.mozilla.org/show_bug.cgi?id=1540913#c37

Note that this is the same pref as support for static import in workers, so all should ship at the same time.