### PR TITLE
FF110 focus fixup rule on Elements

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2484,7 +2484,8 @@
             },
             "firefox": [
               {
-                "version_added": "24"
+                "version_added": "24",
+                "notes": "Focus lost and this event fired when a non-focusable style is applied to the element after version 110. See <a href='https://bugzil.la/1810077'>bug 1810077</a>."
               },
               {
                 "version_added": "6",


### PR DESCRIPTION
FF110 implements the "focus fixup rule" on elements in https://bugzilla.mozilla.org/show_bug.cgi?id=1810077.

This was basically a spec clarification to state what happened to the focus and blur/focus events if focus was lost on an element because:
- A style like `hidden` was applied to the element, which cannot accept focus. 
- The element was removed.

The spec changes says that the first case means blur event should fire, and focus should move to the `body`/viewport. For removal of element from document the focus should move to the `body` but `blur` should not fire. 
Prior to FF110 FF would not release focus even if the style was set to hidden, so the event was not fired. This makes the change so that it is. This matches chromium. 
There are some tests:
- http://wpt.live/css/selectors/focus-display-none-001.html
- http://wpt.live/inert/dynamic-inert-on-focused-element.html

Anyway, the developers [are not sure if BCD entry is warranted](https://bugzilla.mozilla.org/show_bug.cgi?id=1810077#c5). Neither am I, but I'd hate to lose what information we have now, so I have added a note to record this.

Other docs work can be tracked in https://github.com/mdn/content/issues/25496