### PR TITLE
Update Safari to version 16.4

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -244,15 +244,16 @@
         "16.3": {
           "release_date": "2023-01-23",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_3-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "614.4.6"
         },
         "16.4": {
+          "release_date": "2023-03-27",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes",
-          "status": "beta",
+          "status": "current",
           "engine": "WebKit",
-          "engine_version": "615"
+          "engine_version": "615.1.26"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -216,15 +216,16 @@
         "16.3": {
           "release_date": "2023-01-23",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_3-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "614.4.6"
         },
         "16.4": {
+          "release_date": "2023-03-27",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes",
-          "status": "beta",
+          "status": "current",
           "engine": "WebKit",
-          "engine_version": "615"
+          "engine_version": "615.1.26"
         }
       }
     }


### PR DESCRIPTION
#### Summary

This PR updates Safari to version 16.4

* https://webkit.org/blog/13966/webkit-features-in-safari-16-4/
* https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes
