### PR TITLE
Add missing mdn_url for PopStateEvent()

### DIFF
--- a/api/PopStateEvent.json
+++ b/api/PopStateEvent.json
@@ -42,6 +42,7 @@
       "PopStateEvent": {
         "__compat": {
           "description": "<code>PopStateEvent()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PopStateEvent/PopStateEvent",
           "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-popstateevent-interface",
           "support": {
             "chrome": {


### PR DESCRIPTION
The `PopStateEvent()` is been added in mdn/content#25702