### PR TITLE
Lookbehind assertions supported in Safari 16.4

### DIFF
--- a/javascript/regular_expressions.json
+++ b/javascript/regular_expressions.json
@@ -387,7 +387,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
Added in https://github.com/WebKit/WebKit/commit/46e6b3f97425a4a7bb16fc175288903a5f74d5f2 

Part of [Safari Technology preview 161](https://webkit.org/blog/13686/release-notes-for-safari-technology-preview-161/) and 16.4.