### PR TITLE
Safari 16.4 supports importmap

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -483,7 +483,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "16.4"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
https://github.com/WebKit/WebKit/commit/6c1996aea8b85babf563135acc2d05def8aca3cb
https://webkit.org/blog/13966/webkit-features-in-safari-16-4/

Fixes https://github.com/mdn/browser-compat-data/issues/19291