### PR TITLE
Safari 16.4 supports Atomics.waitAsync

### DIFF
--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -574,7 +574,7 @@
               },
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
https://webkit.org/blog/13966/webkit-features-in-safari-16-4/