### PR TITLE
Firefox 113 supports the scripting media feature

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1404,8 +1404,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1166581'>bug 1166581</a>."
+                "version_added": "113"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
#### Summary

Firefox 113 now supports the scripting media feature (`@media(scripting)`), updated data accordingly.

#### Test results and supporting details

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1166581
Intent to ship (and prototype): https://groups.google.com/a/mozilla.org/g/dev-platform/c/BU3zzial8lE/m/NzJhLV0MAgAJ