### PR TITLE
Media features in Chrome 113

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -949,7 +949,7 @@
             "spec_url": "https://w3c.github.io/csswg-drafts/mediaqueries/#mf-overflow-block",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "113"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -984,7 +984,7 @@
             "spec_url": "https://w3c.github.io/csswg-drafts/mediaqueries/#mf-overflow-inline",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "113"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1438,7 +1438,7 @@
             "spec_url": "https://w3c.github.io/csswg-drafts/mediaqueries/#update",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "113"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
#### Summary

There are some additional media features shipping in Chrome 113:

- `overflow-block`
- `overflow-inline`
- `update`

#### Test results and supporting details

- https://chromestatus.com/feature/5093005876264960
- https://chromestatus.com/feature/5154424982339584
