### PR TITLE
Add missing spec_url for ErrorEvent()

### DIFF
--- a/api/ErrorEvent.json
+++ b/api/ErrorEvent.json
@@ -46,6 +46,7 @@
         "__compat": {
           "description": "<code>ErrorEvent()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ErrorEvent/ErrorEvent",
+          "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#errorevent",
           "support": {
             "chrome": {
               "version_added": "16"


### PR DESCRIPTION
This is the closest link in the spec (the link of the keyword _constructor_ is useless)