### PR TITLE
Safari 16.4 supports iframes with loading='lazy'

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -399,15 +399,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/196698'>bug 196698</a>."
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
https://webkit.org/blog/13966/webkit-features-in-safari-16-4/