### PR TITLE
Add a spec_url for Sec-GPC

### DIFF
--- a/http/headers/Sec-GPC.json
+++ b/http/headers/Sec-GPC.json
@@ -43,7 +43,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/http/headers/Sec-GPC.json
+++ b/http/headers/Sec-GPC.json
@@ -4,7 +4,7 @@
       "Sec-GPC": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-GPC",
-          "spec_url": "https://privacycg.github.io/gpc-spec/",
+          "spec_url": "https://privacycg.github.io/gpc-spec/#the-sec-gpc-header-field-for-http-requests",
           "support": {
             "chrome": {
               "version_added": false

--- a/http/headers/Sec-GPC.json
+++ b/http/headers/Sec-GPC.json
@@ -4,6 +4,7 @@
       "Sec-GPC": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-GPC",
+          "spec_url": "https://privacycg.github.io/gpc-spec/",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
#### Summary

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-GPC doesn't have a link to the specification, and it appears to say that this is how to add one.

#### Test results and supporting details

I haven't tested this change.