### PR TITLE
Document WebKit for iOS 16.4 Home Screen web app specific features

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -56,7 +56,7 @@
             "version_added": "7"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "16.4"
           },
           "samsunginternet_android": {
             "version_added": "4.0",
@@ -114,7 +114,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -308,7 +308,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -397,7 +397,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -482,7 +482,7 @@
               "version_added": "16"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -526,7 +526,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -615,7 +615,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -697,7 +697,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -779,7 +779,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -877,7 +877,7 @@
               }
             ],
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -1042,7 +1042,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -1124,7 +1124,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/api/NotificationEvent.json
+++ b/api/NotificationEvent.json
@@ -32,7 +32,7 @@
             "notes": "Supported on macOS 13 and later"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "16.4"
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
@@ -79,7 +79,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/api/PushEvent.json
+++ b/api/PushEvent.json
@@ -34,7 +34,7 @@
             "notes": "Supported on macOS 13 and later"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "16.4"
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
@@ -83,7 +83,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -127,7 +127,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -30,7 +30,7 @@
             "notes": "Supported on macOS 13 and later"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "16.4"
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
@@ -113,7 +113,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -196,7 +196,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -325,7 +325,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -369,7 +369,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": {
               "version_added": "4.0"

--- a/api/PushMessageData.json
+++ b/api/PushMessageData.json
@@ -30,7 +30,7 @@
             "notes": "Supported on macOS 13 and later"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "16.4"
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
@@ -74,7 +74,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -118,7 +118,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -162,7 +162,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -206,7 +206,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/api/PushSubscription.json
+++ b/api/PushSubscription.json
@@ -30,7 +30,7 @@
             "notes": "Supported on macOS 13 and later"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "16.4"
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
@@ -74,7 +74,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -116,7 +116,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -161,7 +161,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -205,7 +205,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -289,7 +289,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -336,7 +336,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/api/PushSubscriptionChangeEvent.json
+++ b/api/PushSubscriptionChangeEvent.json
@@ -29,7 +29,7 @@
             "notes": "Supported on macOS 13 and later"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "16.4"
           },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
@@ -67,7 +67,7 @@
               "version_added": "16.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -108,7 +108,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -149,7 +149,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/api/PushSubscriptionOptions.json
+++ b/api/PushSubscriptionOptions.json
@@ -30,7 +30,7 @@
             "notes": "Supported on macOS 13 and later"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "16.4"
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
@@ -74,7 +74,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -116,7 +116,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -171,7 +171,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -396,7 +396,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -475,7 +475,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {


### PR DESCRIPTION
This data comes from mdn-bcd-collector, albeit modified to run under as a Home Screen web app. This essentially extends what https://github.com/mdn/browser-compat-data/pull/18963 already did.

This follows the precedent set by #19278, documenting Home Screen web app specific features as Safari for iOS features.