### PR TITLE
WIP: Fx support for cache clearing via clearSiteData header runs out in fx113

### DIFF
--- a/http/headers/Clear-Site-Data.json
+++ b/http/headers/Clear-Site-Data.json
@@ -85,18 +85,9 @@
               },
               "firefox": [
                 {
-                  "version_added": "94",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "privacy.clearsitedata.cache.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                },
-                {
                   "version_added": "63",
-                  "version_removed": "94"
+                  "version_removed": "113",
+                  "notes": "See <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1821651'>bug 1821651</a>."
                 }
               ],
               "firefox_android": "mirror",

--- a/http/headers/Clear-Site-Data.json
+++ b/http/headers/Clear-Site-Data.json
@@ -86,7 +86,7 @@
               "firefox": {
                 "version_added": "63",
                 "version_removed": "113",
-                "notes": "See <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1821651'>bug 1821651</a>."
+                "notes": "See <a href='https://bugzil.la/1821651'>bug 1821651</a>."
               },
               "firefox_android": "mirror",
               "ie": {

--- a/http/headers/Clear-Site-Data.json
+++ b/http/headers/Clear-Site-Data.json
@@ -83,13 +83,11 @@
               "edge": {
                 "version_added": "≤79"
               },
-              "firefox": [
-                {
-                  "version_added": "63",
-                  "version_removed": "113",
-                  "notes": "See <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1821651'>bug 1821651</a>."
-                }
-              ],
+              "firefox": {
+                "version_added": "63",
+                "version_removed": "113",
+                "notes": "See <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1821651'>bug 1821651</a>."
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Starting from version 113 Firefox will no longer support cache clearing via the clearSiteData header. It was already disabled by default since 94.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Bugzilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1821651
Phabricator: https://phabricator.services.mozilla.com/D173282

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
