### PR TITLE
Firefox 112 adds support for overlay value for overflow property

### DIFF
--- a/css/properties/overflow-x.json
+++ b/css/properties/overflow-x.json
@@ -123,7 +123,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         }

--- a/css/properties/overflow-x.json
+++ b/css/properties/overflow-x.json
@@ -87,6 +87,45 @@
               "deprecated": false
             }
           }
+        },
+        "overlay": {
+          "__compat": {
+            "description": "<code>overlay</code> value",
+            "support": {
+              "chrome": {
+                "version_added": "15"
+              },
+              "chrome_android": {
+                "version_added": "100"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "112"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": {
+                "version_added": "4.0"
+              },
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
         }
       }
     }

--- a/css/properties/overflow-y.json
+++ b/css/properties/overflow-y.json
@@ -123,7 +123,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         }

--- a/css/properties/overflow-y.json
+++ b/css/properties/overflow-y.json
@@ -87,6 +87,45 @@
               "deprecated": false
             }
           }
+        },
+        "overlay": {
+          "__compat": {
+            "description": "<code>overlay</code> value",
+            "support": {
+              "chrome": {
+                "version_added": "15"
+              },
+              "chrome_android": {
+                "version_added": "100"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "112"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": {
+                "version_added": "4.0"
+              },
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
         }
       }
     }

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -131,7 +131,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "112"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -154,7 +154,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

From Fx112, `overlay` will be recognized as a value for the `overflow` property.

- This PR adds the FX support for `overlay` value to `overflow` property and also updates `deprecated` to `false`.
- This PR also adds the `overlay` value row to browser compat tables for the longhand properties `overflow-x` and `overflow-y`.

#### Test results and supporting details

- Tested in browserstack

- Bug tracker: https://bugzilla.mozilla.org/show_bug.cgi?id=1817189

#### Related issues

Doc issue tracker: https://github.com/mdn/content/issues/25355
Related content update: https://github.com/mdn/content/pull/25749
Spec: https://w3c.github.io/csswg-drafts/css-overflow/#overflow-control
