### PR TITLE
css.at-rules.media.range_syntax : correct data for Firefox and Safari

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1348,9 +1348,15 @@
               "edge": {
                 "version_added": false
               },
-              "firefox": {
-                "version_added": "63"
-              },
+              "firefox": [
+                {
+                  "version_added": "102"
+                },
+                {
+                  "partial_implementation": true,
+                  "version_added": "63"
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1354,7 +1354,8 @@
                 },
                 {
                   "partial_implementation": true,
-                  "version_added": "63"
+                  "version_added": "63",
+                  "notes": "Only supports range notations where the feature name comes before any value <code>(width &#62; 500px)</code>"
                 }
               ],
               "firefox_android": "mirror",
@@ -1367,7 +1368,7 @@
               },
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Add correct data for Firefox and Safari in `css.at-rules.media.range_syntax` 

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

I've tested with `window.matchMedia('(1px < width < 99999px)')` in every Firefox version until landing on 102.

Relevant WPT tests : https://wpt.fyi/results/css/mediaqueries?label=master&label=experimental&aligned

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Release notes for Firefox do not mention this change : https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/102

Release notes for Safari : https://webkit.org/blog/13966/webkit-features-in-safari-16-4/#:~:text=Media%20Queries%20Syntax,width%20or%20height.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixes https://github.com/mdn/browser-compat-data/issues/14593#issuecomment-1491436872

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
