### PR TITLE
Mark the media query range syntax as supported in Edge and Opera

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1345,9 +1345,7 @@
                 "version_added": "104"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": [
                 {
                   "version_added": "102"

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1361,9 +1361,7 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": "16.4"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The media query range syntax (`@media (width > 800px)` is supported in Edge

#### Test results and supporting details

I tested https://codepen.io/preethi-dev/pen/rNvQPeg (which is a demo using this range syntax built for https://css-tricks.com/the-new-css-media-query-range-syntax/) in Edge.

#### Related issues

