### PR TITLE
Update Clear-Site-Data support in Safari 16.4

### DIFF
--- a/http/headers/Clear-Site-Data.json
+++ b/http/headers/Clear-Site-Data.json
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Update for Clear-Site-Data header. Safari 16.4 added support for it.

#### Test results and supporting details

[https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes#HTTP](https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes#HTTP)