### PR TITLE
Safari 15.4 removed support for X-XSS-Protection

### DIFF
--- a/http/headers/X-XSS-Protection.json
+++ b/http/headers/X-XSS-Protection.json
@@ -31,7 +31,8 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": true,
+              "version_removed": "15.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Safari 15.4 removed support for the X-XSS-Protection header both for Mac and iOS.

#### Test results and supporting details

- https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes
- https://webkit.org/blog/12445/new-webkit-features-in-safari-15-4/#security

I also tested the X-XSS-Protection header in a recent version of Safari and can confirm that it no longer has any effect.

![grafik](https://user-images.githubusercontent.com/24568451/229278534-dbdc7d96-dfee-42de-a7b4-043121005a6b.png)

![grafik](https://user-images.githubusercontent.com/24568451/229278523-d01d6560-ffe1-4ae3-b30e-89635fd660f0.png)

![grafik](https://user-images.githubusercontent.com/24568451/229278745-1816a1e5-71f1-427b-9681-b1b7fb125e3b.png)


#### Related issues

Fixes #16627

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
