### PR TITLE
Partial Safari support for Fetch metadata request headers

### DIFF
--- a/http/headers/Sec-Fetch-Dest.json
+++ b/http/headers/Sec-Fetch-Dest.json
@@ -24,7 +24,9 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "16.4",
+              "partial_implementation": true,
+              "notes": "Fetch metadata not yet fully implemented."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/http/headers/Sec-Fetch-Mode.json
+++ b/http/headers/Sec-Fetch-Mode.json
@@ -22,7 +22,9 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "16.4",
+              "partial_implementation": true,
+              "notes": "Fetch metadata not yet fully implemented."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/http/headers/Sec-Fetch-Site.json
+++ b/http/headers/Sec-Fetch-Site.json
@@ -22,7 +22,9 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "16.4",
+              "partial_implementation": true,
+              "notes": "Fetch metadata not yet fully implemented."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Added partial support for Fetch Metadata request headers in Safari 16.4+:
- Sec-Fetch-Dest
- Sec-Fetch-Mode
- Sec-Fetch-Site

#### Test results and supporting details

Note: *I have only tested on a personal iPad running Safari 16.4*

The release notes are limited and mentions of the feature are scattered throughout the following locations:

**Main references**
https://bugs.webkit.org/show_bug.cgi?id=204744
https://github.com/WebKit/WebKit/pull/6211

**Other mentions**
https://github.com/WebKit/WebKit/pull/4186
https://github.com/WebKit/WebKit/pull/11027
https://github.com/WebKit/WebKit/pull/6296
https://bugs.webkit.org/show_bug.cgi?id=237550

#### Related issues

None
