### PR TITLE
Mark `import.meta.resolve(…)` as supported as of Safari 16.4

### DIFF
--- a/javascript/operators/import_meta.json
+++ b/javascript/operators/import_meta.json
@@ -82,7 +82,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Mark `import.meta.resolve(…)` as supported as of Safari 16.4.

#### Test results and supporting details

See https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes#New-Features

#### Related issues

- https://github.com/mdn/browser-compat-data/pull/18737