### PR TITLE
Add note that navigator.serviceWorker is undefined in Firefox private windows

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3963,6 +3963,7 @@
               "version_added": "17"
             },
             "firefox": {
+              "notes": "In Firefox private windows, the <code>serviceWorker</code> object is <code>undefined</code>. See <a href='https://bugzil.la/1320796'>bug 1320796</a>.",
               "version_added": "44"
             },
             "firefox_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds a note that `navigator.serviceWorker` is undefined in Firefox private windows and links to the Bugzilla bug.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

I ran `npm test` and all tests pass. This is my first contribution to the project and I couldn't find a way to preview this by running MDN locally. Is there a way to do this? I think it might be outside of the scope of this repo though!

#### Related issues
N/A

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
