### PR TITLE
Mention COOP/COEP requirement for Atomics for Safari

### DIFF
--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -30,7 +30,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15.2"
+              "version_added": "15.2",
+              "notes": "Before Safari 16.4, <code>Atomics</code> is gated behind COOP/COEP. For more detail, read <a href='https://web.dev/coop-coep/'>Making your website \"cross-origin isolated\" using COOP and COEP</a>."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR re-adds a note regarding Atomics being gated behind COOP and COEP in Safari in older versions.  This reverts its removal in #16047.
