### PR TITLE
Add version_removed to Firefox on ServiceWorkerContainer error_event

### DIFF
--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -120,6 +120,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "44",
+              "version_removed": "106",
               "notes": "See <a href='https://bugzil.la/1714533'>bug 1714533</a>."
             },
             "firefox_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The `error_event` was removed from Firefox in version 106.

#### Test results and supporting details

Tested using a local build of MDN.

Release number sourced from https://bugzil.la/1714533.

#### Related issues

N/A

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
