### PR TITLE
unprefix image-set in Chrome 113

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1395,10 +1395,15 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image/image-set",
             "spec_url": "https://w3c.github.io/csswg-drafts/css-images-4/#image-set-notation",
             "support": {
-              "chrome": {
-                "prefix": "-webkit-",
-                "version_added": "21"
-              },
+              "chrome": [
+                {
+                  "version_added": "113"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "21"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": [


### PR DESCRIPTION
Chrome 113 ships `image-set()` unprefixed.

https://chromestatus.com/feature/5109745420075008