### PR TITLE
Add storage.session.setAccessLevel()

### DIFF
--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -246,6 +246,26 @@
                 }
               }
             }
+          },
+          "setAccessLevel": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/setAccessLevel",
+              "support": {
+                "chrome": {
+                  "version_added": "102"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
           }
         },
         "StorageChange": {


### PR DESCRIPTION
### Description

Add BCD for `storage.session.setAccessLevel()`, a function introduced in Chrome 102.

### Related issues and pull requests

Fixes [#25735](https://github.com/mdn/content/issues/25735)
MDN content in [PR #25939](https://github.com/mdn/content/pull/25939)