### PR TITLE
Update ServiceWorkerContainer messageerror event

### DIFF
--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -264,7 +264,6 @@
       "messageerror_event": {
         "__compat": {
           "description": "<code>messageerror</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ServiceWorkerContainer/messageerror_event",
           "spec_url": "https://w3c.github.io/ServiceWorker/#dom-serviceworkerglobalscope-onmessageerror",
           "support": {
             "chrome": {
@@ -290,11 +289,17 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "11.1",
-              "partial_implementation": true,
-              "notes": "Although the <code>onmessageerror</code> event handler property is supported, the <code>messageerror</code> event is never fired. See <a href='https://webkit.org/b/171216'>bug 171216</a>."
-            },
+            "safari": [
+              {
+                "version_added": "16.4"
+              },
+              {
+                "version_added": "11.1",
+                "version_removed": "16.4",
+                "partial_implementation": true,
+                "notes": "Although the <code>onmessageerror</code> event handler property is supported, the <code>messageerror</code> event is never fired. See <a href='https://webkit.org/b/171216'>bug 171216</a>."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
- Adds full support to Safari from 16.4.
- Removes the MDN link as the page doesn't seem to exist on MDN.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Get the commit revision from the [WebKit bug](https://bugs.webkit.org/show_bug.cgi?id=171216): https://commits.webkit.org/256896@main

```
$ git tag --contains 5e2beb55a112f682aff66e5646e77ce9e079054c | grep Safari
releases/Apple/Safari-16.4-iOS-16.4
releases/Apple/Safari-16.4-iOS-16.4-iPadOS
releases/Apple/Safari-16.4-macOS-13.3
```

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
