### PR TITLE
Updates chrome to version 112

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -774,21 +774,28 @@
         "111": {
           "release_date": "2023-03-07",
           "release_notes": "https://chromereleases.googleblog.com/2023/03/stable-channel-update-for-desktop.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "111"
         },
         "112": {
           "release_date": "2023-04-04",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2023/04/stable-channel-update-for-desktop.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "112"
         },
         "113": {
           "release_date": "2023-05-02",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "113"
+        },
+        "114": {
+          "release_date": "2023-05-30",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "114"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -610,21 +610,28 @@
         "111": {
           "release_date": "2023-03-07",
           "release_notes": "https://chromereleases.googleblog.com/2023/03/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "111"
         },
         "112": {
           "release_date": "2023-04-04",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2023/04/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "112"
         },
         "113": {
           "release_date": "2023-05-02",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "113"
+        },
+        "114": {
+          "release_date": "2023-05-30",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "114"
         }
       }
     }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -574,21 +574,27 @@
         "111": {
           "release_date": "2023-03-01",
           "release_notes": "https://chromereleases.googleblog.com/2023/03/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "111"
         },
         "112": {
           "release_date": "2023-04-04",
-          "status": "beta",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "112"
         },
         "113": {
           "release_date": "2023-05-02",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "113"
+        },
+        "114": {
+          "release_date": "2023-05-30",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "114"
         }
       }
     }


### PR DESCRIPTION
Hi all! 👋

This PR updates Chrome to version 112.

And according to https://chromiumdash.appspot.com/schedule, it also includes Chrome 114 release date.