### PR TITLE
Safari shipped shadowrootmode in 16.4

### DIFF
--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -77,7 +77,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -70,7 +70,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Safari shipped the `shadowrootmode` attribute for Declarative Shadow DOM in version 16.4. Release notes here: https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes

A prior blog post that shows the Technology Preview version it first shipped in: https://webkit.org/blog/13851/declarative-shadow-dom/
