### PR TITLE
Safari 16.4 supports :dir()

### DIFF
--- a/css/selectors/dir.json
+++ b/css/selectors/dir.json
@@ -33,7 +33,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
Fix https://github.com/mdn/browser-compat-data/issues/19297