### PR TITLE
add popover-open selector

### DIFF
--- a/css/selectors/popover-open.json
+++ b/css/selectors/popover-open.json
@@ -21,6 +21,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },

--- a/css/selectors/popover-open.json
+++ b/css/selectors/popover-open.json
@@ -1,40 +1,40 @@
 {
-    "css": {
-        "selectors": {
-            "popover-open": {
-                "__compat": {
-                    "description": "<code>:popover-open</code>",
-                    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:popover-open",
-                    "spec_url": "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-popover-open",
-                    "support": {
-                        "chrome": {
-                            "version_added": "114"
-                        },
-                        "chrome_android": "mirror",
-                        "edge": "mirror",
-                        "firefox": {
-                            "version_added": false
-                        },
-                        "firefox_android": "mirror",
-                        "ie": {
-                            "version_added": false
-                        },
-                        "oculus": "mirror",
-                        "opera": "mirror",
-                        "safari": {
-                            "version_added": false
-                        },
-                        "safari_ios": "mirror",
-                        "samsunginternet_android": "mirror",
-                        "webview_android": "mirror"
-                    },
-                    "status": {
-                        "experimental": true,
-                        "standard_track": true,
-                        "deprecated": false
-                    }
-                }
-            }
+  "css": {
+    "selectors": {
+      "popover-open": {
+        "__compat": {
+          "description": "<code>:popover-open</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:popover-open",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-popover-open",
+          "support": {
+            "chrome": {
+              "version_added": "114"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
         }
+      }
     }
+  }
 }

--- a/css/selectors/popover-open.json
+++ b/css/selectors/popover-open.json
@@ -5,9 +5,7 @@
                 "__compat": {
                     "description": "<code>:popover-open</code>",
                     "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:popover-open",
-                    "spec_url": [
-                        "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-popover-open"
-                    ],
+                    "spec_url": "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-popover-open",
                     "support": {
                         "chrome": {
                             "version_added": "114"

--- a/css/selectors/popover-open.json
+++ b/css/selectors/popover-open.json
@@ -1,0 +1,42 @@
+{
+    "css": {
+        "selectors": {
+            "popover-open": {
+                "__compat": {
+                    "description": "<code>:popover-open</code>",
+                    "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:popover-open",
+                    "spec_url": [
+                        "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-popover-open"
+                    ],
+                    "support": {
+                        "chrome": {
+                            "version_added": "114"
+                        },
+                        "chrome_android": "mirror",
+                        "edge": "mirror",
+                        "firefox": {
+                            "version_added": false
+                        },
+                        "firefox_android": "mirror",
+                        "ie": {
+                            "version_added": false
+                        },
+                        "oculus": "mirror",
+                        "opera": "mirror",
+                        "safari": {
+                            "version_added": false
+                        },
+                        "safari_ios": "mirror",
+                        "samsunginternet_android": "mirror",
+                        "webview_android": "mirror"
+                    },
+                    "status": {
+                        "experimental": true,
+                        "standard_track": true,
+                        "deprecated": false
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
This compat data for the `:popover-open` psuedo selector.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
This is available in the specification: https://developer.mozilla.org/docs/Web/CSS/:popover-open

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->
https://github.com/mdn/content/issues/25125

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
