### PR TITLE
Headers getsetcookie

### DIFF
--- a/api/Headers.json
+++ b/api/Headers.json
@@ -309,6 +309,7 @@
       "getSetCookie": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/getSetCookie",
+          "spec_url": "https://fetch.spec.whatwg.org/#dom-headers-getsetcookie",
           "support": {
             "chrome": {
               "version_added": "113"

--- a/api/Headers.json
+++ b/api/Headers.json
@@ -306,6 +306,42 @@
           }
         }
       },
+      "getSetCookie": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/getSetCookie",
+          "support": {
+            "chrome": {
+              "version_added": "113"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "has": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Headers/has",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The [`Headers.getSetCookie()`](https://fetch.spec.whatwg.org/#dom-headers-getsetcookie) method has been added to Chrome 113. This PR adds the data for that.

This is a pretty straightforward addition. You can find other useful links in my [research document](https://docs.google.com/document/d/1x1fgf7NSsrSnBw2oynXoUndK1wXehzygcegySNLs604/edit#).

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
