### PR TITLE
Updated Safari 16.4 features

### DIFF
--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -270,7 +270,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -375,7 +375,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/selectors/dir.json
+++ b/css/selectors/dir.json
@@ -33,7 +33,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -246,7 +246,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -358,7 +358,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -277,14 +277,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -356,14 +356,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -645,7 +645,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -823,7 +823,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/webextensions/api/declarativeNetRequest.json
+++ b/webextensions/api/declarativeNetRequest.json
@@ -96,7 +96,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "16.4"
               },
               "safari_ios": "mirror"
             }
@@ -712,7 +712,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": "15"
+                  "version_added": "16.4"
                 },
                 "safari_ios": "mirror"
               }
@@ -730,7 +730,7 @@
                   "firefox_android": "mirror",
                   "opera": "mirror",
                   "safari": {
-                    "version_added": "15"
+                    "version_added": "16.4"
                   },
                   "safari_ios": "mirror"
                 }
@@ -750,7 +750,7 @@
                   "firefox_android": "mirror",
                   "opera": "mirror",
                   "safari": {
-                    "version_added": "15"
+                    "version_added": "16.4"
                   },
                   "safari_ios": "mirror"
                 }
@@ -769,7 +769,7 @@
                   "firefox_android": "mirror",
                   "opera": "mirror",
                   "safari": {
-                    "version_added": "15"
+                    "version_added": "16.4"
                   },
                   "safari_ios": "mirror"
                 }
@@ -982,7 +982,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "16.4"
                 },
                 "safari_ios": "mirror"
               }
@@ -1526,7 +1526,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "16.4"
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -456,7 +456,8 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4",
+                "notes": "Available for use in Manifest V2 or later."
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -372,7 +372,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4"
               },
               "safari_ios": "mirror"
             }

--- a/webextensions/manifest/icons.json
+++ b/webextensions/manifest/icons.json
@@ -6,8 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons",
           "support": {
             "chrome": {
-              "version_added": true,
-              "notes": "Chrome does not support SVG format for icons. It is recommended to use PNG images."
+              "version_added": true
             },
             "edge": "mirror",
             "firefox": {
@@ -16,12 +15,30 @@
             "firefox_android": "mirror",
             "opera": "mirror",
             "safari": {
-              "version_added": "14",
-              "notes": "SVG icons are not supported."
+              "version_added": "14"
             },
             "safari_ios": {
-              "version_added": "15",
-              "notes": "SVG icons are not supported."
+              "version_added": "15"
+            }
+          }
+        },
+        "svg_icons": {
+          "__compat": {
+            "description": "SVG icons",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "92"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": "16.4"
+              },
+              "safari_ios": "mirror"
             }
           }
         }


### PR DESCRIPTION
#### Summary

Although the community has done a great job adding Safari 16.4 features, there are still several notable features that need updated:

- `:dir()`
- `lh` and `rlh` units
- `font-size-adjust` support for SVG
- Safari Web Extensions
  - `storage.session`
  - declarativeNetRequest `MAX_NUMBER_OF_DYNAMIC_AND_SESSION_RULES`
  - `scripting.registerContentScript`
  - `scripting.getRegisteredContentScripts`
  - `scripting.unregisterContentScripts`
  - `scripting.updateContentScripts`
  - SVG icons

This also includes a correction for text fragment support which shipped in Safari 16.1 and `modifyHeaders` action in `declarativeNetRequest` which shipped in Safari 16.4.

#### Test results and supporting details

[Safari 16.4 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes)