### PR TITLE
Correct the spec link for `pointer-events`

### DIFF
--- a/css/properties/pointer-events.json
+++ b/css/properties/pointer-events.json
@@ -4,7 +4,10 @@
       "pointer-events": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/pointer-events",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-ui/#pointer-events-control",
+          "spec_url": [
+            "https://w3c.github.io/csswg-drafts/css-ui/#pointer-events-control",
+            "https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/css/properties/pointer-events.json
+++ b/css/properties/pointer-events.json
@@ -4,7 +4,7 @@
       "pointer-events": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/pointer-events",
-          "spec_url": "https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-ui/#pointer-events-control",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
#### Summary

This PR changes the spec link for the CSS property [`pointer-events`](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events) to [CSS Basic User Interface Module](https://w3c.github.io/csswg-drafts/css-ui/#pointer-events-control).

#### Test results and supporting details

The current link points to [Scalable Vector Graphics (SVG) 2](https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty), which seems to be a confusion with the SVG presentational attribute [pointer-events](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/pointer-events).

#### Related issues