### PR TITLE
Firefox supports exponential functions

### DIFF
--- a/css/types/exp.json
+++ b/css/types/exp.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "112"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -30,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/types/hypot.json
+++ b/css/types/hypot.json
@@ -30,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/types/hypot.json
+++ b/css/types/hypot.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "112"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/log.json
+++ b/css/types/log.json
@@ -30,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/types/log.json
+++ b/css/types/log.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "112"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/pow.json
+++ b/css/types/pow.json
@@ -30,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/types/pow.json
+++ b/css/types/pow.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "112"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/sqrt.json
+++ b/css/types/sqrt.json
@@ -30,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/types/sqrt.json
+++ b/css/types/sqrt.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "112"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
#### Summary

Added version added for CSS exponential functions for Firefox and set experimental to false as multiple browsers now support

#### Test results and supporting details

Tested in Firefox Nightly:
- pow() - https://codepen.io/CodeRedDigital/pen/dygYoYP 
- sqrt() - https://codepen.io/CodeRedDigital/pen/gOBabja 
- hypot() - https://codepen.io/CodeRedDigital/pen/poxjJeZ 
- log() - https://codepen.io/CodeRedDigital/pen/VwEvLXK 
- exp() - https://codepen.io/CodeRedDigital/pen/KKGdpJJ 
Also information from this bug [1814469](https://bugzilla.mozilla.org/show_bug.cgi?id=1814469)

#### Related Pull Requests

- [Content](https://github.com/mdn/content/pull/26187)
- [Firefox Release](https://github.com/mdn/content/pull/26203)
