### PR TITLE
Fix spec_url for ::backdrop

### DIFF
--- a/css/selectors/backdrop.json
+++ b/css/selectors/backdrop.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>::backdrop</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::backdrop",
-          "spec_url": "https://drafts.csswg.org/css-position-4/#backdrop",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-position-4/#backdrop",
           "support": {
             "chrome": [
               {

--- a/css/selectors/backdrop.json
+++ b/css/selectors/backdrop.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>::backdrop</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::backdrop",
-          "spec_url": "https://fullscreen.spec.whatwg.org/#::backdrop-pseudo-element",
+          "spec_url": "https://drafts.csswg.org/css-position-4/#backdrop",
           "support": {
             "chrome": [
               {


### PR DESCRIPTION
Fixes #19367 where the spec editor notified us that the definition moved from the original spec to the new one.