### PR TITLE
FF113 supports WebGPU on nightly

### DIFF
--- a/api/GPU.json
+++ b/api/GPU.json
@@ -14,7 +14,9 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/GPU.json
+++ b/api/GPU.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -97,7 +97,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPU.json
+++ b/api/GPU.json
@@ -18,7 +18,9 @@
             "partial_implementation": true,
             "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },
@@ -52,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -89,9 +95,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUAdapter.json
+++ b/api/GPUAdapter.json
@@ -14,7 +14,9 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/GPUAdapter.json
+++ b/api/GPUAdapter.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -97,7 +97,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -138,7 +138,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -179,7 +179,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -220,7 +220,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUAdapter.json
+++ b/api/GPUAdapter.json
@@ -18,7 +18,9 @@
             "partial_implementation": true,
             "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },
@@ -52,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -89,9 +95,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -126,9 +136,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -163,9 +177,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -200,9 +218,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUAdapterInfo.json
+++ b/api/GPUAdapterInfo.json
@@ -14,7 +14,9 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/GPUAdapterInfo.json
+++ b/api/GPUAdapterInfo.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -97,7 +97,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -138,7 +138,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -179,7 +179,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUAdapterInfo.json
+++ b/api/GPUAdapterInfo.json
@@ -18,7 +18,9 @@
             "partial_implementation": true,
             "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },
@@ -52,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -89,9 +95,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -126,9 +136,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -163,9 +177,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUBindGroup.json
+++ b/api/GPUBindGroup.json
@@ -14,7 +14,9 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/GPUBindGroup.json
+++ b/api/GPUBindGroup.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUBindGroup.json
+++ b/api/GPUBindGroup.json
@@ -18,7 +18,9 @@
             "partial_implementation": true,
             "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },
@@ -52,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUBindGroupLayout.json
+++ b/api/GPUBindGroupLayout.json
@@ -14,7 +14,9 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/GPUBindGroupLayout.json
+++ b/api/GPUBindGroupLayout.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUBindGroupLayout.json
+++ b/api/GPUBindGroupLayout.json
@@ -18,7 +18,9 @@
             "partial_implementation": true,
             "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },
@@ -52,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUBuffer.json
+++ b/api/GPUBuffer.json
@@ -14,7 +14,9 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/GPUBuffer.json
+++ b/api/GPUBuffer.json
@@ -18,7 +18,9 @@
             "partial_implementation": true,
             "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },
@@ -52,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -89,9 +95,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -126,9 +136,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -163,9 +177,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -200,9 +218,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -237,9 +259,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -274,9 +300,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -311,9 +341,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUBuffer.json
+++ b/api/GPUBuffer.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -97,7 +97,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -138,7 +138,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -179,7 +179,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -220,7 +220,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -261,7 +261,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -302,7 +302,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -343,7 +343,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCanvasContext.json
+++ b/api/GPUCanvasContext.json
@@ -54,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUCanvasContext.json
+++ b/api/GPUCanvasContext.json
@@ -14,9 +14,13 @@
           },
           "edge": "mirror",
           "firefox": {
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -90,9 +94,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -127,9 +135,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -164,9 +176,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUCanvasContext.json
+++ b/api/GPUCanvasContext.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -100,7 +100,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -141,7 +141,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -182,7 +182,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCommandBuffer.json
+++ b/api/GPUCommandBuffer.json
@@ -14,9 +14,13 @@
           },
           "edge": "mirror",
           "firefox": {
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -50,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUCommandBuffer.json
+++ b/api/GPUCommandBuffer.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCommandEncoder.json
+++ b/api/GPUCommandEncoder.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -97,7 +97,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -138,7 +138,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -179,7 +179,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -220,7 +220,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -261,7 +261,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -302,7 +302,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -343,7 +343,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -384,7 +384,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -425,7 +425,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -466,7 +466,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -507,7 +507,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -548,7 +548,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -589,7 +589,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCommandEncoder.json
+++ b/api/GPUCommandEncoder.json
@@ -14,9 +14,13 @@
           },
           "edge": "mirror",
           "firefox": {
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -50,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -87,9 +95,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -124,9 +136,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -161,9 +177,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -198,9 +218,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -235,9 +259,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -272,9 +300,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -309,9 +341,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -346,9 +382,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -383,9 +423,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -420,9 +464,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -457,9 +505,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -494,9 +546,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -531,9 +587,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUCompilationInfo.json
+++ b/api/GPUCompilationInfo.json
@@ -14,9 +14,13 @@
           },
           "edge": "mirror",
           "firefox": {
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -50,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUCompilationInfo.json
+++ b/api/GPUCompilationInfo.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCompilationMessage.json
+++ b/api/GPUCompilationMessage.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -97,7 +97,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -138,7 +138,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -179,7 +179,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -220,7 +220,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -261,7 +261,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCompilationMessage.json
+++ b/api/GPUCompilationMessage.json
@@ -14,7 +14,9 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/GPUCompilationMessage.json
+++ b/api/GPUCompilationMessage.json
@@ -18,7 +18,9 @@
             "partial_implementation": true,
             "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },

--- a/api/GPUCompilationMessage.json
+++ b/api/GPUCompilationMessage.json
@@ -54,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -91,9 +95,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -128,9 +136,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -165,9 +177,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -202,9 +218,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -239,9 +259,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUComputePassEncoder.json
+++ b/api/GPUComputePassEncoder.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -104,7 +104,7 @@
                 }
               ],
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -143,7 +143,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -184,7 +184,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -225,7 +225,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -266,7 +266,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -307,7 +307,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -348,7 +348,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -389,7 +389,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -429,7 +429,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUComputePassEncoder.json
+++ b/api/GPUComputePassEncoder.json
@@ -14,9 +14,13 @@
           },
           "edge": "mirror",
           "firefox": {
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -50,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -87,7 +95,16 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webgpu.indirect-dispatch.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -124,9 +141,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -161,9 +182,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -198,9 +223,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -235,9 +264,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -272,9 +305,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -309,9 +346,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -346,9 +387,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -382,9 +427,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUComputePipeline.json
+++ b/api/GPUComputePipeline.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -97,7 +97,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUComputePipeline.json
+++ b/api/GPUComputePipeline.json
@@ -14,9 +14,13 @@
           },
           "edge": "mirror",
           "firefox": {
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -50,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -87,9 +95,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -14,7 +14,9 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -97,7 +97,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -138,7 +138,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -179,7 +179,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -220,7 +220,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -261,7 +261,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -302,7 +302,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -380,7 +380,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -421,7 +421,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -462,7 +462,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -503,7 +503,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -544,7 +544,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -585,7 +585,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -626,7 +626,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -667,7 +667,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -708,7 +708,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -749,7 +749,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -790,7 +790,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -831,7 +831,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -872,7 +872,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -913,7 +913,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -954,7 +954,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -996,7 +996,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -18,7 +18,9 @@
             "partial_implementation": true,
             "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },
@@ -52,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -89,9 +95,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -126,9 +136,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -163,9 +177,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -200,9 +218,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -237,9 +259,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -274,9 +300,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -348,9 +378,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -385,9 +419,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -422,9 +460,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -459,9 +501,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -496,9 +542,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -533,9 +583,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -570,9 +624,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -607,9 +665,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -644,9 +706,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -681,9 +747,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -718,9 +788,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -755,9 +829,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -792,9 +870,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -829,9 +911,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -866,9 +952,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -904,9 +994,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUDeviceLostInfo.json
+++ b/api/GPUDeviceLostInfo.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -97,7 +97,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUDeviceLostInfo.json
+++ b/api/GPUDeviceLostInfo.json
@@ -14,9 +14,13 @@
           },
           "edge": "mirror",
           "firefox": {
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -50,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -87,9 +95,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUError.json
+++ b/api/GPUError.json
@@ -14,13 +14,9 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
-          },
-          "firefox_android": {
             "version_added": false
           },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -54,13 +50,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
-            },
-            "firefox_android": {
               "version_added": false
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUError.json
+++ b/api/GPUError.json
@@ -14,9 +14,13 @@
           },
           "edge": "mirror",
           "firefox": {
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -50,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUOutOfMemoryError.json
+++ b/api/GPUOutOfMemoryError.json
@@ -55,9 +55,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUOutOfMemoryError.json
+++ b/api/GPUOutOfMemoryError.json
@@ -14,9 +14,13 @@
           },
           "edge": "mirror",
           "firefox": {
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },

--- a/api/GPUOutOfMemoryError.json
+++ b/api/GPUOutOfMemoryError.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -57,7 +57,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUPipelineLayout.json
+++ b/api/GPUPipelineLayout.json
@@ -14,7 +14,9 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/GPUPipelineLayout.json
+++ b/api/GPUPipelineLayout.json
@@ -54,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUPipelineLayout.json
+++ b/api/GPUPipelineLayout.json
@@ -18,7 +18,9 @@
             "partial_implementation": true,
             "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },

--- a/api/GPUPipelineLayout.json
+++ b/api/GPUPipelineLayout.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUQuerySet.json
+++ b/api/GPUQuerySet.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -97,7 +97,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -138,7 +138,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -179,7 +179,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUQuerySet.json
+++ b/api/GPUQuerySet.json
@@ -14,9 +14,13 @@
           },
           "edge": "mirror",
           "firefox": {
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -50,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -87,9 +95,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -124,9 +136,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -161,9 +177,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUQueue.json
+++ b/api/GPUQueue.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -97,7 +97,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -175,7 +175,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -216,7 +216,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -257,7 +257,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUQueue.json
+++ b/api/GPUQueue.json
@@ -14,9 +14,13 @@
           },
           "edge": "mirror",
           "firefox": {
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -50,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -87,9 +95,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -161,9 +173,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -198,9 +214,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -235,9 +255,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPURenderBundleEncoder.json
+++ b/api/GPURenderBundleEncoder.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -97,7 +97,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -145,7 +145,7 @@
                 }
               ],
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -191,7 +191,7 @@
                 }
               ],
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -230,7 +230,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -271,7 +271,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -349,7 +349,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -390,7 +390,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -431,7 +431,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -472,7 +472,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -513,7 +513,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -554,7 +554,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPURenderBundleEncoder.json
+++ b/api/GPURenderBundleEncoder.json
@@ -14,9 +14,13 @@
           },
           "edge": "mirror",
           "firefox": {
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -50,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -87,9 +95,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -124,7 +136,16 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webgpu.indirect-dispatch.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -161,7 +182,16 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webgpu.indirect-dispatch.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -198,9 +228,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -235,9 +269,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -309,9 +347,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -346,9 +388,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -383,9 +429,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -420,9 +470,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -457,9 +511,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -494,9 +552,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPURenderPassEncoder.json
+++ b/api/GPURenderPassEncoder.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -93,7 +93,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -134,7 +134,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -182,7 +182,7 @@
                 }
               ],
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -228,7 +228,7 @@
                 }
               ],
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -267,7 +267,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -345,7 +345,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -386,7 +386,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -427,7 +427,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -468,7 +468,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -509,7 +509,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -550,7 +550,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -591,7 +591,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -632,7 +632,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -673,7 +673,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -714,7 +714,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -755,7 +755,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -796,7 +796,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -837,7 +837,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPURenderPassEncoder.json
+++ b/api/GPURenderPassEncoder.json
@@ -14,9 +14,13 @@
           },
           "edge": "mirror",
           "firefox": {
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -87,9 +91,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -124,9 +132,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -161,7 +173,16 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webgpu.indirect-dispatch.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -198,7 +219,16 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webgpu.indirect-dispatch.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -235,9 +265,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -309,9 +343,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -346,9 +384,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -383,9 +425,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -420,9 +466,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -457,9 +507,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -494,9 +548,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -531,9 +589,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -568,9 +630,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -605,9 +671,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -642,9 +712,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -679,9 +753,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -716,9 +794,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -753,9 +835,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPURenderPipeline.json
+++ b/api/GPURenderPipeline.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -97,7 +97,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPURenderPipeline.json
+++ b/api/GPURenderPipeline.json
@@ -14,9 +14,13 @@
           },
           "edge": "mirror",
           "firefox": {
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -50,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -87,9 +95,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUSampler.json
+++ b/api/GPUSampler.json
@@ -14,7 +14,9 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/GPUSampler.json
+++ b/api/GPUSampler.json
@@ -54,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUSampler.json
+++ b/api/GPUSampler.json
@@ -18,7 +18,9 @@
             "partial_implementation": true,
             "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },

--- a/api/GPUSampler.json
+++ b/api/GPUSampler.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUShaderModule.json
+++ b/api/GPUShaderModule.json
@@ -14,7 +14,9 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/GPUShaderModule.json
+++ b/api/GPUShaderModule.json
@@ -54,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -91,9 +95,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUShaderModule.json
+++ b/api/GPUShaderModule.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -97,7 +97,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUShaderModule.json
+++ b/api/GPUShaderModule.json
@@ -18,7 +18,9 @@
             "partial_implementation": true,
             "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },

--- a/api/GPUSupportedFeatures.json
+++ b/api/GPUSupportedFeatures.json
@@ -14,7 +14,9 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/GPUSupportedFeatures.json
+++ b/api/GPUSupportedFeatures.json
@@ -18,7 +18,9 @@
             "partial_implementation": true,
             "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },

--- a/api/GPUSupportedFeatures.json
+++ b/api/GPUSupportedFeatures.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false

--- a/api/GPUSupportedLimits.json
+++ b/api/GPUSupportedLimits.json
@@ -53,9 +53,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -89,9 +93,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUSupportedLimits.json
+++ b/api/GPUSupportedLimits.json
@@ -14,7 +14,9 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/GPUSupportedLimits.json
+++ b/api/GPUSupportedLimits.json
@@ -18,7 +18,9 @@
             "partial_implementation": true,
             "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },

--- a/api/GPUSupportedLimits.json
+++ b/api/GPUSupportedLimits.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -55,7 +55,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -95,7 +95,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUTexture.json
+++ b/api/GPUTexture.json
@@ -14,7 +14,9 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/GPUTexture.json
+++ b/api/GPUTexture.json
@@ -18,7 +18,9 @@
             "partial_implementation": true,
             "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },

--- a/api/GPUTexture.json
+++ b/api/GPUTexture.json
@@ -54,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -91,9 +95,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -128,9 +136,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -165,9 +177,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -202,9 +218,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -239,9 +259,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -276,9 +300,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -313,9 +341,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -350,9 +382,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -387,9 +423,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -424,9 +464,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUTexture.json
+++ b/api/GPUTexture.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -97,7 +97,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -138,7 +138,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -179,7 +179,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -220,7 +220,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -261,7 +261,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -302,7 +302,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -343,7 +343,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -384,7 +384,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -425,7 +425,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false
@@ -466,7 +466,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUTextureView.json
+++ b/api/GPUTextureView.json
@@ -14,7 +14,9 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/GPUTextureView.json
+++ b/api/GPUTextureView.json
@@ -54,9 +54,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUTextureView.json
+++ b/api/GPUTextureView.json
@@ -18,7 +18,9 @@
             "partial_implementation": true,
             "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },

--- a/api/GPUTextureView.json
+++ b/api/GPUTextureView.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -56,7 +56,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUUncapturedErrorEvent.json
+++ b/api/GPUUncapturedErrorEvent.json
@@ -14,9 +14,13 @@
           },
           "edge": "mirror",
           "firefox": {
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -51,9 +55,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUUncapturedErrorEvent.json
+++ b/api/GPUUncapturedErrorEvent.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -57,7 +57,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUValidationError.json
+++ b/api/GPUValidationError.json
@@ -14,9 +14,13 @@
           },
           "edge": "mirror",
           "firefox": {
+            "version_added": "preview",
+            "partial_implementation": true,
+            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+          },
+          "firefox_android": {
             "version_added": false
           },
-          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -51,9 +55,13 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/api/GPUValidationError.json
+++ b/api/GPUValidationError.json
@@ -16,7 +16,7 @@
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+            "notes": "Currently supported on Linux and Windows only."
           },
           "firefox_android": {
             "version_added": false
@@ -57,7 +57,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -716,7 +716,7 @@
               "firefox": {
                 "version_added": "preview",
                 "partial_implementation": true,
-                "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+                "notes": "Currently supported on Linux and Windows only."
               },
               "firefox_android": {
                 "version_added": false

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -714,9 +714,13 @@
               },
               "edge": "mirror",
               "firefox": {
+                "version_added": "preview",
+                "partial_implementation": true,
+                "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              },
+              "firefox_android": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1413,7 +1413,9 @@
               "partial_implementation": true,
               "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1409,7 +1409,9 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1411,7 +1411,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only. See <a href='https://bugzil.la/1616739'>bug 1616739</a>."
+              "notes": "Currently supported on Linux and Windows only."
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
FF113 supports WebGPU on nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=1746245

Spec has iterated a lots since this was defined. Probably not worth tracking introduction of various parts behind pref. This just tracks broad WebGPU support as Preview.

Open questions on devs here: https://bugzilla.mozilla.org/show_bug.cgi?id=1746245#c21

Other docs work can be tracked in https://github.com/mdn/content/issues/26157

--- 

List is what is documented and in BCD. X indicates also in WebIdl for FF. So this is check of coverage.

- [x] GPU
- [x] GPUAdapter
- [x] GPUAdapterInfo
- [x] GPUBindGroup
- [x] GPUBindGroupLayout
- [x] GPUBuffer
- [x] GPUCanvasContext
- [x] GPUCommandBuffer
- [x] GPUCommandEncoder
- [x] GPUCompilationInfo
- [x] GPUCompilationMessage
- [x] GPUComputePassEncoder - behind pref `dispatchWorkgroupsIndirect`
- [x] GPUComputePipeline - not yet serializable
- [x] GPUDevice - note, not support createQuerySet()
- [x] GPUDeviceLostInfo
- [ ] GPUError - not in IDL or  visible on console.
- [ ] GPUExternalTexture - not in IDL or  visible on console.
- [ ] GPUInternalError - not in IDL or  visible on console.
- [x] GPUOutOfMemoryError (constructor commented out in IDL but seems to inherit one)
- [ ] GPUPipelineError - not in IDL or  visible on console.
- [x] GPUPipelineLayout
- [x] GPUQuerySet 
- [x] GPUQueue - IDL comment out `onSubmittedWorkDone()`
- [x] GPURenderBundle
- [x] GPURenderBundleEncoder - Behind pref is `drawIndirect()`, `drawIndexedIndirect()`.
- [x] GPURenderPassEncoder - IDL comments out `beginOcclusionQuery`, `endOcclusionQuery`, `beginPipelineStatisticsQuery`, `endPipelineStatisticsQuery()`, `writeTimestamp()`. Also behind pref is `drawIndirect()`, `drawIndexedIndirect()`.
- [x] GPURenderPipeline - not yet serializable
- [x] GPUSampler
- [x] GPUShaderModule
- [x] GPUSupportedFeatures
- [x] GPUSupportedLimits
- [x] GPUTexture
- [x] GPUTextureView
- [x] GPUUncapturedErrorEvent
- [x] GPUValidationError - oddly the `message` is shown as in IDL for FF (not inherited) but as inherited in spec.
- [x] HTMLCanvasElement.getContext()
- [x] Navigator.gpu
- [ ] WorkerNavigator.gpu - NOT supported - so you can't get a handle on this in workers on FF

A few issues:
- GPUComputePipeline  and GPUrenderPipeline are serializable but that isn't supported yet. I don't think we need to track that in preview right? i.e. I assume when this goes to release it will be serializable and that is the only thing that matters. Of course hard to remember that needs to be confirmed.

