### PR TITLE
Update some HTML spec URLs to new nav-history-apis.html filename

### DIFF
--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -3,7 +3,7 @@
     "BeforeUnloadEvent": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/BeforeUnloadEvent",
-        "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-beforeunloadevent-interface",
+        "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-beforeunloadevent-interface",
         "support": {
           "chrome": {
             "version_added": "30"

--- a/api/Document.json
+++ b/api/Document.json
@@ -4828,7 +4828,7 @@
       "location": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/location",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#the-location-interface",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-location-interface",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/HashChangeEvent.json
+++ b/api/HashChangeEvent.json
@@ -3,7 +3,7 @@
     "HashChangeEvent": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/HashChangeEvent",
-        "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-hashchangeevent-interface",
+        "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-hashchangeevent-interface",
         "support": {
           "chrome": {
             "version_added": "8"
@@ -45,7 +45,7 @@
         "__compat": {
           "description": "<code>HashChangeEvent()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HashChangeEvent/HashChangeEvent",
-          "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-hashchangeevent-interface",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-hashchangeevent-interface",
           "support": {
             "chrome": {
               "version_added": "16"
@@ -81,7 +81,7 @@
       "newURL": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HashChangeEvent/newURL",
-          "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#dom-hashchangeevent-newurl-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-hashchangeevent-newurl-dev",
           "support": {
             "chrome": {
               "version_added": "8"
@@ -121,7 +121,7 @@
       "oldURL": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HashChangeEvent/oldURL",
-          "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#dom-hashchangeevent-oldurl-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-hashchangeevent-oldurl-dev",
           "support": {
             "chrome": {
               "version_added": "8"

--- a/api/History.json
+++ b/api/History.json
@@ -3,7 +3,7 @@
     "History": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/History",
-        "spec_url": "https://html.spec.whatwg.org/multipage/history.html#the-history-interface",
+        "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-history-interface",
         "support": {
           "chrome": {
             "version_added": "1"
@@ -42,7 +42,7 @@
       "back": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/History/back",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-history-back-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-back-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -82,7 +82,7 @@
       "forward": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/History/forward",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-history-forward-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-forward-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -122,7 +122,7 @@
       "go": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/History/go",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-history-go-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-go-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -162,7 +162,7 @@
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/History/length",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-history-length-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-length-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -202,7 +202,7 @@
       "pushState": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/History/pushState",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-history-pushstate-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-pushstate-dev",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -284,7 +284,7 @@
       "replaceState": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/History/replaceState",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-history-replacestate-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-replacestate-dev",
           "support": {
             "chrome": {
               "version_added": "5"
@@ -366,7 +366,7 @@
       "scrollRestoration": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/History/scrollRestoration",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-history-scroll-restoration-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-scroll-restoration-dev",
           "support": {
             "chrome": {
               "version_added": "46"
@@ -400,7 +400,7 @@
       "state": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/History/state",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-history-state-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-state-dev",
           "support": {
             "chrome": {
               "version_added": "19"

--- a/api/Location.json
+++ b/api/Location.json
@@ -3,7 +3,7 @@
     "Location": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location",
-        "spec_url": "https://html.spec.whatwg.org/multipage/history.html#the-location-interface",
+        "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-location-interface",
         "support": {
           "chrome": {
             "version_added": "1"
@@ -47,7 +47,7 @@
       "ancestorOrigins": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location/ancestorOrigins",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-location-ancestororigins-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-ancestororigins-dev",
           "support": {
             "chrome": {
               "version_added": "20"
@@ -84,7 +84,7 @@
       "assign": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location/assign",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-location-assign-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-assign-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -129,7 +129,7 @@
       "hash": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location/hash",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-location-hash-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-hash-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -172,7 +172,7 @@
       "host": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location/host",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-location-host-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-host-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -215,7 +215,7 @@
       "hostname": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location/hostname",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-location-hostname-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-hostname-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -258,7 +258,7 @@
       "href": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location/href",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-location-href-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-href-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -301,7 +301,7 @@
       "origin": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location/origin",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-location-origin-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-origin-dev",
           "support": {
             "chrome": {
               "version_added": "8"
@@ -344,7 +344,7 @@
       "pathname": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location/pathname",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-location-pathname-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-pathname-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -389,7 +389,7 @@
       "port": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location/port",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-location-port-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-port-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -432,7 +432,7 @@
       "protocol": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location/protocol",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-location-protocol-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-protocol-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -475,7 +475,7 @@
       "reload": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location/reload",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-location-reload-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-reload-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -520,7 +520,7 @@
       "replace": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location/replace",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-location-replace-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-replace-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -563,7 +563,7 @@
       "search": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location/search",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-location-search-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-search-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -607,7 +607,7 @@
       "toString": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Location/toString",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#dom-location-href-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-href-dev",
           "support": {
             "chrome": {
               "version_added": "52"

--- a/api/PageTransitionEvent.json
+++ b/api/PageTransitionEvent.json
@@ -3,7 +3,7 @@
     "PageTransitionEvent": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PageTransitionEvent",
-        "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-pagetransitionevent-interface",
+        "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-pagetransitionevent-interface",
         "support": {
           "chrome": {
             "version_added": "4"
@@ -43,7 +43,7 @@
         "__compat": {
           "description": "<code>PageTransitionEvent()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PageTransitionEvent/PageTransitionEvent",
-          "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-pagetransitionevent-interface",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-pagetransitionevent-interface",
           "support": {
             "chrome": {
               "version_added": "16"
@@ -77,7 +77,7 @@
       "persisted": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PageTransitionEvent/persisted",
-          "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#dom-pagetransitionevent-persisted-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-pagetransitionevent-persisted-dev",
           "support": {
             "chrome": {
               "version_added": "4"

--- a/api/PopStateEvent.json
+++ b/api/PopStateEvent.json
@@ -3,7 +3,7 @@
     "PopStateEvent": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PopStateEvent",
-        "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-popstateevent-interface",
+        "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-popstateevent-interface",
         "support": {
           "chrome": {
             "version_added": "4"
@@ -43,7 +43,7 @@
         "__compat": {
           "description": "<code>PopStateEvent()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PopStateEvent/PopStateEvent",
-          "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-popstateevent-interface",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-popstateevent-interface",
           "support": {
             "chrome": {
               "version_added": "16"
@@ -79,7 +79,7 @@
       "state": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PopStateEvent/state",
-          "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#dom-popstateevent-state-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-popstateevent-state-dev",
           "support": {
             "chrome": {
               "version_added": "4"

--- a/api/Window.json
+++ b/api/Window.json
@@ -1570,7 +1570,7 @@
       "frameElement": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/frameElement",
-          "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#dom-frameelement-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-frameelement-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -2134,7 +2134,7 @@
       "history": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/history",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#the-history-interface",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-history-interface",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -2489,7 +2489,7 @@
       "location": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/location",
-          "spec_url": "https://html.spec.whatwg.org/multipage/history.html#the-location-interface",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-location-interface",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -3295,7 +3295,7 @@
       "opener": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/opener",
-          "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#dom-opener-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-opener-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -3699,7 +3699,7 @@
       "parent": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/parent",
-          "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#dom-parent-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-parent-dev",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -6119,7 +6119,7 @@
       "top": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/top",
-          "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#dom-top-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-top-dev",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
The multipage HTML spec recently dropped the former `history.html` file and added a new `nav-history-apis.html` file, which includes parts of what had been in the `browsing-the-web.html` file and the `history.html` file.  So, a number of the fragments in BCD spec URLs have moved to the new `nav-history-apis.html` file.