### PR TITLE
Update spec URL for securitypolicyviolation event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -8203,7 +8203,7 @@
           "description": "<code>securitypolicyviolation</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/securitypolicyviolation_event",
           "spec_url": [
-            "https://html.spec.whatwg.org/multipage/indices.html#event-securitypolicyviolation",
+            "https://w3c.github.io/webappsec-csp/#eventdef-globaleventhandlers-securitypolicyviolation",
             "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onsecuritypolicyviolation"
           ],
           "support": {

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -456,7 +456,7 @@
         "__compat": {
           "description": "<code>securitypolicyviolation</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event",
-          "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-securitypolicyviolation",
+          "spec_url": "https://w3c.github.io/webappsec-csp/#eventdef-globaleventhandlers-securitypolicyviolation",
           "support": {
             "chrome": {
               "version_added": "41"


### PR DESCRIPTION
The normative definition for the `securitypolicyviolation` event is now in the CSP spec.