### PR TITLE
Drop spec URL for document-domain permissions policy

### DIFF
--- a/http/headers/Feature-Policy.json
+++ b/http/headers/Feature-Policy.json
@@ -269,7 +269,6 @@
         "document-domain": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/document-domain",
-            "spec_url": "https://html.spec.whatwg.org/multipage/infrastructure.html#document-domain-feature",
             "support": {
               "chrome": {
                 "version_added": "77"

--- a/http/headers/Feature-Policy.json
+++ b/http/headers/Feature-Policy.json
@@ -302,9 +302,9 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
https://github.com/whatwg/html/commit/d7ae2a6 dropped the `document-domain` permissions policy from the HTML spec.