### PR TITLE
Drop spec URL for rel=prerender

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -972,9 +972,9 @@
                 "webview_android": "mirror"
               },
               "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": true
               }
             }
           }

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -946,7 +946,6 @@
           "prerender": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Link_types/prerender",
-              "spec_url": "https://html.spec.whatwg.org/multipage/links.html#link-type-prerender",
               "support": {
                 "chrome": {
                   "version_added": "13"


### PR DESCRIPTION
https://github.com/whatwg/html/pull/8996 dropped `rel=prerender` from the HTML spec.