### PR TITLE
Update css-masking spec URLs

### DIFF
--- a/api/SVGClipPathElement.json
+++ b/api/SVGClipPathElement.json
@@ -46,7 +46,7 @@
       "clipPathUnits": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGClipPathElement/clipPathUnits",
-          "spec_url": "https://drafts.fxtf.org/css-masking-1/#dom-svgclippathelement-clippathunits",
+          "spec_url": "https://drafts.fxtf.org/css-masking/#dom-svgclippathelement-clippathunits",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -90,7 +90,7 @@
       "transform": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGClipPathElement/transform",
-          "spec_url": "https://drafts.fxtf.org/css-masking-1/#dom-svgclippathelement-transform",
+          "spec_url": "https://drafts.fxtf.org/css-masking/#dom-svgclippathelement-transform",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/SVGMaskElement.json
+++ b/api/SVGMaskElement.json
@@ -46,7 +46,7 @@
       "height": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMaskElement/height",
-          "spec_url": "https://drafts.fxtf.org/css-masking-1/#dom-svgmaskelement-height",
+          "spec_url": "https://drafts.fxtf.org/css-masking/#dom-svgmaskelement-height",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -90,7 +90,7 @@
       "maskContentUnits": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMaskElement/maskContentUnits",
-          "spec_url": "https://drafts.fxtf.org/css-masking-1/#dom-svgmaskelement-maskcontentunits",
+          "spec_url": "https://drafts.fxtf.org/css-masking/#dom-svgmaskelement-maskcontentunits",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -132,7 +132,7 @@
       "maskUnits": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMaskElement/maskUnits",
-          "spec_url": "https://drafts.fxtf.org/css-masking-1/#dom-svgmaskelement-maskunits",
+          "spec_url": "https://drafts.fxtf.org/css-masking/#dom-svgmaskelement-maskunits",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -174,7 +174,7 @@
       "width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMaskElement/width",
-          "spec_url": "https://drafts.fxtf.org/css-masking-1/#dom-svgmaskelement-width",
+          "spec_url": "https://drafts.fxtf.org/css-masking/#dom-svgmaskelement-width",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -218,7 +218,7 @@
       "x": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMaskElement/x",
-          "spec_url": "https://drafts.fxtf.org/css-masking-1/#dom-svgmaskelement-x",
+          "spec_url": "https://drafts.fxtf.org/css-masking/#dom-svgmaskelement-x",
           "support": {
             "chrome": {
               "version_added": "1"
@@ -262,7 +262,7 @@
       "y": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMaskElement/y",
-          "spec_url": "https://drafts.fxtf.org/css-masking-1/#dom-svgmaskelement-y",
+          "spec_url": "https://drafts.fxtf.org/css-masking/#dom-svgmaskelement-y",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
These should all be using the unversioned spec URL