### PR TITLE
Update css-contain spec URLs

### DIFF
--- a/api/ContentVisibilityAutoStateChangeEvent.json
+++ b/api/ContentVisibilityAutoStateChangeEvent.json
@@ -3,7 +3,7 @@
     "ContentVisibilityAutoStateChangeEvent": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ContentVisibilityAutoStateChangeEvent",
-        "spec_url": "https://w3c.github.io/csswg-drafts/css-contain-2/#content-visibility-auto-state-change",
+        "spec_url": "https://w3c.github.io/csswg-drafts/css-contain/#content-visibility-auto-state-change",
         "support": {
           "chrome": {
             "version_added": "108"
@@ -44,7 +44,7 @@
         "__compat": {
           "description": "<code>ContentVisibilityAutoStateChangeEvent()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ContentVisibilityAutoStateChangeEvent/ContentVisibilityAutoStateChangeEvent",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-contain-2/#dom-contentvisibilityautostatechangeevent-contentvisibilityautostatechangeevent",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-contain/#dom-contentvisibilityautostatechangeevent-contentvisibilityautostatechangeevent",
           "support": {
             "chrome": {
               "version_added": "108"
@@ -85,7 +85,7 @@
       "skipped": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ContentVisibilityAutoStateChangeEvent/skipped",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-contain-2/#dom-contentvisibilityautostatechangeevent-skipped",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-contain/#dom-contentvisibilityautostatechangeevent-skipped",
           "support": {
             "chrome": {
               "version_added": "108"

--- a/api/Element.json
+++ b/api/Element.json
@@ -3226,7 +3226,7 @@
         "__compat": {
           "description": "<code>contentvisibilityautostatechange</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/contentvisibilityautostatechanged_event",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-contain-2/#content-visibility-auto-state-change",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-contain/#content-visibility-auto-state-change",
           "support": {
             "chrome": {
               "version_added": "108"


### PR DESCRIPTION
These should all be using the unversioned spec URL