### PR TITLE
Update css-fonts spec URLs

### DIFF
--- a/api/CSSFontFeatureValuesRule.json
+++ b/api/CSSFontFeatureValuesRule.json
@@ -3,7 +3,7 @@
     "CSSFontFeatureValuesRule": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSFontFeatureValuesRule",
-        "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts-4/#cssfontfeaturevaluesrule",
+        "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts/#cssfontfeaturevaluesrule",
         "support": {
           "chrome": {
             "version_added": "111"
@@ -35,7 +35,7 @@
       },
       "annotation": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts-4/#dom-cssfontfeaturevaluesrule-annotation",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts/#dom-cssfontfeaturevaluesrule-annotation",
           "support": {
             "chrome": {
               "version_added": "111"
@@ -72,7 +72,7 @@
       },
       "characterVariant": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts-4/#dom-cssfontfeaturevaluesrule-charactervariant",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts/#dom-cssfontfeaturevaluesrule-charactervariant",
           "support": {
             "chrome": {
               "version_added": "111"
@@ -110,7 +110,7 @@
       "fontFamily": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSFontFeatureValuesRule/fontFamily",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts-4/#dom-cssfontfeaturevaluesrule-fontfamily",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts/#dom-cssfontfeaturevaluesrule-fontfamily",
           "support": {
             "chrome": {
               "version_added": "111"
@@ -143,7 +143,7 @@
       },
       "ornaments": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts-4/#dom-cssfontfeaturevaluesrule-ornaments",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts/#dom-cssfontfeaturevaluesrule-ornaments",
           "support": {
             "chrome": {
               "version_added": "111"
@@ -180,7 +180,7 @@
       },
       "styleset": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts-4/#dom-cssfontfeaturevaluesrule-styleset",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts/#dom-cssfontfeaturevaluesrule-styleset",
           "support": {
             "chrome": {
               "version_added": "111"
@@ -217,7 +217,7 @@
       },
       "stylistic": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts-4/#dom-cssfontfeaturevaluesrule-stylistic",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts/#dom-cssfontfeaturevaluesrule-stylistic",
           "support": {
             "chrome": {
               "version_added": "111"
@@ -254,7 +254,7 @@
       },
       "swash": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts-4/#dom-cssfontfeaturevaluesrule-swash",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts/#dom-cssfontfeaturevaluesrule-swash",
           "support": {
             "chrome": {
               "version_added": "111"

--- a/api/CSSFontPaletteValuesRule.json
+++ b/api/CSSFontPaletteValuesRule.json
@@ -3,7 +3,7 @@
     "CSSFontPaletteValuesRule": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSFontPaletteValuesRule",
-        "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts-4/#om-fontpalettevalues",
+        "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts/#om-fontpalettevalues",
         "support": {
           "chrome": {
             "version_added": "101"
@@ -36,7 +36,7 @@
       "basePalette": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSFontPaletteValuesRule/basePalette",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts-4/#dom-cssfontpalettevaluesrule-basepalette",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts/#dom-cssfontpalettevaluesrule-basepalette",
           "support": {
             "chrome": {
               "version_added": "101"
@@ -70,7 +70,7 @@
       "fontFamily": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSFontPaletteValuesRule/fontFamily",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts-4/#dom-cssfontpalettevaluesrule-fontfamily",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts/#dom-cssfontpalettevaluesrule-fontfamily",
           "support": {
             "chrome": {
               "version_added": "101"
@@ -104,7 +104,7 @@
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSFontPaletteValuesRule/name",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts-4/#dom-cssfontpalettevaluesrule-name",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts/#dom-cssfontpalettevaluesrule-name",
           "support": {
             "chrome": {
               "version_added": "101"
@@ -138,7 +138,7 @@
       "overrideColors": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSFontPaletteValuesRule/overrideColors",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts-4/#dom-cssfontpalettevaluesrule-overridecolors",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts/#dom-cssfontpalettevaluesrule-overridecolors",
           "support": {
             "chrome": {
               "version_added": "101"


### PR DESCRIPTION
These should all be using the unversioned spec URL