### PR TITLE
Update css-view-transitions spec URLs

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6438,7 +6438,7 @@
       "startViewTransition": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/startViewTransition",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions-1/#dom-document-startviewtransition",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions/#dom-document-startviewtransition",
           "support": {
             "chrome": {
               "version_added": "111"

--- a/api/ViewTransition.json
+++ b/api/ViewTransition.json
@@ -3,7 +3,7 @@
     "ViewTransition": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ViewTransition",
-        "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions-1/#viewtransition",
+        "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions/#viewtransition",
         "support": {
           "chrome": {
             "version_added": "111"
@@ -36,7 +36,7 @@
       "finished": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ViewTransition/finished",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions-1/#dom-viewtransition-finished",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions/#dom-viewtransition-finished",
           "support": {
             "chrome": {
               "version_added": "111"
@@ -70,7 +70,7 @@
       "ready": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ViewTransition/ready",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions-1/#dom-viewtransition-ready",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions/#dom-viewtransition-ready",
           "support": {
             "chrome": {
               "version_added": "111"
@@ -104,7 +104,7 @@
       "skipTransition": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ViewTransition/skipTransition",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions-1/#dom-viewtransition-skiptransition",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions/#dom-viewtransition-skiptransition",
           "support": {
             "chrome": {
               "version_added": "111"
@@ -138,7 +138,7 @@
       "updateCallbackDone": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ViewTransition/updateCallbackDone",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions-1/#dom-viewtransition-updatecallbackdone",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions/#dom-viewtransition-updatecallbackdone",
           "support": {
             "chrome": {
               "version_added": "111"

--- a/css/properties/view-transition-name.json
+++ b/css/properties/view-transition-name.json
@@ -4,7 +4,7 @@
       "view-transition-name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/view-transition-name",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions-1/#view-transition-name-prop",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions/#view-transition-name-prop",
           "support": {
             "chrome": {
               "version_added": "111"

--- a/css/selectors/view-transition-group.json
+++ b/css/selectors/view-transition-group.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>::view-transition-group()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::view-transition-group",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions-1/#selectordef-view-transition-group-pt-name-selector",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions/#selectordef-view-transition-group-pt-name-selector",
           "support": {
             "chrome": {
               "version_added": "111"

--- a/css/selectors/view-transition-image-pair.json
+++ b/css/selectors/view-transition-image-pair.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>::view-transition-image-pair()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::view-transition-image-pair",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions-1/#selectordef-view-transition-image-pair-pt-name-selector",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions/#selectordef-view-transition-image-pair-pt-name-selector",
           "support": {
             "chrome": {
               "version_added": "111"

--- a/css/selectors/view-transition-new.json
+++ b/css/selectors/view-transition-new.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>::view-transition-new()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::view-transition-new",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions-1/#selectordef-view-transition-new-pt-name-selector",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions/#selectordef-view-transition-new-pt-name-selector",
           "support": {
             "chrome": {
               "version_added": "111"

--- a/css/selectors/view-transition-old.json
+++ b/css/selectors/view-transition-old.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>::view-transition-old()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::view-transition-old",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions-1/#selectordef-view-transition-old-pt-name-selector",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions/#selectordef-view-transition-old-pt-name-selector",
           "support": {
             "chrome": {
               "version_added": "111"

--- a/css/selectors/view-transition.json
+++ b/css/selectors/view-transition.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>::view-transition</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::view-transition",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions-1/#selectordef-view-transition",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-view-transitions/#selectordef-view-transition",
           "support": {
             "chrome": {
               "version_added": "111"


### PR DESCRIPTION
These should all be using the unversioned spec URL