### PR TITLE
Update css-highlight-api spec URLs

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -875,7 +875,7 @@
       },
       "highlights": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api-1/#dom-css-highlights",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api/#dom-css-highlights",
           "support": {
             "chrome": {
               "version_added": "105"

--- a/api/Highlight.json
+++ b/api/Highlight.json
@@ -2,7 +2,7 @@
   "api": {
     "Highlight": {
       "__compat": {
-        "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api-1/#highlight",
+        "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api/#highlight",
         "support": {
           "chrome": {
             "version_added": "105"
@@ -35,7 +35,7 @@
       "Highlight": {
         "__compat": {
           "description": "<code>Highlight()</code> constructor",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api-1/#dom-highlight-highlight",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api/#dom-highlight-highlight",
           "support": {
             "chrome": {
               "version_added": "105"
@@ -292,7 +292,7 @@
       },
       "priority": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api-1/#dom-highlight-priority",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api/#dom-highlight-priority",
           "support": {
             "chrome": {
               "version_added": "105"
@@ -357,7 +357,7 @@
       },
       "type": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api-1/#enumdef-highlighttype",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api/#enumdef-highlighttype",
           "support": {
             "chrome": {
               "version_added": "105"

--- a/api/HighlightRegistry.json
+++ b/api/HighlightRegistry.json
@@ -2,7 +2,7 @@
   "api": {
     "HighlightRegistry": {
       "__compat": {
-        "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api-1/#highlight-registry",
+        "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api/#highlight-registry",
         "support": {
           "chrome": {
             "version_added": "105"

--- a/css/selectors/highlight.json
+++ b/css/selectors/highlight.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>::highlight()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::highlight",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api-1/#custom-highlight-pseudo",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-highlight-api/#custom-highlight-pseudo",
           "support": {
             "chrome": {
               "version_added": "105"


### PR DESCRIPTION
These should all be using the unversioned spec URL