### PR TITLE
Update css-inline spec URL

### DIFF
--- a/css/properties/baseline-source.json
+++ b/css/properties/baseline-source.json
@@ -4,7 +4,7 @@
       "baseline-source": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/baseline-source",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-inline-3/#baseline-source",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-inline/#baseline-source",
           "support": {
             "chrome": {
               "version_added": "111"


### PR DESCRIPTION
This should be using the unversioned spec URL