### PR TITLE
Update contact-picker spec URLs (avoid redirect)

### DIFF
--- a/api/ContactAddress.json
+++ b/api/ContactAddress.json
@@ -2,7 +2,7 @@
   "api": {
     "ContactAddress": {
       "__compat": {
-        "spec_url": "https://w3c.github.io/contact-picker/spec/#contactaddress",
+        "spec_url": "https://w3c.github.io/contact-picker/#contactaddress",
         "support": {
           "chrome": {
             "version_added": false
@@ -36,7 +36,7 @@
       },
       "addressLine": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/contact-picker/spec/#dom-contactaddress-addressLine",
+          "spec_url": "https://w3c.github.io/contact-picker/#dom-contactaddress-addressLine",
           "support": {
             "chrome": {
               "version_added": false
@@ -71,7 +71,7 @@
       },
       "city": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/contact-picker/spec/#dom-contactaddress-city",
+          "spec_url": "https://w3c.github.io/contact-picker/#dom-contactaddress-city",
           "support": {
             "chrome": {
               "version_added": false
@@ -106,7 +106,7 @@
       },
       "country": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/contact-picker/spec/#dom-contactaddress-country",
+          "spec_url": "https://w3c.github.io/contact-picker/#dom-contactaddress-country",
           "support": {
             "chrome": {
               "version_added": false
@@ -141,7 +141,7 @@
       },
       "dependentLocality": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/contact-picker/spec/#dom-contactaddress-dependentLocality",
+          "spec_url": "https://w3c.github.io/contact-picker/#dom-contactaddress-dependentLocality",
           "support": {
             "chrome": {
               "version_added": false
@@ -176,7 +176,7 @@
       },
       "organization": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/contact-picker/spec/#dom-contactaddress-organization",
+          "spec_url": "https://w3c.github.io/contact-picker/#dom-contactaddress-organization",
           "support": {
             "chrome": {
               "version_added": false
@@ -211,7 +211,7 @@
       },
       "phone": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/contact-picker/spec/#dom-contactaddress-phone",
+          "spec_url": "https://w3c.github.io/contact-picker/#dom-contactaddress-phone",
           "support": {
             "chrome": {
               "version_added": false
@@ -246,7 +246,7 @@
       },
       "postalCode": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/contact-picker/spec/#dom-contactaddress-postalCode",
+          "spec_url": "https://w3c.github.io/contact-picker/#dom-contactaddress-postalCode",
           "support": {
             "chrome": {
               "version_added": false
@@ -281,7 +281,7 @@
       },
       "recipient": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/contact-picker/spec/#dom-contactaddress-recipient",
+          "spec_url": "https://w3c.github.io/contact-picker/#dom-contactaddress-recipient",
           "support": {
             "chrome": {
               "version_added": false
@@ -316,7 +316,7 @@
       },
       "region": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/contact-picker/spec/#dom-contactaddress-region",
+          "spec_url": "https://w3c.github.io/contact-picker/#dom-contactaddress-region",
           "support": {
             "chrome": {
               "version_added": false
@@ -351,7 +351,7 @@
       },
       "sortingCode": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/contact-picker/spec/#dom-contactaddress-sortingCode",
+          "spec_url": "https://w3c.github.io/contact-picker/#dom-contactaddress-sortingCode",
           "support": {
             "chrome": {
               "version_added": false
@@ -386,7 +386,7 @@
       },
       "toJSON": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/contact-picker/spec/#dom-contactaddress-toJSON",
+          "spec_url": "https://w3c.github.io/contact-picker/#dom-contactaddress-toJSON",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/ContactsManager.json
+++ b/api/ContactsManager.json
@@ -3,7 +3,7 @@
     "ContactsManager": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ContactsManager",
-        "spec_url": "https://w3c.github.io/contact-picker/spec/#contacts-manager",
+        "spec_url": "https://w3c.github.io/contact-picker/#contacts-manager",
         "support": {
           "chrome": {
             "version_added": false
@@ -46,7 +46,7 @@
       "getProperties": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ContactsManager/getProperties",
-          "spec_url": "https://w3c.github.io/contact-picker/spec/#contacts-manager-getproperties",
+          "spec_url": "https://w3c.github.io/contact-picker/#contacts-manager-getproperties",
           "support": {
             "chrome": {
               "version_added": false
@@ -90,7 +90,7 @@
       "select": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ContactsManager/select",
-          "spec_url": "https://w3c.github.io/contact-picker/spec/#contacts-manager-select",
+          "spec_url": "https://w3c.github.io/contact-picker/#contacts-manager-select",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -672,7 +672,7 @@
       "contacts": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/contacts",
-          "spec_url": "https://w3c.github.io/contact-picker/spec/#dom-navigator-contacts",
+          "spec_url": "https://w3c.github.io/contact-picker/#dom-navigator-contacts",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
https://w3c.github.io/contact-picker/spec redirects to https://w3c.github.io/contact-picker — so, let’s use that rather than everybody needing to run into the redirect unnecessarily.