### PR TITLE
FF102 Console.profile no longer supported

### DIFF
--- a/api/Console.json
+++ b/api/Console.json
@@ -1065,7 +1065,8 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "16"
+              "version_added": "16",
+              "version_removed": "102"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF102 removed the old performance panel UI in https://bugzilla.mozilla.org/show_bug.cgi?id=1668219. This was the last place where you can access [`console.profile`](https://developer.mozilla.org/en-US/docs/Web/API/console/profile) on firefox, so it is effectively removed in this version.

To be very precise the new performance panel was introduced with a preference in FF94 and by default in FF98, so to access this from FF98 to FF101 you needed to use a preference. However I don't think this is useful information now we're up round 112 as release build, so have not bothered to chase the preference detail.

Fixes #19347

FYI @queengooborg 

