### PR TITLE
Drop spec URLs for Intl.Locale.prototype properties no longer in spec

### DIFF
--- a/javascript/builtins/Intl/Locale.json
+++ b/javascript/builtins/Intl/Locale.json
@@ -165,7 +165,6 @@
           "calendars": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/calendars",
-              "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.calendars",
               "support": {
                 "chrome": {
                   "version_added": "99"
@@ -285,7 +284,6 @@
           "collations": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/collations",
-              "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.collations",
               "support": {
                 "chrome": {
                   "version_added": "99"
@@ -365,7 +363,6 @@
           "hourCycles": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/hourCycles",
-              "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.hourCycles",
               "support": {
                 "chrome": {
                   "version_added": "99"
@@ -565,7 +562,6 @@
           "numberingSystems": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numberingSystems",
-              "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.numberingSystems",
               "support": {
                 "chrome": {
                   "version_added": "99"
@@ -725,7 +721,6 @@
           "textInfo": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/textInfo",
-              "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.textInfo",
               "support": {
                 "chrome": {
                   "version_added": "99"
@@ -765,7 +760,6 @@
           "timeZones": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/timeZones",
-              "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.timeZones",
               "support": {
                 "chrome": {
                   "version_added": "99"
@@ -845,7 +839,6 @@
           "weekInfo": {
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/weekInfo",
-              "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.weekInfo",
               "support": {
                 "chrome": {
                   "version_added": "99"

--- a/javascript/builtins/Intl/Locale.json
+++ b/javascript/builtins/Intl/Locale.json
@@ -196,8 +196,8 @@
               },
               "status": {
                 "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+                "standard_track": false,
+                "deprecated": true
               }
             }
           },
@@ -315,8 +315,8 @@
               },
               "status": {
                 "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+                "standard_track": false,
+                "deprecated": true
               }
             }
           },
@@ -394,8 +394,8 @@
               },
               "status": {
                 "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+                "standard_track": false,
+                "deprecated": true
               }
             }
           },
@@ -593,8 +593,8 @@
               },
               "status": {
                 "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+                "standard_track": false,
+                "deprecated": true
               }
             }
           },
@@ -752,8 +752,8 @@
               },
               "status": {
                 "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+                "standard_track": false,
+                "deprecated": true
               }
             }
           },
@@ -791,8 +791,8 @@
               },
               "status": {
                 "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+                "standard_track": false,
+                "deprecated": true
               }
             }
           },
@@ -870,8 +870,8 @@
               },
               "status": {
                 "experimental": false,
-                "standard_track": true,
-                "deprecated": false
+                "standard_track": false,
+                "deprecated": true
               }
             }
           }


### PR DESCRIPTION
The spec URLs removed in this change are for `Intl.Locale.prototype` properties that were apparently once part of the spec (and implemented in some browsers) but that aren’t in the current spec (presumably because they were intentionally removed from the spec).