### PR TITLE
Update webrtc-priority spec URL

### DIFF
--- a/api/RTCRtpEncodingParameters.json
+++ b/api/RTCRtpEncodingParameters.json
@@ -210,7 +210,7 @@
       "priority": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpEncodingParameters#priority",
-          "spec_url": "https://www.w3.org/TR/webrtc-priority/#dom-rtcrtpencodingparameters-priority",
+          "spec_url": "https://w3c.github.io/webrtc-priority/#dom-rtcrtpencodingparameters-priority",
           "support": {
             "chrome": {
               "version_added": "67"


### PR DESCRIPTION
This should be using the URL for the current spec (as the other existing spec URLs do), rather than the URL for the static W3C TR version.