### PR TITLE
Update manifest-incubations spec URL

### DIFF
--- a/html/manifest/file_handlers.json
+++ b/html/manifest/file_handlers.json
@@ -4,7 +4,7 @@
       "file_handlers": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/file_handlers",
-          "spec_url": "https://wicg.github.io/manifest-incubations/index.html#file_handlers-member",
+          "spec_url": "https://wicg.github.io/manifest-incubations/#file_handlers-member",
           "support": {
             "chrome": {
               "version_added": "102"


### PR DESCRIPTION
This should omit the index.html filename part (as other existing spec URLs do)