### PR TITLE
Fix overflow-block and overflow-inline spec URLs

### DIFF
--- a/css/properties/overflow-block.json
+++ b/css/properties/overflow-block.json
@@ -4,7 +4,7 @@
       "overflow-block": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-block",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-overflow/#logical",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-overflow/#overflow-control",
           "support": {
             "chrome": {
               "version_added": false

--- a/css/properties/overflow-inline.json
+++ b/css/properties/overflow-inline.json
@@ -4,7 +4,7 @@
       "overflow-inline": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow-inline",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-overflow/#logical",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-overflow/#overflow-control",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
These just had the wrong spec URL (with non-existent fragment)