### PR TITLE
Fix webkit-line-clamp spec URL

### DIFF
--- a/css/properties/-webkit-line-clamp.json
+++ b/css/properties/-webkit-line-clamp.json
@@ -4,7 +4,7 @@
       "-webkit-line-clamp": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-line-clamp",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-overflow/#webkit-line-clamp",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-overflow-4/#propdef--webkit-line-clamp",
           "support": {
             "chrome": {
               "version_added": "6"


### PR DESCRIPTION
Note also: This property is documented only in the versioned css-overflow-4 (level 4) spec — but in the unversioned spec (which is currently level 3)