### PR TITLE
Deprecate CSP prefetch-src

### DIFF
--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -699,7 +699,6 @@
         "prefetch-src": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/prefetch-src",
-            "spec_url": "https://w3c.github.io/webappsec-csp/#directive-prefetch-src",
             "support": {
               "chrome": {
                 "version_added": false,
@@ -727,9 +726,9 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
https://github.com/w3c/webappsec-csp/pull/582 dropped `prefetch-src` from the CSP spec.