### PR TITLE
Sec-Fetch-Dest: Safari 16.4+ support

### DIFF
--- a/http/headers/Sec-Fetch-Dest.json
+++ b/http/headers/Sec-Fetch-Dest.json
@@ -24,7 +24,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
 - https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes                        
   > Added support for Fetch Metadata Request Headers.                                                             
 - https://bugs.webkit.org/show_bug.cgi?id=238265

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
