### PR TITLE
Fetch Metadata Req Headers: Safari 16.4+ support

### DIFF
--- a/http/headers/Sec-Fetch-Dest.json
+++ b/http/headers/Sec-Fetch-Dest.json
@@ -24,7 +24,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/http/headers/Sec-Fetch-Mode.json
+++ b/http/headers/Sec-Fetch-Mode.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/http/headers/Sec-Fetch-Site.json
+++ b/http/headers/Sec-Fetch-Site.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/http/headers/Sec-Fetch-User.json
+++ b/http/headers/Sec-Fetch-User.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Safari 16.4 added Fetch Metadata Request Headers.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

I tested by viewing request headers in Safari 16.4 on macOS. I also used browser stack to ensure that the headers were not present on Safari 16.3. Lastly, this aligns with the release notes and upstream bug.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

  - https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes
    > Added support for Fetch Metadata Request Headers.
  - https://bugs.webkit.org/show_bug.cgi?id=238265

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Fixes #19389