### PR TITLE
Remove XRCompositionLayer»chromaticAberrationCorrection

### DIFF
--- a/api/XRCompositionLayer.json
+++ b/api/XRCompositionLayer.json
@@ -74,7 +74,6 @@
       "chromaticAberrationCorrection": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRCompositionLayer/chromaticAberrationCorrection",
-          "spec_url": "https://immersive-web.github.io/layers/#dom-xrcompositionlayer-chromaticaberrationcorrection",
           "support": {
             "chrome": {
               "version_added": false
@@ -101,9 +100,9 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },

--- a/api/XRCompositionLayer.json
+++ b/api/XRCompositionLayer.json
@@ -71,41 +71,6 @@
           }
         }
       },
-      "chromaticAberrationCorrection": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRCompositionLayer/chromaticAberrationCorrection",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": {
-              "version_added": "16.1"
-            },
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "destroy": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRCompositionLayer/destroy",


### PR DESCRIPTION
<s>Alternatively, we could just completely remove `chromaticAberrationCorrection` from BCD. Oculus is the only browser that implemented it, and in MDN we anyway don’t expose compat data for Oculus.</s>

Related MDN change https://github.com/mdn/content/pull/26277