### PR TITLE
Safari 16.3 supports WindowClient.navigate()

### DIFF
--- a/api/WindowClient.json
+++ b/api/WindowClient.json
@@ -170,7 +170,7 @@
               },
               {
                 "version_added": "11.1",
-                "version_removed": "16.3",
+                "version_removed": "16",
                 "partial_implementation": true,
                 "notes": "This method exists, but always throws <code>NotSupportedError</code>."
               }

--- a/api/WindowClient.json
+++ b/api/WindowClient.json
@@ -166,7 +166,7 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "16.3"
+                "version_added": "16"
               },
               {
                 "version_added": "11.1",

--- a/api/WindowClient.json
+++ b/api/WindowClient.json
@@ -164,11 +164,17 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "11.1",
-              "partial_implementation": true,
-              "notes": "This method exists, but always throws <code>NotSupportedError</code>."
-            },
+            "safari": [
+              {
+                "version_added": "16.3"
+              },
+              {
+                "version_added": "11.1",
+                "version_removed": "16.3",
+                "partial_implementation": true,
+                "notes": "This method exists, but always throws <code>NotSupportedError</code>."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "4.0"


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/26264

I tested using https://googlechrome.github.io/samples/service-worker/windowclient-navigate/ on browserstack. All works in 16.3 but not on 15.6. It is possible it appeared in 16.2 of course. No information about this in the release notes.

FYI @queengooborg 