### PR TITLE
Remove HTMLVideoElement»autoPictureInPicture

### DIFF
--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -43,40 +43,6 @@
           "deprecated": false
         }
       },
-      "autoPictureInPicture": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/autoPictureInPicture",
-          "spec_url": "https://w3c.github.io/picture-in-picture/#auto-pip",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "13.1"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "cancelVideoFrameCallback": {
         "__compat": {
           "spec_url": "https://wicg.github.io/video-rvfc/#dom-htmlvideoelement-cancelvideoframecallback",


### PR DESCRIPTION
https://github.com/w3c/picture-in-picture/pull/216 removed `HTMLVideoElement`»`autoPictureInPicture` from the spec, and while the current BCD data indicates it was implemented in Safari, that’s not strictly true.

https://github.com/w3c/picture-in-picture/pull/216#issuecomment-1339792930 explains:
> autoPictureInPicture is in WebKit but doesn't actually do anything. See https://github.com/search?q=repo%3AWebKit%2FWebKit+autoPictureInPicture&type=code

So it won’t ever actually do anything in Safari, and won’t ever be implemented in other browsers; so we should remove it from BCD rather than just it hanging around — because it’s not something that web developers will ever be able to actually use, anywhere.

Related MDN change: https://github.com/mdn/content/pull/26278