### PR TITLE
FF113 supports CanvasRenderingContext2D/OffscreenCanvasRenderingContext2D.reset() 

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -2222,7 +2222,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "113"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2239,7 +2239,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -1620,6 +1620,7 @@
       },
       "reset": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/OffscreenCanvasRenderingContext2D#canvasrenderingcontext2d.reset",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-reset",
           "support": {
             "chrome": {
@@ -1628,7 +1629,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "113"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1645,7 +1646,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
FF113 adds support for [`CanvasRenderingContext2D.reset()`](https://developer.mozilla.org/en-US/en-US/docs/Web/API/CanvasRenderingContext2D/reset) and [`OffscreenCanvasRenderingContext2D.reset()`](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvasRenderingContext2D#canvasrenderingcontext2d.reset) in https://bugzilla.mozilla.org/show_bug.cgi?id=1709347

This updates the two features, and removes the experimental flag.

Other docs work for this can be tracked in https://github.com/mdn/content/issues/26148