### PR TITLE
FF113 supports Window.print() in Android

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3942,8 +3942,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1247609'>bug 1247609</a>."
+              "version_added": "113"
             },
             "ie": {
               "version_added": "5"


### PR DESCRIPTION
FF113 supports Window.print() on android in https://bugzilla.mozilla.org/show_bug.cgi?id=1809922

This updates the BCD. 

Other docs in https://github.com/mdn/content/issues/26152