### PR TITLE
(fx112) Add file for ray function and update ray() in offset-path

### DIFF
--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -103,20 +103,40 @@
             "description": "Supports the <code>ray()</code> function as a value",
             "support": {
               "chrome": {
-                "version_added": "64"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "72",
+                "version_added": "64",
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "layout.css.motion-path-ray.enabled",
-                    "value_to_set": "true"
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
                   }
                 ]
               },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": [
+                {
+                  "version_added": "112",
+                  "notes": "<code>&lt;ray-size&gt;</code> is optional with the default value <code>closest-side</code>.",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.motion-path-ray.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "72",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.motion-path-ray.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/css/types/ray.json
+++ b/css/types/ray.json
@@ -50,7 +50,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/types/ray.json
+++ b/css/types/ray.json
@@ -1,0 +1,61 @@
+{
+  "css": {
+    "types": {
+      "ray": {
+        "__compat": {
+          "description": "<code>ray()</code>",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/ray",
+          "spec_url": "https://drafts.fxtf.org/motion/#ray-function",
+          "support": {
+            "chrome": {
+              "version_added": "64"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": [
+              {
+                "version_added": "112",
+                "notes": "<code>&lt;ray-size&gt;</code> is optional with the default value <code>closest-side</code>.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.motion-path-ray.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "72",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.motion-path-ray.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/types/ray.json
+++ b/css/types/ray.json
@@ -8,7 +8,14 @@
           "spec_url": "https://drafts.fxtf.org/motion/#ray-function",
           "support": {
             "chrome": {
-              "version_added": "64"
+              "version_added": "64",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

### Summary

- `ray()` already has a row in `offset-path` BCD table https://developer.mozilla.org/en-US/docs/Web/CSS/offset-path#browser_compatibility, which needs to be updated for Fx112.
- A new `ray()` function page is being created (https://github.com/mdn/content/pull/26266) and a new BCD table needs to be created for this. The new `ray.json` file also adds the spec link.

#### Supporting info

- I have picked most of the `ray()` info for the new table from the `offset-path` BCD table.
- Firefox: `ray()` is still behind the flag `layout.css.motion-path-ray.enabled`. In Fx112, support is added for spec's updated syntax. 
- Chrome:
   - The BCD table on [offset-path](https://developer.mozilla.org/en-US/docs/Web/CSS/offset-path#browser_compatibility)[ page](https://developer.mozilla.org/en-US/docs/Web/CSS/offset-path#browser_compatibility) contains a row on `ray()` that indicates complete support from Chrome 64 (added via https://github.com/mdn/browser-compat-data/pull/5045), which is contrary to what I saw in testing.
   - The last mention in Chrome on `offset-path` seems to have been in 64 (https://chromestatus.com/newfeatures?q=offset-path)
   - On Canary, the feature works with experimental mode enabled.
   - It was working earlier but now it does not seem to be working in Chrome 112 even in experimental mode.
   - In both `offset-path` and `ray()` json files, I have added note for Chrome support in experimental mode.
- For its status in Firefox and Chrome, I have also marked `"experimental": true` in `ray.json` file.

#### Test results and supporting details

The following codepens can be used to test in Firefox and Chrome:
Example 1: https://codepen.io/dipikabh/pen/yLReQaZ
Example 2: https://codepen.io/dipikabh/pen/PoyNQdz

#### Related issues

Doc issue tracker: https://github.com/mdn/content/issues/25358
Content PR: https://github.com/mdn/content/pull/26266
Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1820071
Spec: https://drafts.fxtf.org/motion/#ray-function
