### PR TITLE
Update spec URL for SameSite param of Set-Cookie header

### DIFF
--- a/http/headers/Set-Cookie.json
+++ b/http/headers/Set-Cookie.json
@@ -150,7 +150,7 @@
         "SameSite": {
           "__compat": {
             "description": "<code>SameSite</code>",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value",
             "spec_url": [
               "https://httpwg.org/specs/rfc6265.html#sane-set-cookie",
               "https://httpwg.org/http-extensions/draft-ietf-httpbis-rfc6265bis.html#name-the-samesite-attribute"


### PR DESCRIPTION
https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite redirects to https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value — so let’s use the redirected destination URL instead.