### PR TITLE
relnote(Fx113): CSS Color lvl 4 features are enabled by default

### DIFF
--- a/css/properties/forced-color-adjust.json
+++ b/css/properties/forced-color-adjust.json
@@ -22,7 +22,7 @@
               }
             ],
             "firefox": {
-              "version_added": false
+              "version_added": "113"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -53,14 +53,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "111",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.more_color_4.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "113"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -144,14 +137,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "88",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.color-mix.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "113"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -458,14 +444,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "111",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.more_color_4.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "113"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -500,14 +479,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "111",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.more_color_4.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "113"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -623,14 +595,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "111",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.more_color_4.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "113"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -665,14 +630,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "111",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.more_color_4.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "113"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
Four preferences are flipped to `true` by default in 113, specifically:

* `layout.css.more_color_4.enabled` (for functional notations `lab()` etc.)
* `layout.css.forced-color-adjust.enabled` (for `forced-color-adjust` prop)
* `layout.css.color-mix.enabled` and `layout.css.color-mix.color-spaces.enabled` (for `color-mix()` functional notation)

__Related issues and pull requests:__
- Parent issue https://github.com/mdn/content/issues/26147

__Bugzilla:__

- Tracking bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1352753
- Bugs for individual flags:
  - `more_color_4`: https://bugzilla.mozilla.org/show_bug.cgi?id=1813497
  - `forced-color-adjust`: https://bugzilla.mozilla.org/show_bug.cgi?id=1818819
  - `color-mix` and `color-mix.color-spaces`: https://bugzilla.mozilla.org/show_bug.cgi?id=1824526
