### PR TITLE
Fix CSS Nesting spec URL

### DIFF
--- a/css/selectors/nesting.json
+++ b/css/selectors/nesting.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Nesting selector (<code>&</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Nesting_selectors",
-          "spec_url": "https://drafts.csswg.org/css-nesting/#nesting-selector",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-nesting/#nesting-selector",
           "support": {
             "chrome": {
               "version_added": "112"

--- a/css/selectors/nesting.json
+++ b/css/selectors/nesting.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Nesting selector (<code>&</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Nesting_selectors",
-          "spec_url": "https://www.w3.org/TR/css-nesting-1/#nesting-selector",
+          "spec_url": "https://drafts.csswg.org/css-nesting/#nesting-selector",
           "support": {
             "chrome": {
               "version_added": "112"


### PR DESCRIPTION
This should be the URL for the latest spec, rather than the TR version.