### PR TITLE
Popover attribute - Safari Tech Preview

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1250,7 +1250,7 @@
             "oculus": "mirror",
             "opera": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Safari Tech Preview v168 now has support for the popover attribute. Update the compat data to reflect that.

I read the docs on how to correctly mention that support is only added within a "preview" release.

#### Test results and supporting details

The Safari Tech Preview changelog mentions the addition.
https://webkit.org/blog/14106/release-notes-for-safari-technology-preview-168/

I also manually tested the [MDN page on Popovers](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover) in the newest release of Safari Tech Preview to confirm that it works as expected.

#### Related issues

- There is no support for Safari iOS, so that may need to be updated from "mirror" to something else.
