### PR TITLE
relnote(Fx113): CompressionStream and sub-features supported by default

### DIFF
--- a/api/CompressionStream.json
+++ b/api/CompressionStream.json
@@ -14,7 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "113"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -64,7 +64,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "113"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -103,7 +103,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "113"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -142,7 +142,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "113"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -181,7 +181,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "113"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -221,7 +221,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "113"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -261,7 +261,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "113"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/DecompressionStream.json
+++ b/api/DecompressionStream.json
@@ -14,7 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "113"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -64,7 +64,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "113"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -103,7 +103,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "113"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -142,7 +142,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "113"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -181,7 +181,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "113"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -221,7 +221,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "113"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -261,7 +261,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "113"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
Fx113 adds support for CompressionStream, constructor and co

__tests:__
Manually ran through examples with nightly:

```js
// constructor
let stream = new CompressionStream("gzip");
console.log(stream);
// CompressionStream { readable: ReadableStream, writable: WritableStream } ...
console.log(stream.writable);
// WritableStream { locked: false }
console.log(stream.readable)
// ReadableStream { locked: false }
new CompressionStream("deflate")
// CompressionStream { readable: ReadableStream, writable: WritableStream }
new CompressionStream("deflate-raw")
// CompressionStream { readable: ReadableStream, writable: WritableStream }
```

Same for Decompression stream:

```js
// constructor
let dcstream = new DecompressionStream("gzip");
console.log(dcstream);
// DecompressionStream { readable: ReadableStream, writable: WritableStream }
console.log(dcstream.writable);
// WritableStream { locked: false }
console.log(dcstream.readable)
// ReadableStream { locked: false }
new DecompressionStream("deflate")
// DecompressionStream { readable: ReadableStream, writable: WritableStream }
new DecompressionStream("deflate-raw")
// DecompressionStream { readable: ReadableStream, writable: WritableStream }
```

__Related issues and pull requests:__
- [ ] Parent issue https://github.com/mdn/content/issues/26158

__Bugzilla:__

- Tracking bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1823619

__TODO:__
- [x] check same for `DecompressionStream`

