### PR TITLE
(fx112) ray() - create separate entry for <ray_size> parameter

### DIFF
--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -67,7 +67,7 @@
         },
         "path-support": {
           "__compat": {
-            "description": "Supports the <code>path()</code> function as a value",
+            "description": "Support for <code>path()</code> function as a value",
             "support": {
               "chrome": {
                 "version_added": "64"
@@ -100,7 +100,7 @@
         },
         "ray-support": {
           "__compat": {
-            "description": "Supports the <code>ray()</code> function as a value",
+            "description": "Support for <code>ray()</code> function as a value",
             "support": {
               "chrome": {
                 "version_added": "64",

--- a/css/types/ray.json
+++ b/css/types/ray.json
@@ -19,29 +19,16 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "112",
-                "notes": "<code>&lt;ray-size&gt;</code> is optional with the default value <code>closest-side</code>.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.motion-path-ray.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "72",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.motion-path-ray.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "72",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.motion-path-ray.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -60,6 +47,69 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "size-support": {
+          "__compat": {
+            "description": "<code>&lt;ray-size&gt;</code>",
+            "support": {
+              "chrome": {
+                "version_added": "64",
+                "notes": "<code>&lt;ray-size&gt;</code> is required.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": [
+                {
+                  "version_added": "112",
+                  "notes": "<code>&lt;ray-size&gt;</code> is optional. If omitted, the value <code>closest-side</code> is used.",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.motion-path-ray.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "72",
+                  "notes": "<code>&lt;ray-size&gt;</code> is required.",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.motion-path-ray.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview",
+                "notes": "<code>&lt;ray-size&gt;</code> is required."
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This is a follow up to https://github.com/mdn/browser-compat-data/pull/19421.

This PR creates a separate row in the `ray()` BCD table to call out the difference in implementation of the `<ray_size>` parameter across browsers.

This PR also makes some minor updates to description text in [`offset-path` BCD table](https://developer.mozilla.org/en-US/docs/Web/CSS/offset-path#browser_compatibility).

#### Test results and supporting details

- Firefox 112 behind the flag `layout.css.motion-path-ray.enabled`: `<ray_size>` is optional

![1_fx112_ray](https://user-images.githubusercontent.com/23019147/233380164-0d7a6757-4cfa-4287-befe-7baaa8fa1801.png)

- Chrome Canary with #enable-experimental-web-platform-features: `<ray_size>` is optional - but we don't indicate this in the BCD table

![2_chrome_canary_ray](https://user-images.githubusercontent.com/23019147/233380183-0e72e728-a694-46e4-898e-f3c11d94a1a0.png)

- Chrome 112 with or without #enable-experimental-web-platform-features: `<ray_size>` is required

![3_chrome112_ray](https://user-images.githubusercontent.com/23019147/233380210-f6aea2fd-fd36-4d7e-90b5-68a622a7849f.png)

- Safari TP: `<ray_size>` is required

![4_safariTP_ray](https://user-images.githubusercontent.com/23019147/233380228-c1af5404-1410-428f-b3f5-914b596e8f70.png)


#### Related issues

Doc issue tracker: https://github.com/mdn/content/issues/25358
Content PR: https://github.com/mdn/content/pull/26266
Firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1820071
Spec: https://drafts.fxtf.org/motion/#ray-function