### PR TITLE
FF113 RTCRTPSender.getCapabilities() and setStreams()

### DIFF
--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -115,7 +115,7 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "113"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -788,7 +788,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "113"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF113 adds support for `RTCRTPSender.getCapabilities()` and `RTCRTPSender.setStreams()` in https://bugzilla.mozilla.org/show_bug.cgi?id=1531460 and https://bugzilla.mozilla.org/show_bug.cgi?id=1510802 respectively. This just records the support.

@queengooborg FYI, the `getCapabilities` returns a [`RTCRtpCapabilities`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpCapabilities). My assumption is that we don't need to have subfeatures for the returned object - i.e. it is treated like a parameter, in that you only create a subfeature if you know there is a compatibility issue.

Other docs work for this can be tracked in https://github.com/mdn/content/issues/26146