### PR TITLE
FF113 supports RTCSctpTransport and RTCPeerConnection.sctp

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -2331,8 +2331,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
+              "version_added": "113"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/RTCSctpTransport.json
+++ b/api/RTCSctpTransport.json
@@ -11,8 +11,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
-            "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
+            "version_added": "113"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -45,8 +44,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
+              "version_added": "113"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -80,8 +78,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
+              "version_added": "113"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -115,8 +112,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
+              "version_added": "113"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -149,8 +145,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
+              "version_added": "113"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -184,8 +179,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
+              "version_added": "113"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF113 supports `RTCSctpTransport` and `RTCPeerConnection.sctp` in https://bugzilla.mozilla.org/show_bug.cgi?id=1278299.
This updates the records. 

Other docs work can be tracked in https://github.com/mdn/content/issues/26146