### PR TITLE
Node 20 supports new Array methods toSorted, toReversed, toSpliced, and with

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -2024,7 +2024,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "20.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -2064,7 +2064,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "20.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -2104,7 +2104,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "20.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -2296,7 +2296,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "20.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -1810,7 +1810,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "20.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -1850,7 +1850,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "20.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -1980,7 +1980,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "20.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
#### Summary

Node.js 20.0.0 was recently released and [includes V8 version 11.3.244.4](https://nodejs.org/en/download/releases).

#### Test results and supporting details

I was not sure how or whether to test this.

The change is noted in the [Node 20 changelog](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V20.md#20.0.0) and the relevant [Chrome release](https://chromestatus.com/feature/5068609911521280).

I did ensure that the methods all worked in a terminal.

![Testing the new methods in Node 20 in the terminal. They all work.](https://user-images.githubusercontent.com/31462/233543375-1259e8a5-bd2b-437b-bcdb-b129d6c5036e.png)

