### PR TITLE
FF113 RTCPeerConnection.connectionState and changestatechange event

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -854,7 +854,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "113"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -889,7 +889,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "113"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2331,8 +2331,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1278299'>bug 1278299</a>."
+              "version_added": "113"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF113 supports `RTCPeerConnection.connectionState` and `changestatechange` event in https://bugzilla.mozilla.org/show_bug.cgi?id=1265827

Tested using https://mdn-bcd-collector.gooborg.com/tests/api/RTCPeerConnection/connectionState (and by inspection for the event)

Other docs work can be tracked in https://github.com/mdn/content/issues/26146