### PR TITLE
cookies.CookieStore property details

### DIFF
--- a/webextensions/api/cookies.json
+++ b/webextensions/api/cookies.json
@@ -9,9 +9,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "14"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "45"
               },
@@ -72,9 +70,7 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "63"
                 },
@@ -101,9 +97,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "14"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "45"
               },
@@ -118,6 +112,75 @@
                 "version_added": "15"
               }
             }
+          },
+          "id": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            }
+          },
+          "incognito": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            }
+          },
+          "tabIds": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            }
           }
         },
         "OnChangedCause": {
@@ -127,9 +190,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "45"
               },
@@ -151,9 +212,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "14"
-              },
+              "edge": "mirror",
               "firefox": {
                 "notes": "Provides access to cookies from private browsing mode and container tabs since version 52.",
                 "version_added": "45"
@@ -220,7 +279,7 @@
               },
               "edge": {
                 "notes": "If no URL is provided, cookies are retrieved only for URLs in currently opened tabs. In Chrome, this gets all cookies on a user's machine.",
-                "version_added": "14"
+                "version_added": "79"
               },
               "firefox": {
                 "notes": "Before version 52, the 'tabIds' list was empty and only cookies from the default cookie store were returned. From version 52 onwards, this has been fixed and the result includes cookies from private browsing mode and container tabs.",
@@ -294,7 +353,7 @@
               },
               "edge": {
                 "notes": "Always returns the same default cookie store with ID 0. All cookies belong to this store.",
-                "version_added": "14"
+                "version_added": "79"
               },
               "firefox": {
                 "notes": "Before version 52, only the default cookie store was visible. From version 52 onwards, the cookie stores for private browsing mode and container tabs are also readable.",
@@ -322,9 +381,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "45"
               },
@@ -365,9 +422,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "14"
-              },
+              "edge": "mirror",
               "firefox": {
                 "notes": "Before version 56, this function did not remove cookies from private browsing mode. From version 56 onwards this is fixed.",
                 "version_added": "45"
@@ -431,9 +486,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "63"
               },
@@ -459,9 +512,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "14"
-              },
+              "edge": "mirror",
               "firefox": {
                 "notes": "Before version 56, this function did not modify cookies in private browsing mode. From version 56 onwards this is fixed.",
                 "version_added": "45"
@@ -522,9 +573,7 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "63"
                 },


### PR DESCRIPTION
#### Summary

Fixes #8780 by expanding the property details for `cookies.CookieStore` and marking `incognito` as unsupported in Chrome.

Also amended Edge support details for 79 or earlier to "mirror".
