### PR TITLE
Update Firefox data for SharedArrayBuffer JavaScript builtin

### DIFF
--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -17,7 +17,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "78"
+              "version_added": "79"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -59,7 +59,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "78"
+                "version_added": "79"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -141,7 +141,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "78"
+                "version_added": "79"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -303,7 +303,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "78"
+                "version_added": "79"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -345,7 +345,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "78"
+                "version_added": "79"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `SharedArrayBuffer` JavaScript builtin. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/javascript/builtins/SharedArrayBuffer
