### PR TITLE
Update WebView data for api.DataTransferItem.webkitGetAsEntry

### DIFF
--- a/api/DataTransferItem.json
+++ b/api/DataTransferItem.json
@@ -272,9 +272,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR updates and corrects version values for WebView Android for the `webkitGetAsEntry` member of the `DataTransferItem` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/DataTransferItem/webkitGetAsEntry
