### PR TITLE
(fx112) content-visibility: nightly support in firefox

### DIFF
--- a/css/properties/content-visibility.json
+++ b/css/properties/content-visibility.json
@@ -11,16 +11,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "109",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.content-visibility.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.content-visibility.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Fx bug https://bugzilla.mozilla.org/show_bug.cgi?id=1820058 enables `content-visibility` on Nightly by default.

#### Tests

Tested on Firefox Nightly and confirmed support without enabling `layout.css.content-visibility.enabled`.

#### Related issues

Doc issue: https://github.com/mdn/content/issues/26155
