### PR TITLE
Update Chromium data for api.ClipboardItem.presentationStyle

### DIFF
--- a/api/ClipboardItem.json
+++ b/api/ClipboardItem.json
@@ -153,9 +153,7 @@
             "chrome": {
               "version_added": false
             },
-            "chrome_android": {
-              "version_added": "84"
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": "87",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `presentationStyle` member of the `ClipboardItem` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/ClipboardItem/presentationStyle

Additional Notes: This fixes a bad diff from #18571.
