### PR TITLE
Update Firefox Android data for api.DataTransferItem.webkitGetAsEntry

### DIFF
--- a/api/DataTransferItem.json
+++ b/api/DataTransferItem.json
@@ -260,7 +260,9 @@
             "firefox": {
               "version_added": "50"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox Android for the `webkitGetAsEntry` member of the `DataTransferItem` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/DataTransferItem/webkitGetAsEntry
