### PR TITLE
Update deno versions

### DIFF
--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -205,10 +205,38 @@
         "1.28": {
           "release_date": "2022-11-13",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.28.0",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "10.9"
-        }
+        },
+        "1.29": {
+          "release_date": "2022-12-15",
+          "release_notes": "https://github.com/denoland/deno/releases/tag/v1.29.0",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "10.9"
+        },
+        "1.30": {
+          "release_date": "2023-01-26",
+          "release_notes": "https://github.com/denoland/deno/releases/tag/v1.30.0",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "10.9"
+        },
+        "1.31": {
+          "release_date": "2023-02-24",
+          "release_notes": "https://github.com/denoland/deno/releases/tag/v1.31.0",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "11.0"
+        },
+        "1.32": {
+          "release_date": "2023-03-23",
+          "release_notes": "https://github.com/denoland/deno/releases/tag/v1.32.0",
+          "status": "current",
+          "engine": "V8",
+          "engine_version": "11.2"
+        },
       }
     }
   }

--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -236,7 +236,7 @@
           "status": "current",
           "engine": "V8",
           "engine_version": "11.2"
-        },
+        }
       }
     }
   }


### PR DESCRIPTION
#### Summary

Update deno versions 1.29 through 1.32

#### Test results and supporting details

I'm not sure how to see the engine version in the repo. I've relied on their release notes https://deno.com/blog/v1.31#v8-110 and https://deno.com/blog/v1.32#v8-112

#### Related issues

This should unblock #19447 and #19448
