### PR TITLE
Update archived edge release note in edge.json

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -262,7 +262,7 @@
         },
         "109": {
           "release_date": "2023-01-12",
-          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1090151849-january-12-2023",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1090151849-january-12-2023",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "109"


### PR DESCRIPTION
#### Summary

Every time Edge gets released, a release note comes out. The page where the release notes are located does not contain all versions though. Older versions gets moved to an archive page.

This little PR updates one of the release note links for an older release.