### PR TITLE
Update Chromium data for api.InstallEvent.activeWorker

### DIFF
--- a/api/InstallEvent.json
+++ b/api/InstallEvent.json
@@ -73,7 +73,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/InstallEvent/activeWorker",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `activeWorker` member of the `InstallEvent` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/InstallEvent/activeWorker
