### PR TITLE
Update Chromium data for api.RTCIceTransport.RTCIceTransport

### DIFF
--- a/api/RTCIceTransport.json
+++ b/api/RTCIceTransport.json
@@ -40,7 +40,8 @@
           "description": "<code>RTCIceTransport()</code> constructor",
           "support": {
             "chrome": {
-              "version_added": "75"
+              "version_added": "75",
+              "version_removed": "90"
             },
             "chrome_android": "mirror",
             "edge": {

--- a/api/RTCIceTransport.json
+++ b/api/RTCIceTransport.json
@@ -35,42 +35,6 @@
           "deprecated": false
         }
       },
-      "RTCIceTransport": {
-        "__compat": {
-          "description": "<code>RTCIceTransport()</code> constructor",
-          "support": {
-            "chrome": {
-              "version_added": "75",
-              "version_removed": "90"
-            },
-            "chrome_android": "mirror",
-            "edge": {
-              "version_added": "13"
-            },
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "gatheringState": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceTransport/gatheringState",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `RTCIceTransport` member of the `RTCIceTransport` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/RTCIceTransport/RTCIceTransport
