### PR TITLE
Update Chromium data for api.VideoPlaybackQuality.totalFrameDelay

### DIFF
--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -169,7 +169,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VideoPlaybackQuality/totalFrameDelay",
           "support": {
             "chrome": {
-              "version_added": "23"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `totalFrameDelay` member of the `VideoPlaybackQuality` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/VideoPlaybackQuality/totalFrameDelay
