### PR TITLE
Update Chromium data for XRSystem API

### DIFF
--- a/api/XRSystem.json
+++ b/api/XRSystem.json
@@ -89,7 +89,7 @@
           "spec_url": "https://immersive-web.github.io/webxr/#dom-xrsystem-issessionsupported",
           "support": {
             "chrome": {
-              "version_added": "79"
+              "version_added": "83"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -126,7 +126,7 @@
           "spec_url": "https://immersive-web.github.io/webxr/#dom-xrsystem-requestsession",
           "support": {
             "chrome": {
-              "version_added": "79"
+              "version_added": "83"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `XRSystem` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/XRSystem
