### PR TITLE
mdn-bcd-collector v9.0.3 breakdown list (2023-04-25)

### DIFF
--- a/api/AudioNode.json
+++ b/api/AudioNode.json
@@ -272,12 +272,10 @@
             "description": "<code>destination</code> parameter",
             "support": {
               "chrome": {
-                "version_added": "43"
+                "version_added": false
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤18"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -307,12 +305,10 @@
             "description": "<code>input</code> parameter",
             "support": {
               "chrome": {
-                "version_added": "43"
+                "version_added": false
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤18"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },

--- a/api/AudioParamMap.json
+++ b/api/AudioParamMap.json
@@ -268,26 +268,40 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "66"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
-              "version_added": "76"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "14.1"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/AudioProcessingEvent.json
+++ b/api/AudioProcessingEvent.json
@@ -12,9 +12,11 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "25"
+            "version_added": false
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },
@@ -82,9 +84,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -118,9 +122,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -154,9 +160,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/api/AudioTrack.json
+++ b/api/AudioTrack.json
@@ -423,9 +423,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -682,9 +682,11 @@
                 "version_added": "≤18"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "≤72"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -692,9 +694,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "13.1> ≤14.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.4"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/api/CSPViolationReportBody.json
+++ b/api/CSPViolationReportBody.json
@@ -25,7 +25,7 @@
             "version_added": "48"
           },
           "safari": {
-            "version_added": "preview"
+            "version_added": false
           },
           "safari_ios": "mirror",
           "samsunginternet_android": {
@@ -64,7 +64,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -104,7 +104,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -144,7 +144,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -184,7 +184,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -224,7 +224,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -264,7 +264,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -304,7 +304,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -344,7 +344,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -384,7 +384,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -424,7 +424,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -464,7 +464,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -502,7 +502,7 @@
               "version_added": "48"
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {

--- a/api/CSSGroupingRule.json
+++ b/api/CSSGroupingRule.json
@@ -23,7 +23,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "14.1"
+            "version_added": "≤13.1"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -58,7 +58,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -94,7 +94,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -130,7 +130,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/CSSNumericArray.json
+++ b/api/CSSNumericArray.json
@@ -204,10 +204,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSNumericArray/@@iterator",
           "support": {
             "chrome": {
-              "version_added": "66"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -217,13 +221,21 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "16.4"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/CSSStyleDeclaration.json
+++ b/api/CSSStyleDeclaration.json
@@ -448,28 +448,40 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration/@@iterator",
           "support": {
             "chrome": {
-              "version_added": "51"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
-              "version_added": "18"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "36"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "11"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/CSSTransformValue.json
+++ b/api/CSSTransformValue.json
@@ -307,10 +307,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSTransformValue/@@iterator",
           "support": {
             "chrome": {
-              "version_added": "66"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -320,13 +324,21 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "16.4"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/CSSUnparsedValue.json
+++ b/api/CSSUnparsedValue.json
@@ -239,10 +239,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSUnparsedValue/@@iterator",
           "support": {
             "chrome": {
-              "version_added": "66"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -252,13 +256,21 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "16.4"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -450,10 +450,12 @@
             "spec_url": "https://fedidcg.github.io/FedCM/#dom-credentialrequestoptions-identity",
             "support": {
               "chrome": {
-                "version_added": "108"
+                "version_added": "105"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "105"
+              },
               "firefox": {
                 "version_added": false
               },
@@ -468,7 +470,9 @@
                 "version_added": false
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
+              "samsunginternet_android": {
+                "version_added": "≤20.0"
+              },
               "webview_android": "mirror"
             },
             "status": {

--- a/api/CryptoKey.json
+++ b/api/CryptoKey.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "37"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "deno": {
             "version_added": "1.12"
           },
@@ -49,7 +51,9 @@
             "chrome": {
               "version_added": "37"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": "1.12"
             },
@@ -91,7 +95,9 @@
             "chrome": {
               "version_added": "37"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": [
               {
                 "version_added": "1.13"
@@ -140,7 +146,9 @@
             "chrome": {
               "version_added": "37"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": "1.12"
             },
@@ -182,7 +190,9 @@
             "chrome": {
               "version_added": "37"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": "1.12"
             },

--- a/api/CustomStateSet.json
+++ b/api/CustomStateSet.json
@@ -325,10 +325,14 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "90"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -338,13 +342,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,

--- a/api/DOMTokenList.json
+++ b/api/DOMTokenList.json
@@ -797,28 +797,40 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
-              "version_added": "16"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "36"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "10.1"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -332,7 +332,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-items-dev",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "≤3"
             },
             "chrome_android": "mirror",
             "edge": {

--- a/api/DeprecationReportBody.json
+++ b/api/DeprecationReportBody.json
@@ -243,10 +243,16 @@
           "spec_url": "https://wicg.github.io/deprecation-reporting/#dom-deprecationreportbody-tojson",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "110",
+              "version_removed": "111"
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "110",
+              "version_removed": "111"
+            },
             "firefox": {
               "version_added": false
             },
@@ -256,13 +262,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,

--- a/api/DeviceMotionEventAcceleration.json
+++ b/api/DeviceMotionEventAcceleration.json
@@ -13,9 +13,11 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "6"
+            "version_added": false
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": "11"
           },
@@ -26,7 +28,7 @@
             "version_added": false
           },
           "safari_ios": {
-            "version_added": "4.2"
+            "version_added": false
           },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
@@ -50,9 +52,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "6"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": "11"
             },
@@ -63,7 +67,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": "4.2"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -88,9 +92,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "6"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": "11"
             },
@@ -101,7 +107,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": "4.2"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -126,9 +132,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "6"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": "11"
             },
@@ -139,7 +147,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": "4.2"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/api/DeviceMotionEventRotationRate.json
+++ b/api/DeviceMotionEventRotationRate.json
@@ -13,9 +13,11 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "6"
+            "version_added": false
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": "11"
           },
@@ -26,7 +28,7 @@
             "version_added": false
           },
           "safari_ios": {
-            "version_added": "4.2"
+            "version_added": false
           },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
@@ -50,9 +52,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "6"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": "11"
             },
@@ -63,7 +67,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": "4.2"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -88,9 +92,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "6"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": "11"
             },
@@ -101,7 +107,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": "4.2"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -126,9 +132,11 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "6"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": "11"
             },
@@ -139,7 +147,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": "4.2"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/api/Document.json
+++ b/api/Document.json
@@ -3106,7 +3106,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "≤16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -3148,7 +3148,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -4368,7 +4368,9 @@
               "version_added": "11.1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "≤20.0"
+            },
             "webview_android": "mirror"
           },
           "status": {
@@ -5040,7 +5042,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -5078,7 +5080,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -5419,7 +5421,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "≤20.0"
+            },
             "webview_android": "mirror"
           },
           "status": {
@@ -6086,7 +6090,9 @@
               "version_added": "11.1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "≤20.0"
+            },
             "webview_android": "mirror"
           },
           "status": {

--- a/api/DragEvent.json
+++ b/api/DragEvent.json
@@ -9,7 +9,7 @@
             "version_added": "3"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "≤112"
           },
           "edge": {
             "version_added": "12"
@@ -26,15 +26,21 @@
           "opera": {
             "version_added": "12"
           },
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": "≤74"
+          },
           "safari": {
-            "version_added": "3.1"
+            "version_added": "13.1> ≤14.1"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "≤16.4"
           },
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": "≤20.0"
+          },
+          "webview_android": {
+            "version_added": "≤112"
+          }
         },
         "status": {
           "experimental": false,
@@ -52,7 +58,7 @@
               "version_added": "46"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "≤112"
             },
             "edge": {
               "version_added": "12"
@@ -68,15 +74,21 @@
             "opera": {
               "version_added": "12"
             },
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": "≤74"
+            },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤16.4"
             },
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": "≤20.0"
+            },
+            "webview_android": {
+              "version_added": "≤112"
+            }
           },
           "status": {
             "experimental": false,
@@ -94,7 +106,7 @@
               "version_added": "46"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "≤112"
             },
             "edge": {
               "version_added": "12"
@@ -110,15 +122,21 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": "≤74"
+            },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤16.4"
             },
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": "≤20.0"
+            },
+            "webview_android": {
+              "version_added": "≤112"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/EXT_color_buffer_float.json
+++ b/api/EXT_color_buffer_float.json
@@ -11,7 +11,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "51"
+            "version_added": "80"
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/EXT_frag_depth.json
+++ b/api/EXT_frag_depth.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "38"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "12",
             "version_removed": "79"
@@ -24,15 +26,21 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
             "version_added": "9"
           },
           "safari_ios": {
             "version_added": "15"
           },
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,

--- a/api/EXT_shader_texture_lod.json
+++ b/api/EXT_shader_texture_lod.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "38"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "17",
             "version_removed": "79"
@@ -24,13 +26,19 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
             "version_added": "8"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,

--- a/api/EXT_texture_compression_bptc.json
+++ b/api/EXT_texture_compression_bptc.json
@@ -17,7 +17,7 @@
             }
           ],
           "chrome_android": {
-            "version_added": "92"
+            "version_added": false
           },
           "edge": "mirror",
           "firefox": {
@@ -31,9 +31,11 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
-            "version_added": "16.1"
+            "version_added": "16"
           },
           "safari_ios": {
             "version_added": false
@@ -41,7 +43,9 @@
           "samsunginternet_android": {
             "version_added": false
           },
-          "webview_android": "mirror"
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,

--- a/api/EXT_texture_compression_rgtc.json
+++ b/api/EXT_texture_compression_rgtc.json
@@ -17,7 +17,7 @@
             }
           ],
           "chrome_android": {
-            "version_added": "83"
+            "version_added": false
           },
           "edge": "mirror",
           "firefox": {
@@ -33,7 +33,9 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
             "version_added": "14.1"
           },
@@ -43,7 +45,9 @@
           "samsunginternet_android": {
             "version_added": false
           },
-          "webview_android": "mirror"
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,

--- a/api/EXT_texture_norm16.json
+++ b/api/EXT_texture_norm16.json
@@ -23,7 +23,7 @@
           },
           "opera_android": "mirror",
           "safari": {
-            "version_added": "16.1"
+            "version_added": "16"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -300,16 +300,14 @@
             "spec_url": "https://w3c.github.io/csswg-drafts/web-animations-1/#dom-keyframeeffectoptions-composite",
             "support": {
               "chrome": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features"
-                  }
-                ]
+                "version_added": "≤80"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤112"
+              },
+              "edge": {
+                "version_added": "≤80"
+              },
               "firefox": {
                 "version_added": "80"
               },
@@ -319,13 +317,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
+              "opera_android": {
+                "version_added": "≤74"
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": "≤13.1"
+              },
+              "safari_ios": {
+                "version_added": "≤16.4"
+              },
+              "samsunginternet_android": {
+                "version_added": "≤20.0"
+              },
+              "webview_android": {
+                "version_added": "≤112"
+              }
             },
             "status": {
               "experimental": true,
@@ -355,9 +361,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "≤13.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.4"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -409,7 +417,7 @@
             "support": {
               "chrome": [
                 {
-                  "version_added": "84"
+                  "version_added": "81"
                 },
                 {
                   "version_added": "81",
@@ -424,7 +432,22 @@
                 }
               ],
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": [
+                {
+                  "version_added": "81"
+                },
+                {
+                  "version_added": "81",
+                  "partial_implementation": true,
+                  "notes": "A valid animation object is returned but the targeted pseudoelement is not visually animated.",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features"
+                    }
+                  ]
+                }
+              ],
               "firefox": {
                 "version_added": "75"
               },
@@ -7145,7 +7168,9 @@
               "safari": {
                 "version_added": "16.4"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": false
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -7178,7 +7203,9 @@
               "safari": {
                 "version_added": "16.4"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": false
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/api/Event.json
+++ b/api/Event.json
@@ -749,10 +749,13 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false,
+              "version_added": "≤72",
               "notes": "Temporarily added in 63, removed in 64, briefly added in 65, then removed again while related compatibility issues are sorted out (see <a href='https://bugzil.la/1520756'>bug 1520756</a>)."
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "≤112",
+              "notes": "Temporarily added in 63, removed in 64, briefly added in 65, then removed again while related compatibility issues are sorted out (see <a href='https://bugzil.la/1520756'>bug 1520756</a>)."
+            },
             "ie": {
               "version_added": "6"
             },

--- a/api/EventCounts.json
+++ b/api/EventCounts.json
@@ -261,26 +261,38 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "85"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
-              "version_added": "89"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/File.json
+++ b/api/File.json
@@ -290,7 +290,9 @@
             "firefox": {
               "version_added": "50"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/api/FileList.json
+++ b/api/FileList.json
@@ -98,7 +98,7 @@
           "spec_url": "https://w3c.github.io/FileAPI/#dfn-length",
           "support": {
             "chrome": {
-              "version_added": "2"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "deno": {

--- a/api/FileSystemDirectoryHandle.json
+++ b/api/FileSystemDirectoryHandle.json
@@ -24,9 +24,11 @@
             "version_added": "15.2"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": {
+          "samsunginternet_android": {
             "version_added": false
+          },
+          "webview_android": {
+            "version_added": "≤112"
           }
         },
         "status": {
@@ -59,9 +61,11 @@
               "version_added": "15.2"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
+            "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -95,9 +99,11 @@
               "version_added": "15.2"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
+            "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -131,9 +137,11 @@
               "version_added": "15.2"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
+            "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -167,9 +175,11 @@
               "version_added": "15.2"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
+            "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -203,9 +213,11 @@
               "version_added": "15.2"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
+            "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -239,9 +251,11 @@
               "version_added": "15.2"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
+            "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -275,9 +289,11 @@
               "version_added": "15.2"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
+            "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -292,25 +308,37 @@
           "spec_url": "https://fs.spec.whatwg.org/#api-filesystemdirectoryhandle-asynciterable",
           "support": {
             "chrome": {
-              "version_added": "86"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
-              "version_added": "111"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "16.4"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }

--- a/api/FileSystemFileHandle.json
+++ b/api/FileSystemFileHandle.json
@@ -24,7 +24,9 @@
             "version_added": "15.2"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": "mirror"
         },
         "status": {
@@ -93,9 +95,11 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
+            "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -129,9 +133,11 @@
               "version_added": "15.2"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
+            "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤112"
             }
           },
           "status": {

--- a/api/FileSystemHandle.json
+++ b/api/FileSystemHandle.json
@@ -24,9 +24,11 @@
             "version_added": "15.2"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": {
+          "samsunginternet_android": {
             "version_added": false
+          },
+          "webview_android": {
+            "version_added": "≤112"
           }
         },
         "status": {
@@ -59,9 +61,11 @@
               "version_added": "15.2"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
+            "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -95,9 +99,11 @@
               "version_added": "15.2"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
+            "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -164,9 +170,11 @@
               "version_added": "15.2"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
+            "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -200,9 +208,11 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
+            "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -237,7 +247,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -271,9 +281,11 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
+            "samsunginternet_android": {
               "version_added": false
+            },
+            "webview_android": {
+              "version_added": "≤112"
             }
           },
           "status": {

--- a/api/FileSystemSync.json
+++ b/api/FileSystemSync.json
@@ -5,10 +5,14 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemSync",
         "support": {
           "chrome": {
-            "version_added": "13"
+            "version_added": false
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
           "firefox": {
             "version_added": false
           },
@@ -18,14 +22,20 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
-          "safari": {
-            "version_added": "6"
+          "opera_android": {
+            "version_added": false
           },
-          "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": {
+            "version_added": false
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": {
-            "version_added": "≤37"
+            "version_added": false
           }
         },
         "status": {
@@ -38,10 +48,14 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -51,14 +65,20 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "6"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": false
             }
           },
           "status": {
@@ -72,10 +92,14 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -85,14 +109,20 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "6"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
-              "version_added": "≤37"
+              "version_added": false
             }
           },
           "status": {

--- a/api/FileSystemSyncAccessHandle.json
+++ b/api/FileSystemSyncAccessHandle.json
@@ -26,7 +26,9 @@
             "version_added": "15.2"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
+          "samsunginternet_android": {
+            "version_added": "≤20.0"
+          },
           "webview_android": "mirror"
         },
         "status": {
@@ -61,7 +63,9 @@
               "version_added": "15.2"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "≤20.0"
+            },
             "webview_android": "mirror"
           },
           "status": {
@@ -139,7 +143,9 @@
               "version_added": "15.2"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "≤20.0"
+            },
             "webview_android": "mirror"
           },
           "status": {
@@ -217,7 +223,9 @@
               "version_added": "15.2"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "≤20.0"
+            },
             "webview_android": "mirror"
           },
           "status": {
@@ -295,7 +303,9 @@
               "version_added": "15.2"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "≤20.0"
+            },
             "webview_android": "mirror"
           },
           "status": {
@@ -331,7 +341,9 @@
               "version_added": "15.2"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "≤20.0"
+            },
             "webview_android": "mirror"
           },
           "status": {
@@ -409,7 +421,9 @@
               "version_added": "15.2"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "≤20.0"
+            },
             "webview_android": "mirror"
           },
           "status": {

--- a/api/FileSystemWritableFileStream.json
+++ b/api/FileSystemWritableFileStream.json
@@ -9,7 +9,7 @@
             "version_added": "86"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "≤112"
           },
           "edge": "mirror",
           "firefox": {
@@ -21,13 +21,17 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": "≤74"
+          },
           "safari": {
             "version_added": false
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "webview_android": {
+            "version_added": "≤112"
+          }
         },
         "status": {
           "experimental": false,
@@ -44,7 +48,7 @@
               "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "≤112"
             },
             "edge": "mirror",
             "firefox": {
@@ -56,13 +60,17 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": "≤74"
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": "≤112"
+            }
           },
           "status": {
             "experimental": false,
@@ -80,7 +88,7 @@
               "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "≤112"
             },
             "edge": "mirror",
             "firefox": {
@@ -92,13 +100,17 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": "≤74"
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": "≤112"
+            }
           },
           "status": {
             "experimental": false,
@@ -116,7 +128,7 @@
               "version_added": "86"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "≤112"
             },
             "edge": "mirror",
             "firefox": {
@@ -128,13 +140,17 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": "≤74"
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": "≤112"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -648,26 +648,40 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-font-loading/#fontfaceset",
           "support": {
             "chrome": {
-              "version_added": "48"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
-              "version_added": "41"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "10"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/FontFaceSetLoadEvent.json
+++ b/api/FontFaceSetLoadEvent.json
@@ -26,7 +26,7 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": false
+            "version_added": "≤112"
           }
         },
         "status": {
@@ -62,7 +62,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -133,7 +133,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {

--- a/api/FormData.json
+++ b/api/FormData.json
@@ -613,31 +613,43 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "50"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": "1.0"
             },
             "edge": {
-              "version_added": "18"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "11.1"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/GPU.json
+++ b/api/GPU.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -54,9 +52,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -95,9 +91,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUAdapter.json
+++ b/api/GPUAdapter.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -54,9 +52,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -95,9 +91,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -136,9 +130,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -177,9 +169,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -218,9 +208,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUAdapterInfo.json
+++ b/api/GPUAdapterInfo.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -54,9 +52,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -95,9 +91,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -136,9 +130,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -177,9 +169,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUBindGroup.json
+++ b/api/GPUBindGroup.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -54,9 +52,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUBindGroupLayout.json
+++ b/api/GPUBindGroupLayout.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -54,9 +52,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUBuffer.json
+++ b/api/GPUBuffer.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -28,9 +26,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "15.4"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "≤16.4"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -54,9 +54,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -68,9 +66,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -95,9 +95,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -109,9 +107,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -136,9 +136,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -177,9 +175,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -191,9 +187,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -218,9 +216,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -259,9 +255,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -300,9 +294,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -314,9 +306,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -341,9 +335,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCanvasContext.json
+++ b/api/GPUCanvasContext.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -54,9 +52,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -98,9 +94,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -139,9 +133,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -180,9 +172,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCommandBuffer.json
+++ b/api/GPUCommandBuffer.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -54,9 +52,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCommandEncoder.json
+++ b/api/GPUCommandEncoder.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -28,9 +26,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "15.4"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "≤16.4"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -54,9 +54,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -68,9 +66,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -95,9 +95,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -109,9 +107,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -136,9 +136,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -150,9 +148,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "16"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -177,9 +177,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -191,9 +189,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -218,9 +218,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -232,9 +230,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -259,9 +259,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -273,9 +271,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -300,9 +300,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -314,9 +312,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -341,9 +341,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -355,9 +353,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -382,9 +382,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -396,7 +394,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4",
+              "version_removed": "16"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -423,9 +422,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -464,9 +461,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -478,7 +473,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4",
+              "version_removed": "16"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -505,9 +501,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -519,7 +513,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4",
+              "version_removed": "16"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -546,9 +541,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -560,9 +553,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -587,9 +582,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -601,9 +594,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/GPUCompilationInfo.json
+++ b/api/GPUCompilationInfo.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -54,9 +52,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUCompilationMessage.json
+++ b/api/GPUCompilationMessage.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -54,9 +52,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -95,9 +91,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -136,9 +130,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -177,9 +169,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -218,9 +208,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -259,9 +247,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUComputePassEncoder.json
+++ b/api/GPUComputePassEncoder.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -28,9 +26,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "15.4"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "≤16.4"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -54,9 +54,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -68,9 +66,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "16.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -114,9 +114,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "16.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -141,9 +143,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -155,9 +155,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "16"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -182,9 +184,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -223,9 +223,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -264,9 +262,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -305,9 +301,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -346,9 +340,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -387,9 +379,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -401,9 +391,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/GPUComputePipeline.json
+++ b/api/GPUComputePipeline.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -54,9 +52,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -95,9 +91,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -54,9 +52,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -95,9 +91,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -136,9 +130,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -177,9 +169,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -218,9 +208,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -259,9 +247,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -300,9 +286,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -378,9 +362,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -419,9 +401,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -460,9 +440,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -501,9 +479,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -542,9 +518,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -583,9 +557,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -624,9 +596,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -665,9 +635,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -706,9 +674,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -747,9 +713,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -788,9 +752,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -829,9 +791,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -870,9 +830,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -911,9 +869,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -952,9 +908,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUDeviceLostInfo.json
+++ b/api/GPUDeviceLostInfo.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -54,9 +52,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -95,9 +91,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUOutOfMemoryError.json
+++ b/api/GPUOutOfMemoryError.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -55,9 +53,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUPipelineLayout.json
+++ b/api/GPUPipelineLayout.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -54,9 +52,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUQuerySet.json
+++ b/api/GPUQuerySet.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -54,9 +52,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -95,9 +91,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -136,9 +130,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -177,9 +169,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUQueue.json
+++ b/api/GPUQueue.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -28,9 +26,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "15.4"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "≤16.4"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -54,9 +54,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -68,9 +66,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -95,9 +95,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -146,9 +144,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -173,9 +173,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -187,9 +185,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -214,9 +214,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -228,9 +226,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -255,9 +255,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -269,9 +267,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/GPURenderBundleEncoder.json
+++ b/api/GPURenderBundleEncoder.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -54,9 +52,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -95,9 +91,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -228,9 +222,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -269,9 +261,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -347,9 +337,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -388,9 +376,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -429,9 +415,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -470,9 +454,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -511,9 +493,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -552,9 +532,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPURenderPassEncoder.json
+++ b/api/GPURenderPassEncoder.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -28,9 +26,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "15.4"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "≤16.4"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -64,9 +64,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -91,9 +93,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -132,9 +132,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -265,9 +263,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -279,9 +275,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "16"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -316,9 +314,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -343,9 +343,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -357,9 +355,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -384,9 +384,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -425,9 +423,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -466,9 +462,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -507,9 +501,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -548,9 +540,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -589,9 +579,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -603,9 +591,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -630,9 +620,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -671,9 +659,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -712,9 +698,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -726,9 +710,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -753,9 +739,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -767,9 +751,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -794,9 +780,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -835,9 +819,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -849,9 +831,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/GPURenderPipeline.json
+++ b/api/GPURenderPipeline.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -54,9 +52,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -95,9 +91,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUSampler.json
+++ b/api/GPUSampler.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -54,9 +52,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUShaderModule.json
+++ b/api/GPUShaderModule.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -54,9 +52,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -95,9 +91,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUSupportedFeatures.json
+++ b/api/GPUSupportedFeatures.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false

--- a/api/GPUSupportedLimits.json
+++ b/api/GPUSupportedLimits.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -53,9 +51,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -93,9 +89,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUTexture.json
+++ b/api/GPUTexture.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -54,9 +52,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -95,9 +91,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -136,9 +130,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -177,9 +169,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -218,9 +208,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -259,9 +247,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -300,9 +286,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -341,9 +325,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -382,9 +364,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -423,9 +403,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -464,9 +442,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUTextureView.json
+++ b/api/GPUTextureView.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -54,9 +52,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUUncapturedErrorEvent.json
+++ b/api/GPUUncapturedErrorEvent.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -55,9 +53,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/GPUValidationError.json
+++ b/api/GPUValidationError.json
@@ -14,9 +14,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "partial_implementation": true,
-            "notes": "Currently supported on Linux and Windows only."
+            "version_added": false
           },
           "firefox_android": {
             "version_added": false
@@ -55,9 +53,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false

--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -245,7 +245,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -553,10 +553,12 @@
             "safari": {
               "version_added": "16.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -143,7 +143,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {

--- a/api/GamepadHapticActuator.json
+++ b/api/GamepadHapticActuator.json
@@ -25,7 +25,9 @@
           "safari": {
             "version_added": "16.4"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": false
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -98,7 +100,9 @@
             "safari": {
               "version_added": "16.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -169,7 +173,9 @@
             "safari": {
               "version_added": "16.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -205,7 +211,9 @@
             "safari": {
               "version_added": "16.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/GeolocationCoordinates.json
+++ b/api/GeolocationCoordinates.json
@@ -81,10 +81,15 @@
               "version_removed": "13.4"
             }
           ],
-          "samsunginternet_android": {
-            "alternative_name": "Coordinates",
-            "version_added": "1.0"
-          },
+          "samsunginternet_android": [
+            {
+              "version_added": "≤20.0"
+            },
+            {
+              "alternative_name": "Coordinates",
+              "version_added": "1.0"
+            }
+          ],
           "webview_android": [
             {
               "version_added": "79"

--- a/api/GeolocationPosition.json
+++ b/api/GeolocationPosition.json
@@ -46,10 +46,15 @@
             "alternative_name": "Position",
             "version_added": "16"
           },
-          "opera_android": {
-            "alternative_name": "Position",
-            "version_added": "16"
-          },
+          "opera_android": [
+            {
+              "version_added": "≤74"
+            },
+            {
+              "alternative_name": "Position",
+              "version_added": "16"
+            }
+          ],
           "safari": [
             {
               "version_added": "13.1"

--- a/api/GeolocationPositionError.json
+++ b/api/GeolocationPositionError.json
@@ -46,10 +46,15 @@
             "alternative_name": "PositionError",
             "version_added": "16"
           },
-          "opera_android": {
-            "alternative_name": "PositionError",
-            "version_added": "16"
-          },
+          "opera_android": [
+            {
+              "version_added": "≤74"
+            },
+            {
+              "alternative_name": "PositionError",
+              "version_added": "16"
+            }
+          ],
           "safari": [
             {
               "version_added": "13.1"

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -229,9 +229,11 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "46"
+                  "version_added": false
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false
+                },
                 "ie": {
                   "version_added": false
                 },
@@ -367,9 +369,11 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "≤13.1"
                 },
-                "safari_ios": "mirror",
+                "safari_ios": {
+                  "version_added": "≤16.4"
+                },
                 "samsunginternet_android": "mirror",
                 "webview_android": {
                   "version_added": "37"
@@ -402,7 +406,7 @@
                   "version_added": "75"
                 },
                 "edge": {
-                  "version_added": "81"
+                  "version_added": "≤80"
                 },
                 "firefox": {
                   "version_added": false
@@ -453,9 +457,11 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "≤13.1"
                 },
-                "safari_ios": "mirror",
+                "safari_ios": {
+                  "version_added": "≤16.4"
+                },
                 "samsunginternet_android": "mirror",
                 "webview_android": {
                   "version_added": "37"
@@ -474,30 +480,42 @@
               "spec_url": "https://registry.khronos.org/webgl/specs/latest/1.0/#WEBGLCONTEXTATTRIBUTES",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "≤80"
                 },
-                "chrome_android": "mirror",
-                "edge": "mirror",
+                "chrome_android": {
+                  "version_added": "≤112"
+                },
+                "edge": {
+                  "version_added": "≤80"
+                },
                 "firefox": {
                   "version_added": "63",
                   "partial_implementation": true,
                   "notes": "Firefox respects the GPU hint on macOS only."
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "≤112"
                 },
                 "ie": {
                   "version_added": false
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
+                "opera_android": {
+                  "version_added": "≤74"
                 },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "safari": {
+                  "version_added": "≤13.1"
+                },
+                "safari_ios": {
+                  "version_added": "≤16.4"
+                },
+                "samsunginternet_android": {
+                  "version_added": "≤20.0"
+                },
+                "webview_android": {
+                  "version_added": "≤112"
+                }
               },
               "status": {
                 "experimental": true,
@@ -518,7 +536,7 @@
               "edge": "mirror",
               "firefox": [
                 {
-                  "version_added": "51"
+                  "version_added": "80"
                 },
                 {
                   "version_added": "25",
@@ -566,9 +584,11 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "≤13.1"
                 },
-                "safari_ios": "mirror",
+                "safari_ios": {
+                  "version_added": "≤16.4"
+                },
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },
@@ -599,7 +619,7 @@
                   "version_added": "75"
                 },
                 "edge": {
-                  "version_added": "81"
+                  "version_added": "≤80"
                 },
                 "firefox": {
                   "version_added": false
@@ -648,9 +668,11 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "≤13.1"
                 },
-                "safari_ios": "mirror",
+                "safari_ios": {
+                  "version_added": "≤16.4"
+                },
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },
@@ -667,30 +689,42 @@
               "spec_url": "https://registry.khronos.org/webgl/specs/latest/1.0/#WEBGLCONTEXTATTRIBUTES",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "≤80"
                 },
-                "chrome_android": "mirror",
-                "edge": "mirror",
+                "chrome_android": {
+                  "version_added": "≤112"
+                },
+                "edge": {
+                  "version_added": "≤80"
+                },
                 "firefox": {
                   "version_added": "63",
                   "partial_implementation": true,
                   "notes": "Firefox respects the GPU hint on macOS only."
                 },
                 "firefox_android": {
-                  "version_added": false
+                  "version_added": "≤112"
                 },
                 "ie": {
                   "version_added": false
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
+                "opera_android": {
+                  "version_added": "≤74"
                 },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "safari": {
+                  "version_added": "≤13.1"
+                },
+                "safari_ios": {
+                  "version_added": "≤16.4"
+                },
+                "samsunginternet_android": {
+                  "version_added": "≤20.0"
+                },
+                "webview_android": {
+                  "version_added": "≤112"
+                }
               },
               "status": {
                 "experimental": true,
@@ -869,7 +903,7 @@
                   "version_added": "75"
                 },
                 "edge": {
-                  "version_added": "81"
+                  "version_added": "≤80"
                 },
                 "firefox": {
                   "version_added": false
@@ -884,9 +918,11 @@
                 },
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "14.1> ≤15.1"
                 },
-                "safari_ios": "mirror",
+                "safari_ios": {
+                  "version_added": "≤16.4"
+                },
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1192,7 +1192,7 @@
                 "version_added": "64"
               },
               "chrome_android": {
-                "version_added": false,
+                "version_added": "≤112",
                 "notes": "See <a href='https://crbug.com/953169'>bug 953169</a>."
               },
               "edge": {
@@ -1202,7 +1202,7 @@
                 "version_added": "68"
               },
               "firefox_android": {
-                "version_added": false,
+                "version_added": "≤112",
                 "notes": "See <a href='https://bugzil.la/1544660'>bug 1544660</a>."
               },
               "ie": {
@@ -1210,15 +1210,24 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": "≤74",
+                "notes": "See <a href='https://crbug.com/953169'>bug 953169</a>."
+              },
               "safari": {
                 "version_added": "15"
               },
               "safari_ios": {
                 "version_added": "15.5"
               },
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "samsunginternet_android": {
+                "version_added": "≤20.0",
+                "notes": "See <a href='https://crbug.com/953169'>bug 953169</a>."
+              },
+              "webview_android": {
+                "version_added": "≤112",
+                "notes": "See <a href='https://crbug.com/953169'>bug 953169</a>."
+              }
             },
             "status": {
               "experimental": false,

--- a/api/HTMLHeadElement.json
+++ b/api/HTMLHeadElement.json
@@ -63,9 +63,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "16.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2755,7 +2755,7 @@
             },
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": false
               },
               {
                 "version_added": "64",
@@ -2806,7 +2806,7 @@
             },
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": false
               },
               {
                 "version_added": "64",

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -90,28 +90,40 @@
             "description": "Index as <code>before</code> parameter",
             "support": {
               "chrome": {
-                "version_added": "35"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "8"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": "5.5"
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "9"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -68,7 +68,7 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -104,7 +104,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -582,7 +582,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {

--- a/api/Headers.json
+++ b/api/Headers.json
@@ -541,31 +541,43 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": "1.0"
             },
             "edge": {
-              "version_added": "16"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "10.1"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Highlight.json
+++ b/api/Highlight.json
@@ -424,10 +424,14 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "105"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -437,13 +441,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,

--- a/api/HighlightRegistry.json
+++ b/api/HighlightRegistry.json
@@ -356,10 +356,14 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "105"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -369,13 +373,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -749,13 +749,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "44",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.indexedDB.experimental"
-                }
-              ]
+              "version_added": "≤72"
             },
             "firefox_android": {
               "version_added": "22"

--- a/api/IdentityCredential.json
+++ b/api/IdentityCredential.json
@@ -25,7 +25,9 @@
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": true,
@@ -58,7 +60,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,

--- a/api/ImageBitmapRenderingContext.json
+++ b/api/ImageBitmapRenderingContext.json
@@ -21,7 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "15"
+            "version_added": "≤13.1"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -53,7 +53,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -94,7 +94,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/InputDeviceInfo.json
+++ b/api/InputDeviceInfo.json
@@ -11,9 +11,11 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "39"
+            "version_added": false
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },
@@ -21,9 +23,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "11"
+            "version_added": false
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": false
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },

--- a/api/InstallEvent.json
+++ b/api/InstallEvent.json
@@ -12,9 +12,11 @@
             "version_added": "17"
           },
           "firefox": {
-            "version_added": "44"
+            "version_added": false
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },
@@ -45,9 +47,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "44"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -73,28 +77,38 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/InstallEvent/activeWorker",
           "support": {
             "chrome": {
-              "version_added": "40"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
-              "version_added": "17"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/InterventionReportBody.json
+++ b/api/InterventionReportBody.json
@@ -209,10 +209,16 @@
           "spec_url": "https://wicg.github.io/intervention-reporting/#dom-interventionreportbody-tojson",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "110",
+              "version_removed": "111"
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "110",
+              "version_removed": "111"
+            },
             "firefox": {
               "version_added": false
             },
@@ -222,13 +228,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,

--- a/api/KHR_parallel_shader_compile.json
+++ b/api/KHR_parallel_shader_compile.json
@@ -8,8 +8,13 @@
           "chrome": {
             "version_added": "76"
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "93",
+            "version_removed": "99"
+          },
           "firefox": {
             "version_added": false
           },
@@ -19,13 +24,19 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
             "version_added": "14.1"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,

--- a/api/KeyboardLayoutMap.json
+++ b/api/KeyboardLayoutMap.json
@@ -270,10 +270,14 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -283,13 +287,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,

--- a/api/LaunchParams.json
+++ b/api/LaunchParams.json
@@ -7,7 +7,9 @@
           "chrome": {
             "version_added": "102"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -18,13 +20,19 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
             "version_added": false
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": true,
@@ -39,7 +47,9 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -50,13 +60,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,
@@ -72,7 +88,9 @@
             "chrome": {
               "version_added": "110"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -83,13 +101,17 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,

--- a/api/LaunchQueue.json
+++ b/api/LaunchQueue.json
@@ -7,7 +7,9 @@
           "chrome": {
             "version_added": "102"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -18,13 +20,19 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
             "version_added": false
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": true,
@@ -39,7 +47,9 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -50,13 +60,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,

--- a/api/MIDIInputMap.json
+++ b/api/MIDIInputMap.json
@@ -381,12 +381,16 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
-              "version_added": "108"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -396,13 +400,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/MIDIMessageEvent.json
+++ b/api/MIDIMessageEvent.json
@@ -41,7 +41,7 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": false
+            "version_added": "≤112"
           }
         },
         "status": {
@@ -92,7 +92,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -143,7 +143,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {

--- a/api/MIDIOutput.json
+++ b/api/MIDIOutput.json
@@ -41,7 +41,7 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": false
+            "version_added": "≤112"
           }
         },
         "status": {
@@ -141,7 +141,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {

--- a/api/MIDIOutputMap.json
+++ b/api/MIDIOutputMap.json
@@ -381,12 +381,16 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "43"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
-              "version_added": "108"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -396,13 +400,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Magnetometer.json
+++ b/api/Magnetometer.json
@@ -47,10 +47,14 @@
           "spec_url": "https://w3c.github.io/magnetometer/#dom-magnetometer-magnetometer",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -87,10 +91,14 @@
           "spec_url": "https://w3c.github.io/magnetometer/#magnetometer-x",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -127,10 +135,14 @@
           "spec_url": "https://w3c.github.io/magnetometer/#magnetometer-y",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -167,10 +179,14 @@
           "spec_url": "https://w3c.github.io/magnetometer/#magnetometer-z",
           "support": {
             "chrome": {
-              "version_added": "56"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },

--- a/api/MathMLElement.json
+++ b/api/MathMLElement.json
@@ -54,7 +54,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": false
+              "version_added": "109"
             },
             "firefox": {
               "version_added": false

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -558,7 +558,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": false
               },
               {
                 "version_added": "88",

--- a/api/MediaKeyStatusMap.json
+++ b/api/MediaKeyStatusMap.json
@@ -303,29 +303,39 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
-              "version_added": "16"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "45"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "12.1"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
-              "version_added": "43"
+              "version_added": false
             }
           },
           "status": {

--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -25,7 +25,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "15"
+            "version_added": "13.1> ≤14.1"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -61,7 +61,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -97,7 +97,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -133,7 +133,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -169,7 +169,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -205,7 +205,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -27,7 +27,7 @@
             "version_added": "12.1"
           },
           "safari": {
-            "version_added": "5.1"
+            "version_added": "13.1> ≤14.1"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -104,7 +104,7 @@
               "version_added": "12.1"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -181,7 +181,7 @@
               "version_added": "12.1"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -223,7 +223,7 @@
               "version_added": "12.1"
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -266,7 +266,7 @@
               "version_added": "12.1"
             },
             "safari": {
-              "version_added": "5.1",
+              "version_added": "13.1> ≤14.1",
               "notes": "Before Safari 14, <code>MediaQueryList</code> is based on <code>EventTarget</code>, so you must use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
             },
             "safari_ios": "mirror",

--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -35,9 +35,7 @@
             "version_added": "8"
           },
           "safari_ios": {
-            "version_added": "13",
-            "partial_implementation": true,
-            "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+            "version_added": false
           },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
@@ -91,9 +89,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -167,9 +163,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -212,9 +206,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -288,9 +280,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -331,9 +321,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -376,9 +364,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -465,9 +451,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -518,9 +502,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -561,9 +543,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -603,9 +583,7 @@
               "version_added": "10.1"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -646,9 +624,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -186,7 +186,7 @@
               "version_added": "44"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤112"
             },
             "ie": {
               "version_added": false
@@ -196,7 +196,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤74"
             },
             "safari": {
               "version_added": "11"
@@ -314,7 +314,7 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": {
-              "version_added": false
+              "version_added": "≤74"
             },
             "safari": {
               "version_added": "11"
@@ -356,7 +356,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤74"
             },
             "safari": {
               "version_added": "11"
@@ -433,7 +433,7 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": {
-              "version_added": false
+              "version_added": "≤74"
             },
             "safari": {
               "version_added": "11"
@@ -544,7 +544,7 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": {
-              "version_added": false
+              "version_added": "≤74"
             },
             "safari": {
               "version_added": "11"

--- a/api/MediaStreamTrackProcessor.json
+++ b/api/MediaStreamTrackProcessor.json
@@ -6,12 +6,14 @@
         "spec_url": "https://w3c.github.io/mediacapture-transform/#track-processor-interface",
         "support": {
           "chrome": {
-            "version_added": "94",
-            "partial_implementation": true,
-            "notes": "Chrome incorrectly exposes this interface only on the Window scope, rather than the DedicatedWorker scope as defined in the spec."
+            "version_added": false
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
           "firefox": {
             "version_added": false
           },
@@ -21,13 +23,19 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
             "version_added": false
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": true,
@@ -42,10 +50,14 @@
           "spec_url": "https://w3c.github.io/mediacapture-transform/#dom-mediastreamtrackprocessor-mediastreamtrackprocessor",
           "support": {
             "chrome": {
-              "version_added": "94"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -55,13 +67,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,
@@ -76,10 +94,14 @@
           "spec_url": "https://w3c.github.io/mediacapture-transform/#dom-mediastreamtrackprocessor-readable",
           "support": {
             "chrome": {
-              "version_added": "94"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -89,13 +111,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,

--- a/api/MerchantValidationEvent.json
+++ b/api/MerchantValidationEvent.json
@@ -51,7 +51,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "64",
+              "version_added": false,
               "notes": "Available only in Nightly builds."
             },
             "firefox_android": {
@@ -88,7 +88,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "64",
+              "version_added": false,
               "notes": "Available only in Nightly builds."
             },
             "firefox_android": {
@@ -124,7 +124,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "64",
+              "version_added": false,
               "notes": "Available only in Nightly builds."
             },
             "firefox_android": {
@@ -160,7 +160,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "64",
+              "version_added": false,
               "notes": "Available only in Nightly builds."
             },
             "firefox_android": {

--- a/api/Metadata.json
+++ b/api/Metadata.json
@@ -5,10 +5,14 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Metadata",
         "support": {
           "chrome": {
-            "version_added": "13"
+            "version_added": false
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
           "firefox": {
             "version_added": false
           },
@@ -27,7 +31,9 @@
             "version_added": false
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": {
             "version_added": false
           }
@@ -43,10 +49,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Metadata/modificationTime",
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -65,7 +75,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -82,10 +94,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Metadata/size",
           "support": {
             "chrome": {
-              "version_added": "13"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -104,7 +120,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }

--- a/api/MimeType.json
+++ b/api/MimeType.json
@@ -8,12 +8,14 @@
           "chrome": {
             "version_added": "1"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "1"
+            "version_added": "99"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -24,7 +26,7 @@
             "version_added": "≤12.1"
           },
           "opera_android": {
-            "version_added": "≤12.1"
+            "version_added": false
           },
           "safari": {
             "version_added": "1"
@@ -33,8 +35,12 @@
             "version_added": "1",
             "version_removed": "8"
           },
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -50,12 +56,14 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "99"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -66,7 +74,7 @@
               "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": false
             },
             "safari": {
               "version_added": "1"
@@ -75,8 +83,12 @@
               "version_added": "1",
               "version_removed": "8"
             },
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -93,12 +105,14 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "99"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -109,7 +123,7 @@
               "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": false
             },
             "safari": {
               "version_added": "1"
@@ -118,8 +132,12 @@
               "version_added": "1",
               "version_removed": "8"
             },
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -136,12 +154,14 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "99"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -152,7 +172,7 @@
               "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": false
             },
             "safari": {
               "version_added": "1"
@@ -161,8 +181,12 @@
               "version_added": "1",
               "version_removed": "8"
             },
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -179,12 +203,14 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "99"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -195,7 +221,7 @@
               "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": false
             },
             "safari": {
               "version_added": "1"
@@ -204,8 +230,12 @@
               "version_added": "1",
               "version_removed": "8"
             },
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -600,7 +600,7 @@
             ],
             "safari_ios": [
               {
-                "version_added": "8"
+                "version_added": false
               },
               {
                 "version_added": "6",
@@ -675,7 +675,7 @@
             ],
             "safari_ios": [
               {
-                "version_added": "8"
+                "version_added": false
               },
               {
                 "version_added": "6",
@@ -891,9 +891,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "32"
+              "version_added": "32",
+              "version_removed": "104"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -82,7 +82,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -578,7 +578,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -1323,7 +1323,7 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -1409,9 +1409,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "partial_implementation": true,
-              "notes": "Currently supported on Linux and Windows only."
+              "version_added": false
             },
             "firefox_android": {
               "version_added": false
@@ -4058,7 +4056,7 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -4467,7 +4465,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false,
               "notes": "See <a href='https://crbug.com/921655'>bug 921655</a>."

--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -176,7 +176,7 @@
           "spec_url": "https://wicg.github.io/netinfo/#dom-networkinformation-downlinkmax",
           "support": {
             "chrome": {
-              "version_added": "61",
+              "version_added": false,
               "notes": "Only supported in Chrome OS"
             },
             "chrome_android": {
@@ -336,7 +336,7 @@
           "spec_url": "https://wicg.github.io/netinfo/#dom-networkinformation-type",
           "support": {
             "chrome": {
-              "version_added": "61",
+              "version_added": false,
               "notes": "Only supported in Chrome OS"
             },
             "chrome_android": {

--- a/api/NodeList.json
+++ b/api/NodeList.json
@@ -266,26 +266,40 @@
           "spec_url": "https://dom.spec.whatwg.org/#interface-nodelist",
           "support": {
             "chrome": {
-              "version_added": "51"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
-              "version_added": "36"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "10"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -56,7 +56,7 @@
             "version_added": "7"
           },
           "safari_ios": {
-            "version_added": "16.4"
+            "version_added": false
           },
           "samsunginternet_android": {
             "version_added": "4.0",
@@ -87,7 +87,7 @@
               "version_added": "20"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "≤112"
             },
             "edge": {
               "version_added": "14"
@@ -109,14 +109,18 @@
             "opera": {
               "version_added": "23"
             },
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": "≤74"
+            },
             "safari": {
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": "≤20.0"
+            },
             "webview_android": "mirror"
           },
           "status": {
@@ -308,7 +312,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -397,7 +401,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -482,7 +486,7 @@
               "version_added": "16"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -526,7 +530,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -615,7 +619,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -697,7 +701,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -779,7 +783,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -877,7 +881,7 @@
               }
             ],
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -1042,7 +1046,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -1124,7 +1128,7 @@
               "version_added": "11"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/api/NotificationEvent.json
+++ b/api/NotificationEvent.json
@@ -32,7 +32,7 @@
             "notes": "Supported on macOS 13 and later"
           },
           "safari_ios": {
-            "version_added": "16.4"
+            "version_added": false
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
@@ -79,7 +79,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/api/OES_draw_buffers_indexed.json
+++ b/api/OES_draw_buffers_indexed.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "100"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": "108"
@@ -19,13 +21,19 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
             "version_added": "16"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -41,7 +49,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "108"
@@ -52,13 +62,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": "16"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -75,7 +91,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "108"
@@ -86,13 +104,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": "16"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -109,7 +133,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "108"
@@ -120,13 +146,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": "16"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -143,7 +175,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "108"
@@ -154,13 +188,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": "16"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -177,7 +217,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "108"
@@ -188,13 +230,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": "16"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -211,7 +259,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "108"
@@ -222,13 +272,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": "16"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -245,7 +301,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "108"
@@ -256,13 +314,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": "16"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/OES_element_index_uint.json
+++ b/api/OES_element_index_uint.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "24"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "12"
           },
@@ -21,13 +23,19 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
             "version_added": "8"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,

--- a/api/OES_fbo_render_mipmap.json
+++ b/api/OES_fbo_render_mipmap.json
@@ -8,10 +8,12 @@
           "chrome": {
             "version_added": "80"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
-            "version_added": "71"
+            "version_added": "80"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -19,13 +21,19 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
             "version_added": "14.1"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,

--- a/api/OES_standard_derivatives.json
+++ b/api/OES_standard_derivatives.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "10"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "12"
           },
@@ -21,14 +23,18 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
             "version_added": "8"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": {
-            "version_added": "≤37"
+            "version_added": false
           }
         },
         "status": {

--- a/api/OES_texture_float.json
+++ b/api/OES_texture_float.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "10"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "12"
           },
@@ -21,14 +23,18 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
             "version_added": "8"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": {
-            "version_added": "≤37"
+            "version_added": false
           }
         },
         "status": {

--- a/api/OES_texture_float_linear.json
+++ b/api/OES_texture_float_linear.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "29"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "12"
           },
@@ -21,13 +23,19 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
             "version_added": "8"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,

--- a/api/OES_texture_half_float.json
+++ b/api/OES_texture_half_float.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "27"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "14"
           },
@@ -21,13 +23,19 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
             "version_added": "8"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,

--- a/api/OES_texture_half_float_linear.json
+++ b/api/OES_texture_half_float_linear.json
@@ -6,11 +6,13 @@
         "spec_url": "https://registry.khronos.org/webgl/extensions/OES_texture_half_float_linear/",
         "support": {
           "chrome": {
-            "version_added": "29"
+            "version_added": false
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
-            "version_added": "14"
+            "version_added": false
           },
           "firefox": {
             "version_added": "30"
@@ -23,15 +25,22 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
-            "version_added": "8"
+            "version_added": "8",
+            "version_removed": "14.1> ≤15.1"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": false
+          },
           "samsunginternet_android": {
-            "version_added": "1.5"
+            "version_added": false
           },
-          "webview_android": "mirror"
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,

--- a/api/OES_vertex_array_object.json
+++ b/api/OES_vertex_array_object.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "24"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "17"
           },
@@ -21,13 +23,19 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
             "version_added": "8"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -43,7 +51,9 @@
             "chrome": {
               "version_added": "24"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "17"
             },
@@ -56,13 +66,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": "8"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -79,7 +95,9 @@
             "chrome": {
               "version_added": "24"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "17"
             },
@@ -92,13 +110,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": "8"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -115,7 +139,9 @@
             "chrome": {
               "version_added": "24"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "17"
             },
@@ -128,13 +154,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": "8"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -151,7 +183,9 @@
             "chrome": {
               "version_added": "24"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "17"
             },
@@ -164,13 +198,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": "8"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/OVR_multiview2.json
+++ b/api/OVR_multiview2.json
@@ -11,11 +11,11 @@
             "notes": "Not supported on macOS."
           },
           "chrome_android": {
-            "version_added": "93"
+            "version_added": false
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "71"
+            "version_added": false
           },
           "firefox_android": "mirror",
           "ie": {
@@ -30,8 +30,12 @@
             "version_added": false
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -47,10 +51,12 @@
             "chrome": {
               "version_added": "93"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
-              "version_added": "71"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
@@ -65,8 +71,12 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -303,10 +303,14 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#offscreencontext2d-commit",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": "105"
             },
@@ -316,13 +320,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": "16.4"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -737,9 +747,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "105"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -1100,9 +1112,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "105"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/api/PannerNode.json
+++ b/api/PannerNode.json
@@ -24,7 +24,7 @@
           "opera_android": "mirror",
           "safari": [
             {
-              "version_added": "14.1"
+              "version_added": "≤13.1"
             },
             {
               "version_added": "6",

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -288,7 +288,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤74"
             },
             "safari": {
               "version_added": "11"
@@ -343,7 +343,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤74"
             },
             "safari": {
               "version_added": "11"
@@ -479,7 +479,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "103"
+                "version_added": "101"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -518,7 +518,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "103"
+                "version_added": "101"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -709,7 +709,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,
@@ -787,7 +789,7 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": {
-              "version_added": false
+              "version_added": "≤74"
             },
             "safari": {
               "version_added": "8"
@@ -1083,7 +1085,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤74"
             },
             "safari": {
               "version_added": "14.1"

--- a/api/PictureInPictureEvent.json
+++ b/api/PictureInPictureEvent.json
@@ -41,7 +41,7 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": false
+            "version_added": "≤112"
           }
         },
         "status": {
@@ -92,7 +92,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -108,12 +108,14 @@
           "spec_url": "https://w3c.github.io/picture-in-picture/#dom-pictureinpictureevent-pictureinpicturewindow",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "85"
             },
             "chrome_android": {
               "version_added": "105"
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "85"
+            },
             "firefox": {
               "version_added": false
             },
@@ -125,12 +127,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "13.1"
+              "version_added": "16"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {

--- a/api/PictureInPictureWindow.json
+++ b/api/PictureInPictureWindow.json
@@ -28,7 +28,7 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": false
+            "version_added": "≤112"
           }
         },
         "status": {
@@ -65,7 +65,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -145,7 +145,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {

--- a/api/Plugin.json
+++ b/api/Plugin.json
@@ -311,9 +311,11 @@
               "version_removed": "79"
             },
             "firefox": {
-              "version_added": "3.6"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": "4"
             },

--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -159,7 +159,7 @@
               "version_added": "16"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/api/PushEvent.json
+++ b/api/PushEvent.json
@@ -34,7 +34,7 @@
             "notes": "Supported on macOS 13 and later"
           },
           "safari_ios": {
-            "version_added": "16.4"
+            "version_added": false
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
@@ -83,7 +83,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -127,7 +127,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -30,7 +30,7 @@
             "notes": "Supported on macOS 13 and later"
           },
           "safari_ios": {
-            "version_added": "16.4"
+            "version_added": false
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
@@ -113,7 +113,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -132,29 +132,35 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager/hasPermission",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
-              "version_added": "17"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "48"
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -196,7 +202,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -215,29 +221,35 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager/register",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
-              "version_added": "17"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "48"
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -254,29 +266,35 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager/registrations",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
-              "version_added": "17"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "48"
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -325,7 +343,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -352,10 +370,10 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "48"
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -369,7 +387,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "4.0"
@@ -390,29 +408,35 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushManager/unregister",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
-              "version_added": "17"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "48"
+              "version_added": false
             },
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }

--- a/api/PushMessageData.json
+++ b/api/PushMessageData.json
@@ -30,11 +30,11 @@
             "notes": "Supported on macOS 13 and later"
           },
           "safari_ios": {
-            "version_added": "16.4"
+            "version_added": false
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": false,
+            "version_added": "≤112",
             "notes": "See <a href='https://crbug.com/421921'>bug 421921</a>."
           }
         },
@@ -74,11 +74,11 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -118,11 +118,11 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -162,11 +162,11 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -206,11 +206,11 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {

--- a/api/PushSubscription.json
+++ b/api/PushSubscription.json
@@ -30,7 +30,7 @@
             "notes": "Supported on macOS 13 and later"
           },
           "safari_ios": {
-            "version_added": "16.4"
+            "version_added": false
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
@@ -74,7 +74,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -116,7 +116,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -161,7 +161,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -205,7 +205,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -224,11 +224,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PushSubscription/subscriptionId",
           "support": {
             "chrome": {
-              "version_added": "42"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
-              "version_added": "≤18"
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -239,12 +241,16 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -289,7 +295,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -336,7 +342,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/api/PushSubscriptionChangeEvent.json
+++ b/api/PushSubscriptionChangeEvent.json
@@ -29,7 +29,7 @@
             "notes": "Supported on macOS 13 and later"
           },
           "safari_ios": {
-            "version_added": "16.4"
+            "version_added": false
           },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
@@ -67,7 +67,7 @@
               "version_added": "16.1"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -108,7 +108,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -149,7 +149,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/api/PushSubscriptionOptions.json
+++ b/api/PushSubscriptionOptions.json
@@ -30,7 +30,7 @@
             "notes": "Supported on macOS 13 and later"
           },
           "safari_ios": {
-            "version_added": "16.4"
+            "version_added": false
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
@@ -74,7 +74,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -116,7 +116,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -13,10 +13,13 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": false,
+            "version_added": "82",
             "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": "≤112",
+            "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
+          },
           "ie": {
             "version_added": false
           },
@@ -174,10 +177,13 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false,
+              "version_added": "82",
               "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "≤112",
+              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
+            },
             "ie": {
               "version_added": false
             },

--- a/api/RTCIdentityAssertion.json
+++ b/api/RTCIdentityAssertion.json
@@ -11,11 +11,11 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "40",
-            "partial_implementation": true,
-            "notes": "The <code>RTCIdentityAssertion</code> interface itself is not present, but an object with the same properties is used"
+            "version_added": false
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "ie": {
             "version_added": false
           },
@@ -46,9 +46,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "40"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -80,9 +82,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "40"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -335,13 +335,13 @@
             "description": "<code>configuration.peerIdentity</code> parameter",
             "support": {
               "chrome": {
-                "version_added": "23"
+                "version_added": false
               },
               "chrome_android": {
-                "version_added": "57"
+                "version_added": false
               },
               "edge": {
-                "version_added": "≤79"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "32"
@@ -353,14 +353,20 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": {
-                "version_added": "44"
+                "version_added": false
               },
               "safari": {
-                "version_added": "12.1"
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -636,7 +642,7 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤74"
             },
             "safari": {
               "version_added": "11"
@@ -672,7 +678,7 @@
                 "version_added": false
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "≤74"
               },
               "safari": {
                 "version_added": "11"
@@ -709,7 +715,7 @@
                 "version_added": false
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "≤74"
               },
               "safari": {
                 "version_added": "14.1"
@@ -1035,10 +1041,10 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "22"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "24"
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -2480,7 +2486,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "75"
+                "version_added": "≤72"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -2494,7 +2500,7 @@
                 "version_added": "66"
               },
               "safari": {
-                "version_added": "14.1"
+                "version_added": "≤13.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -895,7 +895,7 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": "34"
+              "version_added": "82"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -261,12 +261,16 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "58"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
-              "version_added": "48"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
@@ -274,13 +278,21 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "11"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -426,9 +426,11 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "110"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/api/ReadableStreamDefaultController.json
+++ b/api/ReadableStreamDefaultController.json
@@ -22,7 +22,7 @@
           ],
           "edge": "mirror",
           "firefox": {
-            "version_added": "65"
+            "version_added": "100"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -71,7 +71,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "65"
+              "version_added": "100"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -111,7 +111,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "65"
+              "version_added": "100"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -151,7 +151,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "65"
+              "version_added": "100"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -191,7 +191,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "65"
+              "version_added": "100"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -22,7 +22,7 @@
           ],
           "edge": "mirror",
           "firefox": {
-            "version_added": "65"
+            "version_added": "100"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -72,7 +72,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "65"
+              "version_added": "100"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -112,7 +112,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "65"
+              "version_added": "100"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -152,7 +152,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "65"
+              "version_added": "100"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -192,7 +192,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "65"
+              "version_added": "100"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -232,7 +232,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "65"
+              "version_added": "100"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Report.json
+++ b/api/Report.json
@@ -6,10 +6,16 @@
         "spec_url": "https://w3c.github.io/reporting/#dom-report",
         "support": {
           "chrome": {
-            "version_added": "69"
+            "version_added": "110",
+            "version_removed": "111"
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "110",
+            "version_removed": "111"
+          },
           "firefox": {
             "version_added": false
           },
@@ -19,13 +25,19 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
             "version_added": "16.4"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -39,10 +51,16 @@
           "spec_url": "https://w3c.github.io/reporting/#dom-report-body",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "110",
+              "version_removed": "111"
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "110",
+              "version_removed": "111"
+            },
             "firefox": {
               "version_added": false
             },
@@ -52,13 +70,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": "16.4"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -72,10 +96,16 @@
           "spec_url": "https://w3c.github.io/reporting/#dom-report-tojson",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "110",
+              "version_removed": "111"
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "110",
+              "version_removed": "111"
+            },
             "firefox": {
               "version_added": false
             },
@@ -85,13 +115,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": "16.4"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -106,10 +142,16 @@
           "spec_url": "https://w3c.github.io/reporting/#dom-report-type",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "110",
+              "version_removed": "111"
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "110",
+              "version_removed": "111"
+            },
             "firefox": {
               "version_added": false
             },
@@ -119,13 +161,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": "16.4"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -140,10 +188,16 @@
           "spec_url": "https://w3c.github.io/reporting/#dom-report-url",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "110",
+              "version_removed": "111"
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "110",
+              "version_removed": "111"
+            },
             "firefox": {
               "version_added": false
             },
@@ -153,13 +207,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": "16.4"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/ReportBody.json
+++ b/api/ReportBody.json
@@ -6,10 +6,16 @@
         "spec_url": "https://w3c.github.io/reporting/#reportbody",
         "support": {
           "chrome": {
-            "version_added": "69"
+            "version_added": "110",
+            "version_removed": "111"
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "110",
+            "version_removed": "111"
+          },
           "firefox": {
             "version_added": false
           },
@@ -19,13 +25,19 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
             "version_added": "16.4"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -38,10 +50,16 @@
           "spec_url": "https://w3c.github.io/reporting/#dom-reportbody-tojson",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "110",
+              "version_removed": "111"
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "110",
+              "version_removed": "111"
+            },
             "firefox": {
               "version_added": false
             },
@@ -51,13 +69,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": "16.4"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Request.json
+++ b/api/Request.json
@@ -196,19 +196,23 @@
             "description": "<code>navigate</code> mode",
             "support": {
               "chrome": {
-                "version_added": "49"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.7"
               },
               "edge": {
-                "version_added": "15"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "46"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -218,10 +222,14 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "10.1"
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
               "webview_android": {
                 "version_added": false
               }
@@ -1026,17 +1034,19 @@
             "description": "<code>navigate</code> mode",
             "support": {
               "chrome": {
-                "version_added": "49"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": false
               },
               "edge": {
-                "version_added": "≤18"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "46"
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -1050,10 +1060,14 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "10.1"
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
               "webview_android": {
                 "version_added": false
               }

--- a/api/Response.json
+++ b/api/Response.json
@@ -173,9 +173,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "≤13.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.4"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/api/SVGAltGlyphDefElement.json
+++ b/api/SVGAltGlyphDefElement.json
@@ -22,9 +22,12 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "6"
+            "version_added": "6",
+            "version_removed": "16.4"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": false
+          },
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "≤37",

--- a/api/SVGAltGlyphElement.json
+++ b/api/SVGAltGlyphElement.json
@@ -24,10 +24,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "4"
+            "version_added": "4",
+            "version_removed": "16.4"
           },
           "safari_ios": {
-            "version_added": "3"
+            "version_added": false
           },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
@@ -61,10 +62,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "16.4"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -101,10 +103,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "16.4"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -142,10 +145,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "16.4"
             },
             "safari_ios": {
-              "version_added": "3"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/api/SVGAltGlyphItemElement.json
+++ b/api/SVGAltGlyphItemElement.json
@@ -22,9 +22,12 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "6"
+            "version_added": "6",
+            "version_removed": "16.4"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": false
+          },
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "≤37",

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -341,10 +341,13 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
+                "version_added": "14.1> ≤15.1",
                 "notes": "See <a href='https://webkit.org/b/178583'>bug 178583</a>."
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.4",
+                "notes": "See <a href='https://webkit.org/b/178583'>bug 178583</a>."
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/api/SVGFontElement.json
+++ b/api/SVGFontElement.json
@@ -28,10 +28,11 @@
             "version_removed": "27"
           },
           "safari": {
-            "version_added": "3"
+            "version_added": "3",
+            "version_removed": "16.4"
           },
           "safari_ios": {
-            "version_added": "1"
+            "version_added": false
           },
           "samsunginternet_android": "mirror",
           "webview_android": {

--- a/api/SVGFontFaceElement.json
+++ b/api/SVGFontFaceElement.json
@@ -22,10 +22,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "3"
+            "version_added": "3",
+            "version_removed": "16.4"
           },
           "safari_ios": {
-            "version_added": "1"
+            "version_added": false
           },
           "samsunginternet_android": "mirror",
           "webview_android": {

--- a/api/SVGFontFaceFormatElement.json
+++ b/api/SVGFontFaceFormatElement.json
@@ -22,10 +22,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "3"
+            "version_added": "3",
+            "version_removed": "16.4"
           },
           "safari_ios": {
-            "version_added": "1"
+            "version_added": false
           },
           "samsunginternet_android": "mirror",
           "webview_android": {

--- a/api/SVGFontFaceNameElement.json
+++ b/api/SVGFontFaceNameElement.json
@@ -22,10 +22,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "3"
+            "version_added": "3",
+            "version_removed": "16.4"
           },
           "safari_ios": {
-            "version_added": "1"
+            "version_added": false
           },
           "samsunginternet_android": "mirror",
           "webview_android": {

--- a/api/SVGFontFaceSrcElement.json
+++ b/api/SVGFontFaceSrcElement.json
@@ -22,10 +22,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "3"
+            "version_added": "3",
+            "version_removed": "16.4"
           },
           "safari_ios": {
-            "version_added": "1"
+            "version_added": false
           },
           "samsunginternet_android": "mirror",
           "webview_android": {

--- a/api/SVGFontFaceUriElement.json
+++ b/api/SVGFontFaceUriElement.json
@@ -22,10 +22,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "3"
+            "version_added": "3",
+            "version_removed": "16.4"
           },
           "safari_ios": {
-            "version_added": "1"
+            "version_added": false
           },
           "samsunginternet_android": "mirror",
           "webview_android": {

--- a/api/SVGGlyphElement.json
+++ b/api/SVGGlyphElement.json
@@ -22,10 +22,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "3"
+            "version_added": "3",
+            "version_removed": "16.4"
           },
           "safari_ios": {
-            "version_added": "1"
+            "version_added": false
           },
           "samsunginternet_android": "mirror",
           "webview_android": {

--- a/api/SVGGlyphRefElement.json
+++ b/api/SVGGlyphRefElement.json
@@ -22,9 +22,12 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "6"
+            "version_added": "6",
+            "version_removed": "16.4"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": false
+          },
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "≤37",
@@ -57,9 +60,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "6"
+              "version_added": "6",
+              "version_removed": "16.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37",
@@ -93,9 +99,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "6"
+              "version_added": "6",
+              "version_removed": "16.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37",
@@ -129,9 +138,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "6"
+              "version_added": "6",
+              "version_removed": "16.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37",
@@ -165,9 +177,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "6"
+              "version_added": "6",
+              "version_removed": "16.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37",
@@ -204,9 +219,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "6"
+              "version_added": "6",
+              "version_removed": "16.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -237,9 +255,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "6"
+              "version_added": "6",
+              "version_removed": "16.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37",
@@ -273,9 +294,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "6"
+              "version_added": "6",
+              "version_removed": "16.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37",

--- a/api/SVGHKernElement.json
+++ b/api/SVGHKernElement.json
@@ -22,9 +22,12 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "6"
+            "version_added": "6",
+            "version_removed": "16.4"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": false
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },

--- a/api/SVGMissingGlyphElement.json
+++ b/api/SVGMissingGlyphElement.json
@@ -28,10 +28,11 @@
             "version_removed": "27"
           },
           "safari": {
-            "version_added": "3"
+            "version_added": "3",
+            "version_removed": "16.4"
           },
           "safari_ios": {
-            "version_added": "1"
+            "version_added": false
           },
           "samsunginternet_android": "mirror",
           "webview_android": {

--- a/api/SVGTRefElement.json
+++ b/api/SVGTRefElement.json
@@ -28,10 +28,11 @@
             "version_removed": "18"
           },
           "safari": {
-            "version_added": "3"
+            "version_added": "3",
+            "version_removed": "16.4"
           },
           "safari_ios": {
-            "version_added": "1"
+            "version_added": false
           },
           "samsunginternet_android": "mirror",
           "webview_android": {

--- a/api/SVGVKernElement.json
+++ b/api/SVGVKernElement.json
@@ -22,9 +22,12 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "5.1"
+            "version_added": "5.1",
+            "version_removed": "16.4"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": false
+          },
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "≤37",

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -24,14 +24,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "83",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "dom.security.sanitizer.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "82",
+            "version_removed": "83"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -216,14 +210,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "83",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.security.sanitizer.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "82",
+              "version_removed": "83"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/ScreenOrientation.json
+++ b/api/ScreenOrientation.json
@@ -139,9 +139,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16.4"
+              "version_added": false
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -215,9 +217,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16.4"
+              "version_added": false
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -51,7 +51,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": "74"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -171,7 +171,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -235,7 +235,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": "74"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -357,7 +357,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,
@@ -396,7 +398,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -475,7 +477,7 @@
               "notes": "Supported on macOS 13 and later"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -955,7 +957,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": "74"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/SharedWorkerGlobalScope.json
+++ b/api/SharedWorkerGlobalScope.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "4"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": "29"
@@ -22,7 +24,7 @@
             "version_added": "10.6"
           },
           "opera_android": {
-            "version_added": "11"
+            "version_added": false
           },
           "safari": [
             {
@@ -42,9 +44,11 @@
               "version_removed": "7"
             }
           ],
-          "samsunginternet_android": "mirror",
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": {
-            "version_added": "≤37"
+            "version_added": false
           }
         },
         "status": {
@@ -61,7 +65,9 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "29"
@@ -75,7 +81,7 @@
               "version_added": "10.6"
             },
             "opera_android": {
-              "version_added": "11"
+              "version_added": false
             },
             "safari": [
               {
@@ -95,8 +101,12 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -172,7 +182,9 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "29"
@@ -186,7 +198,7 @@
               "version_added": "10.6"
             },
             "opera_android": {
-              "version_added": "11"
+              "version_added": false
             },
             "safari": [
               {
@@ -206,8 +218,12 @@
                 "version_removed": "7"
               }
             ],
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -34,9 +34,7 @@
             "version_added": "8"
           },
           "safari_ios": {
-            "version_added": "13",
-            "partial_implementation": true,
-            "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+            "version_added": false
           },
           "samsunginternet_android": [
             {
@@ -83,9 +81,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "2.0"
@@ -267,9 +263,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -387,9 +381,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -467,9 +459,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -563,9 +553,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -649,9 +637,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -722,9 +708,7 @@
               "version_added": "12.1"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -902,9 +886,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -982,9 +964,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -1095,9 +1075,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -1140,9 +1118,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -1526,9 +1502,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0"
@@ -1622,9 +1596,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/api/SourceBufferList.json
+++ b/api/SourceBufferList.json
@@ -40,9 +40,7 @@
             "version_added": "8"
           },
           "safari_ios": {
-            "version_added": "13",
-            "partial_implementation": true,
-            "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+            "version_added": false
           },
           "samsunginternet_android": [
             {
@@ -199,9 +197,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": {
               "version_added": "3.0"

--- a/api/SpeechGrammar.json
+++ b/api/SpeechGrammar.json
@@ -103,10 +103,14 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechgrammar-src",
           "support": {
             "chrome": {
-              "version_added": "25"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": "44",
               "flags": [
@@ -133,7 +137,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -151,10 +157,14 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechgrammar-weight",
           "support": {
             "chrome": {
-              "version_added": "25"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": "44",
               "flags": [
@@ -181,7 +191,9 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }

--- a/api/SpeechGrammarList.json
+++ b/api/SpeechGrammarList.json
@@ -84,10 +84,14 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechgrammarlist-addfromstring",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -106,8 +110,12 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,
@@ -122,10 +130,14 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechgrammarlist-addfromuri",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -144,8 +156,12 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,
@@ -160,10 +176,14 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechgrammarlist-item",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -182,8 +202,12 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,
@@ -198,10 +222,14 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechgrammarlist-length",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -220,8 +248,12 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,

--- a/api/SpeechRecognitionAlternative.json
+++ b/api/SpeechRecognitionAlternative.json
@@ -6,10 +6,14 @@
         "spec_url": "https://wicg.github.io/speech-api/#speechreco-alternative",
         "support": {
           "chrome": {
-            "version_added": "33"
+            "version_added": false
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
           "firefox": {
             "version_added": false
           },
@@ -28,8 +32,12 @@
             "version_added": "14.1"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -43,10 +51,14 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionalternative-confidence",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -65,8 +77,12 @@
               "version_added": "14.1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -81,10 +97,14 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionalternative-transcript",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -103,8 +123,12 @@
               "version_added": "14.1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/SpeechRecognitionErrorEvent.json
+++ b/api/SpeechRecognitionErrorEvent.json
@@ -11,7 +11,7 @@
           },
           "chrome_android": "mirror",
           "edge": {
-            "version_added": "79"
+            "version_added": false
           },
           "firefox": {
             "version_added": false
@@ -28,9 +28,11 @@
             "version_added": false
           },
           "safari": {
-            "version_added": "14.1"
+            "version_added": false
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": false
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -87,10 +89,14 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionerrorevent-error",
           "support": {
             "chrome": {
-              "version_added": "77"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -106,11 +112,17 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "14.1"
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -125,10 +137,14 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionerrorevent-message",
           "support": {
             "chrome": {
-              "version_added": "77"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -144,11 +160,17 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "14.1"
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/SpeechRecognitionEvent.json
+++ b/api/SpeechRecognitionEvent.json
@@ -26,9 +26,11 @@
             "version_added": false
           },
           "safari": {
-            "version_added": "14.1"
+            "version_added": false
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": false
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -82,10 +84,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionEvent/emma",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -104,8 +110,12 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -119,10 +129,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechRecognitionEvent/interpretation",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -141,8 +155,12 @@
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -157,10 +175,14 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionevent-resultindex",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -176,11 +198,17 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "14.1"
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -195,10 +223,14 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionevent-results",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -214,11 +246,17 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "14.1"
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/SpeechRecognitionResult.json
+++ b/api/SpeechRecognitionResult.json
@@ -6,10 +6,14 @@
         "spec_url": "https://wicg.github.io/speech-api/#speechreco-result",
         "support": {
           "chrome": {
-            "version_added": "33"
+            "version_added": false
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
           "firefox": {
             "version_added": false
           },
@@ -28,8 +32,12 @@
             "version_added": "14.1"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -43,10 +51,14 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionresult-isfinal",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -65,8 +77,12 @@
               "version_added": "14.1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -81,10 +97,14 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionresult-item",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -103,8 +123,12 @@
               "version_added": "14.1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -119,10 +143,14 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionresult-length",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -141,8 +169,12 @@
               "version_added": "14.1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/SpeechRecognitionResultList.json
+++ b/api/SpeechRecognitionResultList.json
@@ -6,10 +6,14 @@
         "spec_url": "https://wicg.github.io/speech-api/#speechreco-resultlist",
         "support": {
           "chrome": {
-            "version_added": "33"
+            "version_added": false
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
           "firefox": {
             "version_added": false
           },
@@ -28,8 +32,12 @@
             "version_added": "14.1"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -43,10 +51,14 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionresultlist-item",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -65,8 +77,12 @@
               "version_added": "14.1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -81,10 +97,14 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechrecognitionresultlist-length",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -103,8 +123,12 @@
               "version_added": "14.1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/SpeechSynthesisErrorEvent.json
+++ b/api/SpeechSynthesisErrorEvent.json
@@ -29,7 +29,7 @@
             "version_added": false
           },
           "safari": {
-            "version_added": "7"
+            "version_added": "16"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": {
@@ -116,7 +116,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "16"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {

--- a/api/SpeechSynthesisEvent.json
+++ b/api/SpeechSynthesisEvent.json
@@ -29,7 +29,7 @@
             "version_added": false
           },
           "safari": {
-            "version_added": "7"
+            "version_added": "16"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": {
@@ -118,7 +118,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "16"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -162,9 +162,11 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "16"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
@@ -206,7 +208,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "16"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -301,7 +303,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "16"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -347,7 +349,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "7"
+              "version_added": "16"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {

--- a/api/SpeechSynthesisVoice.json
+++ b/api/SpeechSynthesisVoice.json
@@ -6,17 +6,19 @@
         "spec_url": "https://wicg.github.io/speech-api/#speechsynthesisvoice",
         "support": {
           "chrome": {
-            "version_added": "33"
+            "version_added": false
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
-            "version_added": "14"
+            "version_added": false
           },
           "firefox": {
-            "version_added": "49"
+            "version_added": false
           },
           "firefox_android": {
-            "version_added": "62"
+            "version_added": false
           },
           "ie": {
             "version_added": false
@@ -33,7 +35,7 @@
           },
           "safari_ios": "mirror",
           "samsunginternet_android": {
-            "version_added": "3.0"
+            "version_added": false
           },
           "webview_android": {
             "version_added": false,
@@ -52,17 +54,19 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechsynthesisvoice-default",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
-              "version_added": "14"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "49"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "62"
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -79,7 +83,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "3.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -98,17 +102,19 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechsynthesisvoice-lang",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
-              "version_added": "14"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "49"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "62"
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -125,7 +131,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "3.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -144,17 +150,19 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechsynthesisvoice-localservice",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
-              "version_added": "14"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "49"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "62"
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -171,7 +179,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "3.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -190,17 +198,19 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechsynthesisvoice-name",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
-              "version_added": "14"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "49"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "62"
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -217,7 +227,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "3.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false
@@ -236,17 +246,19 @@
           "spec_url": "https://wicg.github.io/speech-api/#dom-speechsynthesisvoice-voiceuri",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
-              "version_added": "14"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "49"
+              "version_added": false
             },
             "firefox_android": {
-              "version_added": "62"
+              "version_added": false
             },
             "ie": {
               "version_added": false
@@ -263,7 +275,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "3.0"
+              "version_added": false
             },
             "webview_android": {
               "version_added": false

--- a/api/StyleMedia.json
+++ b/api/StyleMedia.json
@@ -21,10 +21,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "5"
+            "version_added": "5",
+            "version_removed": "16.4"
           },
           "safari_ios": {
-            "version_added": "4"
+            "version_added": false
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
@@ -58,10 +59,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "5"
+              "version_added": "5",
+              "version_removed": "16.4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -96,10 +98,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "5"
+              "version_added": "5",
+              "version_removed": "16.4"
             },
             "safari_ios": {
-              "version_added": "4"
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/api/StylePropertyMapReadOnly.json
+++ b/api/StylePropertyMapReadOnly.json
@@ -306,10 +306,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/StylePropertyMapReadOnly/@@iterator",
           "support": {
             "chrome": {
-              "version_added": "66"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -319,13 +323,21 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "16.4"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -533,9 +533,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/api/Touch.json
+++ b/api/Touch.json
@@ -58,7 +58,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "46"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": "6"

--- a/api/TouchList.json
+++ b/api/TouchList.json
@@ -32,7 +32,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "10.1"
+            "version_added": false
           },
           "safari_ios": {
             "version_added": "2"
@@ -78,7 +78,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10.1"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "2"
@@ -125,7 +125,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10.1"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "2"

--- a/api/TransformStreamDefaultController.json
+++ b/api/TransformStreamDefaultController.json
@@ -6,7 +6,7 @@
         "spec_url": "https://streams.spec.whatwg.org/#ts-default-controller-class",
         "support": {
           "chrome": {
-            "version_added": "67"
+            "version_added": "105"
           },
           "chrome_android": "mirror",
           "deno": [
@@ -20,7 +20,9 @@
               "notes": "<code>TransformStreamDefaultController</code> is not exposed on the global scope."
             }
           ],
-          "edge": "mirror",
+          "edge": {
+            "version_added": "105"
+          },
           "firefox": {
             "version_added": "102"
           },
@@ -53,13 +55,15 @@
           "spec_url": "https://streams.spec.whatwg.org/#ts-default-controller-desired-size",
           "support": {
             "chrome": {
-              "version_added": "67"
+              "version_added": "105"
             },
             "chrome_android": "mirror",
             "deno": {
               "version_added": "1.0"
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "105"
+            },
             "firefox": {
               "version_added": "102"
             },
@@ -93,13 +97,15 @@
           "spec_url": "https://streams.spec.whatwg.org/#ts-default-controller-enqueue",
           "support": {
             "chrome": {
-              "version_added": "67"
+              "version_added": "105"
             },
             "chrome_android": "mirror",
             "deno": {
               "version_added": "1.0"
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "105"
+            },
             "firefox": {
               "version_added": "102"
             },
@@ -133,13 +139,15 @@
           "spec_url": "https://streams.spec.whatwg.org/#ts-default-controller-error",
           "support": {
             "chrome": {
-              "version_added": "67"
+              "version_added": "105"
             },
             "chrome_android": "mirror",
             "deno": {
               "version_added": "1.0"
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "105"
+            },
             "firefox": {
               "version_added": "102"
             },
@@ -173,13 +181,15 @@
           "spec_url": "https://streams.spec.whatwg.org/#ts-default-controller-terminate",
           "support": {
             "chrome": {
-              "version_added": "67"
+              "version_added": "105"
             },
             "chrome_android": "mirror",
             "deno": {
               "version_added": "1.0"
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "105"
+            },
             "firefox": {
               "version_added": "102"
             },

--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -102,9 +102,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "≤13.1"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": {
               "version_added": "2.0"
             },

--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -729,19 +729,23 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "49"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": "1.0"
             },
             "edge": {
-              "version_added": "17"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -750,13 +754,21 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "10.1"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/USBPermissionResult.json
+++ b/api/USBPermissionResult.json
@@ -5,10 +5,14 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/USBPermissionResult",
         "support": {
           "chrome": {
-            "version_added": "61"
+            "version_added": false
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": false
+          },
           "firefox": {
             "version_added": false
           },
@@ -18,12 +22,16 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
             "version_added": false
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": {
             "version_added": false
           }
@@ -40,10 +48,14 @@
           "spec_url": "https://wicg.github.io/webusb/#dom-usbpermissionresult-devices",
           "support": {
             "chrome": {
-              "version_added": "61"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -53,12 +65,16 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }

--- a/api/VRDisplay.json
+++ b/api/VRDisplay.json
@@ -49,7 +49,7 @@
           },
           "safari_ios": "mirror",
           "samsunginternet_android": {
-            "version_added": "6.0",
+            "version_added": false,
             "notes": "Google Cardboard supported in Samsung Internet 7.0."
           },
           "webview_android": "mirror"
@@ -109,7 +109,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -170,7 +170,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -231,7 +231,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -292,7 +292,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -353,7 +353,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -414,7 +414,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -475,7 +475,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -536,7 +536,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -597,7 +597,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -713,7 +713,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -774,7 +774,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -835,7 +835,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -896,7 +896,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -957,7 +957,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -1018,7 +1018,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -1079,7 +1079,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -1140,7 +1140,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -1201,7 +1201,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"

--- a/api/VRDisplayCapabilities.json
+++ b/api/VRDisplayCapabilities.json
@@ -49,7 +49,7 @@
           },
           "safari_ios": "mirror",
           "samsunginternet_android": {
-            "version_added": "6.0",
+            "version_added": false,
             "notes": "Google Cardboard supported in Samsung Internet 7.0."
           },
           "webview_android": "mirror"
@@ -109,7 +109,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -170,7 +170,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -353,7 +353,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"

--- a/api/VRDisplayEvent.json
+++ b/api/VRDisplayEvent.json
@@ -49,7 +49,7 @@
           },
           "safari_ios": "mirror",
           "samsunginternet_android": {
-            "version_added": "6.0",
+            "version_added": false,
             "notes": "Google Cardboard supported in Samsung Internet 7.0."
           },
           "webview_android": "mirror"
@@ -110,7 +110,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -171,7 +171,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -232,7 +232,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"

--- a/api/VREyeParameters.json
+++ b/api/VREyeParameters.json
@@ -49,7 +49,7 @@
           },
           "safari_ios": "mirror",
           "samsunginternet_android": {
-            "version_added": "6.0",
+            "version_added": false,
             "notes": "Google Cardboard supported in Samsung Internet 7.0."
           },
           "webview_android": "mirror"
@@ -109,7 +109,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -280,7 +280,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -341,7 +341,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -402,7 +402,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"

--- a/api/VRFieldOfView.json
+++ b/api/VRFieldOfView.json
@@ -49,7 +49,7 @@
           },
           "safari_ios": "mirror",
           "samsunginternet_android": {
-            "version_added": "6.0",
+            "version_added": false,
             "notes": "Google Cardboard supported in Samsung Internet 7.0."
           },
           "webview_android": "mirror"
@@ -109,7 +109,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -170,7 +170,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -231,7 +231,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -292,7 +292,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"

--- a/api/VRFrameData.json
+++ b/api/VRFrameData.json
@@ -49,7 +49,7 @@
           },
           "safari_ios": "mirror",
           "samsunginternet_android": {
-            "version_added": "6.0",
+            "version_added": false,
             "notes": "Google Cardboard supported in Samsung Internet 7.0."
           },
           "webview_android": "mirror"
@@ -110,7 +110,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -171,7 +171,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -232,7 +232,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -293,7 +293,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -354,7 +354,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -415,7 +415,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -476,7 +476,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"

--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -45,11 +45,12 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "≤13.1",
+            "version_removed": "13.1> ≤14.1"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": {
-            "version_added": "6.0",
+            "version_added": false,
             "notes": "Google Cardboard supported in Samsung Internet 7.0."
           },
           "webview_android": "mirror"
@@ -105,11 +106,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "≤13.1",
+              "version_removed": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -166,11 +168,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "≤13.1",
+              "version_removed": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -227,11 +230,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "≤13.1",
+              "version_removed": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -288,11 +292,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "≤13.1",
+              "version_removed": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -349,11 +354,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "≤13.1",
+              "version_removed": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -410,11 +416,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "≤13.1",
+              "version_removed": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"

--- a/api/VRStageParameters.json
+++ b/api/VRStageParameters.json
@@ -49,7 +49,7 @@
           },
           "safari_ios": "mirror",
           "samsunginternet_android": {
-            "version_added": "6.0",
+            "version_added": false,
             "notes": "Google Cardboard supported in Samsung Internet 7.0."
           },
           "webview_android": "mirror"
@@ -109,7 +109,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -170,7 +170,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"
@@ -231,7 +231,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "6.0",
+              "version_added": false,
               "notes": "Google Cardboard supported in Samsung Internet 7.0."
             },
             "webview_android": "mirror"

--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -24,7 +24,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "8"
+            "version_added": false
           },
           "safari_ios": {
             "version_added": false
@@ -67,7 +67,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "8"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -106,7 +106,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "8"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -147,7 +147,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "8"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
@@ -173,7 +173,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": false
             },
             "firefox": {
               "version_added": false
@@ -187,14 +187,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "8"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": "4.4.3"
+              "version_added": false
             }
           },
           "status": {
@@ -228,7 +228,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "8"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": false

--- a/api/VideoTrack.json
+++ b/api/VideoTrack.json
@@ -423,9 +423,7 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "13",
-              "partial_implementation": true,
-              "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
+              "version_added": false
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/api/WEBGL_color_buffer_float.json
+++ b/api/WEBGL_color_buffer_float.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "63"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "17"
           },
@@ -21,15 +23,21 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
             "version_added": "14"
           },
           "safari_ios": {
             "version_added": "15"
           },
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,

--- a/api/WEBGL_compressed_texture_astc.json
+++ b/api/WEBGL_compressed_texture_astc.json
@@ -6,12 +6,16 @@
         "spec_url": "https://registry.khronos.org/webgl/extensions/WEBGL_compressed_texture_astc/",
         "support": {
           "chrome": {
-            "version_added": "47"
+            "version_added": "93"
           },
-          "chrome_android": "mirror",
-          "edge": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": {
+            "version_added": "93"
+          },
           "firefox": {
-            "version_added": "53"
+            "version_added": false
           },
           "firefox_android": "mirror",
           "ie": {
@@ -19,13 +23,19 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
-            "version_added": "16.2"
+            "version_added": false
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -39,12 +49,16 @@
           "spec_url": "https://registry.khronos.org/webgl/extensions/WEBGL_compressed_texture_astc/",
           "support": {
             "chrome": {
-              "version_added": "47"
+              "version_added": "93"
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": "93"
+            },
             "firefox": {
-              "version_added": "53"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
@@ -52,13 +66,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
-              "version_added": "16.2"
+              "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/WEBGL_compressed_texture_etc.json
+++ b/api/WEBGL_compressed_texture_etc.json
@@ -8,10 +8,12 @@
           "chrome": {
             "version_added": "63"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
-            "version_added": "51"
+            "version_added": false
           },
           "firefox_android": "mirror",
           "ie": {
@@ -19,15 +21,21 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
-            "version_added": "16.2"
+            "version_added": false
           },
           "safari_ios": {
             "version_added": "14"
           },
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,

--- a/api/WEBGL_compressed_texture_etc1.json
+++ b/api/WEBGL_compressed_texture_etc1.json
@@ -8,10 +8,12 @@
           "chrome": {
             "version_added": "49"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
-            "version_added": "30"
+            "version_added": false
           },
           "firefox_android": "mirror",
           "ie": {
@@ -19,13 +21,22 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
-          "safari": {
+          "opera_android": {
             "version_added": false
           },
-          "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "safari": {
+            "version_added": "15.2",
+            "version_removed": "15.4"
+          },
+          "safari_ios": {
+            "version_added": "≤16.4"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,

--- a/api/WEBGL_compressed_texture_pvrtc.json
+++ b/api/WEBGL_compressed_texture_pvrtc.json
@@ -9,7 +9,7 @@
             "version_added": false
           },
           "chrome_android": {
-            "version_added": "28"
+            "version_added": false
           },
           "edge": "mirror",
           "firefox": {
@@ -21,13 +21,19 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
-            "version_added": "15.4"
+            "version_added": false
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,

--- a/api/WEBGL_compressed_texture_s3tc_srgb.json
+++ b/api/WEBGL_compressed_texture_s3tc_srgb.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "60"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "80"
           },
@@ -23,13 +25,19 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
-          "safari": {
+          "opera_android": {
             "version_added": false
           },
+          "safari": {
+            "version_added": "13.1> ≤14.1"
+          },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,

--- a/api/WEBGL_debug_renderer_info.json
+++ b/api/WEBGL_debug_renderer_info.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "33"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "12"
           },
@@ -22,14 +24,18 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
             "version_added": "9.1"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
+          "samsunginternet_android": {
+            "version_added": false
+          },
           "webview_android": {
-            "version_added": "37"
+            "version_added": false
           }
         },
         "status": {

--- a/api/WEBGL_debug_shaders.json
+++ b/api/WEBGL_debug_shaders.json
@@ -8,32 +8,34 @@
           "chrome": {
             "version_added": "47"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
-            "version_added": "30",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "webgl.enable-privileged-extensions",
-                "value_to_set": "true"
-              }
-            ],
-            "notes": "The extension is activated by default to privileged contexts (chrome context)."
+            "version_added": "≤72"
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": "≤112"
+          },
           "ie": {
             "version_added": false
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": {
+            "version_added": false
+          },
           "safari": {
             "version_added": "14"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -49,32 +51,34 @@
             "chrome": {
               "version_added": "47"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
-              "version_added": "30",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "webgl.enable-privileged-extensions",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "The extension is activated by default to privileged contexts (chrome context)."
+              "version_added": "≤72"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "≤112"
+            },
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": "14"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/WEBGL_depth_texture.json
+++ b/api/WEBGL_depth_texture.json
@@ -14,7 +14,15 @@
               "prefix": "WEBKIT_"
             }
           ],
-          "chrome_android": "mirror",
+          "chrome_android": [
+            {
+              "version_added": false
+            },
+            {
+              "version_added": "25",
+              "prefix": "WEBKIT_"
+            }
+          ],
           "edge": {
             "version_added": "12"
           },
@@ -34,13 +42,37 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": [
+            {
+              "version_added": false
+            },
+            {
+              "version_added": "14",
+              "prefix": "WEBKIT_"
+            }
+          ],
           "safari": {
             "version_added": "8"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": [
+            {
+              "version_added": false
+            },
+            {
+              "version_added": "1.5",
+              "prefix": "WEBKIT_"
+            }
+          ],
+          "webview_android": [
+            {
+              "version_added": false
+            },
+            {
+              "version_added": "4.4",
+              "prefix": "WEBKIT_"
+            }
+          ]
         },
         "status": {
           "experimental": false,

--- a/api/WEBGL_lose_context.json
+++ b/api/WEBGL_lose_context.json
@@ -14,7 +14,15 @@
               "prefix": "WEBKIT_"
             }
           ],
-          "chrome_android": "mirror",
+          "chrome_android": [
+            {
+              "version_added": false
+            },
+            {
+              "version_added": "18",
+              "prefix": "WEBKIT_"
+            }
+          ],
           "edge": {
             "version_added": "17"
           },
@@ -34,15 +42,31 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
+          "opera_android": [
+            {
+              "version_added": false
+            },
+            {
+              "version_added": "14",
+              "prefix": "WEBKIT_"
+            }
+          ],
           "safari": {
             "version_added": "8"
           },
           "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
+          "samsunginternet_android": [
+            {
+              "version_added": false
+            },
+            {
+              "version_added": "1.0",
+              "prefix": "WEBKIT_"
+            }
+          ],
           "webview_android": [
             {
-              "version_added": "≤37"
+              "version_added": false
             },
             {
               "version_added": "≤37",
@@ -64,7 +88,9 @@
             "chrome": {
               "version_added": "26"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "17"
             },
@@ -84,13 +110,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": "8"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -107,7 +139,9 @@
             "chrome": {
               "version_added": "26"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "17"
             },
@@ -127,13 +161,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": "8"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/WEBGL_multi_draw.json
+++ b/api/WEBGL_multi_draw.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "86"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -23,13 +25,17 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
+            "version_added": "14.1> ≤15.1"
           },
           "safari_ios": {
             "version_added": "15"
           },
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,
@@ -45,7 +51,9 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -60,13 +68,17 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1> ≤15.1"
             },
             "safari_ios": {
               "version_added": "15"
             },
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -83,7 +95,9 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -98,13 +112,17 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1> ≤15.1"
             },
             "safari_ios": {
               "version_added": "15"
             },
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -121,7 +139,9 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -136,13 +156,17 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1> ≤15.1"
             },
             "safari_ios": {
               "version_added": "15"
             },
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -159,7 +183,9 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -174,13 +200,17 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "14.1> ≤15.1"
             },
             "safari_ios": {
               "version_added": "15"
             },
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -13,7 +13,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "51"
+            "version_added": "80"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -48,7 +48,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -84,7 +84,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -120,7 +120,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -156,7 +156,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -192,7 +192,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -231,7 +231,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -267,7 +267,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -303,7 +303,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -342,7 +342,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -378,7 +378,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -414,7 +414,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -453,7 +453,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -489,7 +489,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -525,7 +525,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -561,7 +561,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -597,7 +597,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -633,7 +633,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -669,7 +669,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -705,7 +705,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -774,7 +774,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -810,7 +810,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -846,7 +846,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -915,7 +915,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -986,7 +986,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1022,7 +1022,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1058,7 +1058,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1094,7 +1094,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1163,7 +1163,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1232,7 +1232,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1301,7 +1301,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1337,7 +1337,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1373,7 +1373,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1409,7 +1409,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1445,7 +1445,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1515,7 +1515,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1551,7 +1551,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1620,7 +1620,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1689,7 +1689,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1758,7 +1758,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1794,7 +1794,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1830,7 +1830,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1866,7 +1866,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1902,7 +1902,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1938,7 +1938,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1974,7 +1974,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2010,7 +2010,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2046,7 +2046,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2082,7 +2082,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2118,7 +2118,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2154,7 +2154,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2190,7 +2190,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2226,7 +2226,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2262,7 +2262,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2298,7 +2298,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2334,7 +2334,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2370,7 +2370,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2406,7 +2406,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2442,7 +2442,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2478,7 +2478,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2514,7 +2514,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2550,7 +2550,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2586,7 +2586,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2622,7 +2622,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2658,7 +2658,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2694,7 +2694,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2730,7 +2730,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2766,7 +2766,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2802,7 +2802,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2838,7 +2838,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2874,7 +2874,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2910,7 +2910,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2946,7 +2946,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2982,7 +2982,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3018,7 +3018,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3054,7 +3054,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3090,7 +3090,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3159,7 +3159,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3195,7 +3195,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3231,7 +3231,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3267,7 +3267,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3303,7 +3303,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3339,7 +3339,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3375,7 +3375,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3411,7 +3411,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3447,7 +3447,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3483,7 +3483,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3519,7 +3519,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3555,7 +3555,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3591,7 +3591,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3627,7 +3627,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3663,7 +3663,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3699,7 +3699,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3735,7 +3735,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3771,7 +3771,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3807,7 +3807,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3843,7 +3843,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3879,7 +3879,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3915,7 +3915,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3954,7 +3954,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3990,7 +3990,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4059,7 +4059,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4095,7 +4095,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4131,7 +4131,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4167,7 +4167,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4206,7 +4206,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4242,7 +4242,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4278,7 +4278,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4317,7 +4317,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4353,7 +4353,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4392,7 +4392,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4428,7 +4428,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4464,7 +4464,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4503,7 +4503,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4539,7 +4539,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4575,7 +4575,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4611,7 +4611,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4647,7 +4647,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4683,7 +4683,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4719,7 +4719,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4755,7 +4755,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4794,7 +4794,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4830,7 +4830,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4869,7 +4869,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4905,7 +4905,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4941,7 +4941,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4977,7 +4977,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5016,7 +5016,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5052,7 +5052,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5088,7 +5088,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5124,7 +5124,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5160,7 +5160,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5196,7 +5196,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5232,7 +5232,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5271,7 +5271,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5307,7 +5307,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5343,7 +5343,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5379,7 +5379,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5415,7 +5415,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5451,7 +5451,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5487,7 +5487,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5523,7 +5523,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5559,7 +5559,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5595,7 +5595,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5631,7 +5631,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5666,7 +5666,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5702,7 +5702,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5776,7 +5776,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5816,7 +5816,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5852,7 +5852,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5888,7 +5888,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5924,7 +5924,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5996,7 +5996,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6032,7 +6032,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6068,7 +6068,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6104,7 +6104,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6140,7 +6140,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6176,7 +6176,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6212,7 +6212,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6248,7 +6248,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6284,7 +6284,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6320,7 +6320,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6356,7 +6356,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6392,7 +6392,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6428,7 +6428,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6464,7 +6464,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6503,7 +6503,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6539,7 +6539,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6611,7 +6611,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6650,7 +6650,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6686,7 +6686,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6722,7 +6722,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6761,7 +6761,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6797,7 +6797,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6866,7 +6866,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6902,7 +6902,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6938,7 +6938,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -6974,7 +6974,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7010,7 +7010,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7046,7 +7046,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7082,7 +7082,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7118,7 +7118,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7154,7 +7154,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7190,7 +7190,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7226,7 +7226,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7262,7 +7262,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7298,7 +7298,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7334,7 +7334,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7370,7 +7370,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7406,7 +7406,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7442,7 +7442,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7478,7 +7478,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7514,7 +7514,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7550,7 +7550,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7586,7 +7586,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7622,7 +7622,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7658,7 +7658,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7694,7 +7694,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7730,7 +7730,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7766,7 +7766,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7802,7 +7802,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7871,7 +7871,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -7940,7 +7940,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -8009,7 +8009,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -8078,7 +8078,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -8147,7 +8147,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -8216,7 +8216,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -8285,7 +8285,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -8354,7 +8354,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -8456,7 +8456,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -8492,7 +8492,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -8528,7 +8528,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -8564,7 +8564,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -8633,7 +8633,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -8669,7 +8669,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -8738,7 +8738,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -8774,7 +8774,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -8843,7 +8843,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -8879,7 +8879,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -8948,7 +8948,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -8984,7 +8984,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -9020,7 +9020,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -9089,7 +9089,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -9125,7 +9125,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -9194,7 +9194,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -9230,7 +9230,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -9266,7 +9266,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -9302,7 +9302,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "51"
+              "version_added": "80"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/WebGLQuery.json
+++ b/api/WebGLQuery.json
@@ -23,9 +23,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "preview"
+            "version_added": "≤13.1"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "≤16.4"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -1136,9 +1136,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "105"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -4497,10 +4499,11 @@
               "version_added": false
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤74"
             },
             "safari": {
-              "version_added": false
+              "version_added": "13.1> ≤14.1",
+              "version_removed": "14.1> ≤15.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {

--- a/api/WebGLSampler.json
+++ b/api/WebGLSampler.json
@@ -23,9 +23,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "preview"
+            "version_added": "≤13.1"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "≤16.4"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },

--- a/api/WebGLSync.json
+++ b/api/WebGLSync.json
@@ -23,9 +23,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "preview"
+            "version_added": "≤13.1"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "≤16.4"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },

--- a/api/WebGLVertexArrayObjectOES.json
+++ b/api/WebGLVertexArrayObjectOES.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "24"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": {
             "version_added": "17"
           },
@@ -21,13 +23,21 @@
           },
           "oculus": "mirror",
           "opera": "mirror",
-          "opera_android": "mirror",
-          "safari": {
+          "opera_android": {
             "version_added": false
           },
-          "safari_ios": "mirror",
-          "samsunginternet_android": "mirror",
-          "webview_android": "mirror"
+          "safari": {
+            "version_added": "≤13.1"
+          },
+          "safari_ios": {
+            "version_added": "≤16.4"
+          },
+          "samsunginternet_android": {
+            "version_added": false
+          },
+          "webview_android": {
+            "version_added": false
+          }
         },
         "status": {
           "experimental": false,

--- a/api/Window.json
+++ b/api/Window.json
@@ -1986,12 +1986,16 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }
@@ -2314,7 +2318,9 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -2325,13 +2331,19 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": true,
@@ -3359,7 +3371,7 @@
               "version_added": "≤14"
             },
             "safari": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "≤3"
@@ -5711,7 +5723,8 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "5.1",
-              "notes": "See <a href='https://webkit.org/b/151885'>WebKit bug 151885</a> for possible future removal from Safari."
+              "notes": "See <a href='https://webkit.org/b/151885'>WebKit bug 151885</a> for possible future removal from Safari.",
+              "version_removed": "16.4"
             },
             "safari_ios": {
               "version_added": false

--- a/api/WindowClient.json
+++ b/api/WindowClient.json
@@ -58,7 +58,7 @@
               "version_added": "16"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -147,9 +147,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "14.1> ≤15.1"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -430,9 +430,11 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "96"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "≤112"
+            },
             "ie": {
               "version_added": false
             },
@@ -863,13 +865,15 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": {
-              "version_added": false
+              "version_added": "≤74"
             },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false,
               "notes": "See <a href='https://crbug.com/921655'>bug 921655</a>."

--- a/api/WritableStreamDefaultWriter.json
+++ b/api/WritableStreamDefaultWriter.json
@@ -79,9 +79,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "13.1> ≤14.1"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/XRAnchorSet.json
+++ b/api/XRAnchorSet.json
@@ -243,10 +243,14 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "85"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -256,12 +260,16 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }

--- a/api/XRFrame.json
+++ b/api/XRFrame.json
@@ -84,7 +84,8 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
-              "notes": "Hololens 2 only."
+              "notes": "Hololens 2 only.",
+              "version_removed": "111"
             },
             "firefox": {
               "version_added": false
@@ -123,7 +124,8 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
-              "notes": "Hololens 2 only."
+              "notes": "Hololens 2 only.",
+              "version_removed": "111"
             },
             "firefox": {
               "version_added": false
@@ -270,7 +272,8 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
-              "notes": "Hololens 2 only."
+              "notes": "Hololens 2 only.",
+              "version_removed": "111"
             },
             "firefox": {
               "version_added": false

--- a/api/XRHand.json
+++ b/api/XRHand.json
@@ -11,7 +11,8 @@
           "chrome_android": "mirror",
           "edge": {
             "version_added": "93",
-            "notes": "Hololens 2 only."
+            "notes": "Hololens 2 only.",
+            "version_removed": "111"
           },
           "firefox": {
             "version_added": false
@@ -47,7 +48,8 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
-              "notes": "Hololens 2 only."
+              "notes": "Hololens 2 only.",
+              "version_removed": "111"
             },
             "firefox": {
               "version_added": false
@@ -82,7 +84,8 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
-              "notes": "Hololens 2 only."
+              "notes": "Hololens 2 only.",
+              "version_removed": "111"
             },
             "firefox": {
               "version_added": false
@@ -117,7 +120,8 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
-              "notes": "Hololens 2 only."
+              "notes": "Hololens 2 only.",
+              "version_removed": "111"
             },
             "firefox": {
               "version_added": false
@@ -152,7 +156,8 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
-              "notes": "Hololens 2 only."
+              "notes": "Hololens 2 only.",
+              "version_removed": "111"
             },
             "firefox": {
               "version_added": false
@@ -187,7 +192,8 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
-              "notes": "Hololens 2 only."
+              "notes": "Hololens 2 only.",
+              "version_removed": "111"
             },
             "firefox": {
               "version_added": false
@@ -222,7 +228,8 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
-              "notes": "Hololens 2 only."
+              "notes": "Hololens 2 only.",
+              "version_removed": "111"
             },
             "firefox": {
               "version_added": false
@@ -256,7 +263,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "93",
+              "version_added": false,
               "notes": "Hololens 2 only."
             },
             "firefox": {

--- a/api/XRInputSource.json
+++ b/api/XRInputSource.json
@@ -124,7 +124,8 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
-              "notes": "Hololens 2 only."
+              "notes": "Hololens 2 only.",
+              "version_removed": "111"
             },
             "firefox": {
               "version_added": false

--- a/api/XRInputSourceArray.json
+++ b/api/XRInputSourceArray.json
@@ -229,10 +229,14 @@
         "__compat": {
           "support": {
             "chrome": {
-              "version_added": "79"
+              "version_added": false
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -242,12 +246,16 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
               "version_added": false
             }

--- a/api/XRJointPose.json
+++ b/api/XRJointPose.json
@@ -11,7 +11,8 @@
           "chrome_android": "mirror",
           "edge": {
             "version_added": "93",
-            "notes": "Hololens 2 only."
+            "notes": "Hololens 2 only.",
+            "version_removed": "111"
           },
           "firefox": {
             "version_added": false
@@ -49,7 +50,8 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
-              "notes": "Hololens 2 only."
+              "notes": "Hololens 2 only.",
+              "version_removed": "111"
             },
             "firefox": {
               "version_added": false

--- a/api/XRJointSpace.json
+++ b/api/XRJointSpace.json
@@ -11,7 +11,8 @@
           "chrome_android": "mirror",
           "edge": {
             "version_added": "93",
-            "notes": "Hololens 2 only."
+            "notes": "Hololens 2 only.",
+            "version_removed": "111"
           },
           "firefox": {
             "version_added": false
@@ -49,7 +50,8 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
-              "notes": "Hololens 2 only."
+              "notes": "Hololens 2 only.",
+              "version_removed": "111"
             },
             "firefox": {
               "version_added": false

--- a/api/XRSession.json
+++ b/api/XRSession.json
@@ -193,7 +193,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": false
+              "version_added": "111"
             },
             "firefox": {
               "version_added": false

--- a/api/XRSystem.json
+++ b/api/XRSystem.json
@@ -89,10 +89,12 @@
           "spec_url": "https://immersive-web.github.io/webxr/#dom-xrsystem-issessionsupported",
           "support": {
             "chrome": {
-              "version_added": "79"
+              "version_added": "83"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "83"
+            },
             "firefox": {
               "version_added": false
             },
@@ -126,10 +128,12 @@
           "spec_url": "https://immersive-web.github.io/webxr/#dom-xrsystem-requestsession",
           "support": {
             "chrome": {
-              "version_added": "79"
+              "version_added": "83"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "83"
+            },
             "firefox": {
               "version_added": false
             },

--- a/api/XRWebGLBinding.json
+++ b/api/XRWebGLBinding.json
@@ -26,7 +26,7 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": false
+            "version_added": "≤112"
           }
         },
         "status": {
@@ -62,7 +62,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {

--- a/css/properties/-moz-image-region.json
+++ b/css/properties/-moz-image-region.json
@@ -11,9 +11,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "112"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -76,10 +76,12 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "83"
+                "version_added": "84"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "84"
+              },
               "firefox": {
                 "version_added": "80"
               },
@@ -109,14 +111,14 @@
             "description": "<code>&lt;compat-auto&gt;</code> (compatibility values <code>searchfield</code>, <code>textarea</code>, <code>push-button</code>, <code>slider-horizontal</code>, <code>checkbox</code>, <code>radio</code>, <code>square-button</code>, <code>menulist</code>, <code>listbox</code>, <code>meter</code>, <code>progress-bar</code>, <code>button</code>)",
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": "84"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "84"
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "80"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -126,7 +128,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "3"
+                "version_added": "15.4"
               },
               "safari_ios": {
                 "version_added": "1"
@@ -146,11 +148,11 @@
             "description": "<code>menulist-button</code>",
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": "84"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "84"
               },
               "firefox": [
                 {
@@ -170,7 +172,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "3"
+                "version_added": "15.4"
               },
               "safari_ios": {
                 "version_added": "1"
@@ -189,11 +191,11 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": "84"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "84"
               },
               "firefox": [
                 {
@@ -213,7 +215,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "3"
+                "version_added": "15.4"
               },
               "safari_ios": {
                 "version_added": "3"
@@ -232,14 +234,14 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": "84"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "84"
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "80"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -249,7 +251,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "3"
+                "version_added": "15.4"
               },
               "safari_ios": {
                 "version_added": "1"

--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "13.1> ≤14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -79,7 +79,7 @@
             ],
             "safari": [
               {
-                "version_added": "14"
+                "version_added": "≤13.1"
               },
               {
                 "version_added": "3",
@@ -166,11 +166,11 @@
             "description": "<code>text</code>",
             "support": {
               "chrome": {
-                "version_added": "3",
-                "partial_implementation": true,
-                "notes": "The <code>text</code> value is only supported by <code>-webkit-background-clip</code> (and not by <code>background-clip</code>)."
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "edge": [
                 {
                   "version_added": "15"
@@ -190,7 +190,9 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": false
+              },
               "safari": [
                 {
                   "version_added": "14"
@@ -202,8 +204,12 @@
                 }
               ],
               "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -189,7 +189,7 @@
               "opera_android": "mirror",
               "safari": [
                 {
-                  "version_added": "preview"
+                  "version_added": "≤13.1"
                 },
                 {
                   "prefix": "-webkit-",
@@ -198,7 +198,17 @@
                   "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit. See <a href='https://webkit.org/b/160934'>bug 160934</a>."
                 }
               ],
-              "safari_ios": "mirror",
+              "safari_ios": [
+                {
+                  "version_added": "≤16.4"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "6",
+                  "partial_implementation": true,
+                  "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit. See <a href='https://webkit.org/b/160934'>bug 160934</a>."
+                }
+              ],
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/block-size.json
+++ b/css/properties/block-size.json
@@ -45,11 +45,24 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": "41"
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "41"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤112"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "41"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -60,10 +73,15 @@
                 "version_added": "12.1"
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": {
-                "alternative_name": "-webkit-fill-available",
-                "version_added": "5.0"
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "≤20.0"
+                },
+                {
+                  "alternative_name": "-webkit-fill-available",
+                  "version_added": "5.0"
+                }
+              ],
               "webview_android": "mirror"
             },
             "status": {

--- a/css/properties/caption-side.json
+++ b/css/properties/caption-side.json
@@ -61,9 +61,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "≤13.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.4"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/clear.json
+++ b/css/properties/clear.json
@@ -70,9 +70,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "14.1> ≤15.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.4"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -147,9 +147,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "≤13.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.4"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -214,7 +216,7 @@
                 "version_added": false
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "≤74"
               },
               "safari": [
                 {

--- a/css/properties/color-scheme.json
+++ b/css/properties/color-scheme.json
@@ -39,26 +39,38 @@
             "description": "<code>only dark</code> keyword",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "81"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤112"
+              },
+              "edge": {
+                "version_added": "81"
+              },
               "firefox": {
-                "version_added": false
+                "version_added": "96"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": "≤74"
+              },
               "safari": {
                 "version_added": "13"
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "samsunginternet_android": {
+                "version_added": "≤20.0"
+              },
+              "webview_android": {
+                "version_added": "≤112"
+              }
             },
             "status": {
               "experimental": false,
@@ -78,9 +90,11 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "96"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -93,7 +107,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {

--- a/css/properties/contain-intrinsic-height.json
+++ b/css/properties/contain-intrinsic-height.json
@@ -7,10 +7,12 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-sizing-4/#propdef-contain-intrinsic-height",
           "support": {
             "chrome": {
-              "version_added": "83"
+              "version_added": "95"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "95"
+            },
             "firefox": {
               "version_added": "107"
             },

--- a/css/properties/contain-intrinsic-width.json
+++ b/css/properties/contain-intrinsic-width.json
@@ -7,10 +7,12 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-sizing-4/#propdef-contain-intrinsic-width",
           "support": {
             "chrome": {
-              "version_added": "83"
+              "version_added": "95"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "95"
+            },
             "firefox": {
               "version_added": "107"
             },

--- a/css/properties/content-visibility.json
+++ b/css/properties/content-visibility.json
@@ -13,7 +13,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": false
               },
               {
                 "version_added": "109",

--- a/css/properties/cursor.json
+++ b/css/properties/cursor.json
@@ -35,7 +35,7 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": false
+              "version_added": "≤112"
             }
           },
           "status": {
@@ -77,7 +77,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -120,7 +120,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -161,7 +161,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -204,7 +204,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -247,7 +247,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -290,7 +290,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -335,7 +335,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -378,7 +378,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -419,7 +419,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -460,7 +460,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -549,7 +549,7 @@
                 }
               ],
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -590,7 +590,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -631,7 +631,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -672,7 +672,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -715,7 +715,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -754,7 +754,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -797,7 +797,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -838,7 +838,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -879,7 +879,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -922,7 +922,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -963,7 +963,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -1004,7 +1004,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -1046,7 +1046,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -1086,7 +1086,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -1129,7 +1129,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -1170,7 +1170,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {
@@ -1247,7 +1247,7 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": false
+                "version_added": "≤112"
               }
             },
             "status": {

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -635,7 +635,7 @@
                 "version_added": "70"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤112"
               },
               "ie": {
                 "version_added": false

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -158,12 +158,14 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": {
-                "version_added": false
+                "version_added": "≤74"
               },
               "safari": {
-                "version_added": "preview"
+                "version_added": "15.4"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.4"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -199,7 +201,7 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": {
-                "version_added": false
+                "version_added": "≤74"
               },
               "safari": {
                 "version_added": "16"
@@ -239,7 +241,7 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": {
-                "version_added": false
+                "version_added": "≤74"
               },
               "safari": {
                 "version_added": "16"
@@ -279,7 +281,7 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": {
-                "version_added": false
+                "version_added": "≤74"
               },
               "safari": {
                 "version_added": "16"

--- a/css/properties/float.json
+++ b/css/properties/float.json
@@ -70,9 +70,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "14.1> ≤15.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.4"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/font-optical-sizing.json
+++ b/css/properties/font-optical-sizing.json
@@ -23,7 +23,7 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": {
-              "version_added": false
+              "version_added": "≤74"
             },
             "safari": {
               "version_added": "11"

--- a/css/properties/font-size.json
+++ b/css/properties/font-size.json
@@ -152,7 +152,7 @@
                 "version_added": "70"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤112"
               },
               "ie": {
                 "version_added": false
@@ -162,7 +162,7 @@
                 "version_added": false
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "≤74"
               },
               "safari": {
                 "version_added": "16.4"

--- a/css/properties/font-style.json
+++ b/css/properties/font-style.json
@@ -46,10 +46,14 @@
             "description": "<code>oblique</code> can accept an <code>&lt;angle&gt;</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "≤80"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤112"
+              },
+              "edge": {
+                "version_added": "≤80"
+              },
               "firefox": {
                 "version_added": "61"
               },
@@ -59,13 +63,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "preview"
+              "opera_android": {
+                "version_added": "≤74"
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": "≤13.1"
+              },
+              "safari_ios": {
+                "version_added": "≤16.4"
+              },
+              "samsunginternet_android": {
+                "version_added": "≤20.0"
+              },
+              "webview_android": {
+                "version_added": "≤112"
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/font-synthesis-small-caps.json
+++ b/css/properties/font-synthesis-small-caps.json
@@ -11,17 +11,20 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "111",
               "notes": "<a href='https://bugzil.la/1724892'>bug 1724892</a>."
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "≤112",
+              "notes": "<a href='https://bugzil.la/1724892'>bug 1724892</a>."
+            },
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": {
-              "version_added": false
+              "version_added": "≤74"
             },
             "safari": {
               "version_added": "16.4",

--- a/css/properties/font-synthesis-style.json
+++ b/css/properties/font-synthesis-style.json
@@ -11,17 +11,20 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "111",
               "notes": "<a href='https://bugzil.la/1724892'>bug 1724892</a>."
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "≤112",
+              "notes": "<a href='https://bugzil.la/1724892'>bug 1724892</a>."
+            },
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": {
-              "version_added": false
+              "version_added": "≤74"
             },
             "safari": {
               "version_added": "16.4",

--- a/css/properties/font-synthesis-weight.json
+++ b/css/properties/font-synthesis-weight.json
@@ -11,17 +11,20 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "111",
               "notes": "<a href='https://bugzil.la/1724892'>bug 1724892</a>."
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "≤112",
+              "notes": "<a href='https://bugzil.la/1724892'>bug 1724892</a>."
+            },
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": {
-              "version_added": false
+              "version_added": "≤74"
             },
             "safari": {
               "version_added": "16.4",

--- a/css/properties/font-synthesis.json
+++ b/css/properties/font-synthesis.json
@@ -21,7 +21,7 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": {
-              "version_added": false
+              "version_added": "≤74"
             },
             "safari": {
               "version_added": "9"
@@ -55,7 +55,7 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": {
-                "version_added": false
+                "version_added": "≤74"
               },
               "safari": {
                 "version_added": "10.1"

--- a/css/properties/font-variant-alternates.json
+++ b/css/properties/font-variant-alternates.json
@@ -7,11 +7,17 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts/#font-variant-alternates-prop",
           "support": {
             "chrome": {
-              "version_added": false,
+              "version_added": "111",
               "notes": "See <a href='https://crbug.com/716567'>bug 716567</a>."
             },
-            "chrome_android": "mirror",
-            "edge": "mirror",
+            "chrome_android": {
+              "version_added": "≤112",
+              "notes": "See <a href='https://crbug.com/716567'>bug 716567</a>."
+            },
+            "edge": {
+              "version_added": "111",
+              "notes": "See <a href='https://crbug.com/716567'>bug 716567</a>."
+            },
             "firefox": {
               "version_added": "34"
             },
@@ -27,7 +33,10 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": "≤112",
+              "notes": "See <a href='https://crbug.com/716567'>bug 716567</a>."
+            }
           },
           "status": {
             "experimental": false,
@@ -41,10 +50,14 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#annotation()",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "111"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤112"
+              },
+              "edge": {
+                "version_added": "111"
+              },
               "firefox": {
                 "version_added": "34"
               },
@@ -60,7 +73,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤112"
+              }
             },
             "status": {
               "experimental": false,
@@ -75,10 +90,14 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#character-variant()",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "111"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤112"
+              },
+              "edge": {
+                "version_added": "111"
+              },
               "firefox": {
                 "version_added": "34"
               },
@@ -94,7 +113,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤112"
+              }
             },
             "status": {
               "experimental": false,
@@ -109,10 +130,14 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#ornaments()",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "111"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤112"
+              },
+              "edge": {
+                "version_added": "111"
+              },
               "firefox": {
                 "version_added": "34"
               },
@@ -128,7 +153,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤112"
+              }
             },
             "status": {
               "experimental": false,
@@ -143,10 +170,14 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#styleset()",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "111"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤112"
+              },
+              "edge": {
+                "version_added": "111"
+              },
               "firefox": {
                 "version_added": "34"
               },
@@ -162,7 +193,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤112"
+              }
             },
             "status": {
               "experimental": false,
@@ -177,10 +210,14 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#stylistic()",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "111"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤112"
+              },
+              "edge": {
+                "version_added": "111"
+              },
               "firefox": {
                 "version_added": "34"
               },
@@ -196,7 +233,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤112"
+              }
             },
             "status": {
               "experimental": false,
@@ -211,10 +250,14 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#swash()",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "111"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤112"
+              },
+              "edge": {
+                "version_added": "111"
+              },
               "firefox": {
                 "version_added": "34"
               },
@@ -230,7 +273,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤112"
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/font-variant-emoji.json
+++ b/css/properties/font-variant-emoji.json
@@ -12,9 +12,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "108"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/forced-color-adjust.json
+++ b/css/properties/forced-color-adjust.json
@@ -10,7 +10,7 @@
               "version_added": "89"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "≤112"
             },
             "edge": [
               {
@@ -33,13 +33,19 @@
             "opera": {
               "version_added": false
             },
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": "≤74"
+            },
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "samsunginternet_android": {
+              "version_added": "≤20.0"
+            },
+            "webview_android": {
+              "version_added": "≤112"
+            }
           },
           "status": {
             "experimental": false,

--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -50,9 +50,11 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "94"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/properties/image-orientation.json
+++ b/css/properties/image-orientation.json
@@ -23,7 +23,7 @@
               "version_added": "67"
             },
             "opera_android": {
-              "version_added": false
+              "version_added": "≤74"
             },
             "safari": {
               "version_added": "13.1"

--- a/css/properties/image-rendering.json
+++ b/css/properties/image-rendering.json
@@ -88,10 +88,14 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "28"
+                "version_added": false
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
               "firefox": {
                 "version_added": "3.6"
               },
@@ -102,14 +106,18 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": {
-                "version_added": "14"
+                "version_added": false
               },
               "safari": {
                 "version_added": "7"
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -122,10 +130,14 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "28"
+                "version_added": false
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
               "firefox": {
                 "version_added": "3.6"
               },
@@ -136,14 +148,18 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": {
-                "version_added": "14"
+                "version_added": false
               },
               "safari": {
                 "version_added": "7"
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/inline-size.json
+++ b/css/properties/inline-size.json
@@ -45,11 +45,24 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": "41"
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "41"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤112"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "41"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -60,10 +73,15 @@
                 "version_added": "12.1"
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": {
-                "alternative_name": "-webkit-fill-available",
-                "version_added": "5.0"
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "≤20.0"
+                },
+                {
+                  "alternative_name": "-webkit-fill-available",
+                  "version_added": "5.0"
+                }
+              ],
               "webview_android": "mirror"
             },
             "status": {

--- a/css/properties/line-height.json
+++ b/css/properties/line-height.json
@@ -49,9 +49,11 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "3.6"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -54,11 +54,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -91,11 +95,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -128,11 +136,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -243,11 +255,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -316,11 +332,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -418,10 +438,14 @@
             "description": "<code>cjk-decimal</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤112"
+              },
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": "28"
               },
@@ -431,13 +455,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "preview"
+              "opera_android": {
+                "version_added": "≤74"
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": "14.1> ≤15.1"
+              },
+              "safari_ios": {
+                "version_added": "≤16.4"
+              },
+              "samsunginternet_android": {
+                "version_added": "≤20.0"
+              },
+              "webview_android": {
+                "version_added": "≤112"
+              }
             },
             "status": {
               "experimental": false,
@@ -806,11 +838,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -843,11 +879,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -880,11 +920,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -917,11 +961,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -954,11 +1002,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -991,11 +1043,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -1028,11 +1084,24 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "1",
-                "prefix": "-moz-"
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "≤72"
+                },
+                {
+                  "version_added": "1",
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤112"
+                },
+                {
+                  "version_added": "4",
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -1062,11 +1131,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -1099,11 +1172,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -1136,11 +1213,24 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "1",
-                "prefix": "-moz-"
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "≤72"
+                },
+                {
+                  "version_added": "1",
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤112"
+                },
+                {
+                  "version_added": "4",
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -1148,9 +1238,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "5"
+                "version_added": false
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": false
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -1170,11 +1262,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -1207,11 +1303,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -1244,11 +1344,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -1281,11 +1385,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -1318,11 +1426,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -1355,11 +1467,24 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "1",
-                "prefix": "-moz-"
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "≤72"
+                },
+                {
+                  "version_added": "1",
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤112"
+                },
+                {
+                  "version_added": "4",
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -1391,11 +1516,24 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "1",
-                "prefix": "-moz-"
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "≤72"
+                },
+                {
+                  "version_added": "1",
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤112"
+                },
+                {
+                  "version_added": "4",
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -1427,11 +1565,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -1460,10 +1602,14 @@
             "description": "<code>ethiopic-numeric</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤112"
+              },
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": [
                 {
                   "version_added": "33",
@@ -1480,13 +1626,19 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": "≤74"
+              },
               "safari": {
                 "version_added": "15"
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "samsunginternet_android": {
+                "version_added": "≤20.0"
+              },
+              "webview_android": {
+                "version_added": "≤112"
+              }
             },
             "status": {
               "experimental": false,
@@ -1504,11 +1656,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -1655,11 +1811,24 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "1",
-                "prefix": "-moz-"
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "≤72"
+                },
+                {
+                  "version_added": "1",
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤112"
+                },
+                {
+                  "version_added": "4",
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -1689,11 +1858,24 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "1",
-                "prefix": "-moz-"
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "≤72"
+                },
+                {
+                  "version_added": "1",
+                  "prefix": "-moz-"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤112"
+                },
+                {
+                  "version_added": "4",
+                  "prefix": "-moz-"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -1818,10 +2000,14 @@
             "description": "<code>japanese-formal</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤112"
+              },
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": [
                 {
                   "version_added": "28"
@@ -1837,13 +2023,19 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": "≤74"
+              },
               "safari": {
                 "version_added": "15"
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "samsunginternet_android": {
+                "version_added": "≤20.0"
+              },
+              "webview_android": {
+                "version_added": "≤112"
+              }
             },
             "status": {
               "experimental": false,
@@ -1857,10 +2049,14 @@
             "description": "<code>japanese-informal</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤112"
+              },
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": [
                 {
                   "version_added": "28"
@@ -1876,13 +2072,19 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": "≤74"
+              },
               "safari": {
                 "version_added": "15"
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "samsunginternet_android": {
+                "version_added": "≤20.0"
+              },
+              "webview_android": {
+                "version_added": "≤112"
+              }
             },
             "status": {
               "experimental": false,
@@ -2293,11 +2495,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -2371,11 +2577,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -2558,11 +2768,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -2631,11 +2845,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -2704,11 +2922,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -2816,11 +3038,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -2885,10 +3111,12 @@
             "description": "<code>&lt;string&gt;</code>",
             "support": {
               "chrome": {
-                "version_added": "79"
+                "version_added": "91"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": "39"
               },
@@ -2899,12 +3127,14 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": {
-                "version_added": false
+                "version_added": "≤74"
               },
               "safari": {
-                "version_added": "14.1"
+                "version_added": false
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": false
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -2921,10 +3151,14 @@
             "spec_url": "https://w3c.github.io/csswg-drafts/css-counter-styles/#symbols-function",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤112"
+              },
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": "35"
               },
@@ -2934,13 +3168,19 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": "≤74"
+              },
               "safari": {
                 "version_added": false
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "samsunginternet_android": {
+                "version_added": "≤20.0"
+              },
+              "webview_android": {
+                "version_added": "≤112"
+              }
             },
             "status": {
               "experimental": false,
@@ -2954,10 +3194,14 @@
             "description": "<code>tamil</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤112"
+              },
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": [
                 {
                   "version_added": "33"
@@ -2973,13 +3217,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "preview"
+              "opera_android": {
+                "version_added": "≤74"
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": "14.1> ≤15.1"
+              },
+              "safari_ios": {
+                "version_added": "≤16.4"
+              },
+              "samsunginternet_android": {
+                "version_added": "≤20.0"
+              },
+              "webview_android": {
+                "version_added": "≤112"
+              }
             },
             "status": {
               "experimental": false,
@@ -3079,7 +3331,7 @@
                 "version_added": "33"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤112"
               },
               "ie": {
                 "version_added": false
@@ -3110,11 +3362,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -3144,11 +3400,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -3178,11 +3438,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -3212,11 +3476,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -3246,11 +3514,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -3426,11 +3698,11 @@
             "description": "<code>upper-greek</code>",
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12"
+                "version_added": "91"
               },
               "firefox": {
                 "version_added": "1"
@@ -3469,11 +3741,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -3545,11 +3821,15 @@
                 "version_removed": "45"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "edge": {
+                "version_added": "91"
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -3621,11 +3901,24 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": "33"
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "≤72"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "33"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤112"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "33"
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/list-style.json
+++ b/css/properties/list-style.json
@@ -46,10 +46,14 @@
             "spec_url": "https://w3c.github.io/csswg-drafts/css-counter-styles/#symbols-function",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤112"
+              },
+              "edge": {
+                "version_added": "91"
+              },
               "firefox": {
                 "version_added": "35"
               },
@@ -59,13 +63,19 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": "≤74"
+              },
               "safari": {
                 "version_added": false
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "samsunginternet_android": {
+                "version_added": "≤20.0"
+              },
+              "webview_android": {
+                "version_added": "≤112"
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/margin-block-end.json
+++ b/css/properties/margin-block-end.json
@@ -7,10 +7,12 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-logical/#margin-properties",
           "support": {
             "chrome": {
-              "version_added": "87"
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤80"
+            },
             "firefox": {
               "version_added": "41"
             },

--- a/css/properties/margin-block-start.json
+++ b/css/properties/margin-block-start.json
@@ -7,10 +7,12 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-logical/#margin-properties",
           "support": {
             "chrome": {
-              "version_added": "87"
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤80"
+            },
             "firefox": {
               "version_added": "41"
             },

--- a/css/properties/margin-inline-end.json
+++ b/css/properties/margin-inline-end.json
@@ -8,7 +8,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "87"
+                "version_added": "≤80"
               },
               {
                 "version_added": "2",
@@ -16,7 +16,15 @@
               }
             ],
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": [
+              {
+                "version_added": "≤80"
+              },
+              {
+                "version_added": "79",
+                "alternative_name": "-webkit-margin-end"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/margin-inline-start.json
+++ b/css/properties/margin-inline-start.json
@@ -8,7 +8,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "87"
+                "version_added": "≤80"
               },
               {
                 "version_added": "2",
@@ -16,7 +16,15 @@
               }
             ],
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": [
+              {
+                "version_added": "≤80"
+              },
+              {
+                "version_added": "79",
+                "alternative_name": "-webkit-margin-start"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/mask-clip.json
+++ b/css/properties/mask-clip.json
@@ -49,10 +49,14 @@
             "description": "<code>border<code>",
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
               "firefox": {
                 "version_added": false
               },
@@ -62,14 +66,20 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "4"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
               "webview_android": {
-                "version_added": "2"
+                "version_added": false
               }
             },
             "status": {
@@ -84,10 +94,14 @@
             "description": "<code>content</content>",
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
               "firefox": {
                 "version_added": false
               },
@@ -97,14 +111,20 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "4"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
               "webview_android": {
-                "version_added": "2"
+                "version_added": false
               }
             },
             "status": {
@@ -119,10 +139,14 @@
             "description": "<code>padding</code>",
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
               "firefox": {
                 "version_added": false
               },
@@ -132,14 +156,20 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "4"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
               "webview_android": {
-                "version_added": "2"
+                "version_added": false
               }
             },
             "status": {
@@ -154,10 +184,14 @@
             "description": "<code>text</code>",
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
               "firefox": {
                 "version_added": false
               },
@@ -167,14 +201,20 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "4"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
               "webview_android": {
-                "version_added": "2"
+                "version_added": false
               }
             },
             "status": {

--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -70,29 +70,39 @@
             "description": "Multiple mask images",
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "edge": {
-                "version_added": "18"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "53"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "4"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": false
               }
             },
             "status": {

--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -57,9 +57,11 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "≤72"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -103,14 +105,22 @@
               "opera_android": "mirror",
               "safari": [
                 {
-                  "version_added": "preview"
+                  "version_added": "15.4"
                 },
                 {
                   "prefix": "-webkit-",
                   "version_added": "4"
                 }
               ],
-              "safari_ios": "mirror",
+              "safari_ios": [
+                {
+                  "version_added": "≤16.4"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "3.2"
+                }
+              ],
               "samsunginternet_android": "mirror",
               "webview_android": {
                 "prefix": "-webkit-",
@@ -134,9 +144,11 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "≤72"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -168,9 +180,11 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "≤72"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/properties/max-block-size.json
+++ b/css/properties/max-block-size.json
@@ -46,9 +46,11 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "94"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -59,10 +61,15 @@
                 "version_added": "12.1"
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": {
-                "alternative_name": "-webkit-fill-available",
-                "version_added": "5.0"
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "≤20.0"
+                },
+                {
+                  "alternative_name": "-webkit-fill-available",
+                  "version_added": "5.0"
+                }
+              ],
               "webview_android": "mirror"
             },
             "status": {

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -59,13 +59,28 @@
               ],
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "partial_implementation": true,
-                "prefix": "-moz-",
-                "version_added": "3",
-                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "partial_implementation": true,
+                  "prefix": "-moz-",
+                  "version_added": "3",
+                  "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤112"
+                },
+                {
+                  "partial_implementation": true,
+                  "prefix": "-moz-",
+                  "version_added": "4",
+                  "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -49,11 +49,24 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": "41"
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "41"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤112"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "41"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -64,10 +77,15 @@
                 "version_added": "12.1"
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": {
-                "alternative_name": "-webkit-fill-available",
-                "version_added": "7.0"
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "≤20.0"
+                },
+                {
+                  "alternative_name": "-webkit-fill-available",
+                  "version_added": "7.0"
+                }
+              ],
               "webview_android": "mirror"
             },
             "status": {

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -57,13 +57,28 @@
                 "version_added": "46"
               },
               "edge": "mirror",
-              "firefox": {
-                "partial_implementation": true,
-                "prefix": "-moz-",
-                "version_added": "3",
-                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "partial_implementation": true,
+                  "prefix": "-moz-",
+                  "version_added": "3",
+                  "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤112"
+                },
+                {
+                  "partial_implementation": true,
+                  "prefix": "-moz-",
+                  "version_added": "4",
+                  "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/min-block-size.json
+++ b/css/properties/min-block-size.json
@@ -44,9 +44,11 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "94"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": false
               },
@@ -57,10 +59,15 @@
                 "version_added": "12.1"
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": {
-                "alternative_name": "-webkit-fill-available",
-                "version_added": "7.0"
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "≤20.0"
+                },
+                {
+                  "alternative_name": "-webkit-fill-available",
+                  "version_added": "7.0"
+                }
+              ],
               "webview_android": "mirror"
             },
             "status": {

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -97,12 +97,26 @@
                 "version_added": "46"
               },
               "edge": "mirror",
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": "3",
-                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "3",
+                  "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤112"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4",
+                  "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
+                }
+              ],
               "ie": {
                 "version_added": false
               },

--- a/css/properties/min-inline-size.json
+++ b/css/properties/min-inline-size.json
@@ -43,11 +43,24 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": "41"
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "41"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤112"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "41"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -58,10 +71,15 @@
                 "version_added": "12.1"
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": {
-                "alternative_name": "-webkit-fill-available",
-                "version_added": "7.0"
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "≤20.0"
+                },
+                {
+                  "alternative_name": "-webkit-fill-available",
+                  "version_added": "7.0"
+                }
+              ],
               "webview_android": "mirror"
             },
             "status": {

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -109,12 +109,26 @@
                 "version_added": "46"
               },
               "edge": "mirror",
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": "3",
-                "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
-              },
-              "firefox_android": "mirror",
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "3",
+                  "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤112"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4",
+                  "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -131,10 +145,15 @@
                 }
               ],
               "safari_ios": "mirror",
-              "samsunginternet_android": {
-                "alternative_name": "-webkit-fill-available",
-                "version_added": "5.0"
-              },
+              "samsunginternet_android": [
+                {
+                  "version_added": "≤20.0"
+                },
+                {
+                  "alternative_name": "-webkit-fill-available",
+                  "version_added": "5.0"
+                }
+              ],
               "webview_android": [
                 {
                   "version_added": "46"

--- a/css/properties/offset-anchor.json
+++ b/css/properties/offset-anchor.json
@@ -24,7 +24,9 @@
             "safari": {
               "version_added": "preview"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/offset-distance.json
+++ b/css/properties/offset-distance.json
@@ -21,7 +21,7 @@
               "version_added": "72"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤112"
             },
             "ie": {
               "version_added": false
@@ -32,7 +32,9 @@
             "safari": {
               "version_added": "preview"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -87,7 +87,9 @@
               "safari": {
                 "version_added": "preview"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.4"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -147,7 +149,9 @@
               "safari": {
                 "version_added": "preview"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.4"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/offset-position.json
+++ b/css/properties/offset-position.json
@@ -26,7 +26,9 @@
             "safari": {
               "version_added": "preview"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/offset-rotate.json
+++ b/css/properties/offset-rotate.json
@@ -25,7 +25,7 @@
               "version_added": "72"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤112"
             },
             "ie": {
               "version_added": false
@@ -36,7 +36,9 @@
             "safari": {
               "version_added": "preview"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/offset.json
+++ b/css/properties/offset.json
@@ -21,7 +21,7 @@
               "version_added": "72"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤112"
             },
             "ie": {
               "version_added": false

--- a/css/properties/opacity.json
+++ b/css/properties/opacity.json
@@ -67,7 +67,7 @@
                 "version_added": "70"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤112"
               },
               "ie": {
                 "version_added": false
@@ -77,12 +77,14 @@
                 "version_added": false
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "≤74"
               },
               "safari": {
-                "version_added": "preview"
+                "version_added": "≤13.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.4"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/overflow-anchor.json
+++ b/css/properties/overflow-anchor.json
@@ -15,7 +15,7 @@
               "version_added": "66"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤112"
             },
             "ie": {
               "version_added": false

--- a/css/properties/overflow-block.json
+++ b/css/properties/overflow-block.json
@@ -15,7 +15,7 @@
               "version_added": "69"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤112"
             },
             "ie": {
               "version_added": false

--- a/css/properties/overflow-clip-box-block.json
+++ b/css/properties/overflow-clip-box-block.json
@@ -11,9 +11,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "59"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/overflow-clip-box-inline.json
+++ b/css/properties/overflow-clip-box-inline.json
@@ -11,9 +11,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "59"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/overflow-clip-box.json
+++ b/css/properties/overflow-clip-box.json
@@ -11,9 +11,11 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "29"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/css/properties/overflow-inline.json
+++ b/css/properties/overflow-inline.json
@@ -15,7 +15,7 @@
               "version_added": "69"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤112"
             },
             "ie": {
               "version_added": false

--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -104,7 +104,7 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": {
-                "version_added": false
+                "version_added": "≤74"
               },
               "safari": {
                 "version_added": "15.4"

--- a/css/properties/overflow-x.json
+++ b/css/properties/overflow-x.json
@@ -72,7 +72,7 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": {
-                "version_added": false
+                "version_added": "≤74"
               },
               "safari": {
                 "version_added": "16"

--- a/css/properties/overflow-y.json
+++ b/css/properties/overflow-y.json
@@ -72,7 +72,7 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": {
-                "version_added": false
+                "version_added": "≤74"
               },
               "safari": {
                 "version_added": "16"

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -70,7 +70,7 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": {
-                "version_added": false
+                "version_added": "≤74"
               },
               "safari": {
                 "version_added": "16"
@@ -106,9 +106,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "≤13.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.4"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/overscroll-behavior-block.json
+++ b/css/properties/overscroll-behavior-block.json
@@ -15,7 +15,7 @@
               "version_added": "73"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤112"
             },
             "ie": {
               "version_added": false

--- a/css/properties/overscroll-behavior-inline.json
+++ b/css/properties/overscroll-behavior-inline.json
@@ -15,7 +15,7 @@
               "version_added": "73"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤112"
             },
             "ie": {
               "version_added": false

--- a/css/properties/padding-block-end.json
+++ b/css/properties/padding-block-end.json
@@ -7,10 +7,12 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-logical/#padding-properties",
           "support": {
             "chrome": {
-              "version_added": "87"
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤80"
+            },
             "firefox": {
               "version_added": "41"
             },

--- a/css/properties/padding-block-start.json
+++ b/css/properties/padding-block-start.json
@@ -7,10 +7,12 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-logical/#padding-properties",
           "support": {
             "chrome": {
-              "version_added": "87"
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": "≤80"
+            },
             "firefox": {
               "version_added": "41"
             },

--- a/css/properties/padding-inline-end.json
+++ b/css/properties/padding-inline-end.json
@@ -8,7 +8,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "87"
+                "version_added": "≤80"
               },
               {
                 "version_added": "2",
@@ -16,7 +16,15 @@
               }
             ],
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": [
+              {
+                "version_added": "≤80"
+              },
+              {
+                "version_added": "79",
+                "alternative_name": "-webkit-padding-end"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/padding-inline-start.json
+++ b/css/properties/padding-inline-start.json
@@ -8,7 +8,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "87"
+                "version_added": "≤80"
               },
               {
                 "version_added": "2",
@@ -16,7 +16,15 @@
               }
             ],
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": [
+              {
+                "version_added": "≤80"
+              },
+              {
+                "version_added": "79",
+                "alternative_name": "-webkit-padding-start"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "41"

--- a/css/properties/page.json
+++ b/css/properties/page.json
@@ -22,9 +22,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "≤13.1"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "≤16.4"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/quotes.json
+++ b/css/properties/quotes.json
@@ -53,7 +53,7 @@
                 "version_added": "70"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤112"
               },
               "ie": {
                 "version_added": false,
@@ -62,14 +62,17 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": {
-                "version_added": false,
+                "version_added": "≤74",
                 "notes": "This value is not supported, but the default browser behavior is to choose appropriate quotes for the user's language setting"
               },
               "safari": {
-                "version_added": "preview",
+                "version_added": "13.1> ≤14.1",
                 "notes": "This value is not supported, but the default browser behavior is to choose appropriate quotes for the user's language setting"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.4",
+                "notes": "This value is not supported, but the default browser behavior is to choose appropriate quotes for the user's language setting"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/rotate.json
+++ b/css/properties/rotate.json
@@ -54,9 +54,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "13.1> ≤14.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.4"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/scroll-margin-block-end.json
+++ b/css/properties/scroll-margin-block-end.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "14.1> ≤15.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/scroll-margin-block-start.json
+++ b/css/properties/scroll-margin-block-start.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "14.1> ≤15.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/scroll-margin-block.json
+++ b/css/properties/scroll-margin-block.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "14.1> ≤15.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/scroll-margin-inline-end.json
+++ b/css/properties/scroll-margin-inline-end.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "14.1> ≤15.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/scroll-margin-inline-start.json
+++ b/css/properties/scroll-margin-inline-start.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "14.1> ≤15.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/scroll-margin-inline.json
+++ b/css/properties/scroll-margin-inline.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "14.1> ≤15.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/scroll-snap-type-x.json
+++ b/css/properties/scroll-snap-type-x.json
@@ -22,9 +22,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "9"
+              "version_added": false
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/css/properties/shape-image-threshold.json
+++ b/css/properties/shape-image-threshold.json
@@ -47,7 +47,7 @@
                 "version_added": "70"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤112"
               },
               "ie": {
                 "version_added": false
@@ -57,7 +57,7 @@
                 "version_added": false
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "≤74"
               },
               "safari": {
                 "version_added": false

--- a/css/properties/tab-size.json
+++ b/css/properties/tab-size.json
@@ -74,7 +74,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "53"
+                "version_added": "90> ≤92"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -49,26 +49,68 @@
           "__compat": {
             "description": "Prefixed <code>center</code>, <code>left</code>, and <code>right</code> values for block alignment",
             "support": {
-              "chrome": {
-                "prefix": "-webkit-",
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": "1"
-              },
-              "firefox_android": "mirror",
+              "chrome": [
+                {
+                  "version_added": "≤80"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1"
+                }
+              ],
+              "chrome_android": [
+                {
+                  "version_added": "≤112"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "18"
+                }
+              ],
+              "edge": [
+                {
+                  "version_added": "≤80"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "79"
+                }
+              ],
+              "firefox": [
+                {
+                  "version_added": "≤72"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "1"
+                }
+              ],
+              "firefox_android": [
+                {
+                  "version_added": "≤112"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "4"
+                }
+              ],
               "ie": {
                 "version_added": false
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
+              "opera_android": [
+                {
+                  "version_added": "≤74"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "14"
+                }
+              ],
               "safari": [
                 {
-                  "version_added": "preview"
+                  "version_added": "≤13.1"
                 },
                 {
                   "prefix": "-webkit-",
@@ -79,12 +121,37 @@
                   "version_added": "1"
                 }
               ],
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": {
-                "prefix": "-webkit-",
-                "version_added": "37"
-              }
+              "safari_ios": [
+                {
+                  "version_added": "≤16.4"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1"
+                },
+                {
+                  "prefix": "-khtml-",
+                  "version_added": "1"
+                }
+              ],
+              "samsunginternet_android": [
+                {
+                  "version_added": "≤20.0"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "1.0"
+                }
+              ],
+              "webview_android": [
+                {
+                  "version_added": "≤112"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "37"
+                }
+              ]
             },
             "status": {
               "experimental": false,
@@ -133,10 +200,14 @@
             "description": "<code>match-parent</code>",
             "support": {
               "chrome": {
-                "version_added": "16"
+                "version_added": false
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
               "firefox": {
                 "version_added": "40"
               },
@@ -146,14 +217,18 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": false
+              },
               "safari": {
                 "version_added": "15.4"
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
+              "samsunginternet_android": {
+                "version_added": false
+              },
               "webview_android": {
-                "version_added": "37"
+                "version_added": false
               }
             },
             "status": {

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -43,7 +43,7 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "preview"
+                "version_added": "15.4"
               },
               {
                 "partial_implementation": true,

--- a/css/properties/text-decoration-skip-ink.json
+++ b/css/properties/text-decoration-skip-ink.json
@@ -15,7 +15,7 @@
               "version_added": "70"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤112"
             },
             "ie": {
               "version_added": false
@@ -53,7 +53,7 @@
                 "version_added": "75"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤112"
               },
               "ie": {
                 "version_added": false
@@ -62,9 +62,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "15.4"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.4"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/text-decoration-thickness.json
+++ b/css/properties/text-decoration-thickness.json
@@ -23,7 +23,7 @@
               "version_added": "70"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤112"
             },
             "ie": {
               "version_added": false
@@ -53,28 +53,38 @@
             "description": "percentage values",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤112"
+              },
+              "edge": {
+                "version_added": "87"
+              },
               "firefox": {
                 "version_added": "74"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤112"
               },
               "ie": {
                 "version_added": false
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": "≤74"
+              },
               "safari": {
                 "version_added": false
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "samsunginternet_android": {
+                "version_added": "≤20.0"
+              },
+              "webview_android": {
+                "version_added": "≤112"
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -47,10 +47,14 @@
             "description": "<code>blink</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "≤80"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤112"
+              },
+              "edge": {
+                "version_added": "≤80"
+              },
               "firefox": {
                 "version_added": "1",
                 "version_removed": "23"
@@ -69,11 +73,17 @@
                 "version_removed": "14"
               },
               "safari": {
-                "version_added": "preview"
+                "version_added": "≤13.1"
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari_ios": {
+                "version_added": "≤16.4"
+              },
+              "samsunginternet_android": {
+                "version_added": "≤20.0"
+              },
+              "webview_android": {
+                "version_added": "≤112"
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/text-emphasis-color.json
+++ b/css/properties/text-emphasis-color.json
@@ -29,10 +29,15 @@
               "prefix": "-webkit-",
               "version_added": "15"
             },
-            "opera_android": {
-              "prefix": "-webkit-",
-              "version_added": "14"
-            },
+            "opera_android": [
+              {
+                "version_added": "≤74"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              }
+            ],
             "safari": [
               {
                 "version_added": "7"
@@ -44,10 +49,15 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "4.4"
-            }
+            "webview_android": [
+              {
+                "version_added": "≤112"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4.4"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/text-emphasis-position.json
+++ b/css/properties/text-emphasis-position.json
@@ -29,10 +29,15 @@
               "prefix": "-webkit-",
               "version_added": "15"
             },
-            "opera_android": {
-              "prefix": "-webkit-",
-              "version_added": "14"
-            },
+            "opera_android": [
+              {
+                "version_added": "≤74"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              }
+            ],
             "safari": [
               {
                 "version_added": "7"
@@ -44,10 +49,15 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "4.4"
-            }
+            "webview_android": [
+              {
+                "version_added": "≤112"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4.4"
+              }
+            ]
           },
           "status": {
             "experimental": false,
@@ -60,10 +70,12 @@
             "description": "<code>left</code> and <code>right</code>",
             "support": {
               "chrome": {
-                "version_added": "62"
+                "version_added": "99"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "99"
+              },
               "firefox": {
                 "version_added": "46"
               },

--- a/css/properties/text-emphasis-style.json
+++ b/css/properties/text-emphasis-style.json
@@ -29,10 +29,15 @@
               "prefix": "-webkit-",
               "version_added": "15"
             },
-            "opera_android": {
-              "prefix": "-webkit-",
-              "version_added": "14"
-            },
+            "opera_android": [
+              {
+                "version_added": "≤74"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              }
+            ],
             "safari": [
               {
                 "version_added": "7"
@@ -44,10 +49,15 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "4.4"
-            }
+            "webview_android": [
+              {
+                "version_added": "≤112"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4.4"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/text-emphasis.json
+++ b/css/properties/text-emphasis.json
@@ -29,10 +29,15 @@
               "prefix": "-webkit-",
               "version_added": "15"
             },
-            "opera_android": {
-              "prefix": "-webkit-",
-              "version_added": "14"
-            },
+            "opera_android": [
+              {
+                "version_added": "≤74"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "14"
+              }
+            ],
             "safari": [
               {
                 "version_added": "7"
@@ -44,10 +49,15 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "4.4"
-            }
+            "webview_android": [
+              {
+                "version_added": "≤112"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4.4"
+              }
+            ]
           },
           "status": {
             "experimental": false,

--- a/css/properties/text-justify.json
+++ b/css/properties/text-justify.json
@@ -19,7 +19,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12",
+              "version_added": false,
               "notes": "Standard values <code>inter-character</code> and <code>none</code> are supported. The deprecated <code>distribute</code> value is also supported."
             },
             "firefox": {

--- a/css/properties/text-orientation.json
+++ b/css/properties/text-orientation.json
@@ -59,10 +59,14 @@
             "description": "<code>sideways</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "≤80"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤112"
+              },
+              "edge": {
+                "version_added": "≤80"
+              },
               "firefox": {
                 "version_added": "44",
                 "notes": "<code>sideways-right</code> has become an alias of <code>sideways</code>."
@@ -73,13 +77,19 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": "≤74"
+              },
               "safari": {
-                "version_added": "7"
+                "version_added": "13.1> ≤14.1"
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "samsunginternet_android": {
+                "version_added": "≤20.0"
+              },
+              "webview_android": {
+                "version_added": "≤112"
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/text-overflow.json
+++ b/css/properties/text-overflow.json
@@ -73,9 +73,11 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "9"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },

--- a/css/properties/text-underline-offset.json
+++ b/css/properties/text-underline-offset.json
@@ -15,7 +15,7 @@
               "version_added": "70"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤112"
             },
             "ie": {
               "version_added": false
@@ -23,7 +23,7 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": {
-              "version_added": false
+              "version_added": "≤74"
             },
             "safari": {
               "version_added": "12.1"
@@ -43,28 +43,38 @@
             "description": "percentage values",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": "≤112"
+              },
+              "edge": {
+                "version_added": "87"
+              },
               "firefox": {
                 "version_added": "74"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤112"
               },
               "ie": {
                 "version_added": false
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": "≤74"
+              },
               "safari": {
                 "version_added": false
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "samsunginternet_android": {
+                "version_added": "≤20.0"
+              },
+              "webview_android": {
+                "version_added": "≤112"
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -17,7 +17,7 @@
               "version_added": "74"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "≤112"
             },
             "ie": {
               "version_added": "6"
@@ -35,7 +35,7 @@
               }
             ],
             "safari_ios": {
-              "version_added": false
+              "version_added": "≤16.4"
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -59,7 +59,7 @@
                 "version_removed": "79"
               },
               "firefox": {
-                "version_added": "74"
+                "version_added": false
               },
               "firefox_android": {
                 "version_added": false
@@ -133,7 +133,7 @@
                 "version_added": "74"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤112"
               },
               "ie": {
                 "version_added": false
@@ -143,12 +143,14 @@
                 "version_added": false
               },
               "opera_android": {
-                "version_added": false
+                "version_added": "≤74"
               },
               "safari": {
-                "version_added": "preview"
+                "version_added": "≤13.1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "≤16.4"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -172,7 +174,7 @@
                 "version_added": "74"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤112"
               },
               "ie": {
                 "version_added": false
@@ -207,7 +209,7 @@
                 "version_added": "74"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤112"
               },
               "ie": {
                 "version_added": false
@@ -219,7 +221,7 @@
                 "version_added": "12.1"
               },
               "safari_ios": {
-                "version_added": false
+                "version_added": "≤16.4"
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"

--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -152,10 +152,15 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "prefix": "-webkit-",
-                "version_added": "3"
-              }
+              "webview_android": [
+                {
+                  "version_added": "≤112"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "3"
+                }
+              ]
             },
             "status": {
               "experimental": false,

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -114,29 +114,41 @@
             "description": "Gradients",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "≤80"
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": "≤112"
+              },
               "edge": {
                 "version_added": "12",
                 "version_removed": "79"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "≤72"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "≤112"
+              },
               "ie": {
                 "version_added": "10"
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "preview"
+              "opera_android": {
+                "version_added": "≤74"
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": "≤13.1"
+              },
+              "safari_ios": {
+                "version_added": "≤16.4"
+              },
+              "samsunginternet_android": {
+                "version_added": "≤20.0"
+              },
+              "webview_android": {
+                "version_added": "≤112"
+              }
             },
             "status": {
               "experimental": false,

--- a/css/properties/user-modify.json
+++ b/css/properties/user-modify.json
@@ -61,11 +61,13 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
                 "version_added": false
@@ -76,16 +78,20 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": false
+              },
               "safari": {
-                "version_added": "3"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "5"
+                "version_added": false
               },
-              "samsunginternet_android": "mirror",
+              "samsunginternet_android": {
+                "version_added": false
+              },
               "webview_android": {
-                "version_added": "37"
+                "version_added": false
               }
             },
             "status": {

--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -102,9 +102,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "16"
+                "version_added": false
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": false
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -136,10 +138,10 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "2"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "3"
+                "version_added": false
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
@@ -218,10 +220,10 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "2"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "3"
+                "version_added": false
               },
               "samsunginternet_android": "mirror",
               "webview_android": {
@@ -256,14 +258,10 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "2",
-                "partial_implementation": true,
-                "notes": "Allows typing in the <code>&lt;html&gt;</code> container."
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "3",
-                "partial_implementation": true,
-                "notes": "Allows typing in the <code>&lt;html&gt;</code> container."
+                "version_added": false
               },
               "samsunginternet_android": "mirror",
               "webview_android": {

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -53,7 +53,7 @@
                 "version_added": "69"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "≤112"
               },
               "ie": {
                 "version_added": false

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -80,10 +80,14 @@
             "description": "<code>fill</code>",
             "support": {
               "chrome": {
-                "version_added": "46"
+                "version_added": false
               },
-              "chrome_android": "mirror",
-              "edge": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
               "firefox": {
                 "version_added": false
               },
@@ -93,13 +97,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "12"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/AsyncFunction.json
+++ b/javascript/builtins/AsyncFunction.json
@@ -7,19 +7,23 @@
           "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-async-function-objects",
           "support": {
             "chrome": {
-              "version_added": "55"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": "1.0"
             },
             "edge": {
-              "version_added": "15"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "52"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -39,13 +43,21 @@
             ],
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "10.1"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/javascript/builtins/AsyncGenerator.json
+++ b/javascript/builtins/AsyncGenerator.json
@@ -7,17 +7,23 @@
           "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asyncgenerator-objects",
           "support": {
             "chrome": {
-              "version_added": "63"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": "1.0"
             },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "55"
+            "edge": {
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -37,13 +43,21 @@
             ],
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "12"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -57,17 +71,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asyncgenerator-prototype-next",
             "support": {
               "chrome": {
-                "version_added": "63"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "55"
+              "edge": {
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -87,13 +107,21 @@
               ],
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "12"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -108,17 +136,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asyncgenerator-prototype-return",
             "support": {
               "chrome": {
-                "version_added": "63"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "55"
+              "edge": {
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -138,13 +172,21 @@
               ],
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "12"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -159,17 +201,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asyncgenerator-prototype-throw",
             "support": {
               "chrome": {
-                "version_added": "63"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "55"
+              "edge": {
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -189,13 +237,21 @@
               ],
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "12"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/AsyncGeneratorFunction.json
+++ b/javascript/builtins/AsyncGeneratorFunction.json
@@ -7,17 +7,23 @@
           "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asyncgeneratorfunction-objects",
           "support": {
             "chrome": {
-              "version_added": "63"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": "1.0"
             },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "55"
+            "edge": {
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -37,13 +43,21 @@
             ],
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "12"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/javascript/builtins/AsyncIterator.json
+++ b/javascript/builtins/AsyncIterator.json
@@ -7,17 +7,23 @@
           "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asynciteratorprototype",
           "support": {
             "chrome": {
-              "version_added": "63"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": "1.0"
             },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "57"
+            "edge": {
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -26,13 +32,21 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "11.1"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/javascript/builtins/Generator.json
+++ b/javascript/builtins/Generator.json
@@ -59,19 +59,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-generator.prototype.next",
             "support": {
               "chrome": {
-                "version_added": "39"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "13"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "26"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -91,13 +95,21 @@
               ],
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -112,19 +124,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-generator.prototype.return",
             "support": {
               "chrome": {
-                "version_added": "50"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "13"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "38"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -133,13 +149,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -154,19 +178,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-generator.prototype.throw",
             "support": {
               "chrome": {
-                "version_added": "39"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "13"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "26"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -186,13 +214,21 @@
               ],
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/Intl/Segments.json
+++ b/javascript/builtins/Intl/Segments.json
@@ -8,13 +8,17 @@
             "spec_url": "https://tc39.es/ecma402/#sec-segments-objects",
             "support": {
               "chrome": {
-                "version_added": "87"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.8"
               },
-              "edge": "mirror",
+              "edge": {
+                "version_added": false
+              },
               "firefox": {
                 "version_added": false
               },
@@ -27,13 +31,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "14.1"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -47,13 +59,17 @@
               "spec_url": "https://tc39.es/ecma402/#sec-%segmentsprototype%.containing",
               "support": {
                 "chrome": {
-                  "version_added": "87"
+                  "version_added": false
                 },
-                "chrome_android": "mirror",
+                "chrome_android": {
+                  "version_added": false
+                },
                 "deno": {
                   "version_added": "1.8"
                 },
-                "edge": "mirror",
+                "edge": {
+                  "version_added": false
+                },
                 "firefox": {
                   "version_added": false
                 },
@@ -66,13 +82,21 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "14.1"
+                "opera_android": {
+                  "version_added": false
                 },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,
@@ -87,13 +111,17 @@
               "spec_url": "https://tc39.es/ecma402/#sec-%segmentsprototype%-@@iterator",
               "support": {
                 "chrome": {
-                  "version_added": "87"
+                  "version_added": false
                 },
-                "chrome_android": "mirror",
+                "chrome_android": {
+                  "version_added": false
+                },
                 "deno": {
                   "version_added": "1.8"
                 },
-                "edge": "mirror",
+                "edge": {
+                  "version_added": false
+                },
                 "firefox": {
                   "version_added": false
                 },
@@ -106,13 +134,21 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "14.1"
+                "opera_android": {
+                  "version_added": false
                 },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -7,19 +7,23 @@
           "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-%iteratorprototype%-object",
           "support": {
             "chrome": {
-              "version_added": "38"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": "1.0"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "17"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },
@@ -28,13 +32,21 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "10"
+            "opera_android": {
+              "version_added": false
             },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": {
+              "version_added": false
+            },
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -48,18 +60,20 @@
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-%iteratorprototype%-@@iterator",
             "support": {
               "chrome": {
-                "version_added": "38"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": [
                 {
-                  "version_added": "36"
+                  "version_added": false
                 },
                 {
                   "alternative_name": "@@iterator",
@@ -74,7 +88,23 @@
                   "notes": "A placeholder property named <code>iterator</code> is used."
                 }
               ],
-              "firefox_android": "mirror",
+              "firefox_android": [
+                {
+                  "version_added": false
+                },
+                {
+                  "alternative_name": "@@iterator",
+                  "version_added": "27",
+                  "version_removed": "36",
+                  "notes": "A placeholder property named <code>@@iterator</code> is used."
+                },
+                {
+                  "alternative_name": "iterator",
+                  "version_added": "17",
+                  "version_removed": "27",
+                  "notes": "A placeholder property named <code>iterator</code> is used."
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -83,13 +113,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1393,19 +1393,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-@@match",
             "support": {
               "chrome": {
-                "version_added": "50"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "13"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "49"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -1414,13 +1418,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -1435,17 +1447,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp-prototype-matchall",
             "support": {
               "chrome": {
-                "version_added": "73"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "67"
+              "edge": {
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -1454,15 +1472,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": false
+              },
               "safari": {
-                "version_added": "13"
+                "version_added": false
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": false
+              },
               "samsunginternet_android": {
-                "version_added": "5.0"
+                "version_added": false
               },
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -1477,17 +1501,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-@@replace",
             "support": {
               "chrome": {
-                "version_added": "50"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "49"
+              "edge": {
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -1496,13 +1526,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -1517,19 +1555,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-@@search",
             "support": {
               "chrome": {
-                "version_added": "50"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "13"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "49"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -1538,13 +1580,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -1612,17 +1662,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-@@split",
             "support": {
               "chrome": {
-                "version_added": "50"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "49"
+              "edge": {
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -1631,13 +1687,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -34,7 +34,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,
@@ -76,7 +78,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -158,7 +162,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -198,7 +204,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -238,7 +246,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -278,7 +288,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -320,7 +332,9 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/Temporal/Calendar.json
+++ b/javascript/builtins/Temporal/Calendar.json
@@ -27,7 +27,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -64,7 +64,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -518,7 +518,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -670,7 +670,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -860,7 +860,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -898,7 +898,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/javascript/builtins/Temporal/Duration.json
+++ b/javascript/builtins/Temporal/Duration.json
@@ -27,7 +27,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -64,7 +64,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -102,7 +102,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -178,7 +178,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -216,7 +216,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -254,7 +254,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -292,7 +292,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -330,7 +330,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -368,7 +368,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -406,7 +406,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -444,7 +444,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -482,7 +482,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -520,7 +520,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -558,7 +558,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -634,7 +634,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -672,7 +672,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -748,7 +748,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -824,7 +824,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -900,7 +900,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -938,7 +938,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -976,7 +976,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1014,7 +1014,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/javascript/builtins/Temporal/Instant.json
+++ b/javascript/builtins/Temporal/Instant.json
@@ -27,7 +27,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -64,7 +64,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -102,7 +102,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -178,7 +178,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -216,7 +216,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -254,7 +254,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -292,7 +292,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -330,7 +330,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -368,7 +368,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -406,7 +406,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -444,7 +444,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -482,7 +482,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -520,7 +520,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -558,7 +558,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -596,7 +596,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -634,7 +634,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -672,7 +672,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -710,7 +710,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -748,7 +748,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -862,7 +862,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -900,7 +900,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/javascript/builtins/Temporal/PlainTime.json
+++ b/javascript/builtins/Temporal/PlainTime.json
@@ -27,7 +27,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -64,7 +64,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -102,7 +102,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -140,7 +140,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -177,7 +177,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -215,7 +215,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -253,7 +253,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -291,7 +291,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -329,7 +329,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -367,7 +367,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -405,7 +405,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -443,7 +443,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -481,7 +481,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -519,7 +519,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -557,7 +557,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -595,7 +595,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -633,7 +633,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -671,7 +671,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -785,7 +785,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -861,7 +861,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -899,7 +899,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -937,7 +937,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/javascript/builtins/Temporal/TimeZone.json
+++ b/javascript/builtins/Temporal/TimeZone.json
@@ -27,7 +27,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -64,7 +64,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -102,7 +102,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -406,7 +406,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -444,7 +444,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -482,7 +482,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -7,19 +7,23 @@
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-objects",
           "support": {
             "chrome": {
-              "version_added": "7"
+              "version_added": false
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "deno": {
               "version_added": "1.0"
             },
             "edge": {
-              "version_added": "12"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": false
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": "10"
             },
@@ -31,17 +35,19 @@
               "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": "12"
+              "version_added": false
             },
             "safari": {
-              "version_added": "5.1"
+              "version_added": false
             },
             "safari_ios": {
-              "version_added": "4.2"
+              "version_added": false
             },
-            "samsunginternet_android": "mirror",
+            "samsunginternet_android": {
+              "version_added": false
+            },
             "webview_android": {
-              "version_added": "4"
+              "version_added": false
             }
           },
           "status": {
@@ -56,19 +62,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray.bytes_per_element",
             "support": {
               "chrome": {
-                "version_added": "7"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "4"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": "10"
               },
@@ -80,17 +90,19 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "12"
+                "version_added": false
               },
               "safari": {
-                "version_added": "5.1"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "4.2"
+                "version_added": false
               },
-              "samsunginternet_android": "mirror",
+              "samsunginternet_android": {
+                "version_added": false
+              },
               "webview_android": {
-                "version_added": "4"
+                "version_added": false
               }
             },
             "status": {
@@ -106,17 +118,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.at",
             "support": {
               "chrome": {
-                "version_added": "92"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": false
               },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "90"
+              "edge": {
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -125,13 +143,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "15.4"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -146,19 +172,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-%typedarray%.prototype.buffer",
             "support": {
               "chrome": {
-                "version_added": "7"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "4"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": "10"
               },
@@ -170,17 +200,19 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "12"
+                "version_added": false
               },
               "safari": {
-                "version_added": "5.1"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "4.2"
+                "version_added": false
               },
-              "samsunginternet_android": "mirror",
+              "samsunginternet_android": {
+                "version_added": false
+              },
               "webview_android": {
-                "version_added": "4"
+                "version_added": false
               }
             },
             "status": {
@@ -196,19 +228,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-%typedarray%.prototype.bytelength",
             "support": {
               "chrome": {
-                "version_added": "7"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "4"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": "10"
               },
@@ -220,17 +256,19 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "12"
+                "version_added": false
               },
               "safari": {
-                "version_added": "5.1"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "4.2"
+                "version_added": false
               },
-              "samsunginternet_android": "mirror",
+              "samsunginternet_android": {
+                "version_added": false
+              },
               "webview_android": {
-                "version_added": "4"
+                "version_added": false
               }
             },
             "status": {
@@ -246,19 +284,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-%typedarray%.prototype.byteoffset",
             "support": {
               "chrome": {
-                "version_added": "7"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "4"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": "10"
               },
@@ -270,17 +312,19 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "12"
+                "version_added": false
               },
               "safari": {
-                "version_added": "5.1"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "4.2"
+                "version_added": false
               },
-              "samsunginternet_android": "mirror",
+              "samsunginternet_android": {
+                "version_added": false
+              },
               "webview_android": {
-                "version_added": "4"
+                "version_added": false
               }
             },
             "status": {
@@ -343,19 +387,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.copywithin",
             "support": {
               "chrome": {
-                "version_added": "45"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "34"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -364,13 +412,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "9.1"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -385,19 +441,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.entries",
             "support": {
               "chrome": {
-                "version_added": "45"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "37"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -406,13 +466,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "9.1"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -427,19 +495,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.every",
             "support": {
               "chrome": {
-                "version_added": "45"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "37"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -448,13 +520,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "9.1"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -469,19 +549,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.fill",
             "support": {
               "chrome": {
-                "version_added": "45"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "37"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -490,13 +574,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "9.1"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -511,19 +603,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.filter",
             "support": {
               "chrome": {
-                "version_added": "45"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "38"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -532,13 +628,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "9.1"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -553,19 +657,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.find",
             "support": {
               "chrome": {
-                "version_added": "45"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "37"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -574,13 +682,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "9.1"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -595,19 +711,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.findindex",
             "support": {
               "chrome": {
-                "version_added": "45"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "37"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -616,13 +736,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "9.1"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -637,17 +765,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.findlast",
             "support": {
               "chrome": {
-                "version_added": "97"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.16"
               },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "104"
+              "edge": {
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -656,13 +790,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "15.4"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -677,17 +819,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.findlastindex",
             "support": {
               "chrome": {
-                "version_added": "97"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.16"
               },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "104"
+              "edge": {
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -696,13 +844,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "15.4"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -717,19 +873,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.foreach",
             "support": {
               "chrome": {
-                "version_added": "45"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "38"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -738,13 +898,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -801,19 +969,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.includes",
             "support": {
               "chrome": {
-                "version_added": "47"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "14"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "43"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -833,13 +1005,21 @@
               ],
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -910,20 +1090,25 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.indexof",
             "support": {
               "chrome": {
-                "version_added": "45"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "37",
+                "version_added": false,
                 "notes": "Starting with Firefox 47, this method will no longer return <code>-0</code>. For example, <code>new Uint8Array([0]).indexOf(0, -0)</code> will now always return <code>+0</code>."
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false,
+                "notes": "Starting with Firefox 47, this method will no longer return <code>-0</code>. For example, <code>new Uint8Array([0]).indexOf(0, -0)</code> will now always return <code>+0</code>."
+              },
               "ie": {
                 "version_added": false
               },
@@ -932,13 +1117,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "9.1"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -994,19 +1187,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.join",
             "support": {
               "chrome": {
-                "version_added": "45"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "37"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -1015,13 +1212,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "9.1"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -1036,19 +1241,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.keys",
             "support": {
               "chrome": {
-                "version_added": "38"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "37"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -1057,13 +1266,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -1078,20 +1295,25 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.lastindexof",
             "support": {
               "chrome": {
-                "version_added": "45"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "37",
+                "version_added": false,
                 "notes": "Starting with Firefox 47, this method will no longer return <code>-0</code>. For example, <code>new Uint8Array([0]).lastIndexOf(0, -0)</code> will now always return <code>+0</code>."
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false,
+                "notes": "Starting with Firefox 47, this method will no longer return <code>-0</code>. For example, <code>new Uint8Array([0]).lastIndexOf(0, -0)</code> will now always return <code>+0</code>."
+              },
               "ie": {
                 "version_added": false
               },
@@ -1100,13 +1322,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -1121,19 +1351,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-%typedarray%.prototype.length",
             "support": {
               "chrome": {
-                "version_added": "7"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "4"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": "10"
               },
@@ -1145,17 +1379,19 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "12"
+                "version_added": false
               },
               "safari": {
-                "version_added": "5.1"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "4.2"
+                "version_added": false
               },
-              "samsunginternet_android": "mirror",
+              "samsunginternet_android": {
+                "version_added": false
+              },
               "webview_android": {
-                "version_added": "4"
+                "version_added": false
               }
             },
             "status": {
@@ -1171,19 +1407,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.map",
             "support": {
               "chrome": {
-                "version_added": "45"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "38"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -1192,13 +1432,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "9.1"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -1395,19 +1643,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.reduce",
             "support": {
               "chrome": {
-                "version_added": "45"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "37"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -1416,13 +1668,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -1437,19 +1697,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.reduceright",
             "support": {
               "chrome": {
-                "version_added": "45"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "37"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -1458,13 +1722,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -1479,19 +1751,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.reverse",
             "support": {
               "chrome": {
-                "version_added": "45"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "37"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -1500,13 +1776,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -1521,19 +1805,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.set",
             "support": {
               "chrome": {
-                "version_added": "7"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "4"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": "10"
               },
@@ -1545,17 +1833,19 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "12"
+                "version_added": false
               },
               "safari": {
-                "version_added": "5.1"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "4.2"
+                "version_added": false
               },
-              "samsunginternet_android": "mirror",
+              "samsunginternet_android": {
+                "version_added": false
+              },
               "webview_android": {
-                "version_added": "4"
+                "version_added": false
               }
             },
             "status": {
@@ -1571,19 +1861,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.slice",
             "support": {
               "chrome": {
-                "version_added": "45"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "38"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -1592,13 +1886,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -1613,19 +1915,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.some",
             "support": {
               "chrome": {
-                "version_added": "45"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "37"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -1634,13 +1940,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -1655,19 +1969,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.sort",
             "support": {
               "chrome": {
-                "version_added": "45"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "46"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -1676,13 +1994,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -1697,19 +2023,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.subarray",
             "support": {
               "chrome": {
-                "version_added": "7"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "4"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": "10"
               },
@@ -1721,17 +2051,19 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "12"
+                "version_added": false
               },
               "safari": {
-                "version_added": "5.1"
+                "version_added": false
               },
               "safari_ios": {
-                "version_added": "4.2"
+                "version_added": false
               },
-              "samsunginternet_android": "mirror",
+              "samsunginternet_android": {
+                "version_added": false
+              },
               "webview_android": {
-                "version_added": "4"
+                "version_added": false
               }
             },
             "status": {
@@ -1747,19 +2079,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.tolocalestring",
             "support": {
               "chrome": {
-                "version_added": "7"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "51"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": "10"
               },
@@ -1771,15 +2107,19 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "12"
+                "version_added": false
               },
               "safari": {
-                "version_added": "5.1"
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": false
               }
             },
             "status": {
@@ -1795,13 +2135,17 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.toreversed",
             "support": {
               "chrome": {
-                "version_added": "110"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.31"
               },
-              "edge": "mirror",
+              "edge": {
+                "version_added": false
+              },
               "firefox": {
                 "version_added": false
               },
@@ -1814,13 +2158,19 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "16"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -1835,13 +2185,17 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.tosorted",
             "support": {
               "chrome": {
-                "version_added": "110"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.31"
               },
-              "edge": "mirror",
+              "edge": {
+                "version_added": false
+              },
               "firefox": {
                 "version_added": false
               },
@@ -1854,13 +2208,19 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "16"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -1875,19 +2235,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.tostring",
             "support": {
               "chrome": {
-                "version_added": "7"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "51"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": "10"
               },
@@ -1899,15 +2263,19 @@
                 "version_added": "11.6"
               },
               "opera_android": {
-                "version_added": "12"
+                "version_added": false
               },
               "safari": {
-                "version_added": "5.1"
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
               "webview_android": {
-                "version_added": "≤37"
+                "version_added": false
               }
             },
             "status": {
@@ -1923,19 +2291,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.values",
             "support": {
               "chrome": {
-                "version_added": "38"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "37"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -1944,13 +2316,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -1965,13 +2345,17 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.with",
             "support": {
               "chrome": {
-                "version_added": "110"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.31"
               },
-              "edge": "mirror",
+              "edge": {
+                "version_added": false
+              },
               "firefox": {
                 "version_added": false
               },
@@ -1984,13 +2368,19 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "16"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -2005,18 +2395,20 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype-@@iterator",
             "support": {
               "chrome": {
-                "version_added": "38"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "12"
+                "version_added": false
               },
               "firefox": [
                 {
-                  "version_added": "36"
+                  "version_added": false
                 },
                 {
                   "alternative_name": "@@iterator",
@@ -2031,7 +2423,23 @@
                   "notes": "A placeholder property named <code>iterator</code> is used."
                 }
               ],
-              "firefox_android": "mirror",
+              "firefox_android": [
+                {
+                  "version_added": false
+                },
+                {
+                  "alternative_name": "@@iterator",
+                  "version_added": "27",
+                  "version_removed": "36",
+                  "notes": "A placeholder property named <code>@@iterator</code> is used."
+                },
+                {
+                  "alternative_name": "iterator",
+                  "version_added": "17",
+                  "version_removed": "27",
+                  "notes": "A placeholder property named <code>iterator</code> is used."
+                }
+              ],
               "ie": {
                 "version_added": false
               },
@@ -2040,13 +2448,21 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,
@@ -2061,19 +2477,23 @@
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-%typedarray%-@@species",
             "support": {
               "chrome": {
-                "version_added": "51"
+                "version_added": false
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "deno": {
                 "version_added": "1.0"
               },
               "edge": {
-                "version_added": "13"
+                "version_added": false
               },
               "firefox": {
-                "version_added": "48"
+                "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "ie": {
                 "version_added": false
               },
@@ -2093,13 +2513,21 @@
               ],
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "10"
+              "opera_android": {
+                "version_added": false
               },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": {
+                "version_added": false
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/WebAssembly/Global.json
+++ b/javascript/builtins/WebAssembly/Global.json
@@ -91,17 +91,23 @@
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-global-value",
               "support": {
                 "chrome": {
-                  "version_added": "69"
+                  "version_added": false
                 },
-                "chrome_android": "mirror",
+                "chrome_android": {
+                  "version_added": false
+                },
                 "deno": {
                   "version_added": "1.0"
                 },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "62"
+                "edge": {
+                  "version_added": false
                 },
-                "firefox_android": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
                 "ie": {
                   "version_added": false
                 },
@@ -110,13 +116,21 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "13.1"
+                "opera_android": {
+                  "version_added": false
                 },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,
@@ -131,17 +145,23 @@
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-global-valueof",
               "support": {
                 "chrome": {
-                  "version_added": "69"
+                  "version_added": false
                 },
-                "chrome_android": "mirror",
+                "chrome_android": {
+                  "version_added": false
+                },
                 "deno": {
                   "version_added": "1.0"
                 },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "62"
+                "edge": {
+                  "version_added": false
                 },
-                "firefox_android": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
                 "ie": {
                   "version_added": false
                 },
@@ -150,13 +170,21 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "13.1"
+                "opera_android": {
+                  "version_added": false
                 },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,

--- a/javascript/builtins/WebAssembly/Instance.json
+++ b/javascript/builtins/WebAssembly/Instance.json
@@ -92,19 +92,23 @@
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-instance-exports",
               "support": {
                 "chrome": {
-                  "version_added": "57"
+                  "version_added": false
                 },
-                "chrome_android": "mirror",
+                "chrome_android": {
+                  "version_added": false
+                },
                 "deno": {
                   "version_added": "1.0"
                 },
                 "edge": {
-                  "version_added": "16"
+                  "version_added": false
                 },
                 "firefox": {
-                  "version_added": "52"
+                  "version_added": false
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false
+                },
                 "ie": {
                   "version_added": false
                 },
@@ -113,13 +117,21 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "11"
+                "opera_android": {
+                  "version_added": false
                 },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,

--- a/javascript/builtins/WebAssembly/Memory.json
+++ b/javascript/builtins/WebAssembly/Memory.json
@@ -143,19 +143,23 @@
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-memory-buffer",
               "support": {
                 "chrome": {
-                  "version_added": "57"
+                  "version_added": false
                 },
-                "chrome_android": "mirror",
+                "chrome_android": {
+                  "version_added": false
+                },
                 "deno": {
                   "version_added": "1.0"
                 },
                 "edge": {
-                  "version_added": "16"
+                  "version_added": false
                 },
                 "firefox": {
-                  "version_added": "52"
+                  "version_added": false
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false
+                },
                 "ie": {
                   "version_added": false
                 },
@@ -164,13 +168,21 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "11"
+                "opera_android": {
+                  "version_added": false
                 },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,
@@ -185,19 +197,23 @@
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-memory-grow",
               "support": {
                 "chrome": {
-                  "version_added": "57"
+                  "version_added": false
                 },
-                "chrome_android": "mirror",
+                "chrome_android": {
+                  "version_added": false
+                },
                 "deno": {
                   "version_added": "1.0"
                 },
                 "edge": {
-                  "version_added": "16"
+                  "version_added": false
                 },
                 "firefox": {
-                  "version_added": "52"
+                  "version_added": false
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false
+                },
                 "ie": {
                   "version_added": false
                 },
@@ -206,13 +222,21 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "11"
+                "opera_android": {
+                  "version_added": false
                 },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,

--- a/javascript/builtins/WebAssembly/Module.json
+++ b/javascript/builtins/WebAssembly/Module.json
@@ -92,19 +92,23 @@
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-module-customsections",
               "support": {
                 "chrome": {
-                  "version_added": "57"
+                  "version_added": false
                 },
-                "chrome_android": "mirror",
+                "chrome_android": {
+                  "version_added": false
+                },
                 "deno": {
                   "version_added": "1.0"
                 },
                 "edge": {
-                  "version_added": "16"
+                  "version_added": false
                 },
                 "firefox": {
-                  "version_added": "52"
+                  "version_added": false
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false
+                },
                 "ie": {
                   "version_added": false
                 },
@@ -113,13 +117,21 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "11"
+                "opera_android": {
+                  "version_added": false
                 },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,
@@ -134,19 +146,23 @@
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-module-exports",
               "support": {
                 "chrome": {
-                  "version_added": "57"
+                  "version_added": false
                 },
-                "chrome_android": "mirror",
+                "chrome_android": {
+                  "version_added": false
+                },
                 "deno": {
                   "version_added": "1.0"
                 },
                 "edge": {
-                  "version_added": "16"
+                  "version_added": false
                 },
                 "firefox": {
-                  "version_added": "52"
+                  "version_added": false
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false
+                },
                 "ie": {
                   "version_added": false
                 },
@@ -155,13 +171,21 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "11"
+                "opera_android": {
+                  "version_added": false
                 },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,
@@ -176,19 +200,23 @@
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-module-imports",
               "support": {
                 "chrome": {
-                  "version_added": "57"
+                  "version_added": false
                 },
-                "chrome_android": "mirror",
+                "chrome_android": {
+                  "version_added": false
+                },
                 "deno": {
                   "version_added": "1.0"
                 },
                 "edge": {
-                  "version_added": "16"
+                  "version_added": false
                 },
                 "firefox": {
-                  "version_added": "52"
+                  "version_added": false
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false
+                },
                 "ie": {
                   "version_added": false
                 },
@@ -197,13 +225,21 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "11"
+                "opera_android": {
+                  "version_added": false
                 },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,

--- a/javascript/builtins/WebAssembly/Table.json
+++ b/javascript/builtins/WebAssembly/Table.json
@@ -92,19 +92,23 @@
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-table-get",
               "support": {
                 "chrome": {
-                  "version_added": "57"
+                  "version_added": false
                 },
-                "chrome_android": "mirror",
+                "chrome_android": {
+                  "version_added": false
+                },
                 "deno": {
                   "version_added": "1.0"
                 },
                 "edge": {
-                  "version_added": "16"
+                  "version_added": false
                 },
                 "firefox": {
-                  "version_added": "52"
+                  "version_added": false
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false
+                },
                 "ie": {
                   "version_added": false
                 },
@@ -113,13 +117,21 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "11"
+                "opera_android": {
+                  "version_added": false
                 },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,
@@ -134,19 +146,23 @@
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-table-grow",
               "support": {
                 "chrome": {
-                  "version_added": "57"
+                  "version_added": false
                 },
-                "chrome_android": "mirror",
+                "chrome_android": {
+                  "version_added": false
+                },
                 "deno": {
                   "version_added": "1.0"
                 },
                 "edge": {
-                  "version_added": "16"
+                  "version_added": false
                 },
                 "firefox": {
-                  "version_added": "52"
+                  "version_added": false
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false
+                },
                 "ie": {
                   "version_added": false
                 },
@@ -155,13 +171,21 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "11"
+                "opera_android": {
+                  "version_added": false
                 },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,
@@ -176,19 +200,23 @@
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-table-length",
               "support": {
                 "chrome": {
-                  "version_added": "57"
+                  "version_added": false
                 },
-                "chrome_android": "mirror",
+                "chrome_android": {
+                  "version_added": false
+                },
                 "deno": {
                   "version_added": "1.0"
                 },
                 "edge": {
-                  "version_added": "16"
+                  "version_added": false
                 },
                 "firefox": {
-                  "version_added": "52"
+                  "version_added": false
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false
+                },
                 "ie": {
                   "version_added": false
                 },
@@ -197,13 +225,21 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "11"
+                "opera_android": {
+                  "version_added": false
                 },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,
@@ -218,19 +254,23 @@
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-table-set",
               "support": {
                 "chrome": {
-                  "version_added": "57"
+                  "version_added": false
                 },
-                "chrome_android": "mirror",
+                "chrome_android": {
+                  "version_added": false
+                },
                 "deno": {
                   "version_added": "1.0"
                 },
                 "edge": {
-                  "version_added": "16"
+                  "version_added": false
                 },
                 "firefox": {
-                  "version_added": "52"
+                  "version_added": false
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false
+                },
                 "ie": {
                   "version_added": false
                 },
@@ -239,13 +279,21 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "11"
+                "opera_android": {
+                  "version_added": false
                 },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,

--- a/javascript/builtins/WebAssembly/Tag.json
+++ b/javascript/builtins/WebAssembly/Tag.json
@@ -88,17 +88,23 @@
               "spec_url": "https://webassembly.github.io/exception-handling/js-api/#dom-tag-type",
               "support": {
                 "chrome": {
-                  "version_added": "95"
+                  "version_added": false
                 },
-                "chrome_android": "mirror",
+                "chrome_android": {
+                  "version_added": false
+                },
                 "deno": {
                   "version_added": "1.15"
                 },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "100"
+                "edge": {
+                  "version_added": false
                 },
-                "firefox_android": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
                 "ie": {
                   "version_added": false
                 },
@@ -107,13 +113,19 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": "mirror",
+                "opera_android": {
+                  "version_added": false
+                },
                 "safari": {
                   "version_added": "15.2"
                 },
                 "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
+                "samsunginternet_android": {
+                  "version_added": false
+                },
+                "webview_android": {
+                  "version_added": false
+                }
               },
               "status": {
                 "experimental": false,


### PR DESCRIPTION
This PR is a breakdown list of all the changes created by https://mdn-bcd-collector.gooborg.com v9.0.2 with the results collected as of April 24, 2023. Results are limited to 2020+ browsers in this collector run.

Note that this PR is not intended to be merged directly.

Note: there was an issue with some updates to the JavaScript test generation that have messed up a number of tests.  These will be fixed in the next collector update.
