### PR TITLE
Remove bogus mdn_url for overflow-clip-box

### DIFF
--- a/css/properties/overflow-clip-box.json
+++ b/css/properties/overflow-clip-box.json
@@ -3,7 +3,6 @@
     "properties": {
       "overflow-clip-box": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Gecko/Chrome/CSS/overflow-clip-box",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
We don't have documentation for this (`overflow-clip-box`) and the URL mentioned was incorrect anyway.