### PR TITLE
Remove bogus mdn_url for overflow-clip-box-inline

### DIFF
--- a/css/properties/overflow-clip-box-inline.json
+++ b/css/properties/overflow-clip-box-inline.json
@@ -3,7 +3,6 @@
     "properties": {
       "overflow-clip-box-inline": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Gecko/Chrome/CSS/overflow-clip-box-inline",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
We don't have documentation for this (`overflow-clip-box-inline`) and the URL mentioned was incorrect anyway.