### PR TITLE
Disable commenting on #3555

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,5 +32,5 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Add JSON as a release asset
         run: gh release upload ${GITHUB_REF#refs/*/} build/data.json
-      - name: Publish stats for all data (#3555)
-        run: npm run --silent stats | gh issue comment https://github.com/mdn/browser-compat-data/issues/3555 --body-file -
+      # - name: Publish stats for all data (#3555)
+      #   run: npm run --silent stats | gh issue comment https://github.com/mdn/browser-compat-data/issues/3555 --body-file -


### PR DESCRIPTION
This PR disables the command to write a comment on #3555 whenever a new release is made, as that issue is now closed.
