### PR TITLE
Add data for autocomplete="webauthn"

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -123,7 +123,7 @@
         },
         "new-password": {
           "__compat": {
-            "description": "The <code>new-password</code> value.",
+            "description": "<code>new-password</code> value",
             "support": {
               "chrome": {
                 "version_added": true
@@ -151,6 +151,40 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "webauthn": {
+          "__compat": {
+            "description": "<code>webauthn</code> value",
+            "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill-processing-model:attr-fe-autocomplete-webauthn",
+            "support": {
+              "chrome": {
+                "version_added": "108"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

As part of my work on the WebAuthn API, I was asked to add details of the `autocomplete="webauthn"` value. This PR adds the corresponding BCD.

I was told that the Chrome version it was added was 108 by the Chrome engineers.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
