### PR TITLE
Update Opera data for css.properties.clip-path.path

### DIFF
--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -210,12 +210,8 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": [
                 {
                   "version_added": "13.1"


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `path` member of the `clip-path` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/clip-path/path
