### PR TITLE
Update all browsers data for color-scheme CSS property

### DIFF
--- a/css/properties/color-scheme.json
+++ b/css/properties/color-scheme.json
@@ -39,12 +39,12 @@
             "description": "<code>only dark</code> keyword",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "81"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "96"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -78,7 +78,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "96"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -92,9 +92,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": false
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `color-scheme` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/color-scheme
