### PR TITLE
Update Safari data for css.properties.flex-basis.content

### DIFF
--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -161,7 +161,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": "preview"
+                "version_added": "15.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `content` member of the `flex-basis` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/flex-basis/content
