### PR TITLE
Update all browsers data for font-synthesis-small-caps CSS property

### DIFF
--- a/css/properties/font-synthesis-small-caps.json
+++ b/css/properties/font-synthesis-small-caps.json
@@ -11,8 +11,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "notes": "<a href='https://bugzil.la/1724892'>bug 1724892</a>."
+              "version_added": "111"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -20,9 +19,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "16.4",
               "notes": "<a href='https://webkit.org/b/232009'>bug 232009</a>."


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `font-synthesis-small-caps` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/font-synthesis-small-caps
