### PR TITLE
Update Chromium data for font-variant-alternates CSS property

### DIFF
--- a/css/properties/font-variant-alternates.json
+++ b/css/properties/font-variant-alternates.json
@@ -7,8 +7,7 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-fonts/#font-variant-alternates-prop",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/716567'>bug 716567</a>."
+              "version_added": "111"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -41,7 +40,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#annotation()",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "111"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -75,7 +74,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#character-variant()",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "111"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -109,7 +108,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#ornaments()",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "111"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -143,7 +142,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#styleset()",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "111"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -177,7 +176,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#stylistic()",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "111"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -211,7 +210,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-alternates#swash()",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "111"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `font-variant-alternates` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/font-variant-alternates
