### PR TITLE
Update Chromium data for forced-color-adjust CSS property

### DIFF
--- a/css/properties/forced-color-adjust.json
+++ b/css/properties/forced-color-adjust.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "89"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": [
               {
                 "version_added": "79"
@@ -30,9 +28,7 @@
               "alternative_name": "-ms-high-contrast-adjust"
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `forced-color-adjust` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/forced-color-adjust
