### PR TITLE
Update Opera data for image-orientation CSS property

### DIFF
--- a/css/properties/image-orientation.json
+++ b/css/properties/image-orientation.json
@@ -22,9 +22,7 @@
             "opera": {
               "version_added": "67"
             },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "13.1"
             },


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `image-orientation` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/image-orientation
