### PR TITLE
Update Chromium data for list-style-type CSS property

### DIFF
--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -49,10 +49,15 @@
           "__compat": {
             "description": "<code>afar</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -86,10 +91,15 @@
           "__compat": {
             "description": "<code>amharic</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -123,10 +133,15 @@
           "__compat": {
             "description": "<code>amharic-abegede</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -238,10 +253,15 @@
           "__compat": {
             "description": "<code>asterisks</code>",
             "support": {
-              "chrome": {
-                "version_added": "13",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "13",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -311,10 +331,15 @@
           "__compat": {
             "description": "<code>binary</code>",
             "support": {
-              "chrome": {
-                "version_added": "13",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "13",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -418,7 +443,7 @@
             "description": "<code>cjk-decimal</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -801,10 +826,15 @@
           "__compat": {
             "description": "<code>ethiopic</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -838,10 +868,15 @@
           "__compat": {
             "description": "<code>ethiopic-abegede</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -875,10 +910,15 @@
           "__compat": {
             "description": "<code>ethiopic-abegede-am-et</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -912,10 +952,15 @@
           "__compat": {
             "description": "<code>ethiopic-abegede-gez</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -949,10 +994,15 @@
           "__compat": {
             "description": "<code>ethiopic-abegede-ti-er</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -986,10 +1036,15 @@
           "__compat": {
             "description": "<code>ethiopic-abegede-ti-et</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -1057,10 +1112,15 @@
           "__compat": {
             "description": "<code>ethiopic-halehame-aa-er</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -1094,10 +1154,15 @@
           "__compat": {
             "description": "<code>ethiopic-halehame-aa-et</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -1165,10 +1230,15 @@
           "__compat": {
             "description": "<code>ethiopic-halehame-am-et</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -1202,10 +1272,15 @@
           "__compat": {
             "description": "<code>ethiopic-halehame-gez</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -1239,10 +1314,15 @@
           "__compat": {
             "description": "<code>ethiopic-halehame-om-et</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -1276,10 +1356,15 @@
           "__compat": {
             "description": "<code>ethiopic-halehame-sid-et</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -1313,10 +1398,15 @@
           "__compat": {
             "description": "<code>ethiopic-halehame-so-et</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -1422,10 +1512,15 @@
           "__compat": {
             "description": "<code>ethiopic-halehame-tig</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -1460,7 +1555,7 @@
             "description": "<code>ethiopic-numeric</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1499,10 +1594,15 @@
           "__compat": {
             "description": "<code>footnotes</code>",
             "support": {
-              "chrome": {
-                "version_added": "13",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "13",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -1818,7 +1918,7 @@
             "description": "<code>japanese-formal</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1857,7 +1957,7 @@
             "description": "<code>japanese-informal</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -2288,10 +2388,15 @@
           "__compat": {
             "description": "<code>lower-hexadecimal</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -2366,10 +2471,15 @@
           "__compat": {
             "description": "<code>lower-norwegian</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -2553,10 +2663,15 @@
           "__compat": {
             "description": "<code>octal</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -2626,10 +2741,15 @@
           "__compat": {
             "description": "<code>oromo</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -2699,10 +2819,15 @@
           "__compat": {
             "description": "<code>sidama</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -2811,10 +2936,15 @@
           "__compat": {
             "description": "<code>somali</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -2898,9 +3028,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "14.1"
               },
@@ -2921,7 +3049,7 @@
             "spec_url": "https://w3c.github.io/csswg-drafts/css-counter-styles/#symbols-function",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -2954,7 +3082,7 @@
             "description": "<code>tamil</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -3105,10 +3233,15 @@
           "__compat": {
             "description": "<code>tigre</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -3139,10 +3272,15 @@
           "__compat": {
             "description": "<code>tigrinya-er</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -3173,10 +3311,15 @@
           "__compat": {
             "description": "<code>tigrinya-er-abegede</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -3207,10 +3350,15 @@
           "__compat": {
             "description": "<code>tigrinya-et</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -3241,10 +3389,15 @@
           "__compat": {
             "description": "<code>tigrinya-et-abegede</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -3464,10 +3617,15 @@
           "__compat": {
             "description": "<code>upper-hexadecimal</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
@@ -3540,10 +3698,15 @@
           "__compat": {
             "description": "<code>upper-norwegian</code>",
             "support": {
-              "chrome": {
-                "version_added": "6",
-                "version_removed": "45"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "6",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `list-style-type` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/list-style-type
