### PR TITLE
Update Chromium data for css.properties.list-style.symbols

### DIFF
--- a/css/properties/list-style.json
+++ b/css/properties/list-style.json
@@ -46,7 +46,7 @@
             "spec_url": "https://w3c.github.io/csswg-drafts/css-counter-styles/#symbols-function",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `symbols` member of the `list-style` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/list-style/symbols
