### PR TITLE
Update Safari data for css.properties.mask-origin.non_standard_values

### DIFF
--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -103,7 +103,7 @@
               "opera_android": "mirror",
               "safari": [
                 {
-                  "version_added": "preview"
+                  "version_added": "15.4"
                 },
                 {
                   "prefix": "-webkit-",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `non_standard_values` member of the `mask-origin` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/mask-origin/non_standard_values
