### PR TITLE
Update Firefox data for css.properties.max-block-size.fit-content

### DIFF
--- a/css/properties/max-block-size.json
+++ b/css/properties/max-block-size.json
@@ -46,7 +46,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "94"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `fit-content` member of the `max-block-size` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/max-block-size/fit-content
