### PR TITLE
Update Firefox data for css.properties.max-inline-size.fit-content

### DIFF
--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -49,10 +49,15 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "prefix": "-moz-",
-                "version_added": "41"
-              },
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "41"
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `fit-content` member of the `max-inline-size` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/max-inline-size/fit-content
