### PR TITLE
Update Firefox data for css.properties.opacity.percentages

### DIFF
--- a/css/properties/opacity.json
+++ b/css/properties/opacity.json
@@ -66,9 +66,7 @@
               "firefox": {
                 "version_added": "70"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `percentages` member of the `opacity` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/opacity/percentages
