### PR TITLE
Update Opera data for css.properties.opacity.percentages

### DIFF
--- a/css/properties/opacity.json
+++ b/css/properties/opacity.json
@@ -73,12 +73,8 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "preview"
               },


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `percentages` member of the `opacity` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/opacity/percentages
