### PR TITLE
Update Opera data for css.properties.overflow-wrap.anywhere

### DIFF
--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -103,9 +103,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "15.4"
               },


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `anywhere` member of the `overflow-wrap` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/overflow-wrap/anywhere
