### PR TITLE
Update Opera data for overflow-y CSS property

### DIFF
--- a/css/properties/overflow-y.json
+++ b/css/properties/overflow-y.json
@@ -71,9 +71,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": false
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "16"
               },


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `overflow-y` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/overflow-y
