### PR TITLE
Update Firefox Android data for overscroll-behavior-block CSS property

### DIFF
--- a/css/properties/overscroll-behavior-block.json
+++ b/css/properties/overscroll-behavior-block.json
@@ -14,9 +14,7 @@
             "firefox": {
               "version_added": "73"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox Android for the `overscroll-behavior-block` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/overscroll-behavior-block
