### PR TITLE
Update Opera data for css.properties.quotes.quotes_auto

### DIFF
--- a/css/properties/quotes.json
+++ b/css/properties/quotes.json
@@ -61,10 +61,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": false,
-                "notes": "This value is not supported, but the default browser behavior is to choose appropriate quotes for the user's language setting"
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "preview",
                 "notes": "This value is not supported, but the default browser behavior is to choose appropriate quotes for the user's language setting"


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `quotes_auto` member of the `quotes` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/quotes/quotes_auto
