### PR TITLE
Update Firefox Android data for css.properties.quotes.quotes_auto

### DIFF
--- a/css/properties/quotes.json
+++ b/css/properties/quotes.json
@@ -52,9 +52,7 @@
               "firefox": {
                 "version_added": "70"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false,
                 "notes": "This value is not supported, but the default browser behavior is to choose appropriate quotes for the user's language setting"


### PR DESCRIPTION
This PR updates and corrects version values for Firefox Android for the `quotes_auto` member of the `quotes` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/quotes/quotes_auto
