### PR TITLE
Update Chromium data for text-emphasis-position CSS property

### DIFF
--- a/css/properties/text-emphasis-position.json
+++ b/css/properties/text-emphasis-position.json
@@ -25,14 +25,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "prefix": "-webkit-",
-              "version_added": "15"
-            },
-            "opera_android": {
-              "prefix": "-webkit-",
-              "version_added": "14"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": [
               {
                 "version_added": "7"
@@ -44,10 +38,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "4.4"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -60,7 +51,7 @@
             "description": "<code>left</code> and <code>right</code>",
             "support": {
               "chrome": {
-                "version_added": "62"
+                "version_added": "99"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/text-emphasis-position.json
+++ b/css/properties/text-emphasis-position.json
@@ -51,7 +51,7 @@
             "description": "<code>left</code> and <code>right</code>",
             "support": {
               "chrome": {
-                "version_added": "99"
+                "version_added": "62"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `text-emphasis-position` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/text-emphasis-position
