### PR TITLE
Update Chromium data for text-emphasis CSS property

### DIFF
--- a/css/properties/text-emphasis.json
+++ b/css/properties/text-emphasis.json
@@ -25,14 +25,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "prefix": "-webkit-",
-              "version_added": "15"
-            },
-            "opera_android": {
-              "prefix": "-webkit-",
-              "version_added": "14"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": [
               {
                 "version_added": "7"
@@ -44,10 +38,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "4.4"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `text-emphasis` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/text-emphasis
