### PR TITLE
Update Firefox data for api.BaseAudioContext.createPeriodicWave.constraints_disableNormalization_parameter

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -682,7 +682,7 @@
                 "version_added": "≤18"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "49"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `createPeriodicWave.constraints_disableNormalization_parameter` member of the `BaseAudioContext` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/BaseAudioContext/createPeriodicWave/constraints_disableNormalization_parameter
