### PR TITLE
webNavigation support in Edge and Opera

### DIFF
--- a/webextensions/api/webNavigation.json
+++ b/webextensions/api/webNavigation.json
@@ -9,17 +9,13 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "notes": "'server_redirect' is limited to top-level frames and 'client_redirect' is not supplied when redirections are created by JavaScript.",
                 "version_added": "48"
               },
               "firefox_android": "mirror",
-              "opera": {
-                "version_added": "17"
-              },
+              "opera": "mirror",
               "safari": {
                 "version_added": false
               },
@@ -32,16 +28,12 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "49"
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": "17"
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -57,16 +49,12 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "48"
               },
               "firefox_android": "mirror",
-              "opera": {
-                "version_added": "17"
-              },
+              "opera": "mirror",
               "safari": {
                 "version_added": false
               },
@@ -79,16 +67,12 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": "17"
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -102,17 +86,13 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "48",
                   "notes": "Partially supported as the default transition type for subframes."
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": "17"
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -126,16 +106,12 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "48"
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": "17"
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -149,16 +125,12 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": "17"
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -172,16 +144,12 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": "17"
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -195,16 +163,12 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": "17"
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -218,17 +182,13 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "48",
                   "notes": "Partially supported as the default transition type for top-level frames."
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": "17"
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -242,16 +202,12 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": "17"
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -265,16 +221,12 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "48"
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": "17"
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -288,16 +240,12 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": "17"
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -311,16 +259,12 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": "17"
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -336,9 +280,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "14"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "47",
                 "notes": "The returned objects do not include the <code>errorOccurred</code> property. See <a href='https://bugzil.la/1248418'>bug 1248418</a>."
@@ -347,9 +289,7 @@
                 "version_added": "48",
                 "notes": "The returned objects do not include the <code>errorOccurred</code> property. See <a href='https://bugzil.la/1248418'>bug 1248418</a>."
               },
-              "opera": {
-                "version_added": "17"
-              },
+              "opera": "mirror",
               "safari": {
                 "version_added": "14"
               },
@@ -366,18 +306,14 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "14"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "47"
               },
               "firefox_android": {
                 "version_added": "48"
               },
-              "opera": {
-                "version_added": "17"
-              },
+              "opera": "mirror",
               "safari": {
                 "version_added": "14"
               },
@@ -392,13 +328,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onBeforeNavigate",
             "support": {
               "chrome": {
-                "notes": "If the filter parameter is empty, Chrome matches all URLs.",
+                "notes": "If the filter parameter is empty, all URLs are matched.",
                 "version_added": true
               },
-              "edge": {
-                "notes": "Filtering is not supported.",
-                "version_added": "14"
-              },
+              "edge": "mirror",
               "firefox": {
                 "notes": [
                   "Filtering is supported from version 50.",
@@ -413,16 +346,13 @@
                 ],
                 "version_added": "48"
               },
-              "opera": {
-                "notes": "If the filter parameter is empty, Opera matches all URLs.",
-                "version_added": "17"
-              },
+              "opera": "mirror",
               "safari": {
-                "notes": "If the filter parameter is empty, Safari matches all URLs.",
+                "notes": "If the filter parameter is empty, all URLs are matched.",
                 "version_added": "14"
               },
               "safari_ios": {
-                "notes": "If the filter parameter is empty, Safari matches all URLs.",
+                "notes": "If the filter parameter is empty, all URLs are matched.",
                 "version_added": "15"
               }
             }
@@ -433,13 +363,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onCommitted",
             "support": {
               "chrome": {
-                "notes": "If the filter parameter is empty, Chrome matches all URLs.",
+                "notes": "If the filter parameter is empty, all URLs are matched.",
                 "version_added": true
               },
-              "edge": {
-                "notes": "Filtering is not supported.",
-                "version_added": "14"
-              },
+              "edge": "mirror",
               "firefox": {
                 "notes": [
                   "Filtering is supported from version 50.",
@@ -454,16 +381,13 @@
                 ],
                 "version_added": "48"
               },
-              "opera": {
-                "notes": "If the filter parameter is empty, Opera matches all URLs.",
-                "version_added": "17"
-              },
+              "opera": "mirror",
               "safari": {
-                "notes": "If the filter parameter is empty, Safari matches all URLs.",
+                "notes": "If the filter parameter is empty, all URLs are matched.",
                 "version_added": "14"
               },
               "safari_ios": {
-                "notes": "If the filter parameter is empty, Safari matches all URLs.",
+                "notes": "If the filter parameter is empty, all URLs are matched.",
                 "version_added": "15"
               }
             }
@@ -474,16 +398,12 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "48"
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": "17"
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -497,16 +417,12 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "48"
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": "17"
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -520,13 +436,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onCompleted",
             "support": {
               "chrome": {
-                "notes": "If the filter parameter is empty, Chrome matches all URLs.",
+                "notes": "If the filter parameter is empty, all URLs are matched.",
                 "version_added": true
               },
-              "edge": {
-                "notes": "Filtering is not supported.",
-                "version_added": "14"
-              },
+              "edge": "mirror",
               "firefox": {
                 "notes": [
                   "Filtering is supported from version 50.",
@@ -541,16 +454,13 @@
                 ],
                 "version_added": "48"
               },
-              "opera": {
-                "notes": "If the filter parameter is empty, Opera matches all URLs.",
-                "version_added": "17"
-              },
+              "opera": "mirror",
               "safari": {
-                "notes": "If the filter parameter is empty, Safari matches all URLs.",
+                "notes": "If the filter parameter is empty, all URLs are matched.",
                 "version_added": "14"
               },
               "safari_ios": {
-                "notes": "If the filter parameter is empty, Safari matches all URLs.",
+                "notes": "If the filter parameter is empty, all URLs are matched.",
                 "version_added": "15"
               }
             }
@@ -564,9 +474,7 @@
                 "notes": "If a blocked popup is unblocked by the user, the event is still not sent.",
                 "version_added": true
               },
-              "edge": {
-                "version_added": "14"
-              },
+              "edge": "mirror",
               "firefox": {
                 "notes": [
                   "If the filter parameter is empty, Firefox raises an exception.",
@@ -582,10 +490,7 @@
                 ],
                 "version_added": "54"
               },
-              "opera": {
-                "notes": "If a blocked popup is unblocked by the user, the event is still not sent.",
-                "version_added": "17"
-              },
+              "opera": "mirror",
               "safari": {
                 "version_added": false
               },
@@ -598,16 +503,12 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "14"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": "17"
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -621,17 +522,12 @@
                 "chrome": {
                   "version_added": false
                 },
-                "edge": {
-                  "version_added": "14",
-                  "version_removed": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "54"
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": "17"
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -645,13 +541,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onDOMContentLoaded",
             "support": {
               "chrome": {
-                "notes": "If the filter parameter is empty, Chrome matches all URLs.",
+                "notes": "If the filter parameter is empty, all URLs are matched.",
                 "version_added": true
               },
-              "edge": {
-                "notes": "Filtering is not supported.",
-                "version_added": "14"
-              },
+              "edge": "mirror",
               "firefox": {
                 "notes": [
                   "Filtering is supported from version 50.",
@@ -666,16 +559,13 @@
                 ],
                 "version_added": "48"
               },
-              "opera": {
-                "notes": "If the filter parameter is empty, Opera matches all URLs.",
-                "version_added": "17"
-              },
+              "opera": "mirror",
               "safari": {
-                "notes": "If the filter parameter is empty, Safari matches all URLs.",
+                "notes": "If the filter parameter is empty, all URLs are matched.",
                 "version_added": "14"
               },
               "safari_ios": {
-                "notes": "If the filter parameter is empty, Safari matches all URLs.",
+                "notes": "If the filter parameter is empty, all URLs are matched.",
                 "version_added": "15"
               }
             }
@@ -686,13 +576,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onErrorOccurred",
             "support": {
               "chrome": {
-                "notes": "If the filter parameter is empty, Chrome matches all URLs.",
+                "notes": "If the filter parameter is empty, all URLs are matched.",
                 "version_added": true
               },
-              "edge": {
-                "notes": "Filtering is not supported",
-                "version_added": "14"
-              },
+              "edge": "mirror",
               "firefox": {
                 "notes": [
                   "Filtering is supported from version 50.",
@@ -707,16 +594,13 @@
                 ],
                 "version_added": "48"
               },
-              "opera": {
-                "notes": "If the filter parameter is empty, Opera matches all URLs.",
-                "version_added": "17"
-              },
+              "opera": "mirror",
               "safari": {
-                "notes": "If the filter parameter is empty, Safari matches all URLs.",
+                "notes": "If the filter parameter is empty, all URLs are matched.",
                 "version_added": "14"
               },
               "safari_ios": {
-                "notes": "If the filter parameter is empty, Safari matches all URLs.",
+                "notes": "If the filter parameter is empty, all URLs are matched.",
                 "version_added": "15"
               }
             }
@@ -727,9 +611,7 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "14"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": false
                 },
@@ -754,19 +636,14 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "notes": "Filtering is not supported.",
-                "version_added": "14"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "47"
               },
               "firefox_android": {
                 "version_added": "48"
               },
-              "opera": {
-                "version_added": "17"
-              },
+              "opera": "mirror",
               "safari": {
                 "version_added": false
               },
@@ -779,16 +656,12 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "48"
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": "17"
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -802,16 +675,12 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "48"
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": "17"
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -825,13 +694,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onReferenceFragmentUpdated",
             "support": {
               "chrome": {
-                "notes": "If the filter parameter is empty, Chrome matches all URLs.",
+                "notes": "If the filter parameter is empty, all URLs are matched.",
                 "version_added": true
               },
-              "edge": {
-                "notes": "Filtering is not supported.",
-                "version_added": "14"
-              },
+              "edge": "mirror",
               "firefox": {
                 "notes": [
                   "Filtering is supported from version 50.",
@@ -846,10 +712,7 @@
                 ],
                 "version_added": "48"
               },
-              "opera": {
-                "notes": "If the filter parameter is empty, Opera matches all URLs.",
-                "version_added": "17"
-              },
+              "opera": "mirror",
               "safari": {
                 "version_added": false
               },
@@ -862,16 +725,12 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "48"
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": "17"
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -885,16 +744,12 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "48"
                 },
                 "firefox_android": "mirror",
-                "opera": {
-                  "version_added": "17"
-                },
+                "opera": "mirror",
                 "safari": {
                   "version_added": false
                 },
@@ -910,9 +765,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "14"
-              },
+              "edge": "mirror",
               "firefox": {
                 "notes": "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported.",
                 "version_added": "45"
@@ -921,9 +774,7 @@
                 "notes": "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported.",
                 "version_added": "48"
               },
-              "opera": {
-                "version_added": "17"
-              },
+              "opera": "mirror",
               "safari": {
                 "version_added": false
               },


### PR DESCRIPTION
#### Summary

As noted in #10456, the BCD includes notes about supported features in Edge and Opera for releases prior to the switch of those browsers to Chromium. As the pre-Chromium releases are unlikely to be targets for web extension deployment, took the opportunity to "mirror" all.

#### Related issues

Fixes #10456
