### PR TITLE
Update Safari data for aspect-ratio CSS property

### DIFF
--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -22,7 +22,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14"
+              "version_added": "14",
+              "notes": "Before Safari 15, this property was only supported on <code>&lt;img&gt;</code> and <code>&lt;video&gt;</code> elements."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/aspect-ratio.json
+++ b/css/properties/aspect-ratio.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "14"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `aspect-ratio` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/aspect-ratio