### PR TITLE
Update Samsung Internet data for css.properties.block-size.fit-content

### DIFF
--- a/css/properties/block-size.json
+++ b/css/properties/block-size.json
@@ -65,10 +65,7 @@
                 "version_added": "12.1"
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": {
-                "alternative_name": "-webkit-fill-available",
-                "version_added": "5.0"
-              },
+              "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {


### PR DESCRIPTION
This PR updates and corrects version values for Samsung Internet for the `fit-content` member of the `block-size` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/block-size/fit-content
