### PR TITLE
FF111 ScreenOrientation.lock() enabled preview (flag FF97)

### DIFF
--- a/api/ScreenOrientation.json
+++ b/api/ScreenOrientation.json
@@ -115,11 +115,26 @@
               "version_added": "38"
             },
             "edge": "mirror",
-            "firefox": {
-              "version_added": "43",
-              "partial_implementation": true,
-              "notes": "Always throws <code>NotSupportedError</code>."
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "43",
+                "partial_implementation": true,
+                "notes": "Always throws <code>NotSupportedError</code>."
+              },
+              {
+                "version_added": "97",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.screenorientation.allow-lock",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": [
               {
                 "version_added": "43",


### PR DESCRIPTION
FF111 adds support for `ScreenOrientation.lock()` in nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=1767449
This is also behind a preference from FF97.

This adds the BCD entry. Related to https://github.com/mdn/content/pull/26444