### PR TITLE
Remove api.AudioListener.speedOfSound from BCD

### DIFF
--- a/api/AudioListener.json
+++ b/api/AudioListener.json
@@ -365,48 +365,6 @@
           }
         }
       },
-      "speedOfSound": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioListener/speedOfSound",
-          "support": {
-            "chrome": {
-              "version_added": "14",
-              "version_removed": "56"
-            },
-            "chrome_android": "mirror",
-            "edge": {
-              "version_added": "12",
-              "version_removed": "79"
-            },
-            "firefox": {
-              "version_added": "25",
-              "version_removed": "63"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "6",
-              "version_removed": "14.1"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37",
-              "version_removed": "56"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
-      },
       "upX": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioListener/upX",


### PR DESCRIPTION
This PR removes the `speedOfSound` member of the `AudioListener` API from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/AudioListener/speedOfSound
