### PR TITLE
Remove api.RTCStatsReport.[inbound/outbound]-rtp.qpSum from BCD

### DIFF
--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -2976,43 +2976,6 @@
             }
           }
         },
-        "qpSum": {
-          "__compat": {
-            "description": "<code>qpSum</code> in 'inbound-rtp' stats",
-            "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats-qpsum",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "11",
-                "version_removed": "14.1"
-              },
-              "safari_ios": {
-                "version_added": false
-              },
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "remoteId": {
           "__compat": {
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats-remoteid",
@@ -4827,43 +4790,6 @@
                 "version_added": "13.1"
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "qpSum": {
-          "__compat": {
-            "description": "<code>qpSum</code> in 'outbound-rtp' stats",
-            "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcoutboundrtpstreamstats-qpsum",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "11",
-                "version_removed": "14.1"
-              },
-              "safari_ios": {
-                "version_added": false
-              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },


### PR DESCRIPTION
This PR removes the `[inbound/outbound]-rtp.qpSum` member of the `RTCStatsReport` API from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.0.4).

Tests Used:
https://mdn-bcd-collector.gooborg.com/tests/api/RTCStatsReport/inbound-rtp/qpSum
https://mdn-bcd-collector.gooborg.com/tests/api/RTCStatsReport/outbound-rtp/qpSum
