### PR TITLE
Update nodejs data for api.Headers

### DIFF
--- a/api/Headers.json
+++ b/api/Headers.json
@@ -88,6 +88,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "18.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -128,6 +131,9 @@
             },
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "18.0.0"
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -170,6 +176,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "18.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -208,6 +217,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "18.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -244,6 +256,9 @@
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "18.0.0"
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -289,6 +304,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "18.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -325,6 +343,9 @@
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "19.7.0"
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -367,6 +388,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "18.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -404,6 +428,9 @@
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "18.0.0"
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -482,6 +509,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "18.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -520,6 +550,9 @@
             "ie": {
               "version_added": false
             },
+            "nodejs": {
+              "version_added": "18.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -556,6 +589,9 @@
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
+            },
+            "nodejs": {
+              "version_added": "18.0.0"
             },
             "oculus": "mirror",
             "opera": "mirror",

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -419,6 +419,13 @@
           "engine": "V8",
           "engine_version": "10.7"
         },
+        "19.7.0": {
+          "release_date": "2023-02-21",
+          "release_notes": "https://nodejs.org/en/blog/release/v19.7.0",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "10.8"
+        },
         "20.0.0": {
           "release_date": "2023-04-18",
           "release_notes": "https://nodejs.org/en/blog/announcements/v20-release-announce",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Headers.prototype.getSetCookie was added to nodejs in v19.7.0 (undici v5.19.0) and updates other Header prototype methods that were missing node data.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

- https://github.com/nodejs/undici/releases/tag/v5.19.0
- https://github.com/nodejs/undici/commit/ba5ef44b71eff5a86a8473850a326ff7392664d3
- https://github.com/nodejs/node/pull/46711

I implemented Headers in node so hopefully you can trust my sources 😆

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
