### PR TITLE
Update Safari data for css.properties.float.flow_relative_values

### DIFF
--- a/css/properties/float.json
+++ b/css/properties/float.json
@@ -70,7 +70,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "15"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `flow_relative_values` member of the `float` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.1.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/float/flow_relative_values

Additional Notes: Safari 15 is a complete guesstimate as I don't have access to 15.0, only 14.1 and 15.1.
