### PR TITLE
Update Safari data for scroll-margin-* CSS property

### DIFF
--- a/css/properties/scroll-margin-block-end.json
+++ b/css/properties/scroll-margin-block-end.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "15"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/scroll-margin-block-start.json
+++ b/css/properties/scroll-margin-block-start.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "15"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/scroll-margin-block.json
+++ b/css/properties/scroll-margin-block.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "15"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/scroll-margin-inline-end.json
+++ b/css/properties/scroll-margin-inline-end.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "15"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/scroll-margin-inline-start.json
+++ b/css/properties/scroll-margin-inline-start.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "15"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/scroll-margin-inline.json
+++ b/css/properties/scroll-margin-inline.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "15"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `scroll-margin-*` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.1.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/scroll-margin-*

Additional Notes: Safari 15 is a complete guesstimate as I don't have access to 15.0, only 14.1 and 15.1.
