### PR TITLE
Update Safari data for text-combine-upright CSS property

### DIFF
--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -43,7 +43,7 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "preview"
+                "version_added": "15.4"
               },
               {
                 "partial_implementation": true,
@@ -52,17 +52,7 @@
                 "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='https://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without <code>digits</code>."
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "15.4"
-              },
-              {
-                "partial_implementation": true,
-                "alternative_name": "-webkit-text-combine",
-                "version_added": "5",
-                "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='https://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without <code>digits</code>."
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": [
               {


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `text-combine-upright` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.1.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/text-combine-upright
