### PR TITLE
Update Safari data for css.properties.quotes.quotes_auto

### DIFF
--- a/css/properties/quotes.json
+++ b/css/properties/quotes.json
@@ -61,8 +61,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview",
-                "notes": "This value is not supported, but the default browser behavior is to choose appropriate quotes for the user's language setting"
+                "version_added": "14.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `quotes_auto` member of the `quotes` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.1.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/quotes/quotes_auto

Additional Notes: The note refers to behavior before the feature was supported, and doesn't seem appropriate to retain.
