### PR TITLE
Update RTCStatsReport spec URLs

### DIFF
--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -229,7 +229,7 @@
         "__compat": {
           "description": "<code>candidate-pair</code> stats",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#canditate_pair",
-          "spec_url": "https://www.w3.org/TR/webrtc-stats/#dom-rtcstatstype-candidate-pair",
+          "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-candidate-pair",
           "support": {
             "chrome": {
               "version_added": "58"
@@ -1140,7 +1140,7 @@
         "__compat": {
           "description": "<code>certificate</code> stats",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#certificate",
-          "spec_url": "https://www.w3.org/TR/webrtc-stats/#dom-rtcstatstype-certificate",
+          "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-certificate",
           "support": {
             "chrome": {
               "version_added": "80"
@@ -1379,7 +1379,7 @@
         "__compat": {
           "description": "<code>codec</code> stats",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#codec",
-          "spec_url": "https://www.w3.org/TR/webrtc-stats/#dom-rtcstatstype-codec",
+          "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-codec",
           "support": {
             "chrome": {
               "version_added": "80"
@@ -1720,7 +1720,7 @@
         "__compat": {
           "description": "<code>data-channel</code> stats",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#data_channel",
-          "spec_url": "https://www.w3.org/TR/webrtc-stats/#dom-rtcstatstype-data-channel",
+          "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-data-channel",
           "support": {
             "chrome": {
               "version_added": "80"
@@ -2153,7 +2153,7 @@
         "__compat": {
           "description": "<code>inbound-rtp</code> stats",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#inbound_rtp",
-          "spec_url": "https://www.w3.org/TR/webrtc-stats/#dom-rtcstatstype-inbound-rtp",
+          "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-inbound-rtp",
           "support": {
             "chrome": {
               "version_added": "79"
@@ -3391,7 +3391,7 @@
         "__compat": {
           "description": "<code>local-candidate</code> stats",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#local_candidate",
-          "spec_url": "https://www.w3.org/TR/webrtc-stats/#dom-rtcstatstype-local-candidate",
+          "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-local-candidate",
           "support": {
             "chrome": {
               "version_added": "80"
@@ -3819,7 +3819,7 @@
         "__compat": {
           "description": "<code>media-playout</code> stats",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#media_playout",
-          "spec_url": "https://www.w3.org/TR/webrtc-stats/#dom-rtcstatstype-media-playout",
+          "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-media-playout",
           "support": {
             "chrome": {
               "version_added": "111"
@@ -4160,7 +4160,7 @@
         "__compat": {
           "description": "<code>media-source</code> stats",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#media_source",
-          "spec_url": "https://www.w3.org/TR/webrtc-stats/#dom-rtcstatstype-media-source",
+          "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-media-source",
           "support": {
             "chrome": {
               "version_added": "80"
@@ -4467,7 +4467,7 @@
         "__compat": {
           "description": "<code>outbound-rtp</code> stats",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#outbound_rtp",
-          "spec_url": "https://www.w3.org/TR/webrtc-stats/#dom-rtcstatstype-outbound-rtp",
+          "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-outbound-rtp",
           "support": {
             "chrome": {
               "version_added": "80"
@@ -5190,7 +5190,7 @@
         "__compat": {
           "description": "<code>peer-connection</code> stats",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#peer_connection",
-          "spec_url": "https://www.w3.org/TR/webrtc-stats/#dom-rtcstatstype-peer-connection",
+          "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-peer-connection",
           "support": {
             "chrome": {
               "version_added": "80"
@@ -5395,7 +5395,7 @@
         "__compat": {
           "description": "<code>remote-candidate</code> stats",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#remote_candidate",
-          "spec_url": "https://www.w3.org/TR/webrtc-stats/#dom-rtcstatstype-remote-candidate",
+          "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-remote-candidate",
           "support": {
             "chrome": {
               "version_added": "80"
@@ -5823,7 +5823,7 @@
         "__compat": {
           "description": "<code>remote-inbound-rtp</code> stats",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#remote_inbound_rtp",
-          "spec_url": "https://www.w3.org/TR/webrtc-stats/#dom-rtcstatstype-remote-inbound-rtp",
+          "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-remote-inbound-rtp",
           "support": {
             "chrome": {
               "version_added": "80"
@@ -6368,7 +6368,7 @@
         "__compat": {
           "description": "<code>remote-outbound-rtp</code> stats",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#remote_outbound_rtp",
-          "spec_url": "https://www.w3.org/TR/webrtc-stats/#dom-rtcstatstype-remote-outbound-rtp",
+          "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-remote-outbound-rtp",
           "support": {
             "chrome": {
               "version_added": "96"
@@ -6879,7 +6879,7 @@
         "__compat": {
           "description": "<code>transport</code> stats",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#transport",
-          "spec_url": "https://www.w3.org/TR/webrtc-stats/#dom-rtcstatstype-transport",
+          "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-transport",
           "support": {
             "chrome": {
               "version_added": "80"


### PR DESCRIPTION
These should all be using the URL for the current spec, rather than the W3C TR version.