### PR TITLE
Add Opera to correct target="blank" behavior list

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -280,7 +280,7 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": false
+                "version_added": true
               },
               "opera_android": {
                 "version_added": true


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Addresses issue #17607 by adding Opera to the list of browsers that correctly imply `rel="noopener"` with `target="blank"` for anchor tags in HTML.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

This was tested by @EDVTAZ, as mentioned in the above issue.

#### Related issues

No other known related issues.

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
