### PR TITLE
Fix mdn_url to static members

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -43,7 +43,7 @@
       },
       "abort": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortSignal/abort",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortSignal/abort_static",
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-abortsignal-abort①",
           "support": {
             "chrome": {
@@ -309,7 +309,7 @@
       },
       "timeout": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortSignal/timeout",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortSignal/timeout_static",
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-abortsignal-timeout①",
           "support": {
             "chrome": {

--- a/api/CSS.json
+++ b/api/CSS.json
@@ -739,7 +739,7 @@
       },
       "escape": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/escape",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/escape_static",
           "spec_url": "https://w3c.github.io/csswg-drafts/cssom/#the-css.escape()-method",
           "support": {
             "chrome": {

--- a/api/IDBKeyRange.json
+++ b/api/IDBKeyRange.json
@@ -106,7 +106,7 @@
       },
       "bound": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBKeyRange/bound",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBKeyRange/bound_static",
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbkeyrange-bound①",
           "support": {
             "chrome": {
@@ -216,7 +216,7 @@
       },
       "lowerBound": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBKeyRange/lowerBound",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBKeyRange/lowerBound_static",
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbkeyrange-lowerbound①",
           "support": {
             "chrome": {
@@ -292,7 +292,7 @@
       },
       "only": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBKeyRange/only",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBKeyRange/only_static",
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbkeyrange-only①",
           "support": {
             "chrome": {
@@ -368,7 +368,7 @@
       },
       "upperBound": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBKeyRange/upperBound",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IDBKeyRange/upperBound_static",
           "spec_url": "https://w3c.github.io/IndexedDB/#ref-for-dom-idbkeyrange-upperbound①",
           "support": {
             "chrome": {

--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -251,7 +251,7 @@
       },
       "isTypeSupported": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/isTypeSupported",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/isTypeSupported_static",
           "spec_url": "https://w3c.github.io/mediacapture-record/#dom-mediarecorder-istypesupported",
           "support": {
             "chrome": {

--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -428,7 +428,7 @@
       },
       "isTypeSupported": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSource/isTypeSupported",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaSource/isTypeSupported_static",
           "spec_url": "https://w3c.github.io/media-source/#dom-mediasource-istypesupported",
           "support": {
             "chrome": {

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -751,7 +751,7 @@
       },
       "permission": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Notification/permission",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Notification/permission_static",
           "spec_url": "https://notifications.spec.whatwg.org/#dom-notification-permission",
           "support": {
             "chrome": {

--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -227,7 +227,7 @@
       },
       "supportedEntryTypes": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceObserver/supportedEntryTypes",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceObserver/supportedEntryTypes_static",
           "spec_url": "https://w3c.github.io/performance-timeline/#supportedentrytypes-attribute",
           "support": {
             "chrome": {

--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -175,7 +175,7 @@
       },
       "isUserVerifyingPlatformAuthenticatorAvailable": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/isUserVerifyingPlatformAuthenticatorAvailable",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/isUserVerifyingPlatformAuthenticatorAvailable_static",
           "spec_url": "https://w3c.github.io/webauthn/#dom-publickeycredential-isuserverifyingplatformauthenticatoravailable",
           "support": {
             "chrome": {

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1246,7 +1246,7 @@
       },
       "generateCertificate": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/generateCertificate",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/generateCertificate_static",
           "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcpeerconnection-generatecertificate",
           "support": {
             "chrome": {

--- a/api/Response.json
+++ b/api/Response.json
@@ -384,7 +384,7 @@
       },
       "error": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/error",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/error_static",
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-error①",
           "support": {
             "chrome": {
@@ -584,7 +584,7 @@
       },
       "redirect": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/redirect",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/redirect_static",
           "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-redirect①",
           "support": {
             "chrome": {

--- a/api/URL.json
+++ b/api/URL.json
@@ -131,7 +131,7 @@
       },
       "createObjectURL": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/createObjectURL",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/createObjectURL_static",
           "spec_url": "https://w3c.github.io/FileAPI/#dfn-createObjectURL",
           "support": {
             "chrome": {
@@ -565,7 +565,7 @@
       },
       "revokeObjectURL": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/revokeObjectURL",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/revokeObjectURL_static",
           "spec_url": "https://w3c.github.io/FileAPI/#dfn-revokeObjectURL",
           "support": {
             "chrome": {


### PR DESCRIPTION
MDN moved API pages about static members. This PR fixes the `mdn_url` to them.