### PR TITLE
FF113 Web Transport API updates

### DIFF
--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -2,6 +2,7 @@
   "api": {
     "WebTransport": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport",
         "spec_url": "https://w3c.github.io/webtransport/#web-transport",
         "support": {
           "chrome": {
@@ -9,9 +10,21 @@
           },
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": {
-            "version_added": false
-          },
+          "firefox": [
+            {
+              "version_added": "preview"
+            },
+            {
+              "version_added": "109",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "network.webtransport.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": "mirror",
           "ie": {
             "version_added": false
@@ -35,6 +48,7 @@
       "WebTransport": {
         "__compat": {
           "description": "<code>WebTransport()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport/WebTransport",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransport-webtransport",
           "support": {
             "chrome": {
@@ -42,9 +56,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -75,9 +101,21 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
+              "firefox": [
+                {
+                  "version_added": "preview"
+                },
+                {
+                  "version_added": "109",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "network.webtransport.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -102,6 +140,7 @@
       },
       "close": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport/close",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransport-close",
           "support": {
             "chrome": {
@@ -109,9 +148,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -135,6 +186,7 @@
       },
       "closed": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport/closed",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransport-closed",
           "support": {
             "chrome": {
@@ -142,9 +194,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -168,6 +232,7 @@
       },
       "createBidirectionalStream": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport/createBidirectionalStream",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransport-createbidirectionalstream",
           "support": {
             "chrome": {
@@ -175,9 +240,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -201,6 +278,7 @@
       },
       "createUnidirectionalStream": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport/createUnidirectionalStream",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransport-createunidirectionalstream",
           "support": {
             "chrome": {
@@ -208,9 +286,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -240,9 +330,21 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
+              "firefox": [
+                {
+                  "version_added": "preview"
+                },
+                {
+                  "version_added": "109",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "network.webtransport.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -267,6 +369,7 @@
       },
       "datagrams": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport/datagrams",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransport-datagrams",
           "support": {
             "chrome": {
@@ -274,9 +377,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -300,6 +415,7 @@
       },
       "incomingBidirectionalStreams": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport/incomingBidirectionalStreams",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransport-incomingbidirectionalstreams",
           "support": {
             "chrome": {
@@ -307,9 +423,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -333,6 +461,7 @@
       },
       "incomingUnidirectionalStreams": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport/incomingUnidirectionalStreams",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransport-incomingunidirectionalstreams",
           "support": {
             "chrome": {
@@ -340,9 +469,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -366,6 +507,7 @@
       },
       "ready": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport/ready",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransport-ready",
           "support": {
             "chrome": {
@@ -373,9 +515,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -12,7 +12,7 @@
           "edge": "mirror",
           "firefox": [
             {
-              "version_added": "preview"
+              "version_added": false
             },
             {
               "version_added": "109",
@@ -58,7 +58,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": false
               },
               {
                 "version_added": "109",
@@ -150,7 +150,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": false
               },
               {
                 "version_added": "109",
@@ -196,7 +196,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": false
               },
               {
                 "version_added": "109",
@@ -242,7 +242,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": false
               },
               {
                 "version_added": "109",
@@ -288,7 +288,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": false
               },
               {
                 "version_added": "109",
@@ -379,7 +379,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": false
               },
               {
                 "version_added": "109",
@@ -425,7 +425,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": false
               },
               {
                 "version_added": "109",
@@ -471,7 +471,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": false
               },
               {
                 "version_added": "109",
@@ -517,7 +517,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": false
               },
               {
                 "version_added": "109",
@@ -563,7 +563,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": false
               },
               {
                 "version_added": "109",

--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -413,6 +413,52 @@
           }
         }
       },
+      "getStats": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport/getStats",
+          "spec_url": "https://w3c.github.io/webtransport/#dom-webtransport-getstats",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "incomingBidirectionalStreams": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport/incomingBidirectionalStreams",

--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -12,7 +12,7 @@
           "edge": "mirror",
           "firefox": [
             {
-              "version_added": false
+              "version_added": "preview"
             },
             {
               "version_added": "109",
@@ -58,7 +58,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": false
+                "version_added": "preview"
               },
               {
                 "version_added": "109",
@@ -91,10 +91,148 @@
             "deprecated": false
           }
         },
-        "serverCertificateHashes": {
+        "options_allowPooling_parameter": {
           "__compat": {
-            "description": "<code>serverCertificateHashes</code> option",
-            "spec_url": "https://w3c.github.io/webtransport/#ref-for-dom-webtransportoptions-servercertificatehashes%E2%91%A0",
+            "description": "<code>options.allowPooling</code> parameter",
+            "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportoptions-allowpooling",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": [
+                {
+                  "version_added": "preview"
+                },
+                {
+                  "version_added": "109",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "network.webtransport.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "options_congestionControl_parameter": {
+          "__compat": {
+            "description": "<code>options.congestionControl</code> parameter",
+            "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportoptions-congestioncontrol",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": [
+                {
+                  "version_added": "preview"
+                },
+                {
+                  "version_added": "109",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "network.webtransport.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "options_requireUnreliable_parameter": {
+          "__compat": {
+            "description": "<code>options.requireUnreliable</code> parameter",
+            "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportoptions-requireunreliable",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": [
+                {
+                  "version_added": "preview"
+                },
+                {
+                  "version_added": "109",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "network.webtransport.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "options_serverCertificateHashes_parameter": {
+          "__compat": {
+            "description": "<code>options.serverCertificateHashes</code> parameter",
+            "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportoptions-servercertificatehashes",
             "support": {
               "chrome": {
                 "version_added": "100"
@@ -150,7 +288,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": false
+                "version_added": "preview"
               },
               {
                 "version_added": "109",
@@ -196,7 +334,53 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": false
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "congestionControl": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport/congestionControl",
+          "spec_url": "https://w3c.github.io/webtransport/#dom-webtransport-congestioncontrol",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": [
+              {
+                "version_added": "preview"
               },
               {
                 "version_added": "109",
@@ -242,7 +426,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": false
+                "version_added": "preview"
               },
               {
                 "version_added": "109",
@@ -274,6 +458,52 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "options_sendOrder_parameter": {
+          "__compat": {
+            "description": "<code>options.sendOrder</code> parameter",
+            "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportsendstreamoptions-sendorder",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": [
+                {
+                  "version_added": "preview"
+                },
+                {
+                  "version_added": "109",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "network.webtransport.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "createUnidirectionalStream": {
@@ -288,7 +518,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": false
+                "version_added": "preview"
               },
               {
                 "version_added": "109",
@@ -365,6 +595,52 @@
               "deprecated": false
             }
           }
+        },
+        "options_sendOrder_parameter": {
+          "__compat": {
+            "description": "<code>options.sendOrder</code> parameter",
+            "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportsendstreamoptions-sendorder",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": [
+                {
+                  "version_added": "preview"
+                },
+                {
+                  "version_added": "109",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "network.webtransport.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "datagrams": {
@@ -379,7 +655,53 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": false
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "draining": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport/draining",
+          "spec_url": "https://w3c.github.io/webtransport/#dom-webtransport-draining",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": [
+              {
+                "version_added": "preview"
               },
               {
                 "version_added": "109",
@@ -425,7 +747,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": false
+                "version_added": "preview"
               },
               {
                 "version_added": "109",
@@ -471,7 +793,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": false
+                "version_added": "preview"
               },
               {
                 "version_added": "109",
@@ -517,7 +839,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": false
+                "version_added": "preview"
               },
               {
                 "version_added": "109",
@@ -563,7 +885,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": false
+                "version_added": "preview"
               },
               {
                 "version_added": "109",

--- a/api/WebTransportBidirectionalStream.json
+++ b/api/WebTransportBidirectionalStream.json
@@ -2,6 +2,7 @@
   "api": {
     "WebTransportBidirectionalStream": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransportBidirectionalStream",
         "spec_url": "https://w3c.github.io/webtransport/#webtransportbidirectionalstream",
         "support": {
           "chrome": {
@@ -9,9 +10,21 @@
           },
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": {
-            "version_added": false
-          },
+          "firefox": [
+            {
+              "version_added": "preview"
+            },
+            {
+              "version_added": "109",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "network.webtransport.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": "mirror",
           "ie": {
             "version_added": false
@@ -34,6 +47,7 @@
       },
       "readable": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransportBidirectionalStream/readable",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportbidirectionalstream-readable",
           "support": {
             "chrome": {
@@ -41,9 +55,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -67,6 +93,7 @@
       },
       "writable": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransportBidirectionalStream/writable",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportbidirectionalstream-writable",
           "support": {
             "chrome": {
@@ -74,9 +101,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/WebTransportDatagramDuplexStream.json
+++ b/api/WebTransportDatagramDuplexStream.json
@@ -12,7 +12,7 @@
           "edge": "mirror",
           "firefox": [
             {
-              "version_added": false
+              "version_added": "preview"
             },
             {
               "version_added": "109",
@@ -57,7 +57,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": false
+                "version_added": "preview"
               },
               {
                 "version_added": "109",
@@ -103,7 +103,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": false
+                "version_added": "preview"
               },
               {
                 "version_added": "109",
@@ -149,7 +149,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": false
+                "version_added": "preview"
               },
               {
                 "version_added": "109",
@@ -195,7 +195,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": false
+                "version_added": "preview"
               },
               {
                 "version_added": "109",
@@ -241,7 +241,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": false
+                "version_added": "preview"
               },
               {
                 "version_added": "109",
@@ -287,7 +287,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": false
+                "version_added": "preview"
               },
               {
                 "version_added": "109",
@@ -333,7 +333,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": false
+                "version_added": "preview"
               },
               {
                 "version_added": "109",

--- a/api/WebTransportDatagramDuplexStream.json
+++ b/api/WebTransportDatagramDuplexStream.json
@@ -2,6 +2,7 @@
   "api": {
     "WebTransportDatagramDuplexStream": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransportDatagramDuplexStream",
         "spec_url": "https://w3c.github.io/webtransport/#duplex-stream",
         "support": {
           "chrome": {
@@ -9,9 +10,21 @@
           },
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": {
-            "version_added": false
-          },
+          "firefox": [
+            {
+              "version_added": "preview"
+            },
+            {
+              "version_added": "109",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "network.webtransport.datagrams.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": "mirror",
           "ie": {
             "version_added": false
@@ -34,6 +47,7 @@
       },
       "incomingHighWaterMark": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransportDatagramDuplexStream/incomingHighWaterMark",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportdatagramduplexstream-incominghighwatermark",
           "support": {
             "chrome": {
@@ -41,9 +55,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.datagrams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -67,6 +93,7 @@
       },
       "incomingMaxAge": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransportDatagramDuplexStream/incomingMaxAge",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportdatagramduplexstream-incomingmaxage",
           "support": {
             "chrome": {
@@ -74,9 +101,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.datagrams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -100,6 +139,7 @@
       },
       "maxDatagramSize": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransportDatagramDuplexStream/maxDatagramSize",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportdatagramduplexstream-maxdatagramsize",
           "support": {
             "chrome": {
@@ -107,9 +147,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.datagrams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -133,6 +185,7 @@
       },
       "outgoingHighWaterMark": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransportDatagramDuplexStream/outgoingHighWaterMark",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportdatagramduplexstream-outgoinghighwatermark",
           "support": {
             "chrome": {
@@ -140,9 +193,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.datagrams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -166,6 +231,7 @@
       },
       "outgoingMaxAge": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransportDatagramDuplexStream/outgoingMaxAge",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportdatagramduplexstream-outgoingmaxage",
           "support": {
             "chrome": {
@@ -173,9 +239,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.datagrams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -199,6 +277,7 @@
       },
       "readable": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransportDatagramDuplexStream/readable",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportdatagramduplexstream-readable",
           "support": {
             "chrome": {
@@ -206,9 +285,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.datagrams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -232,6 +323,7 @@
       },
       "writable": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransportDatagramDuplexStream/writable",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportdatagramduplexstream-writable",
           "support": {
             "chrome": {
@@ -239,9 +331,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.datagrams.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/WebTransportDatagramDuplexStream.json
+++ b/api/WebTransportDatagramDuplexStream.json
@@ -12,7 +12,7 @@
           "edge": "mirror",
           "firefox": [
             {
-              "version_added": "preview"
+              "version_added": false
             },
             {
               "version_added": "109",
@@ -57,7 +57,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": false
               },
               {
                 "version_added": "109",
@@ -103,7 +103,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": false
               },
               {
                 "version_added": "109",
@@ -149,7 +149,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": false
               },
               {
                 "version_added": "109",
@@ -195,7 +195,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": false
               },
               {
                 "version_added": "109",
@@ -241,7 +241,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": false
               },
               {
                 "version_added": "109",
@@ -287,7 +287,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": false
               },
               {
                 "version_added": "109",
@@ -333,7 +333,7 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": false
               },
               {
                 "version_added": "109",

--- a/api/WebTransportError.json
+++ b/api/WebTransportError.json
@@ -9,9 +9,21 @@
           },
           "chrome_android": "mirror",
           "edge": "mirror",
-          "firefox": {
-            "version_added": false
-          },
+          "firefox": [
+            {
+              "version_added": "preview"
+            },
+            {
+              "version_added": "109",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "network.webtransport.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
           "firefox_android": "mirror",
           "ie": {
             "version_added": false
@@ -42,9 +54,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -75,9 +99,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -108,9 +144,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/api/WebTransportError.json
+++ b/api/WebTransportError.json
@@ -2,6 +2,7 @@
   "api": {
     "WebTransportError": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransportError",
         "spec_url": "https://w3c.github.io/webtransport/#webtransporterror",
         "support": {
           "chrome": {
@@ -47,6 +48,7 @@
       "WebTransportError": {
         "__compat": {
           "description": "<code>WebTransportError()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransportError/WebTransportError",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransporterror-webtransporterror",
           "support": {
             "chrome": {
@@ -92,6 +94,7 @@
       },
       "source": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransportError/source",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransporterror-source",
           "support": {
             "chrome": {
@@ -137,6 +140,7 @@
       },
       "streamErrorCode": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransportError/streamErrorCode",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransporterror-streamerrorcode",
           "support": {
             "chrome": {


### PR DESCRIPTION
FF113 nightly adds support for WebTransport and friends in https://bugzilla.mozilla.org/show_bug.cgi?id=1818754 (and behind pref in 109). 

The spec has several additions since the BCD before this revision. Tests indicate that Chrome does not implement those additions.
FF appears to fully follow the spec based on its IDL.

I have made updates to this all, along with adding MDN links.

FYI @queengooborg The BCD collector probably a bit out of date here:

WebTransport - 
- constructor - has some new options - a test on existence is not enough.
  - allowPooling
  - requireUnreliable
  - serverCertificateHashes
  - congestionControl
- createBidirectionalStream - takes option
- createUnidirectionalStream - take option

Other docs work for this can be tracked in https://github.com/mdn/content/issues/26153