### PR TITLE
Add CSSImportRule supportsText property

### DIFF
--- a/api/CSSImportRule.json
+++ b/api/CSSImportRule.json
@@ -153,6 +153,46 @@
           }
         }
       },
+      "styleSheet": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSImportRule/styleSheet",
+          "spec_url": "https://w3c.github.io/csswg-drafts/cssom/#dom-cssimportrule-stylesheet",
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": "9"
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "supportsText": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSImportRule/supportsText",

--- a/api/CSSImportRule.json
+++ b/api/CSSImportRule.json
@@ -153,41 +153,42 @@
           }
         }
       },
-      "styleSheet": {
+      "supportsText": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSImportRule/styleSheet",
-          "spec_url": "https://w3c.github.io/csswg-drafts/cssom/#dom-cssimportrule-stylesheet",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSImportRule/supportsText",
+          "spec_url": "https://w3c.github.io/csswg-drafts/cssom/#dom-cssimportrule-supportstext",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": false,
+              "impl_url": "https://crbug.com/1380321"
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": false
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "114"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "9"
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": false
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": false
             },
             "safari": {
-              "version_added": "1"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/CSSImportRule.json
+++ b/api/CSSImportRule.json
@@ -221,7 +221,8 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/256180"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Added data for the new `supportsText` property of `CSSImportRule`.

#### Test results and supporting details

See last 2 subtests of WPT test: https://wpt.fyi/results/css/cssom/cssimportrule.html
