### PR TITLE
Updates chrome browser to version 113

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -781,21 +781,28 @@
         "112": {
           "release_date": "2023-04-04",
           "release_notes": "https://chromereleases.googleblog.com/2023/04/stable-channel-update-for-desktop.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "112"
         },
         "113": {
           "release_date": "2023-05-02",
-          "status": "beta",
+           "release_notes": "https://chromereleases.googleblog.com/2023/05/stable-channel-update-for-desktop.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "113"
         },
         "114": {
           "release_date": "2023-05-30",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "114"
+        },
+        "115": {
+          "release_date": "2023-06-18",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "115"
         }
       }
     }

--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -799,7 +799,7 @@
           "engine_version": "114"
         },
         "115": {
-          "release_date": "2023-06-18",
+          "release_date": "2023-07-18",
           "status": "nightly",
           "engine": "Blink",
           "engine_version": "115"

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -635,7 +635,7 @@
           "engine_version": "114"
         },
         "115": {
-          "release_date": "2023-06-18",
+          "release_date": "2023-07-18",
           "status": "nightly",
           "engine": "Blink",
           "engine_version": "115"

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -617,21 +617,28 @@
         "112": {
           "release_date": "2023-04-04",
           "release_notes": "https://chromereleases.googleblog.com/2023/04/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "112"
         },
         "113": {
           "release_date": "2023-05-02",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2023/05/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "113"
         },
         "114": {
           "release_date": "2023-05-30",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "114"
+        },
+        "115": {
+          "release_date": "2023-06-18",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "115"
         }
       }
     }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -599,7 +599,7 @@
           "engine_version": "114"
         },
         "115": {
-          "release_date": "2023-06-18",
+          "release_date": "2023-07-18",
           "status": "nightly",
           "engine": "Blink",
           "engine_version": "115"

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -580,21 +580,29 @@
         },
         "112": {
           "release_date": "2023-04-04",
-          "status": "current",
+          "release_notes": "https://chromereleases.googleblog.com/2023/04/chrome-for-android-update.html",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "112"
         },
         "113": {
           "release_date": "2023-05-02",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2023/05/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "113"
         },
         "114": {
           "release_date": "2023-05-30",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "114"
+        },
+        "115": {
+          "release_date": "2023-06-18",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "115"
         }
       }
     }


### PR DESCRIPTION
Hi all! 👋

Updating Chrome to version 113.

And according to https://chromiumdash.appspot.com/schedule, it also includes Chrome 115 release date.