### PR TITLE
Update Safari data for api.Document.exitFullscreen.returns_promise

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -3106,7 +3106,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `exitFullscreen.returns_promise` member of the `Document` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.1.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Document/exitFullscreen/returns_promise

Additional Notes: While the collector only tests with the non-prefixed version of the method, running `document.webkitExitFullscreen()` in Safari 16.3 does not return a promise.
