### PR TITLE
Update Safari data for EXT_texture_compression_bptc API

### DIFF
--- a/api/EXT_texture_compression_bptc.json
+++ b/api/EXT_texture_compression_bptc.json
@@ -33,7 +33,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "16.1"
+            "version_added": "16"
           },
           "safari_ios": {
             "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `EXT_texture_compression_bptc` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.1.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/EXT_texture_compression_bptc

Additional Notes: This was changed from 16.0 to 16.1 in #18310.  However, I manually tested the WebGL extension and confirmed support in Safari 16.0.
