### PR TITLE
Update Safari data for OES_texture_half_float_linear API

### DIFF
--- a/api/OES_texture_half_float_linear.json
+++ b/api/OES_texture_half_float_linear.json
@@ -25,7 +25,8 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "8"
+            "version_added": "8",
+            "version_removed": "15"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": {


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `OES_texture_half_float_linear` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.1.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/OES_texture_half_float_linear

Additional Notes: Safari 15.0 was guesstimated from 14.1> ≤15.1.
