### PR TITLE
Update Safari data for api.PictureInPictureEvent.pictureInPictureWindow

### DIFF
--- a/api/PictureInPictureEvent.json
+++ b/api/PictureInPictureEvent.json
@@ -125,7 +125,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "13.1"
+              "version_added": "16"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `pictureInPictureWindow` member of the `PictureInPictureEvent` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.1.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/PictureInPictureEvent/pictureInPictureWindow
