### PR TITLE
Update Safari data for SVGAltGlyphDefElement API

### DIFF
--- a/api/SVGAltGlyphDefElement.json
+++ b/api/SVGAltGlyphDefElement.json
@@ -22,7 +22,8 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "6"
+            "version_added": "6",
+            "version_removed": "16.4"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `SVGAltGlyphDefElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.1.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/SVGAltGlyphDefElement
