### PR TITLE
Update Safari data for SVGAltGlyphElement API

### DIFF
--- a/api/SVGAltGlyphElement.json
+++ b/api/SVGAltGlyphElement.json
@@ -24,7 +24,8 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "4"
+            "version_added": "4",
+            "version_removed": "16.4"
           },
           "safari_ios": {
             "version_added": "3"
@@ -61,7 +62,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "16.4"
             },
             "safari_ios": {
               "version_added": "3"
@@ -101,7 +103,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "16.4"
             },
             "safari_ios": {
               "version_added": "3"
@@ -142,7 +145,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "16.4"
             },
             "safari_ios": {
               "version_added": "3"


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `SVGAltGlyphElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.1.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/SVGAltGlyphElement
