### PR TITLE
FF114 Android Window.print() update

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3942,7 +3942,7 @@
               "version_added": "1"
             },
             "firefox_android": {
-              "version_added": "113"
+              "version_added": "114"
             },
             "ie": {
               "version_added": "5"


### PR DESCRIPTION
Window.print() in FF Android deferred from 113 to 114 as mentioned in https://bugzilla.mozilla.org/show_bug.cgi?id=1809922#c8