### PR TITLE
Add fetch() and Request() constructor priority parameters

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -152,6 +152,43 @@
             }
           }
         },
+        "init_priority_parameter": {
+          "__compat": {
+            "description": "<code>init.priority</code> parameter",
+            "spec_url": "https://fetch.spec.whatwg.org/#dom-requestinit-priority",
+            "support": {
+              "chrome": {
+                "version_added": "101"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "init_referrer_parameter": {
           "__compat": {
             "description": "<code>init.referrer</code> parameter",

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -217,6 +217,42 @@
           }
         }
       },
+      "init_priority_parameter": {
+        "__compat": {
+          "description": "<code>init.priority</code> parameter",
+          "support": {
+            "chrome": {
+              "version_added": "101"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "init_referrerPolicy_parameter": {
         "__compat": {
           "description": "<code>init.referrerPolicy</code> parameter",


### PR DESCRIPTION
In the spec, this is the RequestInit dictionary's priority member, and
that's used both in fetch() and the Request() constructor.

Chrome 101 is from the chromestatus.com entry:
https://chromestatus.com/feature/5273474901737472

It also matches html.elements.img.fetchpriority and related entries.