### PR TITLE
Mirror Opera data for fetch keepalive

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -924,12 +924,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "43"
-            },
-            "opera_android": {
-              "version_added": "43"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "13"
             },

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -197,12 +197,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "43"
-            },
-            "opera_android": {
-              "version_added": "43"
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "13"
             },


### PR DESCRIPTION
43 looks like an off-by-10 human error in https://github.com/mdn/browser-compat-data/pull/1351.

At the time, Opera was 13 versions behind Chrome, but 23 was used instead.