### PR TITLE
`border-image-width`: add notes about interop bug

### DIFF
--- a/css/properties/border-image-width.json
+++ b/css/properties/border-image-width.json
@@ -7,11 +7,13 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-backgrounds/#the-border-image-width",
           "support": {
             "chrome": {
-              "version_added": "15"
+              "version_added": "15",
+              "notes": "Before Chrome 112, a border image's absolute or percentage length width may not take precedence over a narrower <code>border-width</code> (<a href='https://crbug.com/767352'>bug 767352</a>)."
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "Before Edge 112, a border image's absolute or percentage length width may not take precedence over a narrower <code>border-width</code> (<a href='https://crbug.com/767352'>bug 767352</a>)."
             },
             "firefox": {
               "version_added": "13"

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -8,7 +8,8 @@
           "support": {
             "chrome": [
               {
-                "version_added": "16"
+                "version_added": "16",
+                "notes": "Before Chrome 112, a border image's absolute or percentage length width may not take precedence over a narrower <code>border-width</code> (<a href='https://crbug.com/767352'>bug 767352</a>)."
               },
               {
                 "prefix": "-webkit-",
@@ -18,7 +19,8 @@
             "chrome_android": "mirror",
             "edge": [
               {
-                "version_added": "12"
+                "version_added": "12",
+                "notes": "Before Edge 112, a border image's absolute or percentage length width may not take precedence over a narrower <code>border-width</code> (<a href='https://crbug.com/767352'>bug 767352</a>)."
               },
               {
                 "prefix": "-webkit-",
@@ -48,7 +50,8 @@
             "oculus": "mirror",
             "opera": [
               {
-                "version_added": "11"
+                "version_added": "11",
+                "notes": "Before Opera 98, a border image's absolute or percentage length width may not take precedence over a narrower <code>border-width</code> (<a href='https://crbug.com/767352'>bug 767352</a>)."
               },
               {
                 "version_added": "10.5",
@@ -58,7 +61,8 @@
             ],
             "opera_android": [
               {
-                "version_added": "11"
+                "version_added": "11",
+                "notes": "A border image's absolute or percentage length width may not take precedence over a narrower <code>border-width</code> (<a href='https://crbug.com/767352'>bug 767352</a>)."
               },
               {
                 "version_added": "11",
@@ -87,7 +91,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": [
               {
-                "version_added": "4.4"
+                "version_added": "4.4",
+                "notes": "Before WebView 112, a border image's absolute or percentage length width may not take precedence over a narrower <code>border-width</code> (<a href='https://crbug.com/767352'>bug 767352</a>)."
               },
               {
                 "prefix": "-webkit-",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Note [bug 767352](https://bugs.chromium.org/p/chromium/issues/detail?id=767352) for `border-image` and `border-image-width`.

#### Test results and supporting details

This was notable issue for Interop 2022. See https://github.com/web-platform-tests/interop/issues/146.

#### Related issues

- https://github.com/web-platform-dx/feature-set/pull/160

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
