### PR TITLE
Add Chromium versions for abbr HTML element

### DIFF
--- a/html/elements/abbr.json
+++ b/html/elements/abbr.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "2"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
@@ -26,9 +24,7 @@
               "version_added": "7"
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": true
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": true


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `abbr` HTML element. This sets Chrome derivatives to mirror from upstream.
