### PR TITLE
Add Chrome/Safari versions for address HTML element

### DIFF
--- a/html/elements/address.json
+++ b/html/elements/address.json
@@ -7,7 +7,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/sections.html#the-address-element",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -26,9 +26,7 @@
             "safari": {
               "version_added": "1"
             },
-            "safari_ios": {
-              "version_added": true
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `address` HTML element. This mirrors Safari to Chrome and Safari iOS.