### PR TITLE
Add Opera versions for audio HTML element

### DIFF
--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -26,7 +26,7 @@
               "version_added": "10.5"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "11"
             },
             "safari": {
               "version_added": "3.1"
@@ -67,7 +67,7 @@
                 "version_added": "10.5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari": {
                 "version_added": "3.1"
@@ -109,7 +109,7 @@
                 "version_added": "10.5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari": {
                 "version_added": "3.1"
@@ -151,7 +151,7 @@
                 "version_added": "10.5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari": {
                 "version_added": "3.1"
@@ -249,7 +249,7 @@
                 },
                 {
                   "alternative_name": "autobuffer",
-                  "version_added": true,
+                  "version_added": "11",
                   "version_removed": "14"
                 }
               ],
@@ -294,7 +294,7 @@
                 "version_added": "10.5"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari": {
                 "version_added": "3.1"


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Opera and Opera Android for the `audio` HTML element. This mirrors Opera to Opera Android.