### PR TITLE
Update Chromium data for api.HTMLCanvasElement.getContext.webgl_context.options_powerPreference_parameter

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -474,7 +474,7 @@
               "spec_url": "https://registry.khronos.org/webgl/specs/latest/1.0/#WEBGLCONTEXTATTRIBUTES",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "75"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
@@ -500,7 +500,7 @@
                 "webview_android": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -667,7 +667,7 @@
               "spec_url": "https://registry.khronos.org/webgl/specs/latest/1.0/#WEBGLCONTEXTATTRIBUTES",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "75"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
@@ -693,7 +693,7 @@
                 "webview_android": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `getContext.webgl_context.options_powerPreference_parameter` member of the `HTMLCanvasElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.1.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/HTMLCanvasElement/getContext/webgl_context/options_powerPreference_parameter
