### PR TITLE
Add Chrome/Safari versions for bdo HTML element

### DIFF
--- a/html/elements/bdo.json
+++ b/html/elements/bdo.json
@@ -7,7 +7,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-bdo-element",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "≤15"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `bdo` HTML element. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code: https://developer.mozilla.org/docs/Web/HTML/Element/bdo
