### PR TITLE
Add Chrome/Safari versions for button HTML element

### DIFF
--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -7,24 +7,28 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
               "version_added": true
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "≤15"
+            },
+            "opera_android": {
+              "version_added": "≤14"
+            },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `button` HTML element. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code: ```

<button>Hello</button>

```
