### PR TITLE
Add Chrome/Safari versions for fieldset HTML element

### DIFF
--- a/html/elements/fieldset.json
+++ b/html/elements/fieldset.json
@@ -7,7 +7,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#the-fieldset-element",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Does not support <code>flexbox</code> and <code>grid</code> layouts within this element. See <a href='https://crbug.com/262679'>bug 262679</a>."
             },
             "chrome_android": "mirror",
@@ -16,17 +16,21 @@
               "notes": "Does not support <code>flexbox</code> and <code>grid</code> layouts within this element. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/4511145/'>bug 4511145</a>."
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
               "version_added": true
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "≤15"
+            },
+            "opera_android": {
+              "version_added": "≤14"
+            },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -65,7 +69,7 @@
                 "version_added": "12"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "12"
               },
               "safari": {
                 "version_added": "6"


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `fieldset` HTML element. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset
