### PR TITLE
Add Chromium versions for figure HTML element

### DIFF
--- a/html/elements/figure.json
+++ b/html/elements/figure.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "8"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `figure` HTML element. This sets Chrome Android to mirror from upstream.
