### PR TITLE
Add Chrome/Safari versions for h* HTML element

### DIFF
--- a/html/elements/h1.json
+++ b/html/elements/h1.json
@@ -7,7 +7,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/html/elements/h2.json
+++ b/html/elements/h2.json
@@ -7,7 +7,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/html/elements/h3.json
+++ b/html/elements/h3.json
@@ -7,7 +7,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/html/elements/h4.json
+++ b/html/elements/h4.json
@@ -7,7 +7,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/html/elements/h5.json
+++ b/html/elements/h5.json
@@ -7,7 +7,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/html/elements/h6.json
+++ b/html/elements/h6.json
@@ -7,7 +7,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/sections.html#the-h1,-h2,-h3,-h4,-h5,-and-h6-elements",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `h*` HTML element. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code: ```

<h1>Hello world!</h1>

```
