### PR TITLE
Add Chrome/Safari versions for head HTML element

### DIFF
--- a/html/elements/head.json
+++ b/html/elements/head.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
@@ -23,12 +21,10 @@
               "version_added": true
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": true
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -46,9 +42,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -60,12 +54,10 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": true
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "≤4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `head` HTML element. This mirrors data from the interface counterpart.
