### PR TITLE
Add Chromium versions for header HTML element

### DIFF
--- a/html/elements/header.json
+++ b/html/elements/header.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "5"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `header` HTML element. Other
