### PR TITLE
Add all browsers versions for iframe HTML element

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -9,14 +9,12 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "The <code>resize</code> CSS property doesn't have any effect on this element due to <a href='https://bugzil.la/680823'>bug 680823</a>."
             },
             "firefox_android": "mirror",
@@ -25,11 +23,13 @@
             },
             "oculus": "mirror",
             "opera": {
-              "version_added": true
+              "version_added": "≤15"
             },
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": "≤14"
+            },
             "safari": {
-              "version_added": true,
+              "version_added": "≤4",
               "notes": "Safari has a <a href='https://www.quirksmode.org/bugreports/archives/2005/02/hidden_iframes.html'>bug</a> that prevents iframes from loading if the <code>iframe</code> element was hidden when added to the page. <code>iframeElement.src = iframeElement.src</code> should cause it to load the iframe."
             },
             "safari_ios": "mirror",
@@ -1219,26 +1219,22 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": true
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "≤4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for all browsers for the `iframe` HTML element. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code: ```

<iframe src="/"></iframe>

```
