### PR TITLE
Add all browsers versions for image HTML element

### DIFF
--- a/html/elements/image.json
+++ b/html/elements/image.json
@@ -6,12 +6,12 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/image",
           "support": {
             "chrome": {
-              "version_added": null
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Before Firefox 22, creating an &lt;image&gt; element incorrectly resulted in an <code>HTMLSpanElement</code> object, instead of the expected <code>HTMLElement</code>."
             },
             "firefox_android": "mirror",
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for all browsers for the `image` HTML element. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code:
```
<image src="/static/images/background.jpg" />
```
