### PR TITLE
FF113 WebTransportReceiveStream - in nightly

### DIFF
--- a/api/WebTransportReceiveStream.json
+++ b/api/WebTransportReceiveStream.json
@@ -1,0 +1,96 @@
+{
+  "api": {
+    "WebTransportReceiveStream": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransportReceiveStream",
+        "spec_url": "https://w3c.github.io/webtransport/#webtransportreceivestream",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": [
+            {
+              "version_added": "preview"
+            },
+            {
+              "version_added": "109",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "network.webtransport.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            }
+          ],
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "getStats": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransportReceiveStream/getStats",
+          "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportreceivestream-getstats",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": [
+              {
+                "version_added": "preview"
+              },
+              {
+                "version_added": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.webtransport.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
FF113 nightly adds support for WebTransport and friends in https://bugzilla.mozilla.org/show_bug.cgi?id=1818754 (and behind pref in 109). 

When doing docs discovered another object that is relevant `WebTransportReceiveStream` - object not in Chrome but shows up in FF.

This is a follow on from #19605

Other docs work for this can be tracked in https://github.com/mdn/content/issues/26153