### PR TITLE
Add Chromium versions for input HTML element

### DIFF
--- a/html/elements/input.json
+++ b/html/elements/input.json
@@ -7,7 +7,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/input.html#the-input-element",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -22,8 +22,12 @@
               "version_added": true
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
             "safari": {
               "version_added": "1"
             },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `input` HTML element. The data is mirrored from the interface counterpart.