### PR TITLE
Add Chrome/Safari versions for map HTML element

### DIFF
--- a/html/elements/map.json
+++ b/html/elements/map.json
@@ -27,18 +27,12 @@
               "version_added": true
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": true
-            },
-            "opera_android": {
-              "version_added": true
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "1"
             },
-            "safari_ios": {
-              "version_added": true
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -66,18 +60,12 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "1"
               },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `map` HTML element. Chromium derivatives are set to mirror from upstream, and Safari is mirrored from Chrome.