### PR TITLE
Add Chrome/Safari versions for mark HTML element

### DIFF
--- a/html/elements/mark.json
+++ b/html/elements/mark.json
@@ -7,7 +7,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-mark-element",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "7"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -26,7 +26,7 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `mark` HTML element. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code:
```
<p>Several species of <mark>salamander</mark> inhabit the temperate rainforest of the Pacific Northwest.</p>
```
