### PR TITLE
Add Chrome/Safari versions for output HTML element

### DIFF
--- a/html/elements/output.json
+++ b/html/elements/output.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "10"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "≤18"
             },
@@ -27,14 +25,12 @@
               "version_added": "11"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "11"
             },
             "safari": {
               "version_added": "7"
             },
-            "safari_ios": {
-              "version_added": true
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -52,9 +48,7 @@
               "chrome": {
                 "version_added": "10"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "≤18"
               },
@@ -70,14 +64,12 @@
                 "version_added": "11"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "11"
               },
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -94,9 +86,7 @@
               "chrome": {
                 "version_added": "10"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "≤18"
               },
@@ -112,14 +102,12 @@
                 "version_added": "11"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "11"
               },
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -136,9 +124,7 @@
               "chrome": {
                 "version_added": "10"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "≤18"
               },
@@ -154,14 +140,12 @@
                 "version_added": "11"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "11"
               },
               "safari": {
                 "version_added": "7"
               },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `output` HTML element. Chromium derivatives are set to mirror, and Safari is mirrored from Chrome.
