### PR TITLE
FF113 Add RTCPeerConnectionStats dict

### DIFF
--- a/api/RTCPeerConnectionStats.json
+++ b/api/RTCPeerConnectionStats.json
@@ -1,0 +1,208 @@
+{
+  "api": {
+    "RTCPeerConnectionStats": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionStats",
+        "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcpeerconnectionstats",
+        "support": {
+          "chrome": {
+            "version_added": "80"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": "113"
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": "13.1"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "dataChannelsClosed": {
+        "__compat": {
+          "description": "<code>dataChannelsClosed</code> in 'peer-connection' stats",
+          "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcpeerconnectionstats-datachannelsclosed",
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "113"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "dataChannelsOpened": {
+        "__compat": {
+          "description": "<code>dataChannelsOpened</code> in 'peer-connection' stats",
+          "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcpeerconnectionstats-datachannelsopened",
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "113"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "id": {
+        "__compat": {
+          "description": "<code>id</code> in 'peer-connection' stats",
+          "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstats-id",
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "113"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "timestamp": {
+        "__compat": {
+          "description": "<code>timestamp</code> in 'peer-connection' stats",
+          "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstats-timestamp",
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "113"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "type": {
+        "__compat": {
+          "description": "<code>type</code> in 'peer-connection' stats",
+          "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstats-type",
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "113"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "13.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/RTCPeerConnectionStats.json
+++ b/api/RTCPeerConnectionStats.json
@@ -35,7 +35,7 @@
       },
       "dataChannelsClosed": {
         "__compat": {
-          "description": "<code>dataChannelsClosed</code> in 'peer-connection' stats",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionStats/dataChannelsClosed",
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcpeerconnectionstats-datachannelsclosed",
           "support": {
             "chrome": {
@@ -69,7 +69,7 @@
       },
       "dataChannelsOpened": {
         "__compat": {
-          "description": "<code>dataChannelsOpened</code> in 'peer-connection' stats",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionStats/dataChannelsOpened",
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcpeerconnectionstats-datachannelsopened",
           "support": {
             "chrome": {
@@ -103,7 +103,7 @@
       },
       "id": {
         "__compat": {
-          "description": "<code>id</code> in 'peer-connection' stats",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionStats/id",
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstats-id",
           "support": {
             "chrome": {
@@ -137,7 +137,7 @@
       },
       "timestamp": {
         "__compat": {
-          "description": "<code>timestamp</code> in 'peer-connection' stats",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionStats/timestamp",
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstats-timestamp",
           "support": {
             "chrome": {
@@ -171,7 +171,7 @@
       },
       "type": {
         "__compat": {
-          "description": "<code>type</code> in 'peer-connection' stats",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionStats/type",
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstats-type",
           "support": {
             "chrome": {


### PR DESCRIPTION
This adds an `RTCPeerConnectionStats` dict entry, based on RTStatsReport subfeature `type_peer-connection`. As discussed offline, this is a flatted dictionary, and the change matches up to content changes on MDN.

I'll work through and create stats dicts for all cases, then tidy up `RTStatsReport`

This is part of https://github.com/mdn/content/issues/26146