### PR TITLE
Add all browsers versions for plaintext HTML element

### DIFF
--- a/html/elements/plaintext.json
+++ b/html/elements/plaintext.json
@@ -7,7 +7,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#plaintext",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -18,14 +18,13 @@
                 "version_added": "4"
               },
               {
-                "version_added": true,
+                "version_added": "1",
+                "version_removed": "4",
                 "partial_implementation": true,
                 "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."
               }
             ],
-            "firefox_android": {
-              "version_added": "4"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": true
             },
@@ -33,7 +32,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for all browsers for the `plaintext` HTML element. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code: ```

<plaintext>Hello world!

```
