### PR TITLE
Add Chromium versions for progress HTML element

### DIFF
--- a/html/elements/progress.json
+++ b/html/elements/progress.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "6"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
@@ -57,9 +55,7 @@
               "chrome": {
                 "version_added": "6"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -99,9 +95,7 @@
               "chrome": {
                 "version_added": "6"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `progress` HTML element. This sets Chrome Android to mirror from upstream.
