### PR TITLE
Add Chrome/Safari versions for rb HTML element

### DIFF
--- a/html/elements/rb.json
+++ b/html/elements/rb.json
@@ -28,21 +28,9 @@
               "partial_implementation": true,
               "notes": "Safari has support for parsing the <code>rb</code> element, but not for rendering <code>rb</code> content as expected."
             },
-            "safari_ios": {
-              "version_added": true,
-              "partial_implementation": true,
-              "notes": "Safari has support for parsing the <code>rb</code> element, but not for rendering <code>rb</code> content as expected."
-            },
-            "samsunginternet_android": {
-              "version_added": true,
-              "partial_implementation": true,
-              "notes": "Blink has support for parsing the <code>rb</code> element, but not for rendering <code>rb</code> content as expected."
-            },
-            "webview_android": {
-              "version_added": "37",
-              "partial_implementation": true,
-              "notes": "Blink has support for parsing the <code>rb</code> element, but not for rendering <code>rb</code> content as expected."
-            }
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `rb` HTML element. This sets derivative browsers to mirror from upstream.
