### PR TITLE
Add Chrome/Safari versions for ruby HTML element

### DIFF
--- a/html/elements/ruby.json
+++ b/html/elements/ruby.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "5"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
@@ -24,15 +22,11 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": "14"
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "5"
             },
-            "safari_ios": {
-              "version_added": true
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `ruby` HTML element. This sets derivative browsers to mirror from upstream.
