### PR TITLE
Add Chrome/Safari versions for script HTML element

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
@@ -27,11 +25,13 @@
             },
             "oculus": "mirror",
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
             "safari": {
-              "version_added": true
+              "version_added": "3"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -49,9 +49,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -63,12 +61,10 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": true
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "≤4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -87,9 +83,7 @@
               "chrome": {
                 "version_added": "30"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "≤18"
               },
@@ -220,9 +214,7 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": true
-              },
+              "opera": "mirror",
               "opera_android": {
                 "version_added": null
               },
@@ -246,9 +238,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -260,12 +250,10 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": true
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "≤4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -330,9 +318,7 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": true
-              },
+              "opera": "mirror",
               "opera_android": {
                 "version_added": null
               },
@@ -356,9 +342,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -370,12 +354,10 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": true
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "≤4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -394,9 +376,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -408,12 +388,10 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": true
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "≤4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -432,9 +410,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -446,12 +422,10 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": true
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "≤4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `script` HTML element. The primary data is mirrored from the interface counterpart.  Derivatives are set to mirror from upstream, and Safari mirrors from Chrome.
