### PR TITLE
Add Chrome/Safari versions for small HTML element

### DIFF
--- a/html/elements/small.json
+++ b/html/elements/small.json
@@ -7,7 +7,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-small-element",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `small` HTML element. This mirrors data from https://github.com/mdn/browser-compat-data/pull/19657 (it doesn't make sense for `<big>` to be supported and `<small>` not to be).
