### PR TITLE
Add Chrome/Safari versions for source HTML element

### DIFF
--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -7,7 +7,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "3"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -25,7 +25,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "3.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -75,7 +75,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "3"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -90,11 +90,9 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "3.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -152,7 +150,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "3"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -167,11 +165,9 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "3.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -229,7 +225,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "3"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -244,11 +240,9 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "3.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `source` HTML element. This mirrors data from the interface counterpart.
