### PR TITLE
Add Chrome/Safari versions for sup HTML element

### DIFF
--- a/html/elements/sup.json
+++ b/html/elements/sup.json
@@ -7,7 +7,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-sub-and-sup-elements",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `sup` HTML element. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code:

```

<p>Almost every developer's favorite molecule is C<sub>8</sub>H<sub>10</sub>N<sub>4</sub>O<sub>2</sub>, also known as "caffeine."<sup>[1]</sup></p>

```
