### PR TITLE
Add Chrome/Safari versions for table HTML element

### DIFF
--- a/html/elements/table.json
+++ b/html/elements/table.json
@@ -22,13 +22,13 @@
             },
             "oculus": "mirror",
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -59,13 +59,13 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": true
+                "version_added": "≤12.1"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "≤12.1"
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -97,10 +97,10 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": "≤15"
+                "version_added": "≤12.1"
               },
               "opera_android": {
-                "version_added": "≤14"
+                "version_added": "≤12.1"
               },
               "safari": {
                 "version_added": "1"
@@ -135,13 +135,13 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": true
+                "version_added": "≤12.1"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "≤12.1"
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -173,13 +173,13 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": true
+                "version_added": "≤12.1"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "≤12.1"
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -211,13 +211,13 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": true
+                "version_added": "≤12.1"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "≤12.1"
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -249,13 +249,13 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": true
+                "version_added": "≤12.1"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "≤12.1"
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -287,13 +287,13 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": true
+                "version_added": "≤12.1"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "≤12.1"
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -325,13 +325,13 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": true
+                "version_added": "≤12.1"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "≤12.1"
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -363,13 +363,13 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": true
+                "version_added": "≤12.1"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "≤12.1"
               },
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `table` HTML element. This data comes from lots and lots of prior testing.
