### PR TITLE
Add all browsers versions for textarea HTML element

### DIFF
--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -7,14 +7,14 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": [
                 "Before Firefox 6, when a <code>&lt;textarea&gt;</code> was focused, the insertion point was placed at the end of the text by default. Other major browsers place the insertion point at the beginning of the text.",
                 "A default background-image gradient is applied to all <code>&lt;textarea&gt;</code> elements, which can be disabled using <code>background-image: none</code>.",
@@ -26,13 +26,17 @@
               "version_added": true
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": {
-              "version_added": true,
+              "version_added": "≤3",
               "notes": "Unlike other major browsers, a default style of <code>opacity: 0.4</code> is applied to disabled <code>&lt;textarea&gt;</code> elements."
             },
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for all browsers for the `textarea` HTML element. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code: https://developer.mozilla.org/docs/Web/HTML/Element/textarea
