### PR TITLE
Add Chrome/Safari versions for tfoot HTML element

### DIFF
--- a/html/elements/tfoot.json
+++ b/html/elements/tfoot.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
@@ -24,11 +22,13 @@
             },
             "oculus": "mirror",
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `tfoot` HTML element. This data comes from lots and lots of prior testing.
