### PR TITLE
Add Chrome/Safari versions for thead HTML element

### DIFF
--- a/html/elements/thead.json
+++ b/html/elements/thead.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
@@ -24,11 +22,13 @@
             },
             "oculus": "mirror",
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
             "safari": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Backgrounds applied to <code>&lt;thead&gt;</code> elements will be applied to each table cell, rather than the entire header. To mimic the behavior of other browsers, set the <code>background-attachment</code> CSS property to <code>fixed</code>."
             },
             "safari_ios": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `thead` HTML element. This data comes from lots and lots of prior testing.
