### PR TITLE
Add Chrome/Safari versions for track HTML element

### DIFF
--- a/html/elements/track.json
+++ b/html/elements/track.json
@@ -28,17 +28,14 @@
               "version_added": "12.1"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "12.1"
             },
             "safari": {
               "version_added": "6"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": true,
-              "notes": "Doesn't work for fullscreen video."
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -68,14 +65,12 @@
                 "version_added": "12.1"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "12.1"
               },
               "safari": {
                 "version_added": "6"
               },
-              "safari_ios": {
-                "version_added": null
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -107,15 +102,11 @@
               "opera": {
                 "version_added": "12.1"
               },
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "6"
               },
-              "safari_ios": {
-                "version_added": null
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -147,15 +138,11 @@
               "opera": {
                 "version_added": "12.1"
               },
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "6"
               },
-              "safari_ios": {
-                "version_added": null
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -187,15 +174,11 @@
               "opera": {
                 "version_added": "12.1"
               },
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "6"
               },
-              "safari_ios": {
-                "version_added": null
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -263,15 +246,11 @@
               "opera": {
                 "version_added": "12.1"
               },
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "6"
               },
-              "safari_ios": {
-                "version_added": null
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `track` HTML element. This sets all derivative browsers to mirror from upstream.
