### PR TITLE
Add all browsers versions for tt HTML element

### DIFF
--- a/html/elements/tt.json
+++ b/html/elements/tt.json
@@ -7,14 +7,14 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#tt",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."
             },
             "firefox_android": "mirror",
@@ -25,7 +25,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for all browsers for the `tt` HTML element. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tt#basic_example
