### PR TITLE
Add Chromium versions for video HTML element

### DIFF
--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "3"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
@@ -81,9 +79,7 @@
               "chrome": {
                 "version_added": "3"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -122,9 +118,7 @@
               "chrome": {
                 "version_added": "3"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -204,9 +198,7 @@
               "chrome": {
                 "version_added": "3"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -244,9 +236,7 @@
               "chrome": {
                 "version_added": "3"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -284,9 +274,7 @@
               "chrome": {
                 "version_added": "30"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -324,9 +312,7 @@
               "chrome": {
                 "version_added": "3"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -410,9 +396,7 @@
               "chrome": {
                 "version_added": "3"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -450,9 +434,7 @@
               "chrome": {
                 "version_added": "3"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `video` HTML element. This sets Chrome Android to mirror from upstream.
