### PR TITLE
Add Chrome/Safari versions for wbr HTML element

### DIFF
--- a/html/elements/wbr.json
+++ b/html/elements/wbr.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": "1"
@@ -26,14 +24,12 @@
               "version_added": "11.6"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "12"
             },
             "safari": {
               "version_added": "4"
             },
-            "safari_ios": {
-              "version_added": null
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `wbr` HTML element. This sets derivative browsers to mirror from upstream.
