### PR TITLE
Add Chrome/Safari versions for xmp HTML element

### DIFF
--- a/html/elements/xmp.json
+++ b/html/elements/xmp.json
@@ -7,14 +7,14 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#xmp",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true,
+              "version_added": "1",
               "notes": "Before Firefox 4, this element implemented the <code>HTMLSpanElement</code> interface instead of the standard <code>HTMLElement</code> interface."
             },
             "firefox_android": "mirror",
@@ -25,7 +25,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `xmp` HTML element. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code:
```
<xmp>
  L          TE
    A       A
      C    V
       R A
       DOU
       LOU
      REUSE
      QUE TU
      PORTES
    ET QUI T'
    ORNE O CI
     VILISÉ
    OTE-  TU VEUX
     LA    BIEN
    SI      RESPI
            RER       - Apollinaire
</xmp>
```
