### PR TITLE
Update animation-timeline support

### DIFF
--- a/css/properties/animation-timeline.json
+++ b/css/properties/animation-timeline.json
@@ -7,7 +7,14 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-animations-2/#animation-timeline",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "85",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "enable-experimental-web-platform-features",
+                  "value_to_set": "enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
_👋 Hi, Chrome DevRel here!_

Chromium supports `animation-timeline`, behind a flag, as of version 85.

CL: https://chromium-review.googlesource.com/c/chromium/src/+/2223950
Version Info for commit: https://chromiumdash.appspot.com/commit/cdc482ffdb53bfacb937b286b8a6f4bd91211026