### PR TITLE
Firefox 113 is released

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -662,7 +662,7 @@
         "91": {
           "release_date": "2021-08-10",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/91",
-          "status": "esr",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "91"
         },
@@ -809,28 +809,28 @@
         "112": {
           "release_date": "2023-04-11",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/112",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "112"
         },
         "113": {
           "release_date": "2023-05-09",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/113",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "113"
         },
         "114": {
           "release_date": "2023-06-06",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/114",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "114"
         },
         "115": {
           "release_date": "2023-07-04",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/115",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "116"
         },

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -676,28 +676,28 @@
         "112": {
           "release_date": "2023-04-11",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/112",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "112"
         },
         "113": {
           "release_date": "2023-05-09",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/113",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "113"
         },
         "114": {
           "release_date": "2023-06-06",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/114",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "114"
         },
         "115": {
           "release_date": "2023-07-04",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/115",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "116"
         },


### PR DESCRIPTION
Firefox 113 is now released.  This PR marks it as the current release version.  Additionally, this marks the current ESR release as retired, as 113 is the new ESR as well (confirmed by attempting to download Firefox ESR and checking the filename -- "Firefox Setup 113.*").
