### PR TITLE
Add Chromium versions for circle SVG element

### DIFF
--- a/svg/elements/circle.json
+++ b/svg/elements/circle.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `circle` SVG element. This sets Chrome Android to mirror from upstream.
