### PR TITLE
Add Edge versions for cursor SVG element

### DIFF
--- a/svg/elements/cursor.json
+++ b/svg/elements/cursor.json
@@ -10,9 +10,7 @@
               "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "≤79"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -47,9 +45,7 @@
                 "version_added": "50"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": null
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Microsoft Edge for the `cursor` SVG element. This sets Edge to mirror from upstream.
