### PR TITLE
Add Opera versions for desc SVG element

### DIFF
--- a/svg/elements/desc.json
+++ b/svg/elements/desc.json
@@ -27,7 +27,7 @@
               "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.1"


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Opera and Opera Android for the `desc` SVG element. This mirrors Opera Desktop to Opera Android.
