### PR TITLE
Add Chrome/Safari versions for feComposite SVG element

### DIFF
--- a/svg/elements/feComposite.json
+++ b/svg/elements/feComposite.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "≤18"
             },
@@ -50,9 +48,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "≤18",
                 "notes": "Before Edge 79, <code>BackgroundImage</code> and <code>BackgroundAlpha</code> were supported."
@@ -66,11 +62,9 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": "14"
-              },
+              "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": {
@@ -91,9 +85,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "≤18",
                 "notes": "Before Edge 79, <code>BackgroundImage</code> and <code>BackgroundAlpha</code> were supported."
@@ -107,11 +99,9 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": "14"
-              },
+              "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": {
@@ -134,9 +124,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "≤79"
               },
@@ -149,11 +137,9 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": "14"
-              },
+              "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": {
@@ -176,9 +162,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "≤79"
               },
@@ -191,11 +175,9 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": "14"
-              },
+              "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": {
@@ -218,9 +200,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "≤79"
               },
@@ -233,11 +213,9 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": "14"
-              },
+              "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": {
@@ -260,9 +238,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "≤79"
               },
@@ -275,11 +251,9 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": "14"
-              },
+              "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": {
@@ -300,9 +274,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "≤18"
               },
@@ -315,14 +287,14 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": "14"
-              },
+              "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "6"
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
+              "samsunginternet_android": {
+                "version_added": "1.5"
+              },
               "webview_android": "mirror"
             },
             "status": {


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `feComposite` SVG element. This sets Chrome Android to mirror from upstream, and mirrors Chrome to Safari (given when the entire features was supported).
