### PR TITLE
Add Opera versions for feConvolveMatrix SVG element

### DIFF
--- a/svg/elements/feConvolveMatrix.json
+++ b/svg/elements/feConvolveMatrix.json
@@ -22,9 +22,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": null
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": null
             },
@@ -161,9 +159,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": null
               },
@@ -199,9 +195,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": null
               },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Opera and Opera Android for the `feConvolveMatrix` SVG element. This sets Opera Android to mirror from upstream.
