### PR TITLE
Add Opera versions for feFlood SVG element

### DIFF
--- a/svg/elements/feFlood.json
+++ b/svg/elements/feFlood.json
@@ -22,9 +22,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": null
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": null
             },
@@ -57,9 +55,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": null
               },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Opera and Opera Android for the `feFlood` SVG element. svg.elements.feFlood
