### PR TITLE
Add Safari iOS versions for feGaussianBlur SVG element

### DIFF
--- a/svg/elements/feGaussianBlur.json
+++ b/svg/elements/feGaussianBlur.json
@@ -30,9 +30,7 @@
             "safari": {
               "version_added": "9.1"
             },
-            "safari_ios": {
-              "version_added": true
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -101,9 +99,7 @@
               "safari": {
                 "version_added": "9.1"
               },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -143,9 +139,7 @@
               "safari": {
                 "version_added": "9.1"
               },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Safari iOS/iPadOS for the `feGaussianBlur` SVG element. This sets Safari iOS to mirror from upstream.
