### PR TITLE
Add all browsers versions for feImage SVG element

### DIFF
--- a/svg/elements/feImage.json
+++ b/svg/elements/feImage.json
@@ -16,9 +16,7 @@
             "firefox": {
               "version_added": "4"
             },
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": true
             },
@@ -27,7 +25,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": true
@@ -62,9 +60,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "12.1"
               },
@@ -126,10 +122,7 @@
                 "version_added": "4",
                 "notes": "Document fragments (including references to fragments in the current document) are not supported (see <a href='https://bugzil.la/455986'>bug 455986</a>)."
               },
-              "firefox_android": {
-                "version_added": true,
-                "notes": "Document fragments (including references to fragments in the current document) are not supported (see <a href='https://bugzil.la/455986'>bug 455986</a>)."
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": true
               },
@@ -137,9 +130,7 @@
               "opera": {
                 "version_added": "9"
               },
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": null
               },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for all browsers for the `feImage` SVG element. This sets derivative browsers to mirror from upstream.
