### PR TITLE
Add text-wrap and white-space-collapse, and update white-space

### DIFF
--- a/css/properties/text-wrap.json
+++ b/css/properties/text-wrap.json
@@ -1,0 +1,42 @@
+{
+  "css": {
+    "properties": {
+      "text-wrap": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-wrap",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-text-4/#text-wrap",
+          "support": {
+            "chrome": {
+              "version_added": "114",
+              "partial_implementation": true,
+              "notes": "The <code>pretty</code> and <code>stable</code> values are not supported."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/white-space-collapse.json
+++ b/css/properties/white-space-collapse.json
@@ -1,0 +1,42 @@
+{
+  "css": {
+    "properties": {
+      "white-space-collapse": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/white-space-collapse",
+          "spec_url": "https://w3c.github.io/csswg-drafts/css-text-4/#white-space-collapsing",
+          "support": {
+            "chrome": {
+              "version_added": "114",
+              "partial_implementation": true,
+              "notes": "The <code>discard</code> and <code>preserve-spaces</code> values are not supported."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -243,6 +243,41 @@
             }
           }
         },
+        "shorthand_values": {
+          "__compat": {
+            "description": "Accepts shorthand values",
+            "support": {
+              "chrome": {
+                "version_added": "114",
+                "partial_implementation": true,
+                "notes": "Accepts shorthand values for <code>white-space-collapse</code> and <code>text-wrap</code> only."
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "svg_support": {
           "__compat": {
             "description": "Support in SVG",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 114 adds the `text-wrap` and `white-space-collapse` CSS properties, and updates the `white-space` property with new behavior — as well as taking its usual keywords, it can now act as a shorthand property for `text-wrap` and `white-space-collapse`. These items are specified in [CSS Text Level 4](https://www.w3.org/TR/css-text-4/).

This PR adds compat data for those items.

Note - there is another related property, `white-space-trim`, which is specced as being included in the `white-space` shorthand value, but this is not supported yet so I have not added it.

My [research document](https://docs.google.com/document/d/1de7T6UbSEcDvKKmyqz-yS3D2CS7XT67mxFjHhzKYlMc/edit#) provides additional details about this overall project and its required changes.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

I used https://codepen.io/web-dot-dev/pen/QWVXbRM as a test case, along with the Chrome DevTools, to test whether the properties worked and what values were not available. 114 seems correct for the version, plus it has been officially reported as being in 114 beta: see https://developer.chrome.com/blog/chrome-114-beta/#css-headline-balancing.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
