### PR TITLE
Add all browsers versions for feMerge SVG element

### DIFF
--- a/svg/elements/feMerge.json
+++ b/svg/elements/feMerge.json
@@ -16,9 +16,7 @@
             "firefox": {
               "version_added": "4"
             },
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": true
             },
@@ -27,7 +25,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": null


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for all browsers for the `feMerge` SVG element. This sets derivative browsers to mirror from upstream.
