### PR TITLE
Add Opera versions for feMorphology SVG element

### DIFF
--- a/svg/elements/feMorphology.json
+++ b/svg/elements/feMorphology.json
@@ -25,7 +25,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": null
@@ -60,9 +60,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": null
               },
@@ -99,7 +97,7 @@
                 "version_added": "9"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": null
@@ -137,7 +135,7 @@
                 "version_added": "9"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": null
@@ -177,7 +175,7 @@
                 "version_added": "9"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": null


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Opera and Opera Android for the `feMorphology` SVG element. This sets Opera Android to mirror from upstream.
