### PR TITLE
Add all browsers versions for feSpotLight SVG element

### DIFF
--- a/svg/elements/feSpotLight.json
+++ b/svg/elements/feSpotLight.json
@@ -16,9 +16,7 @@
             "firefox": {
               "version_added": "4"
             },
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": true
             },
@@ -27,7 +25,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": null
@@ -57,9 +55,7 @@
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": true
               },
@@ -68,7 +64,7 @@
                 "version_added": "9"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": null
@@ -99,9 +95,7 @@
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": true
               },
@@ -110,7 +104,7 @@
                 "version_added": "9"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": null
@@ -141,9 +135,7 @@
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": true
               },
@@ -152,7 +144,7 @@
                 "version_added": "9"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": null
@@ -183,9 +175,7 @@
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": true
               },
@@ -194,7 +184,7 @@
                 "version_added": "9"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": null
@@ -223,9 +213,7 @@
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": true
               },
@@ -234,7 +222,7 @@
                 "version_added": "9"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": null
@@ -263,9 +251,7 @@
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": true
               },
@@ -274,7 +260,7 @@
                 "version_added": "9"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": null
@@ -303,9 +289,7 @@
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": true
               },
@@ -314,7 +298,7 @@
                 "version_added": "9"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": null
@@ -343,9 +327,7 @@
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": true
               },
@@ -354,7 +336,7 @@
                 "version_added": "9"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": null


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for all browsers for the `feSpotLight` SVG element. This sets derivative browsers to mirror from upstream.
