### PR TITLE
Add all browsers versions for feTile SVG element

### DIFF
--- a/svg/elements/feTile.json
+++ b/svg/elements/feTile.json
@@ -16,9 +16,7 @@
             "firefox": {
               "version_added": "4"
             },
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": true
             },
@@ -27,7 +25,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": null
@@ -55,9 +53,7 @@
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": true
               },
@@ -66,7 +62,7 @@
                 "version_added": "9"
               },
               "opera_android": {
-                "version_added": null
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": null


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for all browsers for the `feTile` SVG element. svg.elements.feTile
