### PR TITLE
Add Firefox Android versions for feTurbulence SVG element

### DIFF
--- a/svg/elements/feTurbulence.json
+++ b/svg/elements/feTurbulence.json
@@ -17,9 +17,7 @@
             "firefox": {
               "version_added": "4"
             },
-            "firefox_android": {
-              "version_added": true
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": true,
               "notes": "Partially supported, see <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/12382004/'>bug 12382004</a>."
@@ -58,9 +56,7 @@
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": true,
                 "notes": "Partially supported, see <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/12382004/'>bug 12382004</a>."
@@ -134,9 +130,7 @@
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": true,
                 "notes": "Partially supported, see <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/12382004/'>bug 12382004</a>."


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Firefox Android for the `feTurbulence` SVG element. This sets Firefox Android to mirror from upstream.
