### PR TITLE
Add Opera versions for image SVG element

### DIFF
--- a/svg/elements/image.json
+++ b/svg/elements/image.json
@@ -25,7 +25,7 @@
               "version_added": "8"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.1"


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Opera and Opera Android for the `image` SVG element. This sets Opera Android to mirror from upstream.
