### PR TITLE
Add Chrome Android versions for metadata SVG element

### DIFF
--- a/svg/elements/metadata.json
+++ b/svg/elements/metadata.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome Android for the `metadata` SVG element. This sets Chrome Android to mirror from upstream.
