### PR TITLE
Add Opera versions for mpath SVG element

### DIFF
--- a/svg/elements/mpath.json
+++ b/svg/elements/mpath.json
@@ -22,9 +22,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": null
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": null
             },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Opera and Opera Android for the `mpath` SVG element. This sets Opera Android to mirror from upstream.
