### PR TITLE
Add Edge versions for svg.elements.pattern.href

### DIFF
--- a/svg/elements/pattern.json
+++ b/svg/elements/pattern.json
@@ -81,9 +81,7 @@
                 "version_added": "50"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": null
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": null
               },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Microsoft Edge for the `href` member of the `pattern` SVG element. This sets Edge to mirror from upstream.
