### PR TITLE
Add Opera versions for radialGradient SVG element

### DIFF
--- a/svg/elements/radialGradient.json
+++ b/svg/elements/radialGradient.json
@@ -25,7 +25,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.1"


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Opera and Opera Android for the `radialGradient` SVG element. This sets Opera Android to mirror from upstream.
