### PR TITLE
Add Node 18.0.0 for new Intl.Locale properties

### DIFF
--- a/javascript/builtins/Intl/Locale.json
+++ b/javascript/builtins/Intl/Locale.json
@@ -265,7 +265,9 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "18.0.0",
+                  "alternative_name": "calendars",
+                  "notes": "Implemented as an accessor property."
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -315,7 +317,9 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "18.0.0",
+                  "alternative_name": "collations",
+                  "notes": "Implemented as an accessor property."
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -365,7 +369,9 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "18.0.0",
+                  "alternative_name": "hourCycles",
+                  "notes": "Implemented as an accessor property."
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -415,7 +421,9 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "18.0.0",
+                  "alternative_name": "numberingSystems",
+                  "notes": "Implemented as an accessor property."
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -465,7 +473,9 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "18.0.0",
+                  "alternative_name": "textInfo",
+                  "notes": "Implemented as an accessor property."
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -515,7 +525,9 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "18.0.0",
+                  "alternative_name": "timeZones",
+                  "notes": "Implemented as an accessor property."
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -565,7 +577,9 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "18.0.0",
+                  "alternative_name": "weekInfo",
+                  "notes": "Implemented as an accessor property."
                 },
                 "oculus": "mirror",
                 "opera": "mirror",


### PR DESCRIPTION
Similarly to [Release 99 Intl.Locale Chromium adds support for some new properties](https://github.com/mdn/browser-compat-data/pull/15505) Node.js shipped with V8 engine version 10.1 in release 18.0.0 with one of the highlights compared to the version included in Node.js 17.9.0 being(from [CHANGELOG_V18](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V18.md)):
- Improvements to the [`Intl.Locale` API](https://v8.dev/blog/v8-release-99#intl.locale-extensions).

Changes are straightforward and same as Chrome support.