### PR TITLE
docs(relnote): Fx114 - dropping mozImageSmoothingEnabled & other deprecated prefixes

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1480,41 +1480,19 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/imageSmoothingEnabled",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-imagesmoothingenabled-dev",
           "support": {
-            "chrome": [
-              {
-                "version_added": "30"
-              },
-              {
-                "version_added": "21",
-                "version_removed": "30",
-                "prefix": "webkit"
-              }
-            ],
+            "chrome": {
+              "version_added": "30"
+            },
             "chrome_android": "mirror",
-            "edge": [
-              {
-                "version_added": "15"
-              },
-              {
-                "version_added": "12",
-                "version_removed": "15",
-                "prefix": "ms"
-              }
-            ],
-            "firefox": [
-              {
-                "version_added": "51"
-              },
-              {
-                "version_added": "3.6",
-                "version_removed": "51",
-                "prefix": "moz"
-              }
-            ],
+            "edge": {
+              "version_added": "15"
+            },
+            "firefox": {
+              "version_added": "51"
+            },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "11",
-              "prefix": "ms"
+              "version_added": "11"
             },
             "oculus": "mirror",
             "opera": "mirror",

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1492,8 +1492,8 @@
             },
             "firefox_android": "mirror",
             "ie": {
-              "prefix": "ms",
-              "version_added": "11"
+              "version_added": "11",
+              "prefix": "ms"
             },
             "oculus": "mirror",
             "opera": "mirror",

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1492,6 +1492,7 @@
             },
             "firefox_android": "mirror",
             "ie": {
+              "prefix": "ms",
               "version_added": "11"
             },
             "oculus": "mirror",


### PR DESCRIPTION
The prop `mozImageSmoothingEnabled` is deprecated for a long time and is now no longer supported in Fx. It looks like the other vendor prefixes for `CanvasRenderingContext2D.{prefix}ImageSmoothingEnabled` may also be removed if that makes sense in the interest of housekeeping.

__Related issues and pull requests:__
- [ ] Parent issue https://github.com/mdn/content/issues/26686
- [ ] docs relnote https://github.com/mdn/content/pull/26726

__Bugzilla:__
- Tracking bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1228850

__Other resources:__
* Intent to Remove: CanvasRenderingContext2D.webkitImageSmoothingEnabled https://groups.google.com/a/chromium.org/g/blink-dev/c/qeFgqezm0cM/m/z708BVaGAAAJ
* https://chromestatus.com/metrics/feature/timeline/popularity/267

