### PR TITLE
Add Safari Tech Preview support for fetchpriority

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -422,7 +422,13 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Fetch Priority"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -262,7 +262,13 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Fetch Priority"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -295,7 +295,13 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "Fetch Priority"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -269,7 +269,13 @@
               },
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Fetch Priority"
+                  }
+                ]
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -183,7 +183,13 @@
               },
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Fetch Priority"
+                  }
+                ]
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -185,7 +185,13 @@
               },
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Fetch Priority"
+                  }
+                ]
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Safari Tech Preview no has support for fetchpriority (formally known as Priority Hints).

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

Tested locally, as per below screenshot

![image](https://github.com/mdn/browser-compat-data/assets/10931297/10bb67d9-eb34-4412-98b7-a7d4aa630afd)

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://bugs.webkit.org/show_bug.cgi?id=252739

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
