### PR TITLE
RTCStatsReport - stats - update links to corresponding dicts for peerconnection and some audio

### DIFF
--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -5115,7 +5115,7 @@
       "type_peer-connection": {
         "__compat": {
           "description": "<code>peer-connection</code> stats",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport#peer_connection",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionStats",
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-peer-connection",
           "support": {
             "chrome": {
@@ -5149,6 +5149,7 @@
         "dataChannelsClosed": {
           "__compat": {
             "description": "<code>dataChannelsClosed</code> in 'peer-connection' stats",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionStats/dataChannelsClosed",
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcpeerconnectionstats-datachannelsclosed",
             "support": {
               "chrome": {
@@ -5183,6 +5184,7 @@
         "dataChannelsOpened": {
           "__compat": {
             "description": "<code>dataChannelsOpened</code> in 'peer-connection' stats",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionStats/dataChannelsOpened",
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcpeerconnectionstats-datachannelsopened",
             "support": {
               "chrome": {
@@ -5217,6 +5219,7 @@
         "id": {
           "__compat": {
             "description": "<code>id</code> in 'peer-connection' stats",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionStats/id",
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstats-id",
             "support": {
               "chrome": {
@@ -5251,6 +5254,7 @@
         "timestamp": {
           "__compat": {
             "description": "<code>timestamp</code> in 'peer-connection' stats",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionStats/timestamp",
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstats-timestamp",
             "support": {
               "chrome": {
@@ -5285,6 +5289,7 @@
         "type": {
           "__compat": {
             "description": "<code>type</code> in 'peer-connection' stats",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCPeerConnectionStats/type",
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstats-type",
             "support": {
               "chrome": {

--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -4156,6 +4156,7 @@
         "audioLevel": {
           "__compat": {
             "description": "<code>audioLevel</code> in 'media-source' stats",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCAudioSourceStats/audioLevel",
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcaudiosourcestats-audiolevel",
             "support": {
               "chrome": {
@@ -4292,6 +4293,7 @@
         "totalAudioEnergy": {
           "__compat": {
             "description": "<code>totalAudioEnergy</code> in 'media-source' stats",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCAudioSourceStats/totalAudioEnergy",
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcaudiosourcestats-totalaudioenergy",
             "support": {
               "chrome": {
@@ -4326,6 +4328,7 @@
         "totalSamplesDuration": {
           "__compat": {
             "description": "<code>totalSamplesDuration</code> in 'media-source' stats",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCAudioSourceStats/totalSamplesDuration",
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcaudiosourcestats-totalsamplesduration",
             "support": {
               "chrome": {


### PR DESCRIPTION
The peer connection stats and audio and video stats in media-source are now dictionaries. Where I can, I have linked to the correct MDN places.

@queengooborg FYI This mismatch is a bit of a pain for links to MDN since you have something `kind` and `id` that appears in multiple places on MDN. I have fixed the ones that have a distinct link? Do you think it is better to have no link, or link to the RTCStatsReport if there is no better option.

Either way, this should be good to merge now.