### PR TITLE
FF114 remove cache directive from HTTP  Clear-Site-Data

### DIFF
--- a/http/headers/Clear-Site-Data.json
+++ b/http/headers/Clear-Site-Data.json
@@ -83,23 +83,10 @@
               "edge": {
                 "version_added": "≤79"
               },
-              "firefox": [
-                {
-                  "version_added": "63",
-                  "version_removed": "94"
-                },
-                {
-                  "version_added": "94",
-                  "version_removed": "114",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "privacy.clearsitedata.cache.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "63",
+                "version_removed": "94"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/http/headers/Clear-Site-Data.json
+++ b/http/headers/Clear-Site-Data.json
@@ -85,7 +85,12 @@
               },
               "firefox": [
                 {
+                  "version_added": "63",
+                  "version_removed": "94"
+                },
+                {
                   "version_added": "94",
+                  "version_removed": "114",
                   "flags": [
                     {
                       "type": "preference",
@@ -93,10 +98,6 @@
                       "value_to_set": "true"
                     }
                   ]
-                },
-                {
-                  "version_added": "63",
-                  "version_removed": "94"
                 }
               ],
               "firefox_android": "mirror",


### PR DESCRIPTION
FF114 removes this in https://bugzilla.mozilla.org/show_bug.cgi?id=1821651

Other docs work for this can be tracked in https://github.com/mdn/content/issues/26246

