### PR TITLE
FF114 Module import in workers and worklets - dynamic/static

### DIFF
--- a/api/ServiceWorker.json
+++ b/api/ServiceWorker.json
@@ -35,6 +35,41 @@
           "deprecated": false
         }
       },
+      "ecmascript_modules": {
+        "__compat": {
+          "description": "Support for ECMAScript modules",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "error_event": {
         "__compat": {
           "description": "<code>error</code> event",

--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -120,6 +120,53 @@
             "deprecated": false
           }
         },
+        "ecmascript_modules": {
+          "__compat": {
+            "description": "Support for ECMAScript modules",
+            "support": {
+              "chrome": {
+                "version_added": "80"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "deno": {
+                "version_added": "1.0"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "114"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "12.17.0",
+                "partial_implementation": true,
+                "notes": "ECMAScript modules are enabled for files ending with <code>.mjs</code> and for files ending with <code>.js</code> when the nearest parent <code>package.json</code> file contains a top-level field <code>\"type\"</code> with a value of <code>\"module\"</code>."
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "15",
+                "notes": [
+                  "Nested workers support was introduced in Safari 15.5.",
+                  "Script loading in nested workers was introduced in Safari 16.4."
+                ]
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "mime_checks": {
           "__compat": {
             "description": "Strict MIME type checks for shared worker scripts",

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -159,25 +159,9 @@
                 "version_added": "1.0"
               },
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "preview",
-                  "partial_implementation": true,
-                  "notes": "Does not support dynamic import. See <a href='https://bugzil.la/1540913'>bug 1540913</a>"
-                },
-                {
-                  "version_added": "111",
-                  "partial_implementation": true,
-                  "notes": "Does not support dynamic import. See <a href='https://bugzil.la/1540913'>bug 1540913</a>",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.workers.modules.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "114"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/api/Worklet.json
+++ b/api/Worklet.json
@@ -66,6 +66,45 @@
             "deprecated": false
           }
         }
+      },
+      "ecmascript_modules": {
+        "__compat": {
+          "description": "Support for ECMAScript modules",
+          "support": {
+            "chrome": {
+              "version_added": "80"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "114"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15",
+              "notes": [
+                "Nested workers support was introduced in Safari 15.5.",
+                "Script loading in nested workers was introduced in Safari 16.4."
+              ]
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/javascript/operators/import.json
+++ b/javascript/operators/import.json
@@ -67,14 +67,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "113",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.workers.modules.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "114"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1514,7 +1514,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "15"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -1553,7 +1553,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "15"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1487,6 +1487,84 @@
               }
             }
           }
+        },
+        "service_worker_support": {
+          "__compat": {
+            "description": "Available in service workers",
+            "support": {
+              "chrome": {
+                "version_added": "91"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "114"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "15"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "worklet_support": {
+          "__compat": {
+            "description": "Available in worklets",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "114"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "15"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "label": {

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1335,21 +1335,9 @@
                 "version_added": "1.0"
               },
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "preview"
-                },
-                {
-                  "version_added": "111",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.workers.modules.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "114"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false


### PR DESCRIPTION
FF114 ships support for worker modules (dynamic and static) in https://bugzilla.mozilla.org/show_bug.cgi?id=1812591

This replaces the preference with a release.

Other docs work for this can be tracked in https://github.com/mdn/content/issues/26695

Note, draft as I am checking if there are any other notes/compatibility or this is "full support" - I pretty much think it is, but no reason not to wait for answer to https://bugzilla.mozilla.org/show_bug.cgi?id=1812591#c11 