### PR TITLE
Add Opera versions for svg.elements.set.to

### DIFF
--- a/svg/elements/set.json
+++ b/svg/elements/set.json
@@ -64,7 +64,7 @@
                 "version_added": "≤12.1"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "≤12.1"
               },
               "safari": {
                 "version_added": "3"


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Opera and Opera Android for the `to` member of the `set` SVG element. This mirrors Opera desktop to Opera Android.
