### PR TITLE
Add Opera versions for stop SVG element

### DIFF
--- a/svg/elements/stop.json
+++ b/svg/elements/stop.json
@@ -25,7 +25,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3"
@@ -66,7 +66,7 @@
                 "version_added": "9"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -108,7 +108,7 @@
                 "version_added": "9"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"
@@ -152,7 +152,7 @@
                 "version_added": "9"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "3"


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Opera and Opera Android for the `stop` SVG element. This mirrors Opera desktop to Opera Android.
