### PR TITLE
Add Chrome Android versions for svg SVG element

### DIFF
--- a/svg/elements/svg.json
+++ b/svg/elements/svg.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
@@ -26,7 +24,9 @@
             "opera": {
               "version_added": "8"
             },
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": "10.1"
+            },
             "safari": {
               "version_added": "3"
             },
@@ -63,9 +63,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": null
               },
@@ -99,9 +97,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": null
               },
@@ -135,9 +131,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": null
               },
@@ -158,9 +152,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -175,7 +167,9 @@
               "opera": {
                 "version_added": "8"
               },
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": "10.1"
+              },
               "safari": {
                 "version_added": "3"
               },
@@ -200,9 +194,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -217,7 +209,9 @@
               "opera": {
                 "version_added": "8"
               },
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": "10.1"
+              },
               "safari": {
                 "version_added": "3"
               },
@@ -257,9 +251,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": null
               },
@@ -280,9 +272,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -297,7 +287,9 @@
               "opera": {
                 "version_added": "8"
               },
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": "10.1"
+              },
               "safari": {
                 "version_added": "3"
               },
@@ -322,9 +314,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -339,7 +329,9 @@
               "opera": {
                 "version_added": "8"
               },
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": "10.1"
+              },
               "safari": {
                 "version_added": "3"
               },
@@ -364,9 +356,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -381,7 +371,9 @@
               "opera": {
                 "version_added": "8"
               },
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": "10.1"
+              },
               "safari": {
                 "version_added": "3"
               },
@@ -406,9 +398,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -423,7 +413,9 @@
               "opera": {
                 "version_added": "8"
               },
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": "10.1"
+              },
               "safari": {
                 "version_added": "3"
               },
@@ -463,9 +455,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": null
               },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome Android for the `svg` SVG element. This mirrors Chrome to Chrome Android, and Opera to Opera Android.
