### PR TITLE
Add Opera versions for switch SVG element

### DIFF
--- a/svg/elements/switch.json
+++ b/svg/elements/switch.json
@@ -25,7 +25,7 @@
               "version_added": "8"
             },
             "opera_android": {
-              "version_added": null
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.1"


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Opera and Opera Android for the `switch` SVG element. This mirrors Opera to Opera Android.
