### PR TITLE
Add Opera versions for symbol SVG element

### DIFF
--- a/svg/elements/symbol.json
+++ b/svg/elements/symbol.json
@@ -25,7 +25,7 @@
               "version_added": "9"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "10.1"
             },
             "safari": {
               "version_added": "3.1"


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Opera and Opera Android for the `symbol` SVG element. This mirrors Opera to Opera Android.
