### PR TITLE
Add Chrome Android versions for text SVG element

### DIFF
--- a/svg/elements/text.json
+++ b/svg/elements/text.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
@@ -26,7 +24,9 @@
             "opera": {
               "version_added": "8"
             },
-            "opera_android": "mirror",
+            "opera_android": {
+              "version_added": "10.1"
+            },
             "safari": {
               "version_added": "3"
             },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome Android for the `text` SVG element. This sets both Chrome Android and Opera Android to mirror from upstream.
