### PR TITLE
Add Opera versions for textPath SVG element

### DIFF
--- a/svg/elements/textPath.json
+++ b/svg/elements/textPath.json
@@ -92,12 +92,8 @@
                 "version_added": null
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": null
-              },
-              "opera_android": {
-                "version_added": null
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Opera and Opera Android for the `textPath` SVG element. This sets Opera to mirror from upstream.
