### PR TITLE
Add Opera versions for tref SVG element

### DIFF
--- a/svg/elements/tref.json
+++ b/svg/elements/tref.json
@@ -20,9 +20,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": null
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "3",
               "version_removed": "16.4"
@@ -55,9 +53,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "3",
                 "version_removed": "16.4"


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Opera and Opera Android for the `tref` SVG element. This sets Opera Android to mirror from upstream.
