### PR TITLE
Add Chrome Android versions for tspan SVG element

### DIFF
--- a/svg/elements/tspan.json
+++ b/svg/elements/tspan.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
@@ -163,9 +161,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": null
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": true
               },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome Android for the `tspan` SVG element. This sets Chrome Android and Opera Android to mirror from upstream.
