### PR TITLE
Add Chrome Android versions for use SVG element

### DIFF
--- a/svg/elements/use.json
+++ b/svg/elements/use.json
@@ -9,9 +9,7 @@
             "chrome": {
               "version_added": "22"
             },
-            "chrome_android": {
-              "version_added": true
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
@@ -54,9 +52,7 @@
               "chrome": {
                 "version_added": "22"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "≤18"
               },
@@ -97,9 +93,7 @@
               "chrome": {
                 "version_added": "22"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "13"
               },
@@ -122,9 +116,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "4.4"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome Android for the `use` SVG element. This sets Chrome Android to mirror from upstream.
