### PR TITLE
Update Firefox statuses related to color interpolation methods

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -333,7 +333,8 @@
                   "chrome_android": "mirror",
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": false
+                    "version_added": false,
+                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -366,7 +367,8 @@
                   "chrome_android": "mirror",
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": false
+                    "version_added": false,
+                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -539,7 +541,8 @@
                   "chrome_android": "mirror",
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": false
+                    "version_added": false,
+                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -572,7 +575,8 @@
                   "chrome_android": "mirror",
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": false
+                    "version_added": false,
+                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -922,7 +926,8 @@
                   "chrome_android": "mirror",
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": false
+                    "version_added": false,
+                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -955,7 +960,8 @@
                   "chrome_android": "mirror",
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": false
+                    "version_added": false,
+                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -1056,7 +1062,8 @@
                   "chrome_android": "mirror",
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": false
+                    "version_added": false,
+                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -1089,7 +1096,8 @@
                   "chrome_android": "mirror",
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": false
+                    "version_added": false,
+                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -1262,7 +1270,8 @@
                   "chrome_android": "mirror",
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": false
+                    "version_added": false,
+                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -1295,7 +1304,8 @@
                   "chrome_android": "mirror",
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": false
+                    "version_added": false,
+                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -1650,7 +1660,8 @@
                   "chrome_android": "mirror",
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": false
+                    "version_added": false,
+                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -1683,7 +1694,8 @@
                   "chrome_android": "mirror",
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": false
+                    "version_added": false,
+                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
                   },
                   "firefox_android": "mirror",
                   "ie": {


### PR DESCRIPTION
#### Summary

This PR adds the links to a Mozilla bug for supporting `<color-interpolation-method>` and `<hue-interpolation-method>` in CSS gradient functions.

#### Test results and supporting details

Mozilla Bug 1824041:
https://bugzilla.mozilla.org/show_bug.cgi?id=1824041

#### Related issues

Relates to https://github.com/mdn/content/pull/26775.