### PR TITLE
Add Safari versions for Alt-Svc HTTP header

### DIFF
--- a/http/headers/Alt-Svc.json
+++ b/http/headers/Alt-Svc.json
@@ -32,7 +32,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Safari (Desktop and iOS/iPadOS) for the `Alt-Svc` HTTP header. This fixes #19856, which is where the data comes from.
