### PR TITLE
Remove poor mdn_url for css.at-rules.container.style_queries_for_custom_properties

### DIFF
--- a/css/at-rules/container.json
+++ b/css/at-rules/container.json
@@ -38,7 +38,6 @@
         "style_queries_for_custom_properties": {
           "__compat": {
             "description": "Style queries for custom properties",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@container",
             "spec_url": "https://w3c.github.io/csswg-drafts/css-contain-3/#style-container",
             "support": {
               "chrome": {


### PR DESCRIPTION
This PR removes the redundant MDN URL from the specified feature, which just links to the page of its parent feature.  Fixes #19836.