### PR TITLE
FF114 @import supports() is implemented

### DIFF
--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -75,6 +75,51 @@
               "deprecated": false
             }
           }
+        },
+        "supports": {
+          "__compat": {
+            "description": "<code>supports( [<supports-condition> | <declaration>] )</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": [
+                {
+                  "version_added": "preview"
+                },
+                {
+                  "version_added": "114",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.import-supports.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -78,7 +78,7 @@
         },
         "supports": {
           "__compat": {
-            "description": "<code>supports( [<supports-condition> | <declaration>] )</code>",
+            "description": "<code>supports() as import condition</code>",
             "spec_url": "https://drafts.csswg.org/css-cascade-5/#typedef-import-conditions",
             "support": {
               "chrome": {

--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -79,6 +79,7 @@
         "supports": {
           "__compat": {
             "description": "<code>supports( [<supports-condition> | <declaration>] )</code>",
+            "spec_url": "https://drafts.csswg.org/css-cascade-5/#typedef-import-conditions",
             "support": {
               "chrome": {
                 "version_added": false


### PR DESCRIPTION
This adds BCD data for the `@import` `supports()` option. It's behind a pref and enabled in nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=1427715

I checked support in latest chrome/safari/FF using http://wpt.live/css/css-cascade/import-conditions.html

Other docs work for this can be tracked in https://github.com/mdn/content/issues/26692