### PR TITLE
Update worker support for structuredClone()

### DIFF
--- a/api/_globals/structuredClone.json
+++ b/api/_globals/structuredClone.json
@@ -74,20 +74,14 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
Mirror all Chromium-based browsers. Support in Opera 84 was confirmed
using https://mdn-bcd-collector.gooborg.com/tests/api/structuredClone.

Support in Safari 15.6 was confirmed using the same test, so assume
support goes back to 15.4.