### PR TITLE
Update Safari versions for etc1 compressed textures

### DIFF
--- a/api/WEBGL_compressed_texture_etc1.json
+++ b/api/WEBGL_compressed_texture_etc1.json
@@ -21,9 +21,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "16.2"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "14"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },


### PR DESCRIPTION
Fix https://github.com/mdn/browser-compat-data/issues/19827

I've used the same version numbers as `_etc` (https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_compressed_texture_etc) given https://bugs.webkit.org/show_bug.cgi?id=197900 mentions both.