### PR TITLE
Add Safari 16.5 as a beta browser

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -254,6 +254,11 @@
           "status": "current",
           "engine": "WebKit",
           "engine_version": "615.1.26"
+        },
+        "16.5": {
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_5-release-notes",
+          "status": "beta",
+          "engine": "WebKit"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -226,6 +226,11 @@
           "status": "current",
           "engine": "WebKit",
           "engine_version": "615.1.26"
+        },
+        "16.5": {
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_5-release-notes",
+          "status": "beta",
+          "engine": "WebKit"
         }
       }
     }


### PR DESCRIPTION
For https://github.com/mdn/browser-compat-data/pull/19831
https://developer.apple.com/documentation/safari-release-notes/safari-16_5-release-notes