### PR TITLE
Fx114: inverted-colors is supported behind flag

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -718,7 +718,14 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "114",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.inverted-colors.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Fx114 adds support for [`inverted-colors`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/inverted-colors) behind the` layout.css.inverted-colors.enabled` flag.

#### Test results and supporting details

Tested on Firefox Nightly and Beta behind the flag. The documented [example](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/inverted-colors#examples) works as expected.
(On mac, Settings > Accessibility > Display > "Invert colors" option)

#### Related issues and links

Doc issue: https://github.com/mdn/content/issues/26691
Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1794628
Spec: https://drafts.csswg.org/mediaqueries-5/#inverted
