### PR TITLE
docs(relnote): Fx114 - 'infinity' and 'NaN' supported in CSS calc()

### DIFF
--- a/css/types/calc-constant.json
+++ b/css/types/calc-constant.json
@@ -55,7 +55,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "16.3"
+                "version_added": "16"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -121,7 +121,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "16.3"
+                "version_added": "16"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/types/calc-constant.json
+++ b/css/types/calc-constant.json
@@ -8,7 +8,7 @@
           "spec_url": "https://w3c.github.io/csswg-drafts/css-values/#calc-constants",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "99"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -40,12 +40,12 @@
             "description": "<code>NaN</code> constant",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "99"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "108"
+                "version_added": "114"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -55,14 +55,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.3"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -106,12 +106,12 @@
             "description": "<code>infinity</code> & <code>-infinity</code> constants",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "99"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "108"
+                "version_added": "114"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -121,14 +121,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.3"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
BCD for `infinity` and `NaN` inside the CSS `calc()` function.

Additionally, added chrome and safari support for `calc-constant` and sub-features

__Related issues and pull requests:__
- [ ] Parent issue https://github.com/mdn/content/issues/26693
- [ ] fixes https://github.com/mdn/browser-compat-data/issues/19168
- [ ] content & relnote https://github.com/mdn/content/pull/26784

__Bugzilla:__
- Tracking bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1830759

__Resources:__
- WPT computed tests: http://wpt.live/css/css-values/calc-infinity-nan-computed.html
- WPT serialized tests: http://wpt.live/css/css-values/calc-infinity-nan-serialize-length.html
- Chrome support https://chromestatus.com/feature/5657825571241984
- Webkit 
  - `calc-constant` (`e`, `pi` in conjunction with `<angle>` types) landed in [engine 613.1.3](https://github.com/WebKit/WebKit/blob/0897986c7f6083ff87823fb0822d170273fb8ea6/Source/WebCore/Configurations/Version.xcconfig) which is stable channel [version 15.4](https://github.com/mdn/browser-compat-data/blob/9e010fc58ace76256192844e859997ffe20ab59e/browsers/safari.json#L202-L207)
  - allowing `infinity` and `NaN`:
    - Allow NaN, infinity, and -infinity in calc https://bugs.webkit.org/show_bug.cgi?id=231044
    - landed in [engine 614.1.7](https://github.com/WebKit/WebKit/blob/c925702c2a1989151bf533e6654f68e8b8f56dc0/Source/WebCore/Configurations/Version.xcconfig) which is stable channel [Version 16](https://github.com/mdn/browser-compat-data/blob/9e010fc58ace76256192844e859997ffe20ab59e/browsers/safari.json#L223-L229)
    - changeset https://trac.webkit.org/changeset/283434/webkit/

__Note:__
I'm omitting the flag data for these features as they're enabled by default on stable release, so this would be 'flagged' for removal anyway.
