### PR TITLE
Update data for input types

### DIFF
--- a/html/elements/input/button.json
+++ b/html/elements/input/button.json
@@ -23,22 +23,14 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": true
-              },
-              "opera_android": {
-                "version_added": true
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "1"
               },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": true
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/html/elements/input/checkbox.json
+++ b/html/elements/input/checkbox.json
@@ -9,18 +9,16 @@
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox)",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
-              "firefox_android": {
-                "version_added": "4"
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": true
               },
@@ -28,7 +26,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -52,9 +52,7 @@
                 "chrome": {
                   "version_added": "20"
                 },
-                "chrome_android": {
-                  "version_added": null
-                },
+                "chrome_android": "mirror",
                 "edge": {
                   "version_added": "14"
                 },
@@ -67,9 +65,7 @@
                   "version_added": false
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": null
-                },
+                "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": null
@@ -91,9 +87,7 @@
                 "chrome": {
                   "version_added": "20"
                 },
-                "chrome_android": {
-                  "version_added": null
-                },
+                "chrome_android": "mirror",
                 "edge": {
                   "version_added": "14"
                 },
@@ -110,9 +104,7 @@
                   "version_added": false
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": null
-                },
+                "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": "12.1"

--- a/html/elements/input/date.json
+++ b/html/elements/input/date.json
@@ -11,9 +11,7 @@
               "chrome": {
                 "version_added": "20"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },

--- a/html/elements/input/datetime-local.json
+++ b/html/elements/input/datetime-local.json
@@ -11,18 +11,14 @@
               "chrome": {
                 "version_added": "20"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
               "firefox": {
                 "version_added": "93"
               },
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -37,7 +33,7 @@
                 "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "5"
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"

--- a/html/elements/input/email.json
+++ b/html/elements/input/email.json
@@ -11,14 +11,12 @@
               "chrome": {
                 "version_added": "5"
               },
-              "chrome_android": {
-                "version_added": null
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": {
                 "version_added": "4"
@@ -31,10 +29,10 @@
                 "version_added": "11"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari": {
-                "version_added": true
+                "version_added": "5"
               },
               "safari_ios": {
                 "version_added": "3",

--- a/html/elements/input/file.json
+++ b/html/elements/input/file.json
@@ -11,9 +11,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -37,9 +35,7 @@
               "safari": {
                 "version_added": "1"
               },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/html/elements/input/hidden.json
+++ b/html/elements/input/hidden.json
@@ -11,9 +11,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -32,9 +30,7 @@
               "safari": {
                 "version_added": "1"
               },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/html/elements/input/image.json
+++ b/html/elements/input/image.json
@@ -9,16 +9,14 @@
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#image-button-state-(type=image)",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": null
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -26,17 +24,13 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": true
-              },
+              "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": true
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/html/elements/input/month.json
+++ b/html/elements/input/month.json
@@ -11,9 +11,7 @@
               "chrome": {
                 "version_added": "20"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },

--- a/html/elements/input/number.json
+++ b/html/elements/input/number.json
@@ -9,14 +9,14 @@
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#number-state-(type=number)",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "7"
               },
               "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "29"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -26,7 +26,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "5.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/input/password.json
+++ b/html/elements/input/password.json
@@ -11,9 +11,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -32,13 +30,9 @@
               "safari": {
                 "version_added": "1"
               },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": null
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/html/elements/input/radio.json
+++ b/html/elements/input/radio.json
@@ -9,18 +9,16 @@
             "spec_url": "https://html.spec.whatwg.org/multipage/input.html#radio-button-state-(type=radio)",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
-              "firefox_android": {
-                "version_added": "4"
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": true
               },
@@ -28,7 +26,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/input/range.json
+++ b/html/elements/input/range.json
@@ -31,7 +31,7 @@
                 "version_added": "11"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "11"
               },
               "safari": {
                 "version_added": "3.1"

--- a/html/elements/input/reset.json
+++ b/html/elements/input/reset.json
@@ -11,9 +11,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -26,16 +24,12 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": true
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": "1"
               },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/html/elements/input/search.json
+++ b/html/elements/input/search.json
@@ -11,18 +11,14 @@
               "chrome": {
                 "version_added": "5"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": {
-                "version_added": true
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": "10"
               },
@@ -34,9 +30,7 @@
               "safari": {
                 "version_added": "5"
               },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/html/elements/input/submit.json
+++ b/html/elements/input/submit.json
@@ -11,9 +11,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -26,16 +24,12 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": true
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": "1"
               },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/html/elements/input/text.json
+++ b/html/elements/input/text.json
@@ -11,9 +11,7 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
@@ -25,16 +23,12 @@
                 "version_added": true
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": true
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": "1"
               },
-              "safari_ios": {
-                "version_added": true
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/html/elements/input/time.json
+++ b/html/elements/input/time.json
@@ -27,18 +27,16 @@
                 "version_added": "10"
               },
               "opera_android": {
-                "version_added": true
+                "version_added": "10"
               },
               "safari": {
                 "version_added": "14.1"
               },
               "safari_ios": {
-                "version_added": true
+                "version_added": "5"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": true
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/html/elements/input/url.json
+++ b/html/elements/input/url.json
@@ -11,14 +11,12 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": true
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -30,7 +28,7 @@
               },
               "opera_android": "mirror",
               "safari": {
-                "version_added": true
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/input/week.json
+++ b/html/elements/input/week.json
@@ -11,9 +11,7 @@
               "chrome": {
                 "version_added": "20"
               },
-              "chrome_android": {
-                "version_added": true
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },


### PR DESCRIPTION
This PR performs an update for all of the HTML input element's types.  Derivative browsers are set to mirror from upstream, whilst all version numbers were manually tested using the example code on the MDN articles.