### PR TITLE
Update support for user-[in]valid in Safari

### DIFF
--- a/css/selectors/user-invalid.json
+++ b/css/selectors/user-invalid.json
@@ -30,7 +30,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16.4"
+              "version_added": "16.5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/selectors/user-valid.json
+++ b/css/selectors/user-valid.json
@@ -30,7 +30,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16.4"
+              "version_added": "16.5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
The [WebKit blogpost for 16.4][] initially announced support for `:user-valid`/`:user-invalid` and a [PR was created based on that information][]. [That blogpost no longer references support][].

[The blogpost for 16.5][] includes a demo for `:user-valid`/`:user-invalid` and I've verified that it wasn't working in 16.4 but does on 16.5.

[WebKit blogpost for 16.4]: https://web.archive.org/web/20230327174803/https://webkit.org/blog/13966/webkit-features-in-safari-16-4/
[PR was created based on that information]: https://github.com/mdn/browser-compat-data/pull/19264
[That blogpost no longer references support]: https://webkit.org/blog/13966/webkit-features-in-safari-16-4/
[The blogpost for 16.5]: https://webkit.org/blog/14154/webkit-features-in-safari-16-5/