### PR TITLE
WebTransport API - FF does not support server certificate option

### DIFF
--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -180,7 +180,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "114"
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
@@ -197,7 +197,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
Just found out in https://bugzilla.mozilla.org/show_bug.cgi?id=1818754#c15 that FF does not implement the server certificate option. This wasn't at all clear in IDL or anything else. I've asked about other things that might be omitted, but we should get this in now.

This is part of https://github.com/mdn/content/issues/26684