### PR TITLE
Add Firefox versions for html.elements.a.coords

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -80,7 +80,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": true,
+                "version_added": "1",
                 "version_removed": "58",
                 "notes": "You can no longer nest an <code>&lt;a&gt;</code> element inside a <code>&lt;map&gt;</code> element to create a hotspot region - <code>coords</code> and <code>shape</code> attribute support removed."
               },


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Firefox and Firefox Android for the `coords` member of the `a` HTML element. This mirrors the version number from the interface counterpart.
