### PR TITLE
Update Chromium data for api.DataTransfer.items

### DIFF
--- a/api/DataTransfer.json
+++ b/api/DataTransfer.json
@@ -332,7 +332,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dnd.html#dom-datatransfer-items-dev",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "3"
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `items` member of the `DataTransfer` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.2.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/DataTransfer/items
