### PR TITLE
Browser compatibility updated

### DIFF
--- a/api/GPU.json
+++ b/api/GPU.json
@@ -12,7 +12,10 @@
           "chrome_android": {
             "version_added": false
           },
-          "edge": "mirror",
+          "edge": {
+            "version_added": "113",
+            "notes": "Currently supported on EdgeOS, macOS, and Windows only."
+          },
           "firefox": {
             "version_added": "preview",
             "partial_implementation": true,
@@ -25,7 +28,10 @@
             "version_added": false
           },
           "oculus": "mirror",
-          "opera": "mirror",
+          "opera": {
+            "version_added": false,
+            "notes": "Currently supported on OperaOS, macOS, and Windows only."
+          },
           "opera_android": "mirror",
           "safari": {
             "version_added": false
@@ -52,7 +58,10 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "113",
+              "notes": "Currently supported on EdgeOS, macOS, and Windows only."
+            },
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
@@ -65,7 +74,10 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": false,
+              "notes": "Currently supported on OperaOS, macOS, and Windows only."
+            },
             "opera_android": "mirror",
             "safari": {
               "version_added": false
@@ -93,7 +105,10 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "113",
+              "notes": "Currently supported on EdgeOS, macOS, and Windows only."
+            },
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
@@ -106,7 +121,10 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": false,
+              "notes": "Currently supported on OperaOS, macOS, and Windows only."
+            },
             "opera_android": "mirror",
             "safari": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
This pr fixes [#8584](https://github.com/mdn/yari/issues/8584)

<!-- ✍️ In a sentence or two, describe your changes. -->
I updated browser compatibility data in GPU.json according to 
https://developer.mozilla.org/en-US/docs/Web/API/GPU/getPreferredCanvasFormat#browser_compatibility
The compatibility for edge was "edge": "mirror".
But in the MDN docs compatibility for Edge is  "Currently supported on EdgeOS, macOS, and Windows only".
 And for opera, it was "opera": "mirror",
But in the MDN docs compatibility for Opera is  "Currently supported on OperaOS, macOS, and Windows only.".

So I changed them accordingly.



<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->


<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
