### PR TITLE
Update Firefox data for MerchantValidationEvent API

### DIFF
--- a/api/MerchantValidationEvent.json
+++ b/api/MerchantValidationEvent.json
@@ -10,7 +10,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "64",
+            "version_added": "preview",
             "notes": "Available only in Nightly builds.",
             "flags": [
               {
@@ -51,12 +51,17 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "64",
-              "notes": "Available only in Nightly builds."
+              "version_added": "preview",
+              "notes": "Available only in Nightly builds.",
+              "flags": [
+                {
+                  "name": "dom.payments.request.supportedRegions",
+                  "type": "preference",
+                  "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
+                }
+              ]
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -88,12 +93,17 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "64",
-              "notes": "Available only in Nightly builds."
+              "version_added": "preview",
+              "notes": "Available only in Nightly builds.",
+              "flags": [
+                {
+                  "name": "dom.payments.request.supportedRegions",
+                  "type": "preference",
+                  "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
+                }
+              ]
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -124,12 +134,17 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "64",
-              "notes": "Available only in Nightly builds."
+              "version_added": "preview",
+              "notes": "Available only in Nightly builds.",
+              "flags": [
+                {
+                  "name": "dom.payments.request.supportedRegions",
+                  "type": "preference",
+                  "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
+                }
+              ]
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -160,12 +175,17 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "64",
-              "notes": "Available only in Nightly builds."
+              "version_added": "preview",
+              "notes": "Available only in Nightly builds.",
+              "flags": [
+                {
+                  "name": "dom.payments.request.supportedRegions",
+                  "type": "preference",
+                  "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
+                }
+              ]
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `MerchantValidationEvent` API. This replaces the version number with "preview" as it is only available in nightly builds of Firefox and should not have a version number associated accordingly.  Flag data is also propogated down to subfeatures as per our guidelines.
