### PR TITLE
Update Firefox data for api.MouseEvent.region

### DIFF
--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -891,7 +891,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "32"
+              "version_added": "32",
+              "version_removed": "104"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `region` member of the `MouseEvent` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.2.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/MouseEvent/region
