### PR TITLE
Update Firefox data for api.Performance.mark

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -479,7 +479,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "103"
+                "version_added": "101"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -518,7 +518,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "103"
+                "version_added": "101"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `mark` member of the `Performance` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.2.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Performance/mark

Additional Notes: These were originally set to 103 in https://github.com/mdn/browser-compat-data/pull/18229, but I think that the commit may have been pulled into an earlier branch.
