### PR TITLE
Update Firefox data for RTCDtlsTransport API

### DIFF
--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -13,8 +13,7 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": false,
-            "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
+            "version_added": "82"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -50,8 +49,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
+              "version_added": "82"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -89,8 +87,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
@@ -135,8 +132,7 @@
               }
             ],
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
@@ -174,8 +170,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
+              "version_added": "82"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -220,8 +215,7 @@
               }
             ],
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1307996'>bug 1307996</a>."
+              "version_added": "82"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `RTCDtlsTransport` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.2.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/RTCDtlsTransport

Additional Notes: The event data was guesstimated as the collector doesn't update event data.
