### PR TITLE
Update Firefox data for api.RTCRtpReceiver.getCapabilities

### DIFF
--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -80,7 +80,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "113"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `getCapabilities` member of the `RTCRtpReceiver` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.2.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/RTCRtpReceiver/getCapabilities
