### PR TITLE
Update Chromium data for html.elements.a.download

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -115,7 +115,8 @@
               "chrome_android": "mirror",
               "edge": [
                 {
-                  "version_added": "18"
+                  "version_added": "18",
+                  "notes": "Starting in Edge 79, cross-origin downloads are not supported on the <code>&lt;a&gt;</code> element."
                 },
                 {
                   "version_added": "13",
@@ -134,12 +135,8 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": "15"
-              },
-              "opera_android": {
-                "version_added": null
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "10.1"
               },
@@ -147,10 +144,7 @@
                 "version_added": "13"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": true,
-                "notes": "Starting in WebView 65, cross-origin downloads are not supported on the <code>&lt;a&gt;</code> element."
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `download` member of the `a` HTML element. This sets derivative browsers of Chrome to mirror from upstream, and manually mirrors a note to Edge.
