### PR TITLE
Add Chrome/Safari versions for html.elements.a.href.href_top

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -197,7 +197,7 @@
               "description": "<code>href = '#top'</code>",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "1"
                 },
                 "chrome_android": "mirror",
                 "edge": {
@@ -214,7 +214,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": true
+                  "version_added": "≤4"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `href.href_top` member of the `a` HTML element. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code:

```

<div style="height: 8000px"></div><a href="#top">Go to top!</a>

```
