### PR TITLE
BeforeInstallPromptEvent.prompt() is non-standard

### DIFF
--- a/api/BeforeInstallPromptEvent.json
+++ b/api/BeforeInstallPromptEvent.json
@@ -108,13 +108,10 @@
       "prompt": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BeforeInstallPromptEvent/prompt",
-          "spec_url": "https://wicg.github.io/manifest-incubations/#dom-beforeinstallpromptevent-prompt",
           "support": {
             "chrome": [
               {
-                "version_added": "76",
-                "notes": "The object returned by the promise returns a property called <code>outcome</code> instead of <code>userChoice</code>.",
-                "partial_implementation": true
+                "version_added": "76"
               },
               {
                 "version_added": "44",
@@ -146,7 +143,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }


### PR DESCRIPTION
This came up in the course of https://github.com/mdn/content/pull/26828. 

The interface on which [`BeforeInstallPromptEvent.prompt()`](https://developer.mozilla.org/en-US/docs/Web/API/BeforeInstallPromptEvent/prompt) is defined is itself [marked non-standard](https://github.com/mdn/browser-compat-data/blob/main/api/BeforeInstallPromptEvent.json#L33), so it doesn't seem to make sense for its members to be standard track.

The Chromium implementation differs from the https://wicg.github.io/manifest-incubation spec in a few ways. It seems silly to document this spec that's (AFAIK) only implemented at all in Chromium, and then document all the ways the Chromium implementation differs from it.

So in my mdn/content PR I've documented this object according to the reality of what's in Chrome. This PR then removes the spec URL, marks this method non-standard, and removes the note that describes one of the ways that Chromium differs from the spec, since we're not documenting the spec in MDN.
