### PR TITLE
Add flagged Chrome support for scrollbar-width

### DIFF
--- a/css/properties/scrollbar-width.json
+++ b/css/properties/scrollbar-width.json
@@ -7,8 +7,14 @@
           "spec_url": "https://drafts.csswg.org/css-scrollbars/#scrollbar-width",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/891944'>bug 891944</a>."
+              "version_added": "preview",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Chrome as of 115 Canary now supports the scrollbar-width CSS property behind the experimental flag.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://chromium-review.googlesource.com/c/chromium/src/+/4536495 - Here's my merged chromium patch that moved this under experimental flag.

Can test in latest canary by running one of the WPT https://wpt.live/css/css-scrollbars/scrollbar-width-parsing.html

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
