### PR TITLE
Add missing features for CSSStyleRule API

### DIFF
--- a/api/CSSStyleRule.json
+++ b/api/CSSStyleRule.json
@@ -39,6 +39,105 @@
           "deprecated": false
         }
       },
+      "cssRules": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-nesting-1/#dom-cssstylerule-cssrules",
+          "support": {
+            "chrome": {
+              "version_added": "112"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "deleteRule": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-nesting-1/#dom-cssstylerule-deleterule",
+          "support": {
+            "chrome": {
+              "version_added": "112"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "insertRule": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-nesting-1/#dom-cssstylerule-insertrule",
+          "support": {
+            "chrome": {
+              "version_added": "112"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "selectorText": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSStyleRule/selectorText",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing features of the `CSSStyleRule` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.2.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CSSStyleRule
