### PR TITLE
Update Chromium data for CanvasFilter API

### DIFF
--- a/api/CanvasFilter.json
+++ b/api/CanvasFilter.json
@@ -2,7 +2,6 @@
   "api": {
     "CanvasFilter": {
       "__compat": {
-        "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#canvasfilter",
         "support": {
           "chrome": [
             {
@@ -48,7 +47,6 @@
       "CanvasFilter": {
         "__compat": {
           "description": "<code>CanvasFilter()</code> constructor",
-          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-canvasfilter",
           "support": {
             "chrome": [
               {

--- a/api/CanvasFilter.json
+++ b/api/CanvasFilter.json
@@ -5,7 +5,8 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#canvasfilter",
         "support": {
           "chrome": {
-            "version_added": "99"
+            "version_added": "99",
+            "version_removed": "113"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -38,7 +39,8 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-canvasfilter",
           "support": {
             "chrome": {
-              "version_added": "99"
+              "version_added": "99",
+              "version_removed": "113"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/CanvasFilter.json
+++ b/api/CanvasFilter.json
@@ -4,10 +4,22 @@
       "__compat": {
         "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#canvasfilter",
         "support": {
-          "chrome": {
-            "version_added": "99",
-            "version_removed": "113"
-          },
+          "chrome": [
+            {
+              "version_added": "113",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            {
+              "version_added": "99",
+              "version_removed": "113"
+            }
+          ],
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
@@ -38,10 +50,22 @@
           "description": "<code>CanvasFilter()</code> constructor",
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-canvasfilter",
           "support": {
-            "chrome": {
-              "version_added": "99",
-              "version_removed": "113"
-            },
+            "chrome": [
+              {
+                "version_added": "113",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              {
+                "version_added": "99",
+                "version_removed": "113"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `CanvasFilter` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.2.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CanvasFilter
