### PR TITLE
Update Edge data for api.MathMLElement.attributeStyleMap

### DIFF
--- a/api/MathMLElement.json
+++ b/api/MathMLElement.json
@@ -53,9 +53,7 @@
               "version_added": "109"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `attributeStyleMap` member of the `MathMLElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.2.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/MathMLElement/attributeStyleMap
