### PR TITLE
Update Safari data for api.SVGElement.focus.options_preventScroll_parameter

### DIFF
--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -343,7 +343,9 @@
               "safari": {
                 "version_added": "15"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "15.5"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -341,8 +341,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/178583'>bug 178583</a>."
+                "version_added": "15"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `focus.options_preventScroll_parameter` member of the `SVGElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.2.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/SVGElement/focus/options_preventScroll_parameter

Additional Notes: I don't have access to Safari 15.0, so it is a guesstimation.
