### PR TITLE
Update Firefox data for api.WorkerNavigator.locks

### DIFF
--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -430,7 +430,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "96"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `locks` member of the `WorkerNavigator` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.2.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/WorkerNavigator/locks
