### PR TITLE
Update Edge data for XR* API

### DIFF
--- a/api/XRFrame.json
+++ b/api/XRFrame.json
@@ -84,6 +84,7 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
+              "version_removed": "111",
               "notes": "Hololens 2 only."
             },
             "firefox": {
@@ -123,6 +124,7 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
+              "version_removed": "111",
               "notes": "Hololens 2 only."
             },
             "firefox": {
@@ -270,6 +272,7 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
+              "version_removed": "111",
               "notes": "Hololens 2 only."
             },
             "firefox": {

--- a/api/XRHand.json
+++ b/api/XRHand.json
@@ -11,6 +11,7 @@
           "chrome_android": "mirror",
           "edge": {
             "version_added": "93",
+            "version_removed": "111",
             "notes": "Hololens 2 only."
           },
           "firefox": {
@@ -47,6 +48,7 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
+              "version_removed": "111",
               "notes": "Hololens 2 only."
             },
             "firefox": {
@@ -82,6 +84,7 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
+              "version_removed": "111",
               "notes": "Hololens 2 only."
             },
             "firefox": {
@@ -117,6 +120,7 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
+              "version_removed": "111",
               "notes": "Hololens 2 only."
             },
             "firefox": {
@@ -152,6 +156,7 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
+              "version_removed": "111",
               "notes": "Hololens 2 only."
             },
             "firefox": {
@@ -187,6 +192,7 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
+              "version_removed": "111",
               "notes": "Hololens 2 only."
             },
             "firefox": {
@@ -222,6 +228,7 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
+              "version_removed": "111",
               "notes": "Hololens 2 only."
             },
             "firefox": {
@@ -257,6 +264,7 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
+              "version_removed": "111",
               "notes": "Hololens 2 only."
             },
             "firefox": {

--- a/api/XRInputSource.json
+++ b/api/XRInputSource.json
@@ -124,6 +124,7 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
+              "version_removed": "111",
               "notes": "Hololens 2 only."
             },
             "firefox": {

--- a/api/XRJointPose.json
+++ b/api/XRJointPose.json
@@ -11,6 +11,7 @@
           "chrome_android": "mirror",
           "edge": {
             "version_added": "93",
+            "version_removed": "111",
             "notes": "Hololens 2 only."
           },
           "firefox": {
@@ -49,6 +50,7 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
+              "version_removed": "111",
               "notes": "Hololens 2 only."
             },
             "firefox": {

--- a/api/XRJointSpace.json
+++ b/api/XRJointSpace.json
@@ -11,6 +11,7 @@
           "chrome_android": "mirror",
           "edge": {
             "version_added": "93",
+            "version_removed": "111",
             "notes": "Hololens 2 only."
           },
           "firefox": {
@@ -49,6 +50,7 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "93",
+              "version_removed": "111",
               "notes": "Hololens 2 only."
             },
             "firefox": {

--- a/api/XRSession.json
+++ b/api/XRSession.json
@@ -193,7 +193,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": false
+              "version_added": "111"
             },
             "firefox": {
               "version_added": false

--- a/api/XRSession.json
+++ b/api/XRSession.json
@@ -192,9 +192,7 @@
               "version_added": "111"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "111"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `XR*` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.2.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used:
https://mdn-bcd-collector.gooborg.com/tests/api/XRFrame
https://mdn-bcd-collector.gooborg.com/tests/api/XRHand
https://mdn-bcd-collector.gooborg.com/tests/api/XRInputSource
https://mdn-bcd-collector.gooborg.com/tests/api/XRJointPose
https://mdn-bcd-collector.gooborg.com/tests/api/XRJointSpace
https://mdn-bcd-collector.gooborg.com/tests/api/XRSession
