### PR TITLE
Update Chromium data for css.properties.background-image.image-set

### DIFF
--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -164,10 +164,15 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/image-set()",
             "spec_url": "https://drafts.csswg.org/css-images-4/#image-set-notation",
             "support": {
-              "chrome": {
-                "prefix": "-webkit-",
-                "version_added": "21"
-              },
+              "chrome": [
+                {
+                  "version_added": "113"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "21"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": [


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `image-set` member of the `background-image` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.2.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/background-image/image-set
