### PR TITLE
Add missing features for GPU* API

### DIFF
--- a/api/GPUBufferUsage.json
+++ b/api/GPUBufferUsage.json
@@ -1,0 +1,36 @@
+{
+  "api": {
+    "GPUBufferUsage": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "113"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/GPUColorWrite.json
+++ b/api/GPUColorWrite.json
@@ -1,0 +1,36 @@
+{
+  "api": {
+    "GPUColorWrite": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "113"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/GPUMapMode.json
+++ b/api/GPUMapMode.json
@@ -1,0 +1,36 @@
+{
+  "api": {
+    "GPUMapMode": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "113"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/GPUShaderStage.json
+++ b/api/GPUShaderStage.json
@@ -1,0 +1,36 @@
+{
+  "api": {
+    "GPUShaderStage": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "113"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/api/GPUTextureUsage.json
+++ b/api/GPUTextureUsage.json
@@ -1,0 +1,36 @@
+{
+  "api": {
+    "GPUTextureUsage": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "113"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing features of the `GPU*` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.2.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used:
https://mdn-bcd-collector.gooborg.com/tests/api/GPUBufferUsage
https://mdn-bcd-collector.gooborg.com/tests/api/GPUColorWrite
https://mdn-bcd-collector.gooborg.com/tests/api/GPUMapMode
https://mdn-bcd-collector.gooborg.com/tests/api/GPUShaderStage
https://mdn-bcd-collector.gooborg.com/tests/api/GPUTextureUsage
