### PR TITLE
FF114 WebTransport.reliability supported

### DIFF
--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -678,6 +678,40 @@
             "deprecated": false
           }
         }
+      },
+      "reliability": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport/reliability",
+          "spec_url": "https://w3c.github.io/webtransport/#dom-webtransport-reliability",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "114"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This was shipped in 114 as part of https://bugzilla.mozilla.org/show_bug.cgi?id=1831073 

I ran the collector for the other platforms to confirm not supported.

Omission noticed by @Elchi3  in  https://github.com/mdn/content/pull/26529#pullrequestreview-1434373382

Other docs work for this tracked in https://github.com/mdn/content/issues/26684