### PR TITLE
FF114 Popover API behind preference

### DIFF
--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -478,7 +478,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "114"
+              "version_added": "114",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.popover.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -495,7 +502,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -512,7 +519,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "114"
+              "version_added": "114",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.popover.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -529,7 +543,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -478,7 +478,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "114"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -495,7 +495,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -512,7 +512,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "114"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -529,7 +529,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2166,7 +2166,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "114",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.popover.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -393,7 +393,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "114",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.popover.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1894,7 +1901,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "114",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.popover.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1329,7 +1329,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "114",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.popover.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1942,7 +1949,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "114",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.popover.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2186,7 +2200,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "114",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.popover.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1397,7 +1397,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "114"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1431,7 +1431,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "114"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1397,7 +1397,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "114"
+              "version_added": "114",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.popover.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1431,7 +1438,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "114"
+              "version_added": "114",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.popover.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/ToggleEvent.json
+++ b/api/ToggleEvent.json
@@ -11,7 +11,14 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "114",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.element.popover.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": "mirror",
           "ie": {
@@ -45,7 +52,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "114",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.popover.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -79,7 +93,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "114",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.popover.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -113,7 +134,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "114",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.popover.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/backdrop.json
+++ b/css/selectors/backdrop.json
@@ -130,7 +130,14 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "114",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.element.popover.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/selectors/popover-open.json
+++ b/css/selectors/popover-open.json
@@ -13,7 +13,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "114",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.popover.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1276,7 +1276,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "114",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.popover.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1317,7 +1317,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "114",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.popover.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1351,7 +1358,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "114",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.popover.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF114 supports popover Javascript API in https://bugzilla.mozilla.org/show_bug.cgi?id=1823757 behind the pref `dom.element.popover.enabled`

This includes:
- [`HTMLButtonElement.popoverTargetAction`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLButtonElement/popoverTargetAction)
- [`HTMLButtonElement.popoverTargetElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLButtonElement/popoverTargetElement)
- [`HTMLInputElement.popoverTargetElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/popoverTargetElement),
- [`HTMLInputElement.popoverTargetAction`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/popoverTargetAction) 
- [`HTMLElement.popover`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/popover) 
- [`HTMLElement.hidePopover()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/hidePopover) 
- [`HTMLElement.showPopover()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/showPopover) 
- [`HTMLElement.togglePopover()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/togglePopover) 
- `HTMLElement` [`beforetoggle` event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/beforetoggle_event) 
- `HTMLElement` [`toggle_event` event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/toggle_event)
- [`ToggleEvent`](https://developer.mozilla.org/en-US/docs/Web/API/ToggleEvent) 
- CSS selector [`::backdrop`](https://developer.mozilla.org/en-US/docs/Web/CSS/::backdrop)
- CSS selector [`:popover-open`](https://developer.mozilla.org/en-US/docs/Web/CSS/:popover-open)
- HTML global attribute: [`popovertarget`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#popovertarget)
- HTML global attribute: [`popovertargetaction`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#popovertargetaction)


Related docs work can be tracked in https://github.com/mdn/content/issues/26694