### PR TITLE
Add all browsers versions for global_attributes HTML feature

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -7,14 +7,14 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#the-accesskey-attribute",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -55,12 +55,8 @@
               "version_added": null
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": null
-            },
-            "opera_android": {
-              "version_added": null
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
@@ -83,7 +79,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete",
           "support": {
             "chrome": {
-              "version_added": true,
+              "version_added": "14",
               "notes": [
                 "In Chrome 66, support was added for the <code>&lt;textarea&gt;</code> and <code>&lt;select&gt;</code> elements.",
                 "Originally only supported on the <code>&lt;input&gt;</code> element.",
@@ -95,7 +91,7 @@
               "version_added": "≤79"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "4"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -103,13 +99,13 @@
             },
             "oculus": "mirror",
             "opera": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "opera_android": {
-              "version_added": true
+              "version_added": "≤12.1"
             },
             "safari": {
-              "version_added": null
+              "version_added": "6"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -126,12 +122,10 @@
             "description": "<code>new-password</code> value",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": false
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "67"
               },
@@ -143,7 +137,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": null
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -285,14 +279,14 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#global-attributes:classes-2",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "32"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -302,7 +296,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -321,7 +315,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#attr-contenteditable",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -340,7 +334,7 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -427,7 +421,7 @@
             "description": "<code>contenteditable=\"plaintext-only\"</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "51"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -538,14 +532,14 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#attr-data-*",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "7"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "6"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -555,7 +549,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -574,14 +568,12 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "79"
-            },
+            "edge": "mirror",
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -591,7 +583,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -610,7 +602,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dnd.html#the-draggable-attribute",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "4"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -629,7 +621,7 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "5"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -719,14 +711,14 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "10"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "4"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -736,7 +728,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -794,7 +786,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#global-attributes:the-id-attribute-2",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -805,7 +797,7 @@
                 "version_added": "32"
               },
               {
-                "version_added": true,
+                "version_added": "1",
                 "version_removed": "32",
                 "partial_implementation": true,
                 "notes": "<code>id</code> is a true global attribute only since Firefox 32."
@@ -819,7 +811,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1131,14 +1123,14 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#attr-lang",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1148,7 +1140,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1458,14 +1450,14 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#the-style-attribute",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1475,7 +1467,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1494,14 +1486,14 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#attr-tabindex",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1.5"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1511,7 +1503,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1530,14 +1522,14 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#the-title-attribute",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": true
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1547,7 +1539,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for all browsers for the `global_attributes` HTML feature. This data comes from a series of manual tests to check if the behavior is as expected.
