### PR TITLE
Safari 16.5 is released

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -251,13 +251,14 @@
         "16.4": {
           "release_date": "2023-03-27",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "615.1.26"
         },
         "16.5": {
+          "release_date": "2023-05-18",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_5-release-notes",
-          "status": "beta",
+          "status": "current",
           "engine": "WebKit"
         }
       }

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -259,7 +259,8 @@
           "release_date": "2023-05-18",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_5-release-notes",
           "status": "current",
-          "engine": "WebKit"
+          "engine": "WebKit",
+          "engine_version": "615.2.9"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -223,13 +223,14 @@
         "16.4": {
           "release_date": "2023-03-27",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "615.1.26"
         },
         "16.5": {
+          "release_date": "2023-05-18",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_5-release-notes",
-          "status": "beta",
+          "status": "current",
           "engine": "WebKit"
         }
       }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -231,7 +231,8 @@
           "release_date": "2023-05-18",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_5-release-notes",
           "status": "current",
-          "engine": "WebKit"
+          "engine": "WebKit",
+          "engine_version": "615.2.9"
         }
       }
     }


### PR DESCRIPTION
https://webkit.org/blog/14154/webkit-features-in-safari-16-5/

I don't know how to set the correct engine_version. Anyone has pointers?