### PR TITLE
Update Safari data for api.Window.showModalDialog

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3359,7 +3359,7 @@
               "version_added": "≤14"
             },
             "safari": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "≤3"
@@ -5711,7 +5711,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "5.1",
-              "notes": "See <a href='https://webkit.org/b/151885'>WebKit bug 151885</a> for possible future removal from Safari."
+              "version_removed": "16.4"
             },
             "safari_ios": {
               "version_added": false

--- a/api/Window.json
+++ b/api/Window.json
@@ -3359,7 +3359,7 @@
               "version_added": "≤14"
             },
             "safari": {
-              "version_added": false
+              "version_added": "16.4"
             },
             "safari_ios": {
               "version_added": "≤3"


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `showModalDialog` member of the `Window` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.2.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Window/showModalDialog
