### PR TITLE
Revert "Update Storage Access API data"

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4330,22 +4330,17 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/hasStorageAccess",
           "spec_url": "https://privacycg.github.io/storage-access/#dom-document-hasstorageaccess",
           "support": {
-            "chrome": [
-              {
-                "version_added": "113"
-              },
-              {
-                "version_added": "78",
-                "version_removed": "112",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#storage-access-api",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "78",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#storage-access-api",
+                  "value_to_set": "Enabled"
+                }
+              ],
+              "notes": "See <a href='https://crbug.com/989663'>bug 989663</a>."
+            },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "85"
@@ -4358,7 +4353,16 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": "65",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#storage-access-api",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
             "opera_android": "mirror",
             "safari": {
               "version_added": "11.1"
@@ -6044,42 +6048,21 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/requestStorageAccess",
           "spec_url": "https://privacycg.github.io/storage-access/#dom-document-requeststorageaccess",
           "support": {
-            "chrome": [
-              {
-                "version_added": "113",
-                "notes": [
-                  "Only resolves <code>requestStorageAccess()</code> calls that come from domains within a <a href='https://developer.chrome.com/docs/privacy-sandbox/first-party-sets/'>first-party set</a>.",
-                  "Client-side storage access granted per-frame, as per spec updates <a href='https://developer.mozilla.org/docs/Web/API/Storage_Access_API#how_it_works'>see explanation</a>."
-                ]
-              },
-              {
-                "version_added": "78",
-                "version_removed": "112",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#storage-access-api",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "Client-side storage access granted per-page (<a href='https://developer.mozilla.org/docs/Web/API/Storage_Access_API#how_it_works'>see explanation</a>)"
-              }
-            ],
+            "chrome": {
+              "version_added": "78",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#storage-access-api",
+                  "value_to_set": "Enabled"
+                }
+              ],
+              "notes": "See <a href='https://crbug.com/989663'>bug 989663</a>."
+            },
             "chrome_android": "mirror",
-            "edge": [
-              {
-                "version_added": "113",
-                "notes": [
-                  "Only resolves <code>requestStorageAccess()</code> calls that come from domains within a <a href='https://developer.chrome.com/docs/privacy-sandbox/first-party-sets/'>first-party set</a>.",
-                  "Each embedded site instance must separately opt in to client-side storage access via a <code>requestStorageAccess()</code> call, as per <a href='https://developer.mozilla.org/docs/Web/API/Storage_Access_API#how_it_works'>spec updates</a>."
-                ]
-              },
-              {
-                "version_added": "85",
-                "version_removed": "112",
-                "notes": "Client-side storage access granted per-page (<a href='https://developer.mozilla.org/docs/Web/API/Storage_Access_API#how_it_works'>see explanation</a>)"
-              }
-            ],
+            "edge": {
+              "version_added": "85"
+            },
             "firefox": {
               "version_added": "65"
             },
@@ -6088,11 +6071,19 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": "65",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#storage-access-api",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1",
-              "notes": "Client-side storage access granted per-page (<a href='https://developer.mozilla.org/docs/Web/API/Storage_Access_API#how_it_works'>see explanation</a>)"
+              "version_added": "11.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -637,6 +637,7 @@
       "permission_speaker-selection": {
         "__compat": {
           "description": "<code>speaker-selection</code> permission",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Permissions/speaker-selection",
           "spec_url": "https://w3c.github.io/mediacapture-output/#dfn-speaker-selection",
           "support": {
             "chrome": {
@@ -660,55 +661,6 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "permission_storage-access": {
-        "__compat": {
-          "description": "<code>storage-access</code> permission",
-          "spec_url": "https://privacycg.github.io/storage-access/#permissions-integration",
-          "support": {
-            "chrome": [
-              {
-                "version_added": "113"
-              },
-              {
-                "version_added": "86",
-                "version_removed": "112",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#storage-access-api",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            }
           },
           "status": {
             "experimental": true,

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -1034,7 +1034,7 @@
               "description": "<code>sandbox=\"allow-storage-access-by-user-activation\"</code>",
               "support": {
                 "chrome": {
-                  "version_added": "113"
+                  "version_added": false
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
@@ -1063,7 +1063,7 @@
                 "webview_android": "mirror"
               },
               "status": {
-                "experimental": false,
+                "experimental": true,
                 "standard_track": false,
                 "deprecated": false
               }

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -1249,40 +1249,6 @@
             }
           }
         },
-        "storage-access": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/storage-access",
-            "spec_url": "https://privacycg.github.io/storage-access/#permissions-policy-integration",
-            "support": {
-              "chrome": {
-                "version_added": "113"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "usb": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/usb",


### PR DESCRIPTION
Reverts mdn/browser-compat-data#19614.  The mdn-bcd-collector project says that these features are not supported.  Looking at the [ChromeStatus entry](https://chromestatus.com/feature/5612590694662144), I don't see any milestones marked, and the [linked bug](https://bugs.chromium.org/p/chromium/issues/detail?id=989663) is Open.

(Also, FYI @chrisdavidmills, the `version_removed` of the flag data should have been `113`, not `112`, unless the feature was completely unavailable in Chrome 112 -- however, that flag data would have also qualified as an irrelevant flag and could be removed entirely!)