### PR TITLE
Update Firefox data for api.HTMLCanvasElement.getContext.bitmaprenderer_context.options_alpha_parameter

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -229,7 +229,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "46"
+                  "version_added": false
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `getContext.bitmaprenderer_context.options_alpha_parameter` member of the `HTMLCanvasElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.2.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/HTMLCanvasElement/getContext/bitmaprenderer_context/options_alpha_parameter
