### PR TITLE
Add Chrome/Safari versions for embed HTML element

### DIFF
--- a/html/elements/embed.json
+++ b/html/elements/embed.json
@@ -7,7 +7,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-embed-element",
           "support": {
             "chrome": {
-              "version_added": true
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -21,10 +21,14 @@
               "version_added": true
             },
             "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
             "safari": {
-              "version_added": true
+              "version_added": "≤4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chrome and Safari for the `embed` HTML element. Since the subfeatures are set to Chrome 1 and Safari ≤4, this is a non-trivial change.
