### PR TITLE
Add collector report schema

### DIFF
--- a/schemas/collector-report.md
+++ b/schemas/collector-report.md
@@ -1,6 +1,6 @@
 # The collector report JSON schema
 
-This document details the structure of reports collected by https://github.com/foolip/mdn-bcd-collector and stored in https://github.com/foolip/mdn-bcd-results.
+This document details the structure of reports collected by https://github.com/GooborgStudios/mdn-bcd-collector and stored in https://github.com/GooborgStudios/mdn-bcd-results.
 
 ## JSON structure
 
@@ -8,7 +8,7 @@ Below is an example of the report data:
 
 ```json
 {
-  "__version": "6.2.7",
+  "__version": "9.3.1",
   "results": {
     "https://mdn-bcd-collector.appspot.com/tests/": [
       {
@@ -32,23 +32,17 @@ Below is an example of the report data:
 
 ### `exposure`
 
-The `exposure` string is a required property. It must be one of four values whether the test was executed in a window (`"Window"`), web worker (`"Worker"`), shared worker (`"SharedWorker"`) or service worker (`"ServiceWorker"`).
+The `exposure` string is a required property. It must be one of four values whether the test was executed in a window (`"Window"`), dedicated worker (`"Worker"`), shared worker (`"SharedWorker"`) or service worker (`"ServiceWorker"`).
 
 ### `message`
 
-The `message` string is a required property if `result` is `null`.
+The `message` string is a required property if `result` is `null` and optional if `result` is a `boolean`.
 
-Some example messages are:
-
-```js
-"threw TypeError: Failed to construct 'Notification': Illegal constructor.";
-'Testing CanvasRenderingContext2D in workers is not yet implemented';
-'Browser does not support detection methods';
-```
+The message can be an error message from the browser or from the test framework, for example "threw TypeError: Failed to construct 'Notification': Illegal constructor." or "Browser does not support detection methods" respectively.
 
 ### `name`
 
-The `name` string is a required property and represents the feature identifier the result is for. The identifier is made of dot-separated elements. For example `"javascript.builtins.Array.at"` points to feature in BCD under `{"javascript": {"builtins": {"Array": {"at": {"__compat": ...}}}}}`.
+The `name` string is a required property and represents the feature identifier the result is for. The identifier is a dot-separated path commonly used in BCD. For example, "javascript.builtins.Array.at" refers to the feature at `{"javascript": {"builtins": {"Array": {"at": {"__compat": ...}}}}}`.
 
 ### `result`
 
@@ -56,11 +50,11 @@ The `result` boolean or `null` value is a required property indicating if the te
 
 ### `__version`
 
-The `__version` string is a required property and the version of https://github.com/foolip/mdn-bcd-collector that collected the report.
+The `__version` string is a required property and the version of mdn-bcd-collector that collected the report.
 
 ### `results`
 
-The `results` object is a required property and maps the collection page endpoint to an array of test results. There must be at least one key in the map. Each key must start with `https://mdn-bcd-collector.appspot.com/tests/`.
+The `results` object is a required property and maps the collection page endpoint to an array of test results. There must be at least one key in the map.
 
 ### `userAgent`
 

--- a/schemas/collector-report.md
+++ b/schemas/collector-report.md
@@ -1,6 +1,6 @@
 # The collector report JSON schema
 
-This document details the structure of reports collected by https://github.com/GooborgStudios/mdn-bcd-collector and stored in https://github.com/GooborgStudios/mdn-bcd-results.
+This document details the structure of reports produced by https://mdn-bcd-collector.appspot.com/, https://mdn-bcd-collector.gooborg.com/, and potentially other tooling.
 
 ## JSON structure
 
@@ -10,7 +10,7 @@ Below is an example of the report data:
 {
   "__version": "9.3.1",
   "results": {
-    "https://mdn-bcd-collector.appspot.com/tests/": [
+    "https://mdn-bcd-collector.example/tests/": [
       {
         "exposure": "ServiceWorker",
         "name": "api.AbortController.AbortController",

--- a/schemas/collector-report.md
+++ b/schemas/collector-report.md
@@ -1,0 +1,67 @@
+# The collector report JSON schema
+
+This document details the structure of reports collected by https://github.com/foolip/mdn-bcd-collector and stored in https://github.com/foolip/mdn-bcd-results.
+
+## JSON structure
+
+Below is an example of the report data:
+
+```json
+{
+  "__version": "6.2.7",
+  "results": {
+    "https://mdn-bcd-collector.appspot.com/tests/": [
+      {
+        "exposure": "ServiceWorker",
+        "name": "api.AbortController.AbortController",
+        "result": false
+      },
+      {
+        "exposure": "Window",
+        "message": "threw TypeError: Array.isArray is not a function",
+        "name": "api.AbortController.AbortController",
+        "result": null
+      }
+    ]
+  },
+  "userAgent": "Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.8) Gecko/20051111 Firefox/1.5"
+}
+```
+
+## Properties
+
+### `exposure`
+
+The `exposure` string is a required property. It must be one of four values whether the test was executed in a window (`"Window"`), web worker (`"Worker"`), shared worker (`"SharedWorker"`) or service worker (`"ServiceWorker"`).
+
+### `message`
+
+The `message` string is a required property if `result` is `null`.
+
+Some example messages are:
+
+```js
+"threw TypeError: Failed to construct 'Notification': Illegal constructor.";
+'Testing CanvasRenderingContext2D in workers is not yet implemented';
+'Browser does not support detection methods';
+```
+
+### `name`
+
+The `name` string is a required property and represents the feature identifier the result is for. The identifier is made of dot-separated elements. For example `"javascript.builtins.Array.at"` points to feature in BCD under `{"javascript": {"builtins": {"Array": {"at": {"__compat": ...}}}}}`.
+
+### `result`
+
+The `result` boolean or `null` value is a required property indicating if the tested feature under the given `exposure` is present, not present, or cannot be determined by the test.
+
+### `__version`
+
+The `__version` string is a required property and the version of https://github.com/foolip/mdn-bcd-collector that collected the report.
+
+### `results`
+
+The `results` object is a required property and maps the collection page endpoint to an array of test results. There must be at least one key in the map. Each key must start with `https://mdn-bcd-collector.appspot.com/tests/`.
+
+### `userAgent`
+
+The `userAgent` string is a required property and states the user agent of the tested browser the results were collected from.

--- a/schemas/collector-report.schema.json
+++ b/schemas/collector-report.schema.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/schema",
+
+  "definitions": {
+    "exposure": {
+      "type": "string",
+      "enum": ["ServiceWorker", "SharedWorker", "Window", "Worker"]
+    },
+
+    "feature_name": {
+      "type": "string",
+      "pattern": "^[a-zA-Z_0-9-$@.]*$",
+      "description": "Dot separated identifier path.\n\n@example \"javascript.builtins.Array.at\"",
+      "examples": ["javascript.builtins.Array.at"]
+    },
+
+    "collector_result": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "exposure": { "$ref": "#/definitions/exposure" },
+            "name": { "$ref": "#/definitions/feature_name" },
+            "result": { "type": "boolean" }
+          },
+          "additionalProperties": false,
+          "required": ["exposure", "name", "result"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "exposure": { "$ref": "#/definitions/exposure" },
+            "message": {
+              "type": "string",
+              "pattern": "^threw .*$|^Testing .* in workers is not yet implemented$|^Browser does not support detection methods$",
+              "description": "Reason a result could not be collected.\n\n@example \"threw TypeError: Failed to construct 'Notification': Illegal constructor.\"\n@example \"Testing CanvasRenderingContext2D in workers is not yet implemented\"\n@example \"Browser does not support detection methods\""
+            },
+            "name": { "$ref": "#/definitions/feature_name" },
+            "result": { "type": "null" }
+          },
+          "additionalProperties": false,
+          "required": ["exposure", "message", "name", "result"]
+        }
+      ]
+    }
+  },
+
+  "title": "CollectorReport",
+  "type": "object",
+  "properties": {
+    "__version": {
+      "type": "string",
+      "pattern": "^[0-9.]+$",
+      "description": "Version of mdn-bcd-collector that collected the report."
+    },
+    "results": {
+      "type": "object",
+      "patternProperties": {
+        "^https://mdn-bcd-collector.appspot.com/tests/.*$": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/collector_result"
+          }
+        }
+      },
+      "minProperties": 1
+    },
+    "userAgent": {
+      "type": "string",
+      "description": "User agent of tested browser."
+    }
+  },
+  "required": ["__version", "results", "userAgent"],
+  "additionalProperties": false
+}

--- a/schemas/collector-report.schema.json
+++ b/schemas/collector-report.schema.json
@@ -10,8 +10,12 @@
     "feature_name": {
       "type": "string",
       "pattern": "^[a-zA-Z_0-9-$@.]*$",
-      "description": "Dot separated identifier path.\n\n@example \"javascript.builtins.Array.at\"",
-      "examples": ["javascript.builtins.Array.at"]
+      "description": "Dot separated identifier path.\n\n@example \"javascript.builtins.Array.at\""
+    },
+
+    "result_message": {
+      "type": "string",
+      "description": "An error message from the browser or from the test framework.\n\n@example \"threw TypeError: Failed to construct 'Notification': Illegal constructor.\"\n@example \"Testing CanvasRenderingContext2D in workers is not yet implemented\"\n@example \"Browser does not support detection methods\""
     },
 
     "collector_result": {
@@ -20,6 +24,7 @@
           "type": "object",
           "properties": {
             "exposure": { "$ref": "#/definitions/exposure" },
+            "message": { "$ref": "#/definitions/result_message" },
             "name": { "$ref": "#/definitions/feature_name" },
             "result": { "type": "boolean" }
           },
@@ -30,11 +35,7 @@
           "type": "object",
           "properties": {
             "exposure": { "$ref": "#/definitions/exposure" },
-            "message": {
-              "type": "string",
-              "pattern": "^threw .*$|^Testing .* in workers is not yet implemented$|^Browser does not support detection methods$",
-              "description": "Reason a result could not be collected.\n\n@example \"threw TypeError: Failed to construct 'Notification': Illegal constructor.\"\n@example \"Testing CanvasRenderingContext2D in workers is not yet implemented\"\n@example \"Browser does not support detection methods\""
-            },
+            "message": { "$ref": "#/definitions/result_message" },
             "name": { "$ref": "#/definitions/feature_name" },
             "result": { "type": "null" }
           },
@@ -53,10 +54,16 @@
       "pattern": "^[0-9.]+$",
       "description": "Version of mdn-bcd-collector that collected the report."
     },
+    "extensions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "results": {
       "type": "object",
       "patternProperties": {
-        "^https://mdn-bcd-collector.appspot.com/tests/.*$": {
+        "^.*://.*$": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/collector_result"


### PR DESCRIPTION
#### Summary

- Add a mdn-bcd-results schema

This schema validates the reports created by `mdn-bcd-collector` and stored in `mdn-bcd-results`.

#### Test results and supporting details

All reports in mdn-bcd-results validate without error with this schema using `ajv-cli`.

#### Related issues

https://github.com/mdn/browser-compat-data/issues/19868
https://github.com/mdn/browser-compat-data/issues/18514
