### PR TITLE
Addition of commands.onChanged

### DIFF
--- a/webextensions/api/commands.json
+++ b/webextensions/api/commands.json
@@ -9,9 +9,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "48"
               },
@@ -33,9 +31,7 @@
                 "chrome": {
                   "version_added": true
                 },
-                "edge": {
-                  "version_added": "79"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "48"
                 },
@@ -79,9 +75,7 @@
               "chrome": {
                 "version_added": true
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "48"
               },
@@ -95,6 +89,28 @@
               "safari_ios": {
                 "version_added": "15"
               }
+            }
+          }
+        },
+        "onChanged": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/commands/onChanged",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "115"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
             }
           }
         },


### PR DESCRIPTION
#### Summary

Add details for Firefox support of commands.onChanged in 115.

#### Related issues

Addresses the dev-docs-needed requirement of [Bug 1801531](https://bugzilla.mozilla.org/show_bug.cgi?id=1801531) Implement browser.commands.onChanged

Related content changes in https://github.com/mdn/content/pull/26942