### PR TITLE
Set Safari iOS to mirror on SVGFont*Element APIs

### DIFF
--- a/api/SVGFontElement.json
+++ b/api/SVGFontElement.json
@@ -31,9 +31,7 @@
             "version_added": "3",
             "version_removed": "16.4"
           },
-          "safari_ios": {
-            "version_added": "1"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "≤37",

--- a/api/SVGFontFaceElement.json
+++ b/api/SVGFontFaceElement.json
@@ -25,9 +25,7 @@
             "version_added": "3",
             "version_removed": "16.4"
           },
-          "safari_ios": {
-            "version_added": "1"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "≤37",

--- a/api/SVGFontFaceFormatElement.json
+++ b/api/SVGFontFaceFormatElement.json
@@ -25,9 +25,7 @@
             "version_added": "3",
             "version_removed": "16.4"
           },
-          "safari_ios": {
-            "version_added": "1"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "≤37",

--- a/api/SVGFontFaceNameElement.json
+++ b/api/SVGFontFaceNameElement.json
@@ -25,9 +25,7 @@
             "version_added": "3",
             "version_removed": "16.4"
           },
-          "safari_ios": {
-            "version_added": "1"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "≤37",

--- a/api/SVGFontFaceSrcElement.json
+++ b/api/SVGFontFaceSrcElement.json
@@ -25,9 +25,7 @@
             "version_added": "3",
             "version_removed": "16.4"
           },
-          "safari_ios": {
-            "version_added": "1"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "≤37",

--- a/api/SVGFontFaceUriElement.json
+++ b/api/SVGFontFaceUriElement.json
@@ -25,9 +25,7 @@
             "version_added": "3",
             "version_removed": "16.4"
           },
-          "safari_ios": {
-            "version_added": "1"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "≤37",


### PR DESCRIPTION
This sets Safari iOS to mirror from upstream on the SVGFont*Element APIs.