### PR TITLE
Set Safari iOS to mirror on SVG element interfaces

### DIFF
--- a/api/SVGFontElement.json
+++ b/api/SVGFontElement.json
@@ -31,9 +31,7 @@
             "version_added": "3",
             "version_removed": "16.4"
           },
-          "safari_ios": {
-            "version_added": "1"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "≤37",

--- a/api/SVGFontFaceElement.json
+++ b/api/SVGFontFaceElement.json
@@ -25,9 +25,7 @@
             "version_added": "3",
             "version_removed": "16.4"
           },
-          "safari_ios": {
-            "version_added": "1"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "≤37",

--- a/api/SVGFontFaceFormatElement.json
+++ b/api/SVGFontFaceFormatElement.json
@@ -25,9 +25,7 @@
             "version_added": "3",
             "version_removed": "16.4"
           },
-          "safari_ios": {
-            "version_added": "1"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "≤37",

--- a/api/SVGFontFaceNameElement.json
+++ b/api/SVGFontFaceNameElement.json
@@ -25,9 +25,7 @@
             "version_added": "3",
             "version_removed": "16.4"
           },
-          "safari_ios": {
-            "version_added": "1"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "≤37",

--- a/api/SVGFontFaceSrcElement.json
+++ b/api/SVGFontFaceSrcElement.json
@@ -25,9 +25,7 @@
             "version_added": "3",
             "version_removed": "16.4"
           },
-          "safari_ios": {
-            "version_added": "1"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "≤37",

--- a/api/SVGFontFaceUriElement.json
+++ b/api/SVGFontFaceUriElement.json
@@ -25,9 +25,7 @@
             "version_added": "3",
             "version_removed": "16.4"
           },
-          "safari_ios": {
-            "version_added": "1"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "≤37",

--- a/api/SVGGlyphElement.json
+++ b/api/SVGGlyphElement.json
@@ -25,9 +25,7 @@
             "version_added": "3",
             "version_removed": "16.4"
           },
-          "safari_ios": {
-            "version_added": "1"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "≤37",

--- a/api/SVGMissingGlyphElement.json
+++ b/api/SVGMissingGlyphElement.json
@@ -31,9 +31,7 @@
             "version_added": "3",
             "version_removed": "16.4"
           },
-          "safari_ios": {
-            "version_added": "1"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "≤37",

--- a/api/SVGTRefElement.json
+++ b/api/SVGTRefElement.json
@@ -31,9 +31,7 @@
             "version_added": "3",
             "version_removed": "16.4"
           },
-          "safari_ios": {
-            "version_added": "1"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "1",


### PR DESCRIPTION
This PR sets Safari iOS to mirror from upstream on the interfaces for SVG elements.