### PR TITLE
Remove html.elements.area.media from BCD

### DIFF
--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -279,40 +279,6 @@
             }
           }
         },
-        "media": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": true
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": true
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": true
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "name": {
           "__compat": {
             "support": {


### PR DESCRIPTION
This PR removes the `media` member of the `area` HTML element from BCD. There's no documentation that indicates that this attribute was ever implemented.

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/area/media
