### PR TITLE
docs(relnote): Fx114 - CSS :lang() pseudo accepts comma-separated language codes

### DIFF
--- a/css/selectors/lang.json
+++ b/css/selectors/lang.json
@@ -61,7 +61,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "9.1"
+                "version_added": "≤9.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -94,7 +94,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "9.1"
+                "version_added": "≤9.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/selectors/lang.json
+++ b/css/selectors/lang.json
@@ -16,9 +16,7 @@
             },
             "firefox": {
               "version_added": "114",
-              "notes": [
-                "Prior to Firefox 114, the CSS Selectors Level 2 specification was implemented. Firefox 114 supports CSS Selectors Level 4 which introduces comma-separated lists of language codes as well as wildcard matching of language codes."
-              ]
+              "notes": "Prior to Firefox 114, the CSS Selectors Level 2 specification was implemented. Firefox 114 supports CSS Selectors Level 4 which introduces comma-separated lists of language codes as well as wildcard matching of language codes."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/lang.json
+++ b/css/selectors/lang.json
@@ -8,15 +8,17 @@
           "spec_url": "https://drafts.csswg.org/selectors/#lang-pseudo",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "CSS Selectors Level 2 support."
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "notes": "CSS Selectors Level 2 support."
             },
             "firefox": {
-              "version_added": "114",
-              "notes": "Prior to Firefox 114, the CSS Selectors Level 2 specification was implemented. Firefox 114 supports CSS Selectors Level 4 which introduces comma-separated lists of language codes as well as wildcard matching of language codes."
+              "version_added": "1",
+              "notes": "As of Firefox 114, support for CSS Selectors Level 4 which introduces comma-separated lists of language codes as well as wildcard matching of language codes."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -24,13 +26,16 @@
             },
             "oculus": "mirror",
             "opera": {
-              "version_added": "8"
+              "version_added": "8",
+              "notes": "CSS Selectors Level 2 support."
             },
             "opera_android": {
-              "version_added": "10.1"
+              "version_added": "10.1",
+              "notes": "CSS Selectors Level 2 support."
             },
             "safari": {
-              "version_added": "3.1"
+              "version_added": "3.1",
+              "notes": "As of Safari 9.1, support for CSS Selectors Level 4 which introduces comma-separated lists of language codes as well as wildcard matching of language codes."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/selectors/lang.json
+++ b/css/selectors/lang.json
@@ -61,7 +61,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤9.1"
+                "version_added": "9.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -94,7 +94,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤9.1"
+                "version_added": "9.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/selectors/lang.json
+++ b/css/selectors/lang.json
@@ -61,7 +61,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "9.1"
+                "version_added": "9"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -94,7 +94,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "9.1"
+                "version_added": "9"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/selectors/lang.json
+++ b/css/selectors/lang.json
@@ -8,17 +8,14 @@
           "spec_url": "https://drafts.csswg.org/selectors/#lang-pseudo",
           "support": {
             "chrome": {
-              "version_added": "1",
-              "notes": "CSS Selectors Level 2 support."
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12",
-              "notes": "CSS Selectors Level 2 support."
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "1",
-              "notes": "As of Firefox 114, support for CSS Selectors Level 4 which introduces comma-separated lists of language codes as well as wildcard matching of language codes."
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -26,16 +23,13 @@
             },
             "oculus": "mirror",
             "opera": {
-              "version_added": "8",
-              "notes": "CSS Selectors Level 2 support."
+              "version_added": "8"
             },
             "opera_android": {
-              "version_added": "10.1",
-              "notes": "CSS Selectors Level 2 support."
+              "version_added": "10.1"
             },
             "safari": {
-              "version_added": "3.1",
-              "notes": "As of Safari 9.1, support for CSS Selectors Level 4 which introduces comma-separated lists of language codes as well as wildcard matching of language codes."
+              "version_added": "3.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -45,6 +39,72 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "argument_list": {
+          "__compat": {
+            "description": "Comma-separated list of language codes as <code>:lang(A, B)</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "114"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "9.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "wildcards": {
+          "__compat": {
+            "description": "Matching language codes with wildcards as <code>:lang(*-Latn)</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "114"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "9.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/css/selectors/lang.json
+++ b/css/selectors/lang.json
@@ -15,7 +15,10 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "114",
+              "notes": [
+                "Prior to Firefox 114, the CSS Selectors Level 2 specification was implemented. Firefox 114 supports CSS Selectors Level 4 which introduces comma-separated lists of language codes as well as wildcard matching of language codes."
+              ]
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
Fx 114 supports (CSS Selectors Level 4) comma-separated values as params for the `:lang()` CSS pseudo. Additionally included is compliant string-based matching for language codes / subtags so that explicit wildcards `*-Latn` may be used, e.g.:

```css
:lang("nl", "de") {
  color: green;
}
:lang("*-Latn") {
  color: red;
}
```

__TODO:__
- [x] Add sub-features for wildcards and comma-separated values

__Related issues and pull requests:__
- [ ] Parent issue: https://github.com/mdn/content/issues/26688
- [ ] Content: https://github.com/mdn/content/pull/26924

__Bugzilla:__
- Tracking bug: [BUG-1121792](https://bugzilla.mozilla.org/show_bug.cgi?id=1121792)

__Resources:__
- Spec https://drafts.csswg.org/selectors/#the-lang-pseudo
- codepen: https://codepen.io/bsmth/pen/xxyMwxa
- wpt-like tests: https://hg.mozilla.org/mozilla-central/rev/bc74ba399e3a


