### PR TITLE
Update Safari data for api.WritableStreamDefaultWriter.WritableStreamDefaultWriter

### DIFF
--- a/api/WritableStreamDefaultWriter.json
+++ b/api/WritableStreamDefaultWriter.json
@@ -79,7 +79,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `WritableStreamDefaultWriter` member of the `WritableStreamDefaultWriter` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.3.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/WritableStreamDefaultWriter/WritableStreamDefaultWriter
