### PR TITLE
Update Safari data for api.WorkerGlobalScope.fonts

### DIFF
--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -147,7 +147,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "15"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -129,7 +129,7 @@
       "fonts": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/fonts",
-          "spec_url": "https://drafts.csswg.org/css-font-loading/#FontFaceSet-interface",
+          "spec_url": "https://drafts.csswg.org/css-font-loading/#dom-fontfacesource-fonts",
           "support": {
             "chrome": {
               "version_added": "69"


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `fonts` member of the `WorkerGlobalScope` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.3.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/WorkerGlobalScope/fonts
