### PR TITLE
Update Safari data for WEBGL_multi_draw API

### DIFF
--- a/api/WEBGL_multi_draw.json
+++ b/api/WEBGL_multi_draw.json
@@ -23,11 +23,9 @@
             "version_added": false
           },
           "safari": {
-            "version_added": false
-          },
-          "safari_ios": {
             "version_added": "15"
           },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -60,11 +58,9 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
               "version_added": "15"
             },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -98,11 +94,9 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
               "version_added": "15"
             },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -136,11 +130,9 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
               "version_added": "15"
             },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -174,11 +166,9 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
-            },
-            "safari_ios": {
               "version_added": "15"
             },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `WEBGL_multi_draw` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.3.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/WEBGL_multi_draw
