### PR TITLE
Update Safari data for StyleMedia API

### DIFF
--- a/api/StyleMedia.json
+++ b/api/StyleMedia.json
@@ -21,11 +21,10 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "5"
+            "version_added": "5",
+            "version_removed": "16.4"
           },
-          "safari_ios": {
-            "version_added": "4"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "≤37"
@@ -58,11 +57,10 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "5"
+              "version_added": "5",
+              "version_removed": "16.4"
             },
-            "safari_ios": {
-              "version_added": "4"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"
@@ -96,11 +94,10 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "5"
+              "version_added": "5",
+              "version_removed": "16.4"
             },
-            "safari_ios": {
-              "version_added": "4"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37"


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `StyleMedia` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.3.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/StyleMedia
