### PR TITLE
Update edge browser data file to version 113

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -269,7 +269,7 @@
         },
         "110": {
           "release_date": "2023-02-09",
-          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1100158741-february-9-2023",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1100158741-february-9-2023",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "110"
@@ -284,21 +284,28 @@
         "112": {
           "release_date": "2023-04-06",
           "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1120172234-april-6-2023",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "112"
         },
         "113": {
-          "release_date": "2023-05-04",
-          "status": "beta",
+          "release_date": "2023-05-05",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1130177435-may-5-2023",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "113"
         },
         "114": {
           "release_date": "2023-06-01",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "114"
+        },
+        "115": {
+          "release_date": "2023-07-20",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "115"
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Edge 113 was released at the beginning of this month, but the edge.json file hasn't been updated yet.
This PR adds Edge 113 to the file, and fixes a few URLs as usual.

