### PR TITLE
Update Samsung Internet to version 21.0

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -255,9 +255,15 @@
         },
         "20.0": {
           "release_date": "2023-02-10",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "106"
+        },
+        "21.0": {
+          "release_date": "2023-05-19",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "110"
         }
       }
     }


### PR DESCRIPTION
#### Summary

Update Samsung Internet to version 21.0

#### Test results and supporting details

- Version number is 21.0.0.41, obtained from the preference menu of the app.
- Release date is May 19, obtained from the official Google play page [1]
- Chromium version is 110.0.5481.154, obtained from the UA string [2]

[1] https://play.google.com/store/apps/details?id=com.sec.android.app.sbrowser
[2] https://www.whatismybrowser.com/detect/what-is-my-user-agent/

#### Related issues

N/A