### PR TITLE
Remove javascript.builtins.WebAssembly.Tag.type from BCD

### DIFF
--- a/javascript/builtins/WebAssembly/Tag.json
+++ b/javascript/builtins/WebAssembly/Tag.json
@@ -81,46 +81,6 @@
                 "deprecated": false
               }
             }
-          },
-          "type": {
-            "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag/type",
-              "spec_url": "https://webassembly.github.io/exception-handling/js-api/#dom-tag-type",
-              "support": {
-                "chrome": {
-                  "version_added": "95"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.15"
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "100"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "17.0.0"
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "15.2"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
           }
         }
       }


### PR DESCRIPTION
This PR removes the `Tag.type` member of the `WebAssembly` JavaScript builtin from BCD. This feature has never been supported as indicated by the mdn-bcd-collector project.

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/javascript/builtins/WebAssembly/Tag/type
