### PR TITLE
animation-timeline is enabled by default in Chrome 115

### DIFF
--- a/css/properties/animation-timeline.json
+++ b/css/properties/animation-timeline.json
@@ -6,16 +6,21 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-timeline",
           "spec_url": "https://drafts.csswg.org/css-animations-2/#animation-timeline",
           "support": {
-            "chrome": {
-              "version_added": "85",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
+            "chrome": [
+              {
+                "version_added": "115"
+              },
+              {
+                "version_added": "85",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "enable-experimental-web-platform-features",
+                    "value_to_set": "enabled"
+                  }
+                ]
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
_👋 Hi, Chrome DevRel here!_

The `animation-timeline` property is enabled by default in Chrome 115, as part of Scroll-Driven Animations that are shipping with it.

- ChromeStatus: https://chromestatus.com/feature/6752840701706240
- CL that enabled the feature by default: https://chromium-review.googlesource.com/c/chromium/src/+/4522412
- Commit that enabled the feature by default: https://chromiumdash.appspot.com/commit/7f3389e42baa78fa4ffd4d6d03b442c0c2ed2279

In the CL link  you can find back that `animation-timeline` is added. In the commit link you can see that it is included in the 115.0.5768.0 build.

There’s more properties that this feature adds. I’ll file a separate PR to add those.