### PR TITLE
docs(css): style containment partially implemented in Chrome and Safari

### DIFF
--- a/css/properties/contain.json
+++ b/css/properties/contain.json
@@ -91,7 +91,6 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "15.4",
-                "partial_implementation": true,
                 "notes": "Style containment does not affect quotes, see <a href='https://webkit.org/b/232083'>WebKit bug 232083</a>)."
               },
               "safari_ios": "mirror",


### PR DESCRIPTION
CSS `contain: style;` should scope quotes as well as counters. 

Demo: https://developer.mozilla.org/en-US/docs/Web/CSS/contain#style_containment

__Related issues and pull requests:__
- [x] https://github.com/mdn/content/issues/26804

__Resources:__
* Webkit bug https://bugs.webkit.org/show_bug.cgi?id=232083
* Resolved Chromium bug https://github.com/chromium/chromium/commit/1d4f01eeafb366dcf0f8e26a1475521a717944c5
  * Resolved in `115.0.5740.0` in https://storage.googleapis.com/chromium-find-releases-static/1d4.html#1d4f01eeafb366dcf0f8e26a1475521a717944c5
* WPT: https://wpt.fyi/results/css/css-contain?label=master&label=experimental&aligned


__Open questions:__
This is currently working in Chrome canary (Version 116.0.5793.0) - should I bump the version number to reflect this with an experimental flag?