### PR TITLE
Only Firefox supports "contain: style"

### DIFF
--- a/css/properties/contain.json
+++ b/css/properties/contain.json
@@ -74,7 +74,7 @@
             "spec_url": "https://drafts.csswg.org/css-contain/#valdef-contain-style",
             "support": {
               "chrome": {
-                "version_added": "52"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -89,7 +89,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "15.4"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Only Firefox supports "contain: style", as per [26804](https://github.com/mdn/content/issues/26804).

