### PR TITLE
Removed outdated Firefox note from scrollbar-color

### DIFF
--- a/css/properties/scrollbar-color.json
+++ b/css/properties/scrollbar-color.json
@@ -13,12 +13,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "64",
-              "notes": "On macOS, you need to set the <em>General</em> &gt; <em>Show scroll bars</em> setting in System Preferences to \"Always\" for this property to have any effect."
-            },
-            "firefox_android": {
               "version_added": "64"
             },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Removed a note about macOS and Firefox.

This note is outdated overlay scrollbars are correctly themed in Firefox. I'm not aware of the exact version but I believe it was long enough ago to not worry about keeping the note for the appropriate version range.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Always:

![image](https://github.com/mdn/browser-compat-data/assets/32498324/3b7565f1-b952-4889-a760-f61c2b139ddc)


Overflow (when scrolling):

![image](https://github.com/mdn/browser-compat-data/assets/32498324/083ae534-1a26-43a9-b874-52c454057a96)


#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

fixes #19495