### PR TITLE
Name change for pref for scroll linked animations

### DIFF
--- a/css/properties/animation-timeline.json
+++ b/css/properties/animation-timeline.json
@@ -18,16 +18,29 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "97",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.scroll-linked-animations.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "110",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-driven-animations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "97",
+                "version_removed": "110",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-linked-animations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -59,17 +72,31 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "101",
-                "notes": "Zero scroll range is treated as 100% but should be 0% (see <a href='https://bugzil.la/1780865'>bug 1780865</a>).",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.scroll-linked-animations.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
+              "firefox": [
+                {
+                  "version_added": "110",
+                  "notes": "Zero scroll range is treated as 100% but should be 0% (see <a href='https://bugzil.la/1780865'>bug 1780865</a>).",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.scroll-driven-animations.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "101",
+                  "version_removed": "110",
+                  "notes": "Zero scroll range is treated as 100% but should be 0% (see <a href='https://bugzil.la/1780865'>bug 1780865</a>).",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.scroll-linked-animations.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/css/properties/scroll-timeline-axis.json
+++ b/css/properties/scroll-timeline-axis.json
@@ -35,7 +35,10 @@
             "firefox": [
               {
                 "version_added": "111",
-                "notes": "The syntax of the shorthand property uses the fixed order of name and then the axis.",
+                "notes": [
+                  "The syntax of the shorthand property uses the fixed order of name and then the axis.",
+                  "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`."
+                ],
                 "flags": [
                   {
                     "type": "preference",
@@ -46,6 +49,7 @@
               },
               {
                 "version_added": "103",
+                "version_removed": "110",
                 "notes": "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
                 "flags": [
                   {

--- a/css/properties/scroll-timeline-name.json
+++ b/css/properties/scroll-timeline-name.json
@@ -35,7 +35,10 @@
             "firefox": [
               {
                 "version_added": "111",
-                "notes": "The syntax of the shorthand property uses the fixed order of name and then the axis.",
+                "notes": [
+                  "The syntax of the shorthand property uses the fixed order of name and then the axis.",
+                  "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`."
+                ],
                 "flags": [
                   {
                     "type": "preference",
@@ -46,6 +49,7 @@
               },
               {
                 "version_added": "103",
+                "version_removed": "110",
                 "notes": "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
                 "flags": [
                   {

--- a/css/properties/scroll-timeline.json
+++ b/css/properties/scroll-timeline.json
@@ -35,7 +35,10 @@
             "firefox": [
               {
                 "version_added": "111",
-                "notes": "The syntax of the shorthand property uses the fixed order of name and then the axis.",
+                "notes": [
+                  "The syntax of the shorthand property uses the fixed order of name and then the axis.",
+                  "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`."
+                ],
                 "flags": [
                   {
                     "type": "preference",
@@ -46,6 +49,7 @@
               },
               {
                 "version_added": "103",
+                "version_removed": "110",
                 "notes": "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
                 "flags": [
                   {


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/26994

In https://bugzilla.mozilla.org/show_bug.cgi?id=1807685 the pref `layout.css.scroll-linked-animations.enabled` was changed to `layout.css.scroll-driven-animations.enabled`.

This adds a new item for the new pref (if there isn't already a record) and makes the record with the the old pref as version removed. In some cases the old pref had different notes than the new pref, so I duplicated the note from the old pref to the new pref to make it clear the information still applies. 

Hopefully this will ship soon and we can remove all this detail. 