### PR TITLE
WebTransport FF114 - clarify support

### DIFF
--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -204,6 +204,39 @@
           }
         }
       },
+      "byob_readers": {
+        "__compat": {
+          "description": "BYOB reader support",
+          "support": {
+            "chrome": {
+              "version_added": "109"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "114"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "close": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport/close",
@@ -453,6 +486,42 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "114"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getStats": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport/getStats",
+          "spec_url": "https://w3c.github.io/webtransport/#dom-webtransport-getstats",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "114",
+              "partial_implementation": true,
+              "notes": "Method is defined but throws a not-implemented error."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -338,40 +338,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "options_sendOrder_parameter": {
-          "__compat": {
-            "description": "<code>options.sendOrder</code> parameter",
-            "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportsendstreamoptions-sendorder",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "114"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "createUnidirectionalStream": {
@@ -439,40 +405,6 @@
               "deprecated": false
             }
           }
-        },
-        "options_sendOrder_parameter": {
-          "__compat": {
-            "description": "<code>options.sendOrder</code> parameter",
-            "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportsendstreamoptions-sendorder",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "114"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "datagrams": {
@@ -513,40 +445,6 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport/draining",
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransport-draining",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "114"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "getStats": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport/getStats",
-          "spec_url": "https://w3c.github.io/webtransport/#dom-webtransport-getstats",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/WebTransportDatagramDuplexStream.json
+++ b/api/WebTransportDatagramDuplexStream.json
@@ -33,6 +33,39 @@
           "deprecated": false
         }
       },
+      "byob_readers": {
+        "__compat": {
+          "description": "BYOB reader support",
+          "support": {
+            "chrome": {
+              "version_added": "109"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "incomingHighWaterMark": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransportDatagramDuplexStream/incomingHighWaterMark",


### PR DESCRIPTION
WebTransport team finally got back to me with more detail on what FF supports and does not. The answers are kind of hand-wavy and this is not easy to test, so I may well not have it all. However I have tried to update the things I am clear on.

Specifically 
- FF does not support `WebTransport.sendOrder`, which means no one does, so I have removed that - this is planned in https://bugzilla.mozilla.org/show_bug.cgi?id=1816925
- FF implements `WebTransport.getStats` but can see in code it just throws: https://searchfox.org/mozilla-central/source/dom/webtransport/api/WebTransport.cpp#473-475
- FF does not support BYOB readers for datagrams, based on test here: https://wpt.fyi/results/webtransport/datagrams.https.any.html?label=experimental&label=master&aligned
  Chrome does support it, but is not clear for sure what version Chrome _started_ supporting these on, so I have mirrored the WebTransport byob support from 110.
  
This is the main set of things identified in https://bugzilla.mozilla.org/show_bug.cgi?id=1818754#c17 plus a search on bug and implementation and throw in the source - which is what caught getStats. There might be other things to infer from WPT https://wpt.fyi/results/webtransport?label=experimental&label=master&aligned, but these are the ones that engineering identified.

This is part of https://github.com/mdn/content/issues/26684

FYI @queengooborg 




