### PR TITLE
HTTP Want-Digest and Digest are deprecated

### DIFF
--- a/http/headers/Digest.json
+++ b/http/headers/Digest.json
@@ -31,7 +31,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/http/headers/Want-Digest.json
+++ b/http/headers/Want-Digest.json
@@ -31,7 +31,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
The last version of the spec in which they appear is https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers-07

They have been replaced by Repr-Digest and Repr-Want-Digest.

No idea what versions they are supported in. 

Ths falls out of https://github.com/mdn/content/pull/26885