### PR TITLE
docs(relnote): Fx114 - crossorigin attribute for image and feImage elements

### DIFF
--- a/api/SVGFEImageElement.json
+++ b/api/SVGFEImageElement.json
@@ -39,6 +39,40 @@
           "deprecated": false
         }
       },
+      "crossOrigin": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEImageElement",
+          "spec_url": "https://drafts.fxtf.org/filter-effects/#element-attrdef-feimage-crossorigin",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "114"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "height": {
         "__compat": {
           "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfilterprimitivestandardattributes-height",

--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -43,6 +43,39 @@
           "deprecated": false
         }
       },
+      "crossOrigin": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement/crossorigin",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "114"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "decode": {
         "__compat": {
           "description": "<code>decode()</code>",

--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -46,6 +46,7 @@
       "crossOrigin": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement/crossorigin",
+          "spec_url": "https://svgwg.org/svg2-draft/embedded.html#__svg__SVGImageElement__crossOrigin",
           "support": {
             "chrome": {
               "version_added": false

--- a/svg/elements/feImage.json
+++ b/svg/elements/feImage.json
@@ -40,6 +40,38 @@
             "deprecated": false
           }
         },
+        "crossorigin": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "114"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "href": {
           "__compat": {
             "support": {

--- a/svg/elements/feImage.json
+++ b/svg/elements/feImage.json
@@ -42,6 +42,8 @@
         },
         "crossorigin": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/crossorigin",
+            "spec_url": "https://drafts.fxtf.org/filter-effects/#dom-svgfilterprimitivestandardattributes-height",
             "support": {
               "chrome": {
                 "version_added": false

--- a/svg/elements/image.json
+++ b/svg/elements/image.json
@@ -42,6 +42,38 @@
             "deprecated": false
           }
         },
+        "crossorigin": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "114"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "height": {
           "__compat": {
             "support": {

--- a/svg/elements/image.json
+++ b/svg/elements/image.json
@@ -44,6 +44,8 @@
         },
         "crossorigin": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/crossorigin",
+            "spec_url": "https://svgwg.org/svg2-draft/embedded.html#ImageElementCrossoriginAttribute",
             "support": {
               "chrome": {
                 "version_added": false


### PR DESCRIPTION
Fx 114 supports `crossorigin` attribute on `<image>` and `<feimage>` elements which allow for specifying client behavior for cross-origin resource requests.

```html
<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
  <image
    href="https://example.com/mdn_logo_dark.png"
    height="200"
    width="200"
    crossorigin="use-credentials" />
</svg>
```
__Related issues and pull requests:__
- [ ] Parent issue https://github.com/mdn/content/issues/26690
- [x] content: https://github.com/mdn/content/pull/27065

__Bugzilla:__
- [BUG-1240357](https://bugzilla.mozilla.org/show_bug.cgi?id=1240357)

__Resources:__
* WPT: https://wpt.live/svg/embedded/image-crossorigin.sub.html
* WPT overview: https://wpt.fyi/results/svg/embedded/image-crossorigin.sub.html?label=master&product=chrome%5Bstable%5D&product=edge%5Bstable%5D&product=firefox%5Bexperimental%5D&product=safari%5Bstable%5D&aligned
* specs
  * https://svgwg.org/svg2-draft/embedded.html#ImageElementCrossoriginAttribute
  * https://drafts.fxtf.org/filter-effects/#element-attrdef-feimage-crossorigin


