### PR TITLE
Node.js 20 supports resizable array buffers

### DIFF
--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -121,7 +121,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "20.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -297,7 +297,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "20.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -337,7 +337,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "20.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -377,7 +377,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "20.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -109,7 +109,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "20.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -196,7 +196,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "20.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -238,7 +238,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "20.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -280,7 +280,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "20.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
Fix https://github.com/mdn/browser-compat-data/issues/19974
Fix https://github.com/mdn/browser-compat-data/issues/19973

Release notes: https://nodejs.org/en/blog/announcements/v20-release-announce#v8-113

Edit: 20k BCD pull requests/issues !!!