### PR TITLE
Safari 14.1 implements WEBGL_compressed_texture_s3tc_srgb

### DIFF
--- a/api/WEBGL_compressed_texture_s3tc_srgb.json
+++ b/api/WEBGL_compressed_texture_s3tc_srgb.json
@@ -25,7 +25,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "14.1"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",


### PR DESCRIPTION
See https://github.com/WebKit/WebKit/commit/e9f97ba9db299ab74cedfc39eb86fa32811b9e61