### PR TITLE
Safari 15 supports WebGL2 interfaces

### DIFF
--- a/api/WebGLQuery.json
+++ b/api/WebGLQuery.json
@@ -23,7 +23,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "preview"
+            "version_added": "15"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",

--- a/api/WebGLSampler.json
+++ b/api/WebGLSampler.json
@@ -23,7 +23,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "preview"
+            "version_added": "15"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",

--- a/api/WebGLSync.json
+++ b/api/WebGLSync.json
@@ -23,7 +23,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "preview"
+            "version_added": "15"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",

--- a/api/WebGLVertexArrayObjectOES.json
+++ b/api/WebGLVertexArrayObjectOES.json
@@ -23,7 +23,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "15"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",

--- a/api/WebGLVertexArrayObjectOES.json
+++ b/api/WebGLVertexArrayObjectOES.json
@@ -23,9 +23,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "15"
+            "version_added": "5.1"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "9"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },


### PR DESCRIPTION
Safari 15 shipped WebGL 2 and these interfaces belong to WebGL 2.