### PR TITLE
WebGL contexts have no commit method

### DIFF
--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -1468,40 +1468,6 @@
           }
         }
       },
-      "commit": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/commit",
-          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#offscreencontext-commit",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "105"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "compileShader": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/compileShader",

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -1125,40 +1125,6 @@
           }
         }
       },
-      "commit": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/commit",
-          "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#offscreencontext-commit",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "105"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "compileShader": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/compileShader",


### PR DESCRIPTION
As far as I can tell this is only a method of the OffscreenCanvasContext.
Spec https://html.spec.whatwg.org/multipage/canvas.html#offscreencontext-commit 
The collector also suggests false for Firefox