### PR TITLE
Update Safari data for CSSGroupingRule API

### DIFF
--- a/api/CSSGroupingRule.json
+++ b/api/CSSGroupingRule.json
@@ -22,9 +22,16 @@
           "oculus": "mirror",
           "opera": "mirror",
           "opera_android": "mirror",
-          "safari": {
-            "version_added": "14.1"
-          },
+          "safari": [
+            {
+              "version_added": "14.1"
+            },
+            {
+              "version_added": "3",
+              "partial_implementation": true,
+              "notes": "The <code>CSSGroupingRule</code> interface itself is not present, but many of the methods are available on various interfaces such as the <a href='https://developer.mozilla.org/docs/Web/API/CSSMediaRule'><code>CSSMediaRule</code></a> and <a href='https://developer.mozilla.org/docs/Web/API/CSSPageRule'><code>CSSPageRule</code></a> interfaces."
+            }
+          ],
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
@@ -58,7 +65,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "3"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -94,7 +101,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "3"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -130,7 +137,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "14.1"
+              "version_added": "3"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `CSSGroupingRule` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.3.1).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CSSGroupingRule

Additional Notes: Additional manual testing was performed to narrow down the version number from ≤13.1 to 3.
