### PR TITLE
Update Firefox data for RTCStatsReport API

### DIFF
--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -1728,7 +1728,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "78"
+              "version_added": "79"
             },
             "firefox_android": {
               "version_added": false
@@ -1763,7 +1763,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "78"
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": false
@@ -1799,7 +1799,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "78"
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": false
@@ -1835,7 +1835,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "78"
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": false
@@ -1871,7 +1871,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "78"
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": false
@@ -1907,7 +1907,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "78"
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": false
@@ -1943,7 +1943,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "78"
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": false
@@ -1979,7 +1979,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "78"
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": false
@@ -2015,7 +2015,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "78"
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": false
@@ -2051,7 +2051,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "78"
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": false
@@ -2087,7 +2087,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "78"
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": false
@@ -2123,7 +2123,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "78"
+                "version_added": "79"
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `RTCStatsReport` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.3.1).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/RTCStatsReport
