### PR TITLE
Update Firefox data for WEBGL_compressed_texture_etc API

### DIFF
--- a/api/WEBGL_compressed_texture_etc.json
+++ b/api/WEBGL_compressed_texture_etc.json
@@ -11,9 +11,11 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
             "version_added": "51"
           },
-          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },

--- a/api/WEBGL_compressed_texture_etc1.json
+++ b/api/WEBGL_compressed_texture_etc1.json
@@ -11,9 +11,11 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
+            "version_added": false
+          },
+          "firefox_android": {
             "version_added": "30"
           },
-          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `WEBGL_compressed_texture_etc` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.3.1).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/WEBGL_compressed_texture_etc

Additional Notes: Testing this WebGL extension in macOS, Windows and Android, it turns out that the only platform that supports it is Android.
