### PR TITLE
Update all browsers data for javascript.builtins.WebAssembly.Tag.type

### DIFF
--- a/javascript/builtins/WebAssembly/Tag.json
+++ b/javascript/builtins/WebAssembly/Tag.json
@@ -88,7 +88,7 @@
               "spec_url": "https://webassembly.github.io/exception-handling/js-api/#dom-tag-type",
               "support": {
                 "chrome": {
-                  "version_added": "95"
+                  "version_added": false
                 },
                 "chrome_android": "mirror",
                 "deno": {
@@ -96,7 +96,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "100"
+                  "version_added": false
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `Tag.type` member of the `WebAssembly` JavaScript builtin. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.3.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/javascript/builtins/WebAssembly/Tag/type
