### PR TITLE
RTCStatsReport - add MDN links and speclinks for maplike

### DIFF
--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -35,6 +35,8 @@
       },
       "entries": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport/entries",
+          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcstatsreport",
           "support": {
             "chrome": {
               "version_added": "58"
@@ -67,6 +69,8 @@
       },
       "forEach": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport/forEach",
+          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcstatsreport",
           "support": {
             "chrome": {
               "version_added": "58"
@@ -99,6 +103,8 @@
       },
       "get": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport/get",
+          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcstatsreport",
           "support": {
             "chrome": {
               "version_added": "58"
@@ -131,6 +137,8 @@
       },
       "has": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport/has",
+          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcstatsreport",
           "support": {
             "chrome": {
               "version_added": "58"
@@ -163,6 +171,8 @@
       },
       "keys": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport/keys",
+          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcstatsreport",
           "support": {
             "chrome": {
               "version_added": "58"
@@ -195,6 +205,8 @@
       },
       "size": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCStatsReport/size",
+          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcstatsreport",
           "support": {
             "chrome": {
               "version_added": "59"


### PR DESCRIPTION
RTCStatsReport is "maplike" - see https://w3c.github.io/webrtc-pc/#dom-rtcstatsreport - which means it adds entries, keys, iterator .... 

What this does is add a spec link for each of those maplike interfaces to https://w3c.github.io/webrtc-pc/#dom-rtcstatsreport and also a link to the MDN docs that are being added in https://github.com/mdn/content/pull/27028