### PR TITLE
Update Safari data for background-clip CSS property

### DIFF
--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -79,7 +79,7 @@
             ],
             "safari": [
               {
-                "version_added": "14"
+                "version_added": "5"
               },
               {
                 "version_added": "3",
@@ -89,7 +89,7 @@
             ],
             "safari_ios": [
               {
-                "version_added": "14"
+                "version_added": "5"
               },
               {
                 "version_added": "1",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `background-clip` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.3.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/background-clip
