### PR TITLE
Update Safari data for css.properties.background-image.image-set

### DIFF
--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -194,7 +194,7 @@
               "opera_android": "mirror",
               "safari": [
                 {
-                  "version_added": "preview"
+                  "version_added": "10"
                 },
                 {
                   "prefix": "-webkit-",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `image-set` member of the `background-image` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.3.2).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/background-image/image-set
