### PR TITLE
Update Chrome/Safari data for css.properties.font-style.oblique-angle

### DIFF
--- a/css/properties/font-style.json
+++ b/css/properties/font-style.json
@@ -46,7 +46,7 @@
             "description": "<code>oblique</code> can accept an <code>&lt;angle&gt;</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "62"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -61,7 +61,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "11.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `oblique-angle` member of the `font-style` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.4.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/font-style/oblique-angle
