### PR TITLE
Update Firefox data for mask-origin CSS property

### DIFF
--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -57,7 +57,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "54"
+                "version_added": "53"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -134,7 +134,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "54"
+                "version_added": "53"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -168,7 +168,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "54"
+                "version_added": "53"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -57,7 +57,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "54"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -134,7 +134,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "54"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -168,7 +168,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "54"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `mask-origin` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.4.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/mask-origin
