### PR TITLE
Add decoding attribute to SVG <image>

### DIFF
--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -133,7 +133,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "11.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/svg/elements/image.json
+++ b/svg/elements/image.json
@@ -97,7 +97,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "11.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/svg/elements/image.json
+++ b/svg/elements/image.json
@@ -76,6 +76,40 @@
             }
           }
         },
+        "decoding": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/decoding",
+            "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-decoding",
+            "support": {
+              "chrome": {
+                "version_added": "65"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "63"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "height": {
           "__compat": {
             "support": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

The `decoding` attribute has been supported for quite some time, for SVG and HTML images. I noticed that we were missing the `decoding` attribute from the SVG `<image>` element. This PR adds that.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
