### PR TITLE
Update Safari data for MediaMetadata API

### DIFF
--- a/api/MediaMetadata.json
+++ b/api/MediaMetadata.json
@@ -25,7 +25,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "15"
+            "version_added": "14"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -61,7 +61,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "14"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -97,7 +97,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "14"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -133,7 +133,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "14"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -169,7 +169,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "14"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -205,7 +205,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15"
+              "version_added": "14"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `MediaMetadata` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.4.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/MediaMetadata
