### PR TITLE
Details of support for sessions.storage

### DIFF
--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -389,7 +389,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "115"
               },
               "firefox_android": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
#### Summary

Update to note that support for `session.storage` was provided in Firefox 115. See  [Bug 1823713](https://bugzilla.mozilla.org/show_bug.cgi?id=1823713) Implement storage.session in extension process.