### PR TITLE
Update Firefox data for api.IDBObjectStore.openKeyCursor

### DIFF
--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -751,9 +751,7 @@
             "firefox": {
               "version_added": "44"
             },
-            "firefox_android": {
-              "version_added": "22"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "10"
             },

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -749,13 +749,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "44",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.indexedDB.experimental"
-                }
-              ]
+              "version_added": "44"
             },
             "firefox_android": {
               "version_added": "22"


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `openKeyCursor` member of the `IDBObjectStore` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.4.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/IDBObjectStore/openKeyCursor

Additional Notes: The indicated flag is required for _prior_ Firefox versions, not Firefox 44 and newer.
