### PR TITLE
Update Firefox data for api.Event.returnValue

### DIFF
--- a/api/Event.json
+++ b/api/Event.json
@@ -748,10 +748,15 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": false,
-              "notes": "Temporarily added in 63, removed in 64, briefly added in 65, then removed again while related compatibility issues are sorted out (see <a href='https://bugzil.la/1520756'>bug 1520756</a>)."
-            },
+            "firefox": [
+              {
+                "version_added": "66"
+              },
+              {
+                "version_added": "63",
+                "version_removed": "64"
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "6"


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `returnValue` member of the `Event` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.4.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Event/returnValue
