### PR TITLE
Update Safari data for api.TransitionEvent.TransitionEvent

### DIFF
--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -101,9 +101,15 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "preview"
-            },
+            "safari": [
+              {
+                "version_added": "7"
+              },
+              {
+                "prefix": "WebKit",
+                "version_added": "6"
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "2.0"


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `TransitionEvent` member of the `TransitionEvent` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.4.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/TransitionEvent/TransitionEvent
