### PR TITLE
Update Edge data for api.XRSession.enabledFeatures

### DIFF
--- a/api/XRSession.json
+++ b/api/XRSession.json
@@ -192,9 +192,7 @@
               "version_added": "111"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `enabledFeatures` member of the `XRSession` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.4.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/XRSession/enabledFeatures
