### PR TITLE
Remove css.properties.text-decoration.blink

### DIFF
--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -47,7 +47,7 @@
             "description": "<code>blink</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "23"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -69,7 +69,7 @@
                 "version_removed": "14"
               },
               "safari": {
-                "version_added": "preview"
+                "version_added": "7"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -42,46 +42,6 @@
             "deprecated": false
           }
         },
-        "blink": {
-          "__compat": {
-            "description": "<code>blink</code>",
-            "support": {
-              "chrome": {
-                "version_added": "23"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "1",
-                "version_removed": "23"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": {
-                "version_added": "4",
-                "version_removed": "15"
-              },
-              "opera_android": {
-                "version_added": "10.1",
-                "version_removed": "14"
-              },
-              "safari": {
-                "version_added": "7"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
-            }
-          }
-        },
         "shorthand": {
           "__compat": {
             "description": "Shorthand",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `blink` member of the `text-decoration` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.4.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/text-decoration/blink
