### PR TITLE
Update Edge data for text-justify CSS property

### DIFF
--- a/css/properties/text-justify.json
+++ b/css/properties/text-justify.json
@@ -18,10 +18,24 @@
               "notes": "<code>inter-word</code> and <code>distribute</code> (deprecated) values are supported, but <code>distribute</code> behavior is buggy."
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "12",
-              "notes": "Standard values <code>inter-character</code> and <code>none</code> are supported. The deprecated <code>distribute</code> value is also supported."
-            },
+            "edge": [
+              {
+                "version_added": "79",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "<code>inter-word</code> and <code>distribute</code> (deprecated) values are supported, but <code>distribute</code> behavior is buggy."
+              },
+              {
+                "version_added": "12",
+                "version_removed": "79",
+                "notes": "Standard values <code>inter-character</code> and <code>none</code> are supported. The deprecated <code>distribute</code> value is also supported."
+              }
+            ],
             "firefox": {
               "version_added": "55"
             },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `text-justify` CSS property. This mirrors the data from Chrome.
