### PR TITLE
Update Chromium data for css.properties.text-orientation.sideways

### DIFF
--- a/css/properties/text-orientation.json
+++ b/css/properties/text-orientation.json
@@ -59,7 +59,7 @@
             "description": "<code>sideways</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "25"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `sideways` member of the `text-orientation` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.4.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/text-orientation/sideways
