### PR TITLE
Add back manifest shortcuts compat data

### DIFF
--- a/html/manifest/shortcuts.json
+++ b/html/manifest/shortcuts.json
@@ -1,0 +1,52 @@
+{
+  "html": {
+    "manifest": {
+      "shortcuts": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/shortcuts",
+          "spec_url": "https://w3c.github.io/manifest/#shortcuts-member",
+          "support": {
+            "chrome": [
+              {
+                "version_added": "96"
+              },
+              {
+                "version_added": "85",
+                "version_removed": "96",
+                "partial_implementation": true,
+                "notes": "Supported on Windows only."
+              }
+            ],
+            "chrome_android": {
+              "version_added": "84"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false,
+              "notes": "See <a href='https://bugzil.la/1582341'>bug 1582341</a>."
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false,
+              "notes": "See <a href='https://webkit.org/b/201964'>bug 201964</a>."
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Compatibility data for `shortcuts` property for app manifests seems to have been unintentionally removed in #18427. This change readds the file, along with the update that Chrome [now supports](https://chromestatus.com/feature/5706099464339456) shortcuts on non-Windows platforms after version 96.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixes #18829

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
