### PR TITLE
Update Chrome data for css.properties.[margin/padding]-[block/inline]

### DIFF
--- a/css/properties/margin-block-end.json
+++ b/css/properties/margin-block-end.json
@@ -7,7 +7,7 @@
           "spec_url": "https://drafts.csswg.org/css-logical/#margin-properties",
           "support": {
             "chrome": {
-              "version_added": "87"
+              "version_added": "69"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/margin-block-start.json
+++ b/css/properties/margin-block-start.json
@@ -7,7 +7,7 @@
           "spec_url": "https://drafts.csswg.org/css-logical/#margin-properties",
           "support": {
             "chrome": {
-              "version_added": "87"
+              "version_added": "69"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/margin-inline-end.json
+++ b/css/properties/margin-inline-end.json
@@ -8,7 +8,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "87"
+                "version_added": "69"
               },
               {
                 "version_added": "2",

--- a/css/properties/margin-inline-start.json
+++ b/css/properties/margin-inline-start.json
@@ -8,7 +8,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "87"
+                "version_added": "69"
               },
               {
                 "version_added": "2",

--- a/css/properties/padding-block-end.json
+++ b/css/properties/padding-block-end.json
@@ -7,7 +7,7 @@
           "spec_url": "https://drafts.csswg.org/css-logical/#padding-properties",
           "support": {
             "chrome": {
-              "version_added": "87"
+              "version_added": "69"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/padding-block-start.json
+++ b/css/properties/padding-block-start.json
@@ -7,7 +7,7 @@
           "spec_url": "https://drafts.csswg.org/css-logical/#padding-properties",
           "support": {
             "chrome": {
-              "version_added": "87"
+              "version_added": "69"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/padding-inline-end.json
+++ b/css/properties/padding-inline-end.json
@@ -8,7 +8,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "87"
+                "version_added": "69"
               },
               {
                 "version_added": "2",

--- a/css/properties/padding-inline-start.json
+++ b/css/properties/padding-inline-start.json
@@ -8,7 +8,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "87"
+                "version_added": "69"
               },
               {
                 "version_added": "2",


### PR DESCRIPTION
This PR updates the Chromium data for eight CSS properties, using results from the mdn-bcd-collector project (v9.4.0), followed by manual testing.

Tests Used:
https://mdn-bcd-collector.gooborg.com/tests/css/properties/margin-block-end
https://mdn-bcd-collector.gooborg.com/tests/css/properties/margin-block-start
https://mdn-bcd-collector.gooborg.com/tests/css/properties/margin-inline-end
https://mdn-bcd-collector.gooborg.com/tests/css/properties/margin-inline-start
https://mdn-bcd-collector.gooborg.com/tests/css/properties/padding-block-end
https://mdn-bcd-collector.gooborg.com/tests/css/properties/padding-block-start
https://mdn-bcd-collector.gooborg.com/tests/css/properties/padding-inline-end
https://mdn-bcd-collector.gooborg.com/tests/css/properties/padding-inline-start