### PR TITLE
Fix incorrect information about path()

### DIFF
--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -182,12 +182,19 @@
             "support": {
               "chrome": [
                 {
-                  "version_added": "88"
+                  "version_added": "88",
+                  "partial_implementation": true,
+                  "notes": "Only supported on the <code>d</code> SVG presentation attribute and the <code>clip-path</code> and <code>offset-path</code> properties."
                 },
                 {
-                  "version_added": "46",
+                  "version_added": "56",
                   "partial_implementation": true,
-                  "notes": "Only supported on the <code>offset-path</code> property."
+                  "notes": "Only supported on the <code>d</code> SVG presentation attribute and the <code>offset-path</code> property."
+                },
+                {
+                  "version_added": "52",
+                  "partial_implementation": true,
+                  "notes": "Only supported on the <code>d</code> SVG presentation attribute."
                 }
               ],
               "chrome_android": "mirror",
@@ -199,14 +206,9 @@
                   "notes": "Only supported on the <code>d</code> SVG presentation attribute and the <code>clip-path</code> and <code>offset-path</code> CSS properties. Not supported on the <code>shape-outside</code> CSS property."
                 },
                 {
-                  "version_added": "71",
+                  "version_added": "72",
                   "partial_implementation": true,
                   "notes": "Only supported on the <code>clip-path</code> and <code>offset-path</code> properties."
-                },
-                {
-                  "version_added": "63",
-                  "partial_implementation": true,
-                  "notes": "Only supported on the <code>offset-path</code> property."
                 }
               ],
               "firefox_android": "mirror",
@@ -216,10 +218,37 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
+              "safari": [
+                {
+                  "version_added": "16",
+                  "partial_implementation": true,
+                  "notes": "Only supported on the <code>offset-path</code> and <code>clip-path</code> properties."
+                },
+                {
+                  "version_added": "13.1",
+                  "partial_implementation": true,
+                  "notes": "Only supported on the <code>clip-path</code> property."
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "10.1",
+                  "partial_implementation": true,
+                  "notes": "Only supported on the <code>clip-path</code> property."
+                }
+              ],
+              "safari_ios": [
+                {
+                  "version_added": "13",
+                  "partial_implementation": true,
+                  "notes": "Only supported on the <code>clip-path</code> property."
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "10.3",
+                  "partial_implementation": true,
+                  "notes": "Only supported on the <code>clip-path</code> property."
+                }
+              ],
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -227,6 +256,167 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "clip-path": {
+            "__compat": {
+              "description": "In <code>clip-path</code>",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/clip-path",
+              "spec_url": [
+                "https://drafts.fxtf.org/css-masking/#the-clip-path",
+                "https://drafts.csswg.org/css-shapes/#supported-basic-shapes"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "88"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "72"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": [
+                  {
+                    "version_added": "13.1"
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "10.1"
+                  }
+                ],
+                "safari_ios": [
+                  {
+                    "version_added": "13"
+                  },
+                  {
+                    "prefix": "-webkit-",
+                    "version_added": "10.3"
+                  }
+                ],
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "d": {
+            "__compat": {
+              "description": "In <code>d</code> as CSS property",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/d#using_d_as_a_css_property",
+              "spec_url": "https://svgwg.org/svg2-draft/paths.html#DProperty",
+              "support": {
+                "chrome": {
+                  "version_added": "52"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "97"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": {
+                  "version_added": "60"
+                },
+                "opera_android": {
+                  "version_added": "51"
+                },
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "offset-path": {
+            "__compat": {
+              "description": "In <code>offset-path</code>",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/offset-path",
+              "spec_url": "https://drafts.fxtf.org/motion/#offset-path-property",
+              "support": {
+                "chrome": {
+                  "version_added": "56"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "72"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "16"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "shape-outside": {
+            "__compat": {
+              "description": "In <code>shape-outside</code>",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/shape-outside",
+              "spec_url": "https://drafts.csswg.org/css-shapes/#shape-outside-property",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Compat data about where `path()` can be used is outdated and inconsistent with other MDN pages, [especially `clip-path`](https://developer.mozilla.org/en-US/docs/Web/CSS/clip-path).

This PR aims to fix this and adds an additional row for every place where `path()` could or could not be used.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

I tested that support for path in clip-path was indeed present for the three major browsers, see my comment in #20004.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

There is a small mismatch in two version numbers with css.properties.offset-path vs css.types.basic-shape.path:
* `offset-path` with `path()` added in firefox version 72 vs 63
* `offset-path` with `path()` added in chrome version 64 vs 46

I haven't been able to find the truth.

[Git logs for chrome 64](https://chromium.googlesource.com/chromium/src/+log/63.0.3239.132..64.0.3282.119/?pretty=fuller&n=10000&s=b025f38e480ca0964457142ac7f805c70c0a084d) contain some mentions of `offset-path` and `path()`, but it seems only animation of these was implemented in that release.
[Git logs for chrome 46](https://chromium.googlesource.com/chromium/src/+log/45.0.2454.101..46.0.2490.71?pretty=fuller&n=10000) make no mention of `offset-path` at all.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixes #20004, #15961

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
