### PR TITLE
fix: Update experimental value for media feature `scripting`

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1478,7 +1478,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The [scripting](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/scripting) media feature is currently supported only in [Firefox](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/scripting#browser_compatibility). This PR updates the value of `experimental` key.

Content PR: https://github.com/mdn/content/pull/27192