### PR TITLE
Update all browsers data for html.elements.iframe.sandbox

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -616,12 +616,12 @@
               "description": "<code>sandbox=\"allow-downloads-without-user-activation\"</code>",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -650,12 +650,12 @@
               "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-forms",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "≤49"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": null
+                  "version_added": "≤49"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -665,7 +665,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": null
+                  "version_added": "≤10.1"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -699,7 +699,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": null
+                  "version_added": "11.1"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -718,12 +718,12 @@
               "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-orientation-lock",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "68"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": null
+                  "version_added": "≤49"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -733,7 +733,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -752,12 +752,12 @@
               "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-pointer-lock",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "≤49"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": null
+                  "version_added": "≤49"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -767,7 +767,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": null
+                  "version_added": "≤10.1"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -786,7 +786,7 @@
               "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-popups",
               "support": {
                 "chrome": {
-                  "version_added": true
+                  "version_added": "4"
                 },
                 "chrome_android": "mirror",
                 "edge": {
@@ -803,11 +803,9 @@
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
-                "opera_android": {
-                  "version_added": null
-                },
+                "opera_android": "mirror",
                 "safari": {
-                  "version_added": null
+                  "version_added": "≤10.1"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -838,14 +836,10 @@
                   "version_added": false
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": "32"
-                },
-                "opera_android": {
-                  "version_added": "32"
-                },
+                "opera": "mirror",
+                "opera_android": "mirror",
                 "safari": {
-                  "version_added": null
+                  "version_added": "11.1"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -879,7 +873,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -900,34 +894,26 @@
               "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-same-origin",
               "support": {
                 "chrome": {
-                  "version_added": true,
+                  "version_added": "≤49",
                   "notes": "Chrome 70 and earlier block script execution without <code>allow-scripts</code>, even if <code>allow-same-origin</code> is set. For example, any bound handlers for click events of nodes inside an iframe throw an error for blocked script execution."
                 },
-                "chrome_android": {
-                  "version_added": true
-                },
-                "edge": {
-                  "version_added": true
-                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
                 "firefox": {
-                  "version_added": true
+                  "version_added": "≤49"
                 },
                 "firefox_android": "mirror",
                 "ie": {
                   "version_added": true
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": true
-                },
+                "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": true,
+                  "version_added": "≤10.1",
                   "notes": "Safari blocks script execution without <code>allow-scripts</code> even if <code>allow-same-origin</code> is set. For example, any bound handlers for click events of nodes inside an iframe throw an error for blocked script execution."
                 },
-                "safari_ios": {
-                  "version_added": true
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },
@@ -944,12 +930,12 @@
               "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-scripts",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "≤49"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": null
+                  "version_added": "≤49"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -959,7 +945,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": null
+                  "version_added": "≤10.1"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1018,12 +1004,12 @@
               "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-top-navigation",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": "≤49"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": null
+                  "version_added": "≤49"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1033,7 +1019,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": null
+                  "version_added": "≤10.1"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -1069,9 +1055,7 @@
                 "safari": {
                   "version_added": "11.1"
                 },
-                "safari_ios": {
-                  "version_added": null
-                },
+                "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"
               },
@@ -1088,12 +1072,12 @@
               "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#attr-iframe-sandbox-allow-top-navigation-to-custom-protocols",
               "support": {
                 "chrome": {
-                  "version_added": null
+                  "version_added": false
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": null
+                  "version_added": "101"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -1103,7 +1087,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": null
+                  "version_added": "16"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `sandbox` member of the `iframe` HTML element. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code:

```html
<!DOCTYPE html>
<html>
	<head>
		<!-- <meta content="width=device-width"> -->
		<style id="persistent-style">
			/* Persistent styling */
			body {
				background-color: black;
				color: white;
				margin: 0;
				padding: 0;
			}
			canvas {
				background-color: white;
			}
			#test {
				min-height: 100vh;
			}
		</style>

		<style id="test-style">
			.true {
				color: lime;
			}
			.false {
				color: red;
			}
		</style>
	</head>
	<body>
		<div id="test">

		</div>

		<script>
			var el = document.createElement('iframe');
			var output = document.getElementById('test');

			function getResult(name) {
				var supported = null;

				if (el.sandbox instanceof DOMTokenList && 'supports' in el.sandbox) {
					supported = el.sandbox.supports(name);
				} else {
					// XXX Have to manually test at this point
				}

				output.innerHTML += (name + ': <span class="' + supported + '">' + supported + '</span><br />');
			}

			getResult('allow-downloads-without-user-activation');
			getResult('allow-forms');
			getResult('allow-modals');
			getResult('allow-orientation-lock');
			getResult('allow-pointer-lock');
			getResult('allow-popups');
			getResult('allow-popups-to-escape-sandbox');
			getResult('allow-presentation');
			getResult('allow-same-origin');
			getResult('allow-scripts');
			getResult('allow-top-navigation');
			getResult('allow-top-navigation-to-custom-protocols');
		</script>
	</body>
</html>
```
