### PR TITLE
Fix mirroring ranges from Safari to Safari iOS

### DIFF
--- a/scripts/release/mirror.ts
+++ b/scripts/release/mirror.ts
@@ -22,7 +22,6 @@ type Notes = string | string[] | null;
  */
 
 const matchingSafariVersions = new Map([
-  ['≤4', '≤3'],
   ['1', '1'],
   ['1.1', '1'],
   ['1.2', '1'],
@@ -52,6 +51,7 @@ export const getMatchingBrowserVersion = (
   sourceVersion: string,
 ) => {
   const browserData = browsers[targetBrowser];
+  const range = sourceVersion.includes('≤');
 
   /* c8 ignore start */
   if (!browserData.upstream) {
@@ -70,12 +70,12 @@ export const getMatchingBrowserVersion = (
     // cannot be entirely derived from the WebKit versions. After Safari 15
     // the versions have been the same, so map earlier versions manually
     // and then assume if the versions are identical it's also a match.
-    const v = matchingSafariVersions.get(sourceVersion);
+    const v = matchingSafariVersions.get(sourceVersion.replace('≤', ''));
     if (v) {
-      return v;
+      return (range ? '≤' : '') + v;
     }
-    if (sourceVersion in browserData.releases) {
-      return sourceVersion;
+    if (sourceVersion.replace('≤', '') in browserData.releases) {
+      return (range ? '≤' : '') + sourceVersion;
     }
     throw new Error(`Cannot find iOS version matching Safari ${sourceVersion}`);
   }
@@ -83,7 +83,6 @@ export const getMatchingBrowserVersion = (
   const releaseKeys = Object.keys(browserData.releases);
   releaseKeys.sort(compareVersions);
 
-  const range = sourceVersion.includes('≤');
   const sourceRelease =
     browsers[browserData.upstream].releases[sourceVersion.replace('≤', '')];
 


### PR DESCRIPTION
This PR fixes an issue with mirroring a ranged value from Safari to Safari iOS.  The mirroring script was programmed to handle ranges like a special case, and when we increased the number of ranged values available, this code never got updated.
