### PR TITLE
Remove non-standard, unsupported contenteditable types

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -346,76 +346,6 @@
             "deprecated": false
           }
         },
-        "caret": {
-          "__compat": {
-            "description": "<code>contenteditable=\"caret\"</code>",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "events": {
-          "__compat": {
-            "description": "<code>contenteditable=\"events\"</code>",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "plaintext-only": {
           "__compat": {
             "description": "<code>contenteditable=\"plaintext-only\"</code>",
@@ -446,41 +376,6 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "typing": {
-          "__compat": {
-            "description": "<code>contenteditable=\"typing\"</code>",
-            "support": {
-              "chrome": {
-                "version_added": true
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
This PR removes the three non-standard and unsupported `contenteditable` attribute values.  These may have been supported at one point, but they are not supported in modern browser versions, nor are they defined in the specification.
