### PR TITLE
Notate Safari 17 support for @counter-style

### DIFF
--- a/css/at-rules/counter-style.json
+++ b/css/at-rules/counter-style.json
@@ -23,8 +23,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/167645'>bug 167645</a>."
+              "version_added": "17"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -58,7 +57,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -93,7 +92,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -128,7 +127,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -163,7 +162,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -198,7 +197,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -233,7 +232,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -342,7 +341,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -377,7 +376,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Safari 17 (currently in beta) added working support for `@counter-style`.

#### Test results and supporting details

All samples on the `@counter-style` [demo page](https://mdn.github.io/css-examples/counter-style-demo/) function correctly in Safari 17 beta and Safari Technology Preview 171 for Ventura. Also tested the `pad` descriptor manually using [this JSFiddle](https://jsfiddle.net/su6eyhwt/).

- [Safari 17 beta release notes](https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes#CSS)
- [Safari Technology Preview 171 release notes](https://developer.apple.com/documentation/safari-technology-preview-release-notes/stp-release-171#CSS-Counter-Styles)
