### PR TITLE
FF115 Array.fromAsync() supported

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -796,7 +796,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "115"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -816,7 +816,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
FF115 ships support for `Array.fromAsync()` in https://bugzilla.mozilla.org/show_bug.cgi?id=1795816

Since Safari has this too, it is no longer experimental. 

Other docs work can be tracked in https://github.com/mdn/content/issues/22145

FYI @queengooborg 

**WARNING: Still at stage 3 - does that change our rule for marking as experimental?**