### PR TITLE
FF115 Response.json() static supported

### DIFF
--- a/api/Response.json
+++ b/api/Response.json
@@ -543,6 +543,43 @@
           }
         }
       },
+      "json_static": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/json_static",
+          "spec_url": "https://fetch.spec.whatwg.org/#dom-response-json-data-init-init",
+          "support": {
+            "chrome": {
+              "version_added": "105"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.22"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "115"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "ok": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/ok",

--- a/api/Response.json
+++ b/api/Response.json
@@ -546,7 +546,7 @@
       "json_static": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Response/json_static",
-          "spec_url": "https://fetch.spec.whatwg.org/#dom-response-json-data-init-init",
+          "spec_url": "https://fetch.spec.whatwg.org/#ref-for-dom-response-json①",
           "support": {
             "chrome": {
               "version_added": "105"


### PR DESCRIPTION
FF115 adds support for [`Response: json()` static method](https://developer.mozilla.org/en-US/docs/Web/API/Response/json_static) in https://bugzilla.mozilla.org/show_bug.cgi?id=1758943

This adds a BCD entry for the whole method. I use this WPT test to check the browser versions: http://wpt.live/fetch/api/response/response-static-json.any.html
For deno I found info in the release notes: https://deno.com/blog/v1.22#new-responsejson-static-method

This is part of docs for https://github.com/mdn/content/issues/27169

FYI @queengooborg 