### PR TITLE
Safari enabled strict mime checks for workers

### DIFF
--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -188,7 +188,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16",
+                "notes": "See <a href='https://webkit.org/b/236411'>WebKit bug 236411</a>."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -189,7 +189,6 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "16",
-                "notes": "See <a href='https://webkit.org/b/236411'>WebKit bug 236411</a>."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -188,7 +188,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "16",
+                "version_added": "16"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -219,8 +219,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/192749'>WebKit bug 192749</a>."
+                "version_added": "16",
+                "notes": "See <a href='https://webkit.org/b/236411'>WebKit bug 236411</a>."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -220,7 +220,6 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "16",
-                "notes": "See <a href='https://webkit.org/b/236411'>WebKit bug 236411</a>."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -219,7 +219,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "16",
+                "version_added": "16"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -227,7 +227,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Safari 16.0+ has enabled strict MIME type checks for all worker scripts + their imports.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

[Test results for MIME checks on `Worker` and `SharedWorker` scripts.](https://wpt.fyi/results/workers/Worker_script_mimetype.htm?label=master&product=safari-16.0%20%2817614.1.25.9.10%29&product=safari-15.6.1%20%2817613.3.9.1.16%29)

[Test results for MIME checks on imported scripts in `Worker`.](https://wpt.fyi/results/workers/importscripts_mime.any.worker.html?label=master&product=safari-16.0%20%2817614.1.25.9.10%29&product=safari-15.6.1%20%2817613.3.9.1.16%29)

[Test results for MIME checks on imported scripts in `SharedWorker`.](https://wpt.fyi/results/workers/importscripts_mime.any.sharedworker.html?label=master&product=safari-16.0%20%2817614.1.25.9.10%29&product=safari-15.6.1%20%2817613.3.9.1.16%29)

[Test results for MIME checks on imported scripts in `ServiceWorker`.](https://wpt.fyi/results/workers/importscripts_mime.any.serviceworker.html?label=master&product=safari-16.0%20%2817614.1.25.9.10%29&product=safari-15.6.1%20%2817613.3.9.1.16%29) (no change, this was already enabled)

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Tracking bug: https://webkit.org/b/236411

Release notes mention several fixes relating to workers: https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
