### PR TITLE
Track support for regex unicodeSets flag

### DIFF
--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1387,6 +1387,45 @@
             }
           }
         },
+        "unicodeSets": {
+          "__compat": {
+            "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp.prototype.unicodesets",
+            "support": {
+              "chrome": {
+                "version_added": "112"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.32"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "116"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "20.0.0"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "@@match": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@match",

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1389,6 +1389,7 @@
         },
         "unicodeSets": {
           "__compat": {
+           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp.prototype.unicodesets",
             "support": {
               "chrome": {

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -1389,7 +1389,7 @@
         },
         "unicodeSets": {
           "__compat": {
-           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicodeSets",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp.prototype.unicodesets",
             "support": {
               "chrome": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

This adds support data for the new `unicodeSets` regex flag :)

The link to the spec will work properly when https://github.com/tc39/ecma262/pull/2418 is merged.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

I manually tested all major browsers, and checked that my results were consistent with the following documentation. I have not run any advanced tests to ensure that the browsers follow the spec correctly.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Added in Chrome 112:
https://chromestatus.com/feature/5144156542861312

Added in Safari 17:
https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes

Added in Firefox 116:
https://bugzilla.mozilla.org/show_bug.cgi?id=1826574

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
