### PR TITLE
FF115 Access-Control-Allow-Headers - wildcard not include Authorization header

### DIFF
--- a/http/headers/Access-Control-Allow-Headers.json
+++ b/http/headers/Access-Control-Allow-Headers.json
@@ -44,6 +44,46 @@
             "deprecated": false
           }
         },
+        "authorization_not_covered_by_wildcard": {
+          "__compat": {
+            "description": "<code>Authorization</code> header is not covered by wildcard",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "115",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.cors_preflight.authorization_covered_by_wildcard",
+                    "value_to_set": "false"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "wildcard": {
           "__compat": {
             "description": "Wildcard (<code>*</code>)",


### PR DESCRIPTION
The spec states that if [`Access-Control-Allow-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) specifies a wildcard, that does not automatically include the `Authorization` header. Browsers were wildcarding the `Authorization` header but are not preparing to deprecate that behaviour.

FF115 does so behind a preference in https://bugzilla.mozilla.org/show_bug.cgi?id=1687364. Chrome was planning to to this in M116 but is waiting on others to catch up: see https://chromestatus.com/feature/5742041264816128 and https://groups.google.com/a/chromium.org/g/blink-dev/c/yXxYCo3ytQU/m/Z6woo8enAgAJ

This adds the FF information. 

Note, I have not been able to test this because the relevant WPT live test appears to fail this for other reasons: https://wpt.live/fetch/api/cors/cors-preflight-star.any.html

Related docs work can be tracked in https://github.com/mdn/content/issues/27230

FYI @queengooborg 