### PR TITLE
FF115 URL.canParse() static method

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -129,7 +129,7 @@
           }
         }
       },
-      "canParse": {
+      "canParse_static": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/canParse_static",
           "spec_url": "https://url.spec.whatwg.org/#ref-for-dom-url-canparse",

--- a/api/URL.json
+++ b/api/URL.json
@@ -129,6 +129,46 @@
           }
         }
       },
+      "canParse": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/canParse_static",
+          "spec_url": "https://url.spec.whatwg.org/#ref-for-dom-url-canparse",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.33"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "115"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": "20.0.0"
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "17"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "createObjectURL": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/createObjectURL_static",


### PR DESCRIPTION
FF, safari, node, deno all support new URL.canParse() static method. This adds a feature for the method.

- FF115: https://bugzilla.mozilla.org/show_bug.cgi?id=1823354
- Node 19.9 (closest is 20) https://nodejs.org/en/blog/release/v19.9.0
- Safari 17: https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes
- Deno 1.33 : https://deno.land/api@v1.33.0?s=URL&p=canParse

FYI @queengooborg 

Related docs work can be tracked in https://github.com/mdn/content/issues/27170