### PR TITLE
Correct data for Storage Access API

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4332,11 +4332,12 @@
           "support": {
             "chrome": [
               {
-                "version_added": "113"
+                "version_added": "113",
+                "partial_implementation": true,
+                "notes": "Only available to Google Chrome's <a href='https://developer.chrome.com/docs/privacy-sandbox/first-party-sets/'>first-party sets</a>."
               },
               {
                 "version_added": "78",
-                "version_removed": "112",
                 "flags": [
                   {
                     "type": "preference",
@@ -6047,14 +6048,14 @@
             "chrome": [
               {
                 "version_added": "113",
+                "partial_implementation": true,
                 "notes": [
-                  "Only resolves <code>requestStorageAccess()</code> calls that come from domains within a <a href='https://developer.chrome.com/docs/privacy-sandbox/first-party-sets/'>first-party set</a>.",
+                  "Only available to Google Chrome's <a href='https://developer.chrome.com/docs/privacy-sandbox/first-party-sets/'>first-party sets</a>.",
                   "Client-side storage access granted per-frame, as per spec updates <a href='https://developer.mozilla.org/docs/Web/API/Storage_Access_API#how_it_works'>see explanation</a>."
                 ]
               },
               {
                 "version_added": "78",
-                "version_removed": "112",
                 "flags": [
                   {
                     "type": "preference",

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -675,11 +675,12 @@
           "support": {
             "chrome": [
               {
-                "version_added": "113"
+                "version_added": "113",
+                "partial_implementation": true,
+                "notes": "Only available to Google Chrome's <a href='https://developer.chrome.com/docs/privacy-sandbox/first-party-sets/'>first-party sets</a>."
               },
               {
                 "version_added": "86",
-                "version_removed": "112",
                 "flags": [
                   {
                     "type": "preference",


### PR DESCRIPTION
This PR corrects the data for the Storage Access API for Chrome.  This feature is reserved to Chrome's proprietary first-party sets and is not available to all websites, so it is marked as partial implementation.
