### PR TITLE
Update Safari data for HTMLCanvasElement API

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -566,7 +566,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "15"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -648,7 +648,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "15"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -686,7 +686,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "15"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -884,7 +884,7 @@
                 },
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "15"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `HTMLCanvasElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.4.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/HTMLCanvasElement
