### PR TITLE
Update Edge data for api.VideoPlaybackQuality.totalFrameDelay

### DIFF
--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -173,7 +173,8 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "version_removed": "79"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `totalFrameDelay` member of the `VideoPlaybackQuality` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.4.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/VideoPlaybackQuality/totalFrameDelay
