### PR TITLE
Update Safari data for VRPose API

### DIFF
--- a/api/VRPose.json
+++ b/api/VRPose.json
@@ -45,7 +45,8 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "≤13.1",
+            "version_removed": "14.1"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": {
@@ -105,7 +106,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "≤13.1",
+              "version_removed": "14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -166,7 +168,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "≤13.1",
+              "version_removed": "14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -227,7 +230,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "≤13.1",
+              "version_removed": "14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -288,7 +292,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "≤13.1",
+              "version_removed": "14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -349,7 +354,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "≤13.1",
+              "version_removed": "14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
@@ -410,7 +416,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "≤13.1",
+              "version_removed": "14.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `VRPose` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v9.4.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/VRPose
