### PR TITLE
List requestStorageAccess() as partial support

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6047,6 +6047,7 @@
             "chrome": [
               {
                 "version_added": "113",
+                "partial_implementation": true,
                 "notes": [
                   "Only resolves <code>requestStorageAccess()</code> calls that come from domains within a <a href='https://developer.chrome.com/docs/privacy-sandbox/first-party-sets/'>first-party set</a>.",
                   "Client-side storage access granted per-frame, as per spec updates <a href='https://developer.mozilla.org/docs/Web/API/Storage_Access_API#how_it_works'>see explanation</a>."
@@ -6069,6 +6070,7 @@
             "edge": [
               {
                 "version_added": "113",
+                "partial_implementation": true,
                 "notes": [
                   "Only resolves <code>requestStorageAccess()</code> calls that come from domains within a <a href='https://developer.chrome.com/docs/privacy-sandbox/first-party-sets/'>first-party set</a>.",
                   "Each embedded site instance must separately opt in to client-side storage access via a <code>requestStorageAccess()</code> call, as per <a href='https://developer.mozilla.org/docs/Web/API/Storage_Access_API#how_it_works'>spec updates</a>."


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

As per the discussion at https://github.com/mdn/browser-compat-data/pull/19614#issuecomment-1556146782, this PR updates `Document.requestStorageAccess()` to show partial support, given that it is currently only supported on Chromium on domains in first-party sets.

I did a bit of testing, and it looks like this is the only part of the associated functionality gated like this. For example, `Document.hasStorageAccess()` and `Navigator.permissions.query({ name: "storage-access" })` seem to work OK regardless.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
