### PR TITLE
Update Firefox data for SpeechSynthesisVoice API

### DIFF
--- a/api/SpeechSynthesisVoice.json
+++ b/api/SpeechSynthesisVoice.json
@@ -14,7 +14,7 @@
           },
           "firefox": {
             "version_added": "49",
-            "notes": "In Firefox, speech synthesis voices do not start loading until after the first call to <code>window.speechSynthesis.getVoices()</code>. A way to mitigate this issue is to call the method at the beginning of page load, then wait a few seconds before calling the method again."
+            "notes": "In Firefox, speech synthesis voices do not start loading until after the first call to <code>window.speechSynthesis.getVoices()</code>. A way to mitigate this issue is to call the method at the beginning of page load, then wait a few seconds before calling the method again. Voices will remain loaded until all tabs that have called this method have been closed."
           },
           "firefox_android": {
             "version_added": "62"

--- a/api/SpeechSynthesisVoice.json
+++ b/api/SpeechSynthesisVoice.json
@@ -13,7 +13,8 @@
             "version_added": "14"
           },
           "firefox": {
-            "version_added": "49"
+            "version_added": "49",
+            "notes": "In Firefox, speech synthesis voices do not start loading until after the first call to <code>window.speechSynthesis.getVoices()</code>. A way to mitigate this issue is to call the method at the beginning of page load, then wait a few seconds before calling the method again."
           },
           "firefox_android": {
             "version_added": "62"


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `SpeechSynthesisVoice` API. This bug was discovered when writing tests for the mdn-bcd-collector. This adds a note mentioning this bug and recommending a solution based on https://github.com/GooborgStudios/mdn-bcd-collector/commit/365ad25c361516fc26340f3946884ff90c85f342.
