### PR TITLE
FF115 supports animation-composition by default

### DIFF
--- a/css/properties/animation-composition.json
+++ b/css/properties/animation-composition.json
@@ -11,16 +11,21 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "104",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.animation-composition.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "115"
+              },
+              {
+                "version_added": "104",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.animation-composition.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

FF115 has added default support for [`animation-composition`](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-composition#browser_compatibility).

#### Test results and supporting details

https://wpt.fyi/results/css/css-animations/animation-composition.html?label=master&label=beta&product=firefox-115.0b4&aligned

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Related bugzilla issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1823862
Doc issue tracker: https://github.com/mdn/content/issues/27179
