### PR TITLE
devtools as optional permission

### DIFF
--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -344,7 +344,9 @@
               "firefox": {
                 "version_added": "77"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "opera": "mirror",
               "safari": {
                 "version_added": false

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -333,6 +333,26 @@
             }
           }
         },
+        "devtools": {
+          "__compat": {
+            "description": "<code>devtools</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "77"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "downloads": {
           "__compat": {
             "description": "<code>downloads</code>",

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -413,6 +413,26 @@
             }
           }
         },
+        "devtools": {
+          "__compat": {
+            "description": "<code>devtools</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "54"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": "16"
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "dns": {
           "__compat": {
             "description": "<code>dns</code>",

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -422,9 +422,11 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "54"
+                "version_added": "77"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false
+              },
               "opera": "mirror",
               "safari": {
                 "version_added": "16"


### PR DESCRIPTION
#### Summary

Addresses the documentation needs of [Bug 1606862](https://bugzilla.mozilla.org/show_bug.cgi?id=1606862) Make devtools an optional permission.

No reference found to this permission in the Chrome documentation e.g. https://developer.chrome.com/docs/extensions/mv3/declare_permissions/#permissions or https://developer.chrome.com/docs/extensions/reference/devtools_inspectedWindow/

Confirmed as included in Safari on this page: https://developer.apple.com/documentation/safariservices/safari_web_extensions/adding_a_web_development_tool_to_safari_web_inspector#3966899
