### PR TITLE
FF115 HTMLMediaElement.mozPreservesPitch disabled by default

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2278,7 +2278,8 @@
               {
                 "prefix": "moz",
                 "version_added": "20",
-                "notes": "May be removed in a future release, see <a href='https://bugzil.la/1765201'>bug 1765201</a>."
+                "version_removed": "115",
+                "notes": "Disable by default in version 115 (behind preference <code>dom.media.mozPreservesPitch.enabled</code>). May be fully removed in a future release (see <a href='https://bugzil.la/1765201'>bug 1765201</a>)."
               }
             ],
             "firefox_android": "mirror",


### PR DESCRIPTION
FF115 disables [HTMLMediaElement.mozPreservesPitch](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/preservesPitch) behind a preference by default in https://bugzilla.mozilla.org/show_bug.cgi?id=1831205.
This is in preparation for eventual removal.

Related docs work in https://github.com/mdn/content/issues/27181