### PR TITLE
Update browser data for dirname on firefox

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -447,7 +447,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "116"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -243,7 +243,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "116"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/html/elements/input.json
+++ b/html/elements/input.json
@@ -252,7 +252,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "116"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -127,7 +127,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "116"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Update data for the `dirname` attribute on `input` and `textarea` elements, as firefox supports this from version 116.0a1 onwards.

#### Test results and supporting details
- `npm test` ran successfully
- Release Notes under "Developer" [116.0a1](https://www.mozilla.org/en-US/firefox/116.0a1/releasenotes/)
