### PR TITLE
Add a notable change regarding the latest release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,10 @@
 
 June 13, 2023
 
+### Notable changes
+
+Static methods are now suffixed with `_static`. See [#16613](https://github.com/mdn/browser-compat-data/issues/16613) for more details.
+
 ### Removals
 
 - `api.AbortSignal.abort` ([#20063](https://github.com/mdn/browser-compat-data/pull/20063))


### PR DESCRIPTION
This PR adds a notable change regarding the `_static` suffixes to the release notes.