### PR TITLE
Update Safari data for PannerNode API

### DIFF
--- a/api/PannerNode.json
+++ b/api/PannerNode.json
@@ -22,16 +22,9 @@
           "oculus": "mirror",
           "opera": "mirror",
           "opera_android": "mirror",
-          "safari": [
-            {
-              "version_added": "14.1"
-            },
-            {
-              "version_added": "6",
-              "version_removed": "14.1",
-              "prefix": "webkit"
-            }
-          ],
+          "safari": {
+            "version_added": "6"
+          },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `PannerNode` API. This removes the prefix data from the interface, as it is only for internal naming and has no effect on accessing the interface.  (The constructor was added in Safari 14.1 when the prefix was removed, and I have confirmed neither a `webkit` or `WebKit` prefix is supported; the interface was not exposed before then.)
