### PR TITLE
Update all browsers data for javascript.builtins.WeakSet.WeakSet.iterable_allowed

### DIFF
--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -89,17 +89,15 @@
               "description": "<code>new WeakSet(iterable)</code>",
               "support": {
                 "chrome": {
-                  "version_added": "38"
+                  "version_added": false
                 },
                 "chrome_android": "mirror",
                 "deno": {
                   "version_added": "1.0"
                 },
-                "edge": {
-                  "version_added": "12"
-                },
+                "edge": "mirror",
                 "firefox": {
-                  "version_added": "34"
+                  "version_added": false
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -112,7 +110,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "9"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `WeakSet.iterable_allowed` member of the `WeakSet` JavaScript builtin. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/javascript/builtins/WeakSet/WeakSet/iterable_allowed

Additional Notes: The test code is brand new for this feature, however I don't believe that it is incorrect. I would love review on the test code, however.
