### PR TITLE
Update Chrome/Safari data for ReadableStreamDefaultController API

### DIFF
--- a/api/ReadableStreamDefaultController.json
+++ b/api/ReadableStreamDefaultController.json
@@ -6,7 +6,7 @@
         "spec_url": "https://streams.spec.whatwg.org/#rs-default-controller-class",
         "support": {
           "chrome": {
-            "version_added": "89"
+            "version_added": "≤80"
           },
           "chrome_android": "mirror",
           "deno": [
@@ -45,7 +45,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "16.4"
+            "version_added": "≤13.1"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -63,7 +63,7 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-rs-default-controller-close①",
           "support": {
             "chrome": {
-              "version_added": "89"
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
             "deno": {
@@ -84,7 +84,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16.4"
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -103,7 +103,7 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-rs-default-controller-desired-size②",
           "support": {
             "chrome": {
-              "version_added": "89"
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
             "deno": {
@@ -124,7 +124,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16.4"
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -143,7 +143,7 @@
           "spec_url": "https://streams.spec.whatwg.org/#ref-for-rs-default-controller-enqueue①",
           "support": {
             "chrome": {
-              "version_added": "89"
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
             "deno": {
@@ -164,7 +164,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16.4"
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -183,7 +183,7 @@
           "spec_url": "https://streams.spec.whatwg.org/#rs-default-controller-error",
           "support": {
             "chrome": {
-              "version_added": "89"
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
             "deno": {
@@ -204,7 +204,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16.4"
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `ReadableStreamDefaultController` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/ReadableStreamDefaultController
