### PR TITLE
Add BCD for isUrlFilterCaseSensitive field

### DIFF
--- a/webextensions/api/declarativeNetRequest.json
+++ b/webextensions/api/declarativeNetRequest.json
@@ -931,26 +931,6 @@
               }
             }
           },
-          "isUrlFilterCaseSensitive": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "84",
-                  "notes": "From 118 default value is false."
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "113"
-                },
-                "firefox_android": "mirror",
-                "opera": "mirror",
-                "safari": {
-                  "version_added": "16.4"
-                },
-                "safari_ios": "mirror"
-              }
-            }
-          },
           "excludedRequestDomains": {
             "__compat": {
               "support": {
@@ -984,6 +964,26 @@
                 "opera": "mirror",
                 "safari": {
                   "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "isUrlFilterCaseSensitive": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "84",
+                  "notes": "From 118 default value is false."
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "113"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "16.4"
                 },
                 "safari_ios": "mirror"
               }

--- a/webextensions/api/declarativeNetRequest.json
+++ b/webextensions/api/declarativeNetRequest.json
@@ -974,7 +974,7 @@
               "support": {
                 "chrome": {
                   "version_added": "84",
-                  "notes": "From 118 default value is false."
+                  "notes": "The default value changed from true to false in Chrome 118."
                 },
                 "edge": "mirror",
                 "firefox": {

--- a/webextensions/api/declarativeNetRequest.json
+++ b/webextensions/api/declarativeNetRequest.json
@@ -945,7 +945,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": 16.4
+                  "version_added": "16.4"
                 },
                 "safari_ios": "mirror"
               }

--- a/webextensions/api/declarativeNetRequest.json
+++ b/webextensions/api/declarativeNetRequest.json
@@ -983,7 +983,8 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": "16.4"
+                  "version_added": "15",
+                  "notes": "The default value changed from true to false in Safari 16.4."
                 },
                 "safari_ios": "mirror"
               }

--- a/webextensions/api/declarativeNetRequest.json
+++ b/webextensions/api/declarativeNetRequest.json
@@ -931,6 +931,26 @@
               }
             }
           },
+          "isUrlFilterCaseSensitive": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "84",
+                  "notes": "From 118 default value is false."
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "113"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": 16.4
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "excludedRequestDomains": {
             "__compat": {
               "support": {


### PR DESCRIPTION
#### Summary

I've added browser compatibility data for isUrlFilterCaseSensitive

#### Test results and supporting details

Version data was taken from this comment

https://github.com/mdn/content/pull/26908#pullrequestreview-1468579425

Chrome version information was taken from this message

https://groups.google.com/a/chromium.org/g/chromium-extensions/c/TXYUmvDHUlw/m/9JdxXG2cAgAJ

#### Related issues

This PR is related to this PR https://github.com/mdn/content/pull/26908
