### PR TITLE
Remove mdn url for non-existent page (move method of FileSystemHandle interface)

### DIFF
--- a/api/FileSystemHandle.json
+++ b/api/FileSystemHandle.json
@@ -109,7 +109,7 @@
       },
       "move": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileSystemHandle/move",
+          "description": "<code>move</code>",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/FileSystemHandle.json
+++ b/api/FileSystemHandle.json
@@ -109,7 +109,6 @@
       },
       "move": {
         "__compat": {
-          "description": "<code>move</code>",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->



The `move` method is not documented.

This method is currently supported only in Firefox. The [FileSystemHandle BCD table](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemHandle#browser_compatibility) also has the icon for "Non-standard" next to `move`.

For now, removing the MDN URL from the BCD table to avoid a 404.

### Additional info

- In the [spec](https://wicg.github.io/file-system-access/#api-filesystemhandle) linked for `queryPermission()` and `requestPermission()` methods of the `FileSystemHandle` interface, there's no mention of `move` and `remove` methods.
- There's no spec linked on [`remove`](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemHandle/remove#specifications) method page. Like `move`, this method is non-standard and experimental.

