### PR TITLE
Add WebAssembly features as a new category

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ Data for [SVG](https://developer.mozilla.org/en-US/docs/Web/SVG) features, inclu
 - `attributes` - Attributes
 - `elements` - Elements
 
+### [`webassembly`](webassembly)
+
+Data for [WebAssembly](https://developer.mozilla.org/docs/WebAssembly) features.
+
 ### [`webdriver`](webdriver)
 
 Data for [WebDriver](https://developer.mozilla.org/en-US/docs/Web/WebDriver) features.

--- a/index.ts
+++ b/index.ts
@@ -59,6 +59,7 @@ export default (await load(
   'javascript',
   'mathml',
   'svg',
+  'webassembly',
   'webdriver',
   'webextensions',
 )) as CompatData;

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -187,7 +187,7 @@
     "spec_url_value": {
       "type": "string",
       "format": "uri",
-      "pattern": "(^https://[^#]+#.+)|(^https://registry.khronos.org/webgl/extensions/[^/]+/)"
+      "pattern": "(^https://[^#]+#.+)|(^https://github.com/WebAssembly/.+)|(^https://registry.khronos.org/webgl/extensions/[^/]+/)"
     },
 
     "impl_url_value": {

--- a/scripts/fix/index.ts
+++ b/scripts/fix/index.ts
@@ -71,6 +71,7 @@ if (esMain(import.meta)) {
       'javascript',
       'mathml',
       'test',
+      'webassembly',
       'webdriver',
       'webextensions',
     );

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -35,6 +35,8 @@ const compatDataTypes = {
   mathml:
     'Contains data for [MathML](https://developer.mozilla.org/docs/Web/MathML) elements, attributes, and global attributes.',
   svg: 'Contains data for [SVG](https://developer.mozilla.org/docs/Web/SVG) elements, attributes, and global attributes.',
+  webassembly:
+    'Contains data for [WebAssembly](https://developer.mozilla.org/docs/WebAssembly) features.',
   webdriver:
     'Contains data for [WebDriver](https://developer.mozilla.org/docs/Web/WebDriver) commands.',
   webextensions:

--- a/scripts/migrations/002-remove-webview-flags.ts
+++ b/scripts/migrations/002-remove-webview-flags.ts
@@ -117,6 +117,7 @@ if (esMain(import.meta)) {
       'javascript',
       'mathml',
       'test',
+      'webassembly',
       'webdriver',
       'webextensions',
     );

--- a/scripts/migrations/007-experimental-false.ts
+++ b/scripts/migrations/007-experimental-false.ts
@@ -139,6 +139,7 @@ if (esMain(import.meta)) {
       'javascript',
       'mathml',
       'test',
+      'webassembly',
       'webdriver',
       'webextensions',
     );

--- a/scripts/migrations/010-set-oculus-to-mirror.ts
+++ b/scripts/migrations/010-set-oculus-to-mirror.ts
@@ -100,6 +100,7 @@ if (esMain(import.meta)) {
       'javascript',
       'mathml',
       'test',
+      'webassembly',
       'webdriver',
     );
   }

--- a/scripts/remove-redundant-flags.ts
+++ b/scripts/remove-redundant-flags.ts
@@ -206,6 +206,7 @@ if (esMain(import.meta)) {
             'javascript',
             'mathml',
             'test',
+            'webassembly',
             'webdriver',
             'webextensions',
           ],

--- a/scripts/traverse.ts
+++ b/scripts/traverse.ts
@@ -124,6 +124,7 @@ const main = (
     'svg',
     'javascript',
     'mathml',
+    'webassembly',
     'webdriver',
   ],
   browsers: BrowserName[] = Object.keys(bcd.browsers) as BrowserName[],

--- a/test/lint.ts
+++ b/test/lint.ts
@@ -104,6 +104,7 @@ const main = async (
     'svg',
     'javascript',
     'mathml',
+    'webassembly',
     'webdriver',
     'webextensions',
   ],

--- a/test/linter/test-obsolete.ts
+++ b/test/linter/test-obsolete.ts
@@ -21,6 +21,7 @@ const categoriesToCheck = [
   // 'javascript',
   // 'mathml',
   // 'svg',
+  // 'webassembly',
   // 'webdriver',
   // 'webextensions'
 ];

--- a/test/linter/test-obsolete.ts
+++ b/test/linter/test-obsolete.ts
@@ -21,7 +21,7 @@ const categoriesToCheck = [
   // 'javascript',
   // 'mathml',
   // 'svg',
-  // 'webassembly',
+  'webassembly',
   // 'webdriver',
   // 'webextensions'
 ];

--- a/test/linter/test-spec-urls.ts
+++ b/test/linter/test-spec-urls.ts
@@ -38,6 +38,13 @@ const specsExceptions = [
   // Remove once https://github.com/whatwg/html/pull/8502
   // is merged and the new URL is live
   'https://wicg.github.io/navigation-api',
+
+  // Proposals for WebAssembly
+  'https://github.com/WebAssembly/spec/blob/master/proposals',
+  'https://github.com/WebAssembly/exception-handling/blob/master/proposals',
+  'https://github.com/WebAssembly/extended-const/blob/master/proposals',
+  'https://github.com/WebAssembly/tail-call/blob/master/proposals',
+  'https://github.com/WebAssembly/threads/blob/master/proposal',
 ];
 
 const allowedSpecURLs = [

--- a/test/linter/test-spec-urls.ts
+++ b/test/linter/test-spec-urls.ts
@@ -40,11 +40,11 @@ const specsExceptions = [
   'https://wicg.github.io/navigation-api',
 
   // Proposals for WebAssembly
-  'https://github.com/WebAssembly/spec/blob/master/proposals',
-  'https://github.com/WebAssembly/exception-handling/blob/master/proposals',
-  'https://github.com/WebAssembly/extended-const/blob/master/proposals',
-  'https://github.com/WebAssembly/tail-call/blob/master/proposals',
-  'https://github.com/WebAssembly/threads/blob/master/proposal',
+  'https://github.com/WebAssembly/spec/blob/main/proposals',
+  'https://github.com/WebAssembly/exception-handling/blob/main/proposals',
+  'https://github.com/WebAssembly/extended-const/blob/main/proposals',
+  'https://github.com/WebAssembly/tail-call/blob/main/proposals',
+  'https://github.com/WebAssembly/threads/blob/main/proposal',
 ];
 
 const allowedSpecURLs = [

--- a/test/linter/test-versions.ts
+++ b/test/linter/test-versions.ts
@@ -49,6 +49,7 @@ const realValuesRequired: { [category: string]: string[] } = {
   svg: [],
   javascript: [...realValuesTargetBrowsers, 'nodejs'],
   mathml: realValuesTargetBrowsers,
+  webassembly: realValuesTargetBrowsers,
   webdriver: realValuesTargetBrowsers,
   webextensions: [],
 };

--- a/utils/walk.test.ts
+++ b/utils/walk.test.ts
@@ -18,6 +18,7 @@ describe('lowLevelWalk()', () => {
       'javascript',
       'mathml',
       'svg',
+      'webassembly',
       'webdriver',
       'webextensions',
     ];

--- a/webassembly/BigInt-to-i64-integration.json
+++ b/webassembly/BigInt-to-i64-integration.json
@@ -1,0 +1,36 @@
+{
+  "webassembly": {
+    "BigInt-to-i64-integration": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "85"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": "78"
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": "14.1"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/webassembly/bulk-memory-operations.json
+++ b/webassembly/bulk-memory-operations.json
@@ -2,6 +2,7 @@
   "webassembly": {
     "bulk-memory-operations": {
       "__compat": {
+        "spec_url": "https://github.com/WebAssembly/spec/blob/master/proposals/bulk-memory-operations/Overview.md",
         "support": {
           "chrome": {
             "version_added": "≤80"

--- a/webassembly/bulk-memory-operations.json
+++ b/webassembly/bulk-memory-operations.json
@@ -28,7 +28,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }

--- a/webassembly/bulk-memory-operations.json
+++ b/webassembly/bulk-memory-operations.json
@@ -2,7 +2,7 @@
   "webassembly": {
     "bulk-memory-operations": {
       "__compat": {
-        "spec_url": "https://github.com/WebAssembly/spec/blob/master/proposals/bulk-memory-operations/Overview.md",
+        "spec_url": "https://github.com/WebAssembly/spec/blob/main/proposals/bulk-memory-operations/Overview.md",
         "support": {
           "chrome": {
             "version_added": "≤80"

--- a/webassembly/bulk-memory-operations.json
+++ b/webassembly/bulk-memory-operations.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "bulk-memory-operations": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤80"
+          },
+          "chrome_android": "mirror",
+          "edge": {
+            "version_added": "≤80"
+          },
+          "firefox": {
+            "version_added": "78"
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": "15.1"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/webassembly/exception-handling.json
+++ b/webassembly/exception-handling.json
@@ -2,6 +2,7 @@
   "webassembly": {
     "exception-handling": {
       "__compat": {
+        "spec_url": "https://github.com/WebAssembly/exception-handling/blob/master/proposals/exception-handling/Exceptions.md",
         "support": {
           "chrome": {
             "version_added": "95"
@@ -26,7 +27,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }

--- a/webassembly/exception-handling.json
+++ b/webassembly/exception-handling.json
@@ -2,7 +2,7 @@
   "webassembly": {
     "exception-handling": {
       "__compat": {
-        "spec_url": "https://github.com/WebAssembly/exception-handling/blob/master/proposals/exception-handling/Exceptions.md",
+        "spec_url": "https://github.com/WebAssembly/exception-handling/blob/main/proposals/exception-handling/Exceptions.md",
         "support": {
           "chrome": {
             "version_added": "95"

--- a/webassembly/exception-handling.json
+++ b/webassembly/exception-handling.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "exception-handling": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "95"
+          },
+          "chrome_android": "mirror",
+          "edge": {
+            "version_added": "95"
+          },
+          "firefox": {
+            "version_added": "100"
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": "15.2"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/webassembly/exception-handling.json
+++ b/webassembly/exception-handling.json
@@ -7,9 +7,7 @@
             "version_added": "95"
           },
           "chrome_android": "mirror",
-          "edge": {
-            "version_added": "95"
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": "100"
           },
@@ -28,7 +26,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }

--- a/webassembly/exception-handling.json
+++ b/webassembly/exception-handling.json
@@ -27,7 +27,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }

--- a/webassembly/extended-constant-expressions.json
+++ b/webassembly/extended-constant-expressions.json
@@ -2,6 +2,7 @@
   "webassembly": {
     "extended-constant-expressions": {
       "__compat": {
+        "spec_url": "https://github.com/WebAssembly/extended-const/blob/master/proposals/extended-const/Overview.md",
         "support": {
           "chrome": {
             "version_added": false

--- a/webassembly/extended-constant-expressions.json
+++ b/webassembly/extended-constant-expressions.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "extended-constant-expressions": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": "mirror",
+          "edge": {
+            "version_added": false
+          },
+          "firefox": {
+            "version_added": "112"
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/webassembly/extended-constant-expressions.json
+++ b/webassembly/extended-constant-expressions.json
@@ -2,7 +2,7 @@
   "webassembly": {
     "extended-constant-expressions": {
       "__compat": {
-        "spec_url": "https://github.com/WebAssembly/extended-const/blob/master/proposals/extended-const/Overview.md",
+        "spec_url": "https://github.com/WebAssembly/extended-const/blob/main/proposals/extended-const/Overview.md",
         "support": {
           "chrome": {
             "version_added": false

--- a/webassembly/extended-constant-expressions.json
+++ b/webassembly/extended-constant-expressions.json
@@ -7,9 +7,7 @@
             "version_added": false
           },
           "chrome_android": "mirror",
-          "edge": {
-            "version_added": false
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": "112"
           },

--- a/webassembly/fixed-width-SIMD.json
+++ b/webassembly/fixed-width-SIMD.json
@@ -2,6 +2,7 @@
   "webassembly": {
     "fixed-width-SIMD": {
       "__compat": {
+        "spec_url": "https://github.com/WebAssembly/spec/tree/master/proposals/simd/SIMD.md",
         "support": {
           "chrome": {
             "version_added": "91"

--- a/webassembly/fixed-width-SIMD.json
+++ b/webassembly/fixed-width-SIMD.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "fixed-width-SIMD": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "91"
+          },
+          "chrome_android": "mirror",
+          "edge": {
+            "version_added": "91"
+          },
+          "firefox": {
+            "version_added": "89"
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": "16.4"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/webassembly/fixed-width-SIMD.json
+++ b/webassembly/fixed-width-SIMD.json
@@ -7,9 +7,7 @@
             "version_added": "91"
           },
           "chrome_android": "mirror",
-          "edge": {
-            "version_added": "91"
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": "89"
           },
@@ -28,7 +26,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }

--- a/webassembly/fixed-width-SIMD.json
+++ b/webassembly/fixed-width-SIMD.json
@@ -2,7 +2,7 @@
   "webassembly": {
     "fixed-width-SIMD": {
       "__compat": {
-        "spec_url": "https://github.com/WebAssembly/spec/tree/master/proposals/simd/SIMD.md",
+        "spec_url": "https://github.com/WebAssembly/spec/blob/master/proposals/simd/SIMD.md",
         "support": {
           "chrome": {
             "version_added": "91"

--- a/webassembly/fixed-width-SIMD.json
+++ b/webassembly/fixed-width-SIMD.json
@@ -2,7 +2,7 @@
   "webassembly": {
     "fixed-width-SIMD": {
       "__compat": {
-        "spec_url": "https://github.com/WebAssembly/spec/blob/master/proposals/simd/SIMD.md",
+        "spec_url": "https://github.com/WebAssembly/spec/blob/main/proposals/simd/SIMD.md",
         "support": {
           "chrome": {
             "version_added": "91"

--- a/webassembly/multi-value.json
+++ b/webassembly/multi-value.json
@@ -2,6 +2,7 @@
   "webassembly": {
     "multi-value": {
       "__compat": {
+        "spec_url": "https://github.com/WebAssembly/spec/blob/master/proposals/multi-value/Overview.md",
         "support": {
           "chrome": {
             "version_added": "86"

--- a/webassembly/multi-value.json
+++ b/webassembly/multi-value.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "multi-value": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "86"
+          },
+          "chrome_android": "mirror",
+          "edge": {
+            "version_added": "86"
+          },
+          "firefox": {
+            "version_added": "78"
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": "≤13.1"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/webassembly/multi-value.json
+++ b/webassembly/multi-value.json
@@ -2,7 +2,7 @@
   "webassembly": {
     "multi-value": {
       "__compat": {
-        "spec_url": "https://github.com/WebAssembly/spec/blob/master/proposals/multi-value/Overview.md",
+        "spec_url": "https://github.com/WebAssembly/spec/blob/main/proposals/multi-value/Overview.md",
         "support": {
           "chrome": {
             "version_added": "86"

--- a/webassembly/multi-value.json
+++ b/webassembly/multi-value.json
@@ -7,9 +7,7 @@
             "version_added": "86"
           },
           "chrome_android": "mirror",
-          "edge": {
-            "version_added": "86"
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": "78"
           },
@@ -28,7 +26,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }

--- a/webassembly/mutable-globals.json
+++ b/webassembly/mutable-globals.json
@@ -28,7 +28,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }

--- a/webassembly/mutable-globals.json
+++ b/webassembly/mutable-globals.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "mutable-globals": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤80"
+          },
+          "chrome_android": "mirror",
+          "edge": {
+            "version_added": "≤80"
+          },
+          "firefox": {
+            "version_added": "≤72"
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": "≤13.1"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/webassembly/non-trapping-float-to-int-conversions.json
+++ b/webassembly/non-trapping-float-to-int-conversions.json
@@ -2,6 +2,7 @@
   "webassembly": {
     "non-trapping-float-to-int-conversions": {
       "__compat": {
+        "spec_url": "https://github.com/WebAssembly/spec/blob/master/proposals/nontrapping-float-to-int-conversion/Overview.md",
         "support": {
           "chrome": {
             "version_added": "≤80"

--- a/webassembly/non-trapping-float-to-int-conversions.json
+++ b/webassembly/non-trapping-float-to-int-conversions.json
@@ -28,7 +28,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }

--- a/webassembly/non-trapping-float-to-int-conversions.json
+++ b/webassembly/non-trapping-float-to-int-conversions.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "non-trapping-float-to-int-conversions": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤80"
+          },
+          "chrome_android": "mirror",
+          "edge": {
+            "version_added": "≤80"
+          },
+          "firefox": {
+            "version_added": "≤72"
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": "15.1"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/webassembly/non-trapping-float-to-int-conversions.json
+++ b/webassembly/non-trapping-float-to-int-conversions.json
@@ -2,7 +2,7 @@
   "webassembly": {
     "non-trapping-float-to-int-conversions": {
       "__compat": {
-        "spec_url": "https://github.com/WebAssembly/spec/blob/master/proposals/nontrapping-float-to-int-conversion/Overview.md",
+        "spec_url": "https://github.com/WebAssembly/spec/blob/main/proposals/nontrapping-float-to-int-conversion/Overview.md",
         "support": {
           "chrome": {
             "version_added": "≤80"

--- a/webassembly/reference-types.json
+++ b/webassembly/reference-types.json
@@ -2,6 +2,7 @@
   "webassembly": {
     "reference-types": {
       "__compat": {
+        "spec_url": "https://github.com/WebAssembly/spec/blob/master/proposals/reference-types/Overview.md",
         "support": {
           "chrome": {
             "version_added": "96"

--- a/webassembly/reference-types.json
+++ b/webassembly/reference-types.json
@@ -7,9 +7,7 @@
             "version_added": "96"
           },
           "chrome_android": "mirror",
-          "edge": {
-            "version_added": "96"
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": "79"
           },
@@ -28,7 +26,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }

--- a/webassembly/reference-types.json
+++ b/webassembly/reference-types.json
@@ -2,7 +2,7 @@
   "webassembly": {
     "reference-types": {
       "__compat": {
-        "spec_url": "https://github.com/WebAssembly/spec/blob/master/proposals/reference-types/Overview.md",
+        "spec_url": "https://github.com/WebAssembly/spec/blob/main/proposals/reference-types/Overview.md",
         "support": {
           "chrome": {
             "version_added": "96"

--- a/webassembly/reference-types.json
+++ b/webassembly/reference-types.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "reference-types": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "96"
+          },
+          "chrome_android": "mirror",
+          "edge": {
+            "version_added": "96"
+          },
+          "firefox": {
+            "version_added": "79"
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": "15.1"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/webassembly/sign-extension-operations.json
+++ b/webassembly/sign-extension-operations.json
@@ -2,6 +2,7 @@
   "webassembly": {
     "sign-extension-operations": {
       "__compat": {
+        "spec_url": "https://github.com/WebAssembly/spec/blob/master/proposals/sign-extension-ops/Overview.md",
         "support": {
           "chrome": {
             "version_added": "≤80"

--- a/webassembly/sign-extension-operations.json
+++ b/webassembly/sign-extension-operations.json
@@ -28,7 +28,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }

--- a/webassembly/sign-extension-operations.json
+++ b/webassembly/sign-extension-operations.json
@@ -2,7 +2,7 @@
   "webassembly": {
     "sign-extension-operations": {
       "__compat": {
-        "spec_url": "https://github.com/WebAssembly/spec/blob/master/proposals/sign-extension-ops/Overview.md",
+        "spec_url": "https://github.com/WebAssembly/spec/blob/main/proposals/sign-extension-ops/Overview.md",
         "support": {
           "chrome": {
             "version_added": "≤80"

--- a/webassembly/sign-extension-operations.json
+++ b/webassembly/sign-extension-operations.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "sign-extension-operations": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤80"
+          },
+          "chrome_android": "mirror",
+          "edge": {
+            "version_added": "≤80"
+          },
+          "firefox": {
+            "version_added": "≤72"
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": "14.1"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/webassembly/tail-calls.json
+++ b/webassembly/tail-calls.json
@@ -2,6 +2,7 @@
   "webassembly": {
     "tail-calls": {
       "__compat": {
+        "spec_url": "https://github.com/WebAssembly/tail-call/blob/master/proposals/tail-call/Overview.md",
         "support": {
           "chrome": {
             "version_added": "112"

--- a/webassembly/tail-calls.json
+++ b/webassembly/tail-calls.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "tail-calls": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "112"
+          },
+          "chrome_android": "mirror",
+          "edge": {
+            "version_added": "112"
+          },
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/webassembly/tail-calls.json
+++ b/webassembly/tail-calls.json
@@ -2,7 +2,7 @@
   "webassembly": {
     "tail-calls": {
       "__compat": {
-        "spec_url": "https://github.com/WebAssembly/tail-call/blob/master/proposals/tail-call/Overview.md",
+        "spec_url": "https://github.com/WebAssembly/tail-call/blob/main/proposals/tail-call/Overview.md",
         "support": {
           "chrome": {
             "version_added": "112"

--- a/webassembly/tail-calls.json
+++ b/webassembly/tail-calls.json
@@ -7,9 +7,7 @@
             "version_added": "112"
           },
           "chrome_android": "mirror",
-          "edge": {
-            "version_added": "112"
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": false
           },

--- a/webassembly/threads-and-atomics.json
+++ b/webassembly/threads-and-atomics.json
@@ -3,6 +3,7 @@
     "threads-and-atomics": {
       "__compat": {
         "support": {
+          "spec_url": "https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md",
           "chrome": {
             "version_added": "≤80"
           },
@@ -28,7 +29,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": false,
+          "experimental": true,
           "standard_track": true,
           "deprecated": false
         }

--- a/webassembly/threads-and-atomics.json
+++ b/webassembly/threads-and-atomics.json
@@ -28,7 +28,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }

--- a/webassembly/threads-and-atomics.json
+++ b/webassembly/threads-and-atomics.json
@@ -2,7 +2,7 @@
   "webassembly": {
     "threads-and-atomics": {
       "__compat": {
-        "spec_url": "https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md",
+        "spec_url": "https://github.com/WebAssembly/threads/blob/main/proposals/threads/Overview.md",
         "support": {
           "chrome": {
             "version_added": "≤80"

--- a/webassembly/threads-and-atomics.json
+++ b/webassembly/threads-and-atomics.json
@@ -2,8 +2,8 @@
   "webassembly": {
     "threads-and-atomics": {
       "__compat": {
+        "spec_url": "https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md",
         "support": {
-          "spec_url": "https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md",
           "chrome": {
             "version_added": "≤80"
           },

--- a/webassembly/threads-and-atomics.json
+++ b/webassembly/threads-and-atomics.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "threads-and-atomics": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "≤80"
+          },
+          "chrome_android": "mirror",
+          "edge": {
+            "version_added": "≤80"
+          },
+          "firefox": {
+            "version_added": "79"
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": "15.2"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}

--- a/webassembly/threads-and-atomics.json
+++ b/webassembly/threads-and-atomics.json
@@ -29,7 +29,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }


### PR DESCRIPTION
This PR adds a brand new category for WebAssembly features -- that is, features within the WebAssembly code itself rather than just the JavaScript API.  The results were collected by the mdn-bcd-collector project (v10.0.0).

CC @MendyBerger