### PR TITLE
Remove alt. name on XRSystem

### DIFF
--- a/api/XRSystem.json
+++ b/api/XRSystem.json
@@ -5,16 +5,9 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSystem",
         "spec_url": "https://immersive-web.github.io/webxr/#xrsystem-interface",
         "support": {
-          "chrome": [
-            {
-              "version_added": "83"
-            },
-            {
-              "alternative_name": "XR",
-              "version_added": "79",
-              "version_removed": "83"
-            }
-          ],
+          "chrome": {
+            "version_added": "79"
+          },
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {


### PR DESCRIPTION
This PR removes the alternative name data for the XRSystem API.  Because this has no constructor and is only accessed via `navigator.xr`, the underlying interface name is irrelevant.