### PR TITLE
Remove api.InstallEvent.activeWorker from BCD

### DIFF
--- a/api/InstallEvent.json
+++ b/api/InstallEvent.json
@@ -67,41 +67,6 @@
             "deprecated": true
           }
         }
-      },
-      "activeWorker": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/InstallEvent/activeWorker",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": {
-              "version_added": "17"
-            },
-            "firefox": {
-              "version_added": "44"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
This PR removes the `activeWorker` member of the `InstallEvent` API from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.1).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/InstallEvent/activeWorker

Additional Notes: I looked through Firefox's IDL and couldn't find any evidence that this was supported any longer.
