### PR TITLE
Update Firefox data for api.ReadableStreamDefaultReader.ReadableStreamDefaultReader

### DIFF
--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -72,7 +72,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "65"
+              "version_added": "100"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `ReadableStreamDefaultReader` member of the `ReadableStreamDefaultReader` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.1).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/ReadableStreamDefaultReader/ReadableStreamDefaultReader
