### PR TITLE
Fix data for contain-intrinsic-[height/width]

### DIFF
--- a/css/properties/contain-intrinsic-height.json
+++ b/css/properties/contain-intrinsic-height.json
@@ -7,7 +7,7 @@
           "spec_url": "https://drafts.csswg.org/css-sizing-4/#propdef-contain-intrinsic-height",
           "support": {
             "chrome": {
-              "version_added": "83"
+              "version_added": "95"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/contain-intrinsic-width.json
+++ b/css/properties/contain-intrinsic-width.json
@@ -7,7 +7,7 @@
           "spec_url": "https://drafts.csswg.org/css-sizing-4/#propdef-contain-intrinsic-width",
           "support": {
             "chrome": {
-              "version_added": "83"
+              "version_added": "95"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR is a follow-up to #17890 that corrects the data for the `contain-intrinsic-width` and `contain-intrinsic-height` CSS properties.  They were mis-set as Chrome 83, even though the ChromeStatus feature linked on the previous PR indicates support was added in 95.  (The other ChromeStatus feature that is marked as supported in Chrome 83 is for the `content-size` property.)