### PR TITLE
Update Firefox data for font-variant-emoji CSS property

### DIFF
--- a/css/properties/font-variant-emoji.json
+++ b/css/properties/font-variant-emoji.json
@@ -12,7 +12,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "108"
+              "version_added": "108",
+              "flags": [
+                {
+                  "name": "layout.css.font-variant-emoji.enabled",
+                  "type": "preference",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `font-variant-emoji` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.1).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/font-variant-emoji

Additional Notes: This is a follow-up to #18381, which set Firefox as supported but did not include the required flag data (which Dipika later pointed out).
