### PR TITLE
Remove css.properties.line-height.-moz-block-height from BCD

### DIFF
--- a/css/properties/line-height.json
+++ b/css/properties/line-height.json
@@ -39,38 +39,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "-moz-block-height": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "3.6"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": false
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
This PR removes the `-moz-block-height` member of the `line-height` CSS property from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.1).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/line-height/-moz-block-height
