### PR TITLE
Update Safari data for page CSS property

### DIFF
--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -30,7 +30,7 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -136,7 +136,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "≤13.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": {

--- a/css/properties/page.json
+++ b/css/properties/page.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `page` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.1).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/page
