### PR TITLE
Update Chromium data for image-rendering CSS property

### DIFF
--- a/css/properties/image-rendering.json
+++ b/css/properties/image-rendering.json
@@ -88,7 +88,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "28"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -101,9 +101,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": "14"
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "7"
               },
@@ -122,7 +120,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "28"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -135,9 +133,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": "14"
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "7"
               },


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `image-rendering` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.1).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/image-rendering
