### PR TITLE
Update deno data for Cache API

### DIFF
--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -17,6 +17,9 @@
             }
           ],
           "chrome_android": "mirror",
+          "deno": {
+            "version_added": "1.26"
+          },
           "edge": {
             "version_added": "16"
           },
@@ -92,6 +95,9 @@
               }
             ],
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.26"
+            },
             "edge": {
               "version_added": "16"
             },
@@ -128,6 +134,9 @@
               "version_added": "40"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.26"
+            },
             "edge": {
               "version_added": "16"
             },
@@ -164,6 +173,9 @@
               "version_added": "40"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.26"
+            },
             "edge": {
               "version_added": "16"
             },
@@ -200,6 +212,9 @@
               "version_added": "40"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "16"
             },
@@ -243,6 +258,9 @@
               }
             ],
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
             "edge": {
               "version_added": "16"
             },
@@ -279,6 +297,9 @@
               "version_added": "40"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.26"
+            },
             "edge": {
               "version_added": "16"
             },

--- a/api/_globals/caches.json
+++ b/api/_globals/caches.json
@@ -10,7 +10,7 @@
           },
           "chrome_android": "mirror",
           "deno": {
-            "version_added": false
+            "version_added": "1.26"
           },
           "edge": {
             "version_added": "16"
@@ -83,7 +83,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "1.26"
             },
             "edge": {
               "version_added": "16"


### PR DESCRIPTION
#### Summary

This PR updates and corrects version value for Deno for `caches` object and `CacheStorage` interface. The data comes from the [Deno Runtime APIs document][deno-doc].

#### Test results and supporting details

I couldn't make the test on Deno `1.26.0`. But I've tested the `caches` object and methods from `CacheStorage` interface in Deno `1.34.4` and can confirm it does work.

##### Supporting details

- [Deno Runtime APIs document][deno-doc]

#### Related issues

None


[deno-doc]: https://deno.land/api@v1.26.0?s=Cache