### PR TITLE
Remove patch versions from NodeJS releases

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -6,427 +6,427 @@
       "accepts_flags": true,
       "accepts_webextensions": false,
       "releases": {
-        "0.10.0": {
+        "0.10": {
           "release_date": "2013-03-11",
           "release_notes": "https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V010.md",
           "status": "retired",
           "engine": "V8",
           "engine_version": "3.14"
         },
-        "0.12.0": {
+        "0.12": {
           "release_date": "2015-02-06",
           "release_notes": "https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V012.md",
           "status": "retired",
           "engine": "V8",
           "engine_version": "3.28"
         },
-        "4.0.0": {
+        "4.0": {
           "release_date": "2015-09-08",
           "release_notes": "https://nodejs.org/en/blog/release/v4.0.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "4.5"
         },
-        "5.0.0": {
+        "5.0": {
           "release_date": "2015-10-29",
           "release_notes": "https://nodejs.org/en/blog/release/v5.0.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "4.6"
         },
-        "6.0.0": {
+        "6.0": {
           "release_date": "2016-04-26",
           "release_notes": "https://nodejs.org/en/blog/release/v6.0.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "5"
         },
-        "6.5.0": {
+        "6.5": {
           "release_date": "2016-08-26",
           "release_notes": "https://nodejs.org/en/blog/release/v6.5.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "5.1"
         },
-        "7.0.0": {
+        "7.0": {
           "release_date": "2016-10-25",
           "release_notes": "https://nodejs.org/en/blog/release/v7.0.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "5.4"
         },
-        "7.5.0": {
+        "7.5": {
           "release_date": "2017-01-31",
           "release_notes": "https://nodejs.org/en/blog/release/v7.5.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "5.4"
         },
-        "7.6.0": {
+        "7.6": {
           "release_date": "2017-02-21",
           "release_notes": "https://nodejs.org/en/blog/release/v7.6.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "5.5"
         },
-        "7.7.0": {
+        "7.7": {
           "release_date": "2017-02-28",
           "release_notes": "https://nodejs.org/en/blog/release/v7.7.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "5.5"
         },
-        "7.10.0": {
+        "7.10": {
           "release_date": "2017-05-02",
           "release_notes": "https://nodejs.org/en/blog/release/v7.10.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "5.5"
         },
-        "8.0.0": {
+        "8.0": {
           "release_date": "2017-05-30",
           "release_notes": "https://nodejs.org/en/blog/release/v8.0.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "5.8"
         },
-        "8.3.0": {
+        "8.3": {
           "release_date": "2017-08-09",
           "release_notes": "https://nodejs.org/en/blog/release/v8.3.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "6.0"
         },
-        "8.5.0": {
+        "8.5": {
           "release_date": "2017-09-12",
           "release_notes": "https://nodejs.org/en/blog/release/v8.5.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "6.0"
         },
-        "8.7.0": {
+        "8.7": {
           "release_date": "2017-10-11",
           "release_notes": "https://nodejs.org/en/blog/release/v8.7.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "6.1"
         },
-        "8.10.0": {
+        "8.10": {
           "release_date": "2018-03-06",
           "release_notes": "https://nodejs.org/en/blog/release/v8.10.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "6.2"
         },
-        "9.3.0": {
+        "9.3": {
           "release_date": "2017-12-12",
           "release_notes": "https://nodejs.org/en/blog/release/v9.3.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "6.2"
         },
-        "10.0.0": {
+        "10.0": {
           "release_date": "2018-04-24",
           "release_notes": "https://nodejs.org/en/blog/release/v10.0.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "6.6"
         },
-        "10.4.0": {
+        "10.4": {
           "release_date": "2018-06-06",
           "release_notes": "https://nodejs.org/en/blog/release/v10.4.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "6.7"
         },
-        "10.5.0": {
+        "10.5": {
           "release_date": "2018-06-20",
           "release_notes": "https://nodejs.org/en/blog/release/v10.5.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "6.7"
         },
-        "10.7.0": {
+        "10.7": {
           "release_date": "2018-07-18",
           "release_notes": "https://nodejs.org/en/blog/release/v10.7.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "6.7"
         },
-        "10.9.0": {
+        "10.9": {
           "release_date": "2018-08-16",
           "release_notes": "https://nodejs.org/en/blog/release/v10.9.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "6.8"
         },
-        "11.0.0": {
+        "11.0": {
           "release_date": "2018-10-23",
           "release_notes": "https://nodejs.org/en/blog/release/v11.0.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "7.0"
         },
-        "11.7.0": {
+        "11.7": {
           "release_date": "2019-01-18",
           "release_notes": "https://nodejs.org/en/blog/release/v11.7.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "7.0"
         },
-        "12.0.0": {
+        "12.0": {
           "release_date": "2019-04-23",
           "release_notes": "https://nodejs.org/en/blog/release/v12.0.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "7.4"
         },
-        "12.5.0": {
+        "12.5": {
           "release_date": "2019-06-27",
           "release_notes": "https://nodejs.org/en/blog/release/v12.5.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "7.5"
         },
-        "12.6.0": {
+        "12.6": {
           "release_date": "2019-07-03",
           "release_notes": "https://nodejs.org/en/blog/release/v12.6.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "7.5"
         },
-        "12.9.0": {
+        "12.9": {
           "release_date": "2019-08-20",
           "release_notes": "https://nodejs.org/en/blog/release/v12.9.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "7.6"
         },
-        "12.11.0": {
+        "12.11": {
           "release_date": "2019-09-25",
           "release_notes": "https://nodejs.org/en/blog/release/v12.11.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "7.7"
         },
-        "12.17.0": {
+        "12.17": {
           "release_date": "2020-05-26",
           "release_notes": "https://nodejs.org/en/blog/release/v12.17.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "7.8"
         },
-        "13.0.0": {
+        "13.0": {
           "release_date": "2019-10-10",
           "release_notes": "https://nodejs.org/en/blog/release/v13.0.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "7.8"
         },
-        "13.2.0": {
+        "13.2": {
           "release_date": "2019-11-21",
           "release_notes": "https://nodejs.org/en/blog/release/v13.2.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "7.9"
         },
-        "14.0.0": {
+        "14.0": {
           "release_date": "2020-04-21",
           "release_notes": "https://nodejs.org/en/blog/release/v14.0.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "8.1"
         },
-        "14.3.0": {
+        "14.3": {
           "release_date": "2020-05-19",
           "release_notes": "https://nodejs.org/en/blog/release/v14.3.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "8.3"
         },
-        "14.5.0": {
+        "14.5": {
           "release_date": "2020-06-30",
           "release_notes": "https://nodejs.org/en/blog/release/v14.5.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "8.3"
         },
-        "14.6.0": {
+        "14.6": {
           "release_date": "2020-07-21",
           "release_notes": "https://nodejs.org/en/blog/release/v14.6.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "8.4"
         },
-        "14.7.0": {
+        "14.7": {
           "release_date": "2020-07-29",
           "release_notes": "https://nodejs.org/en/blog/release/v14.7.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "8.4"
         },
-        "14.8.0": {
+        "14.8": {
           "release_date": "2020-08-11",
           "release_notes": "https://nodejs.org/en/blog/release/v14.8.0/",
           "status": "esr",
           "engine": "V8",
           "engine_version": "8.4"
         },
-        "15.0.0": {
+        "15.0": {
           "release_date": "2020-10-20",
           "release_notes": "https://nodejs.org/en/blog/release/v15.0.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "8.6"
         },
-        "15.4.0": {
+        "15.4": {
           "release_date": "2020-12-09",
           "release_notes": "https://nodejs.org/en/blog/release/v15.4.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "8.6"
         },
-        "15.7.0": {
+        "15.7": {
           "release_date": "2021-01-26",
           "release_notes": "https://nodejs.org/en/blog/release/v15.7.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "8.6"
         },
-        "15.12.0": {
+        "15.12": {
           "release_date": "2021-03-17",
           "release_notes": "https://nodejs.org/en/blog/release/v15.12.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "8.6"
         },
-        "16.0.0": {
+        "16.0": {
           "release_date": "2021-04-20",
           "release_notes": "https://nodejs.org/en/blog/release/v16.0.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "9.0"
         },
-        "16.1.0": {
+        "16.1": {
           "release_date": "2021-05-04",
           "release_notes": "https://nodejs.org/en/blog/release/v16.1.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "9.0"
         },
-        "16.4.0": {
+        "16.4": {
           "release_date": "2021-06-23",
           "release_notes": "https://nodejs.org/en/blog/release/v16.4.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "9.1"
         },
-        "16.5.0": {
+        "16.5": {
           "release_date": "2021-07-14",
           "release_notes": "https://nodejs.org/en/blog/release/v16.5.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "9.2"
         },
-        "16.6.0": {
+        "16.6": {
           "release_date": "2021-07-29",
           "release_notes": "https://nodejs.org/en/blog/release/v16.6.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "9.2"
         },
-        "16.7.0": {
+        "16.7": {
           "release_date": "2021-08-17",
           "release_notes": "https://nodejs.org/en/blog/release/v16.7.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "9.2"
         },
-        "16.9.0": {
+        "16.9": {
           "release_date": "2021-09-07",
           "release_notes": "https://nodejs.org/en/blog/release/v16.9.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "9.3"
         },
-        "16.11.0": {
+        "16.11": {
           "release_date": "2021-10-08",
           "release_notes": "https://nodejs.org/en/blog/release/v16.11.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "9.4"
         },
-        "16.14.0": {
+        "16.14": {
           "release_date": "2022-02-08",
           "release_notes": "https://nodejs.org/en/blog/release/v16.14.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "9.4"
         },
-        "16.15.0": {
+        "16.15": {
           "release_date": "2022-04-27",
           "release_notes": "https://nodejs.org/en/blog/release/v16.15.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "9.4"
         },
-        "16.17.0": {
+        "16.17": {
           "release_date": "2022-08-16",
           "release_notes": "https://nodejs.org/en/blog/release/v16.17.0/",
           "status": "esr",
           "engine": "V8",
           "engine_version": "9.4"
         },
-        "17.0.0": {
+        "17.0": {
           "release_date": "2021-10-19",
           "release_notes": "https://nodejs.org/en/blog/release/v17.0.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "9.5"
         },
-        "17.2.0": {
+        "17.2": {
           "release_date": "2021-11-30",
           "release_notes": "https://nodejs.org/en/blog/release/v17.2.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "9.6"
         },
-        "17.3.0": {
+        "17.3": {
           "release_date": "2021-12-17",
           "release_notes": "https://nodejs.org/en/blog/release/v17.3.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "9.6"
         },
-        "17.5.0": {
+        "17.5": {
           "release_date": "2022-02-10",
           "release_notes": "https://nodejs.org/en/blog/release/v17.5.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "9.6"
         },
-        "18.0.0": {
+        "18.0": {
           "release_date": "2022-04-19",
           "release_notes": "https://nodejs.org/en/blog/release/v18.0.0/",
           "status": "esr",
           "engine": "V8",
           "engine_version": "10.1"
         },
-        "19.0.0": {
+        "19.0": {
           "release_date": "2022-10-18",
           "release_notes": "https://nodejs.org/en/blog/release/v19.0.0/",
           "status": "retired",
           "engine": "V8",
           "engine_version": "10.7"
         },
-        "19.7.0": {
+        "19.7": {
           "release_date": "2023-02-21",
           "release_notes": "https://nodejs.org/en/blog/release/v19.7.0",
           "status": "retired",
           "engine": "V8",
           "engine_version": "10.8"
         },
-        "20.0.0": {
+        "20.0": {
           "release_date": "2023-04-18",
           "release_notes": "https://nodejs.org/en/blog/announcements/v20-release-announce",
           "status": "current",


### PR DESCRIPTION
This PR fixes #18777 by stripping out the patch versions in the NodeJS releases, leaving only major and minor release numbers.  This follows our conventions better.