### PR TITLE
Add NodeJS v20.2.0

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -428,7 +428,14 @@
         },
         "20.0.0": {
           "release_date": "2023-04-18",
-          "release_notes": "https://nodejs.org/en/blog/announcements/v20-release-announce",
+          "release_notes": "https://nodejs.org/en/blog/release/v20.0.0",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "11.3"
+        },
+        "20.2.0": {
+          "release_date": "2023-05-16",
+          "release_notes": "https://nodejs.org/en/blog/release/v20.2.0",
           "status": "current",
           "engine": "V8",
           "engine_version": "11.3"


### PR DESCRIPTION
This PR adds NodeJS v20.2.0 to our browser data.  This unblocks #20110.

Additionally, this fixes the URL to the release notes for NodeJS v20.0.0 to point to the proper release notes rather than the blog post.