### PR TITLE
FF84 ApplicationCache disabled - FF115 removed

### DIFF
--- a/api/ApplicationCache.json
+++ b/api/ApplicationCache.json
@@ -13,7 +13,8 @@
             "version_removed": "86"
           },
           "firefox": {
-            "version_added": "3"
+            "version_added": "3",
+            "version_removed": "84"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -102,7 +103,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "84"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -146,7 +148,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "84"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -190,7 +193,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "84"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -234,7 +238,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "84"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -278,7 +283,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "84"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -322,7 +328,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3.5"
+              "version_added": "3.5",
+              "version_removed": "84"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -366,7 +373,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "84"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -409,7 +417,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "84"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -458,7 +467,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "84"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -507,7 +517,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "84"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -557,7 +568,8 @@
               "version_removed": "86"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "84"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
ApplicationCache was disabled in release in FF84 behind a preference - but I missed the ApplicationCache entry back then in https://github.com/mdn/browser-compat-data/pull/7481. In FF115 it was fully removed.

My thinking is that this should simply marked as removed in FF84. BUT, given how long ago that was, should we simply purge this whole record? Note that it is not linked on MDN.

Other docs work can be tracked in https://github.com/mdn/content/issues/27176

FYI @queengooborg 