### PR TITLE
Remove duplicate entry for page property in page at-rule

### DIFF
--- a/css/at-rules/page.json
+++ b/css/at-rules/page.json
@@ -44,41 +44,6 @@
             "deprecated": false
           }
         },
-        "page": {
-          "__compat": {
-            "description": "<code>page</code> property",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/page",
-            "spec_url": "https://drafts.csswg.org/css-page/#using-named-pages",
-            "support": {
-              "chrome": {
-                "version_added": "85"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "110"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "page-orientation": {
           "__compat": {
             "description": "<code>page-orientation</code> descriptor",


### PR DESCRIPTION
I found that there was a duplicate entry for the `page` property in the `@page` at-rule data.  This, however, is unconventional to BCD and shouldn't be placed in the at-rules data.