### PR TITLE
FF115 supports change array by copy methods

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -2017,7 +2017,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "115"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -2057,7 +2057,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "115"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -2097,7 +2097,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "115"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -2289,7 +2289,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "115"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -1803,7 +1803,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "115"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1843,7 +1843,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "115"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1973,7 +1973,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "115"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
FF115 supports the Array/TypedArray "change array by copy" methods in https://bugzilla.mozilla.org/show_bug.cgi?id=1811057.

This adds the relevant version to:

- Array.toReversed()
- Array.toSorted(compareFn) -> Array
- Array.toSpliced(start, deleteCount, ...items) -> Array
- Array.with(index, value)
- TypedArrays.toReversed
- TypedArrays.toSorted
- TypedArrays.with()

Related docs work can be tracked in  https://github.com/mdn/content/issues/27175