### PR TITLE
Remove api.WebTransport.draining from BCD

### DIFF
--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -474,40 +474,6 @@
           }
         }
       },
-      "draining": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport/draining",
-          "spec_url": "https://w3c.github.io/webtransport/#dom-webtransport-draining",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "114"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "getStats": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebTransport/getStats",


### PR DESCRIPTION
This PR removes the `draining` member of the `WebTransport` API from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/WebTransport/draining

Note: the collector shows that Firefox does not actually support this property.