### PR TITLE
Remove api.Plugin.version from BCD

### DIFF
--- a/api/Plugin.json
+++ b/api/Plugin.json
@@ -297,42 +297,6 @@
             "deprecated": true
           }
         }
-      },
-      "version": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Plugin/version",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": {
-              "version_added": "12",
-              "version_removed": "79"
-            },
-            "firefox": {
-              "version_added": "3.6"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": "4"
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": true
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
This PR removes the `version` member of the `Plugin` API from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Plugin/version

Additional Notes: The collector states this property is no longer supported.
