### PR TITLE
FF115 Add Sec-Purpose HTTP header

### DIFF
--- a/http/headers/Sec-Purpose.json
+++ b/http/headers/Sec-Purpose.json
@@ -14,7 +14,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "115",
-              "notes": "<code>Sec-Purpose: prefetch</code> replaces <code>X-moz: prefetch</code> that was used to indicate a prefetch request in earlier versions."
+              "notes": "<code>Sec-Purpose: prefetch</code> replaces <code>X-moz: prefetch</code>, which was used to indicate a prefetch request in earlier versions. This is incorrectly sent with <code>Accept: */*</code> instead of the accept string used for navigation requests."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/http/headers/Sec-Purpose.json
+++ b/http/headers/Sec-Purpose.json
@@ -1,0 +1,44 @@
+{
+  "http": {
+    "headers": {
+      "Sec-Purpose": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-Purpose",
+          "spec_url": "https://fetch.spec.whatwg.org/#sec-purpose-header",
+          "support": {
+            "chrome": {
+              "version_added": false,
+              "notes": "Chrome uses the legacy <code>Purpose: prefetch</code> header to indicate a request is a prefetch. See <a href='https://crbug.com/1358419'>bug 1358419</a>."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "115",
+              "notes": "<code>Sec-Purpose: prefetch</code> replaces <code>X-moz: prefetch</code> that was used to indicate a prefetch request in earlier versions."
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": false
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/Sec-Purpose.json
+++ b/http/headers/Sec-Purpose.json
@@ -14,7 +14,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "115",
-              "notes": "<code>Sec-Purpose: prefetch</code> replaces <code>X-moz: prefetch</code>, which was used to indicate a prefetch request in earlier versions. This is incorrectly sent with <code>Accept: */*</code> instead of the accept string used for navigation requests."
+              "notes": "<code>Sec-Purpose: prefetch</code> replaces the non-standard <code>X-moz: prefetch</code> header that was used to indicate a prefetch request in earlier versions. Prefetch requests should also include the header <code>Accept</code> header string for navigations, but <code>Accept: */*</code> is sent instead."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF115 adds support for `Sec-Purpose` header in https://bugzilla.mozilla.org/show_bug.cgi?id=1836328.

The other browsers are not supported according to https://wpt.fyi/results/preload/prefetch-headers.https.html?label=experimental&label=master&aligned in Chrome 116, Safari 172. 

`Sec-Purpose: prefetch` is the new way to indicate a request is a prefetch request. In Firefox it replaces `X-moz: prefetch` and in Chromium it will replace `Purpose: prefetch`, though it has not been implemented yet.

I want to avoid adding data for  `X-moz: prefetch`  and `Purpose: prefetch` as both are effectively non-standard, and it is difficult enough to capture what is happening with `Sec-Purpose`. 

Related docs work can be tracked in https://github.com/mdn/content/issues/27171
