### PR TITLE
Update Chromium data for css.properties.text-align.match-parent

### DIFF
--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -143,7 +143,8 @@
             "description": "<code>match-parent</code>",
             "support": {
               "chrome": {
-                "version_added": "16"
+                "version_added": "16",
+                "prefix": "-webkit-"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `match-parent` member of the `text-align` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.3).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/text-align/match-parent

Additional Notes: After seeing the collector reports no support from this property, I tested it in Chrome and found that it is supported with a prefix.
