### PR TITLE
Remove css.properties.width.fill from BCD

### DIFF
--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -75,39 +75,6 @@
             }
           }
         },
-        "fill": {
-          "__compat": {
-            "description": "<code>fill</code>",
-            "support": {
-              "chrome": {
-                "version_added": "46"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "12"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": false
-            }
-          }
-        },
         "fit-content": {
           "__compat": {
             "description": "<code>fit-content</code>",


### PR DESCRIPTION
This PR removes the `fill` member of the `width` CSS property from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.3).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/width/fill
