### PR TITLE
Update Firefox data for api.RTCRtpSender.transport

### DIFF
--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -895,7 +895,7 @@
               "version_added": "13"
             },
             "firefox": {
-              "version_added": "34"
+              "version_added": "82"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `transport` member of the `RTCRtpSender` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.3).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/RTCRtpSender/transport

Additional Notes: The original data comes from the wiki migration, so I have little trust in it.
