### PR TITLE
Update Chromium data for RTCStatsReport API

### DIFF
--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -1597,7 +1597,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtccodecstats-sdpfmtpline",
             "support": {
               "chrome": {
-                "version_added": "108"
+                "version_added": "83"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -2993,7 +2993,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats-remoteid",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -4821,7 +4821,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcoutboundrtpstreamstats-remoteid",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "81"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -5030,7 +5030,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcoutboundrtpstreamstats-totalpacketsenddelay",
             "support": {
               "chrome": {
-                "version_added": "109"
+                "version_added": "80"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -6317,7 +6317,7 @@
           "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstatstype-remote-outbound-rtp",
           "support": {
             "chrome": {
-              "version_added": "96"
+              "version_added": "91"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -6350,7 +6350,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcsentrtpstreamstats-bytessent",
             "support": {
               "chrome": {
-                "version_added": "96"
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -6384,7 +6384,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcrtpstreamstats-codecid",
             "support": {
               "chrome": {
-                "version_added": "96"
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -6418,7 +6418,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstats-id",
             "support": {
               "chrome": {
-                "version_added": "96"
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -6452,7 +6452,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcrtpstreamstats-kind",
             "support": {
               "chrome": {
-                "version_added": "96"
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -6486,7 +6486,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcremoteoutboundrtpstreamstats-localid",
             "support": {
               "chrome": {
-                "version_added": "96"
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -6520,7 +6520,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcsentrtpstreamstats-packetssent",
             "support": {
               "chrome": {
-                "version_added": "96"
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -6554,7 +6554,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcremoteoutboundrtpstreamstats-remotetimestamp",
             "support": {
               "chrome": {
-                "version_added": "96"
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -6588,7 +6588,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcremoteoutboundrtpstreamstats-reportssent",
             "support": {
               "chrome": {
-                "version_added": "96"
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -6656,7 +6656,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcrtpstreamstats-ssrc",
             "support": {
               "chrome": {
-                "version_added": "96"
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -6690,7 +6690,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstats-timestamp",
             "support": {
               "chrome": {
-                "version_added": "96"
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -6758,7 +6758,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcrtpstreamstats-transportid",
             "support": {
               "chrome": {
-                "version_added": "96"
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -6792,7 +6792,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcstats-type",
             "support": {
               "chrome": {
-                "version_added": "96"
+                "version_added": "91"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `RTCStatsReport` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.3).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/RTCStatsReport
