### PR TITLE
Update Firefox data for api.RTCStatsReport.type_inbound-rtp.remoteId

### DIFF
--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -2998,7 +2998,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "96"
+                "version_added": "≤72"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `type_inbound-rtp.remoteId` member of the `RTCStatsReport` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.3).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/RTCStatsReport/type_inbound-rtp/remoteId
