### PR TITLE
Add notes on Firefox proprietary scroll axis values

### DIFF
--- a/css/properties/animation-timeline.json
+++ b/css/properties/animation-timeline.json
@@ -80,7 +80,10 @@
               "firefox": [
                 {
                   "version_added": "110",
-                  "notes": "Zero scroll range is treated as 100% but should be 0% (see <a href='https://bugzil.la/1780865'>bug 1780865</a>).",
+                  "notes": [
+                    "Zero scroll range is treated as 100% but should be 0% (see <a href='https://bugzil.la/1780865'>bug 1780865</a>).",
+                    "Supports the deprecated <code>horizontal</code> and <code>vertical</code> axis values, and not the <code>x</code> and <code>y</code> values."
+                  ],
                   "flags": [
                     {
                       "type": "preference",
@@ -92,7 +95,10 @@
                 {
                   "version_added": "101",
                   "version_removed": "110",
-                  "notes": "Zero scroll range is treated as 100% but should be 0% (see <a href='https://bugzil.la/1780865'>bug 1780865</a>).",
+                  "notes": [
+                    "Zero scroll range is treated as 100% but should be 0% (see <a href='https://bugzil.la/1780865'>bug 1780865</a>).",
+                    "Supports the deprecated <code>horizontal</code> and <code>vertical</code> axis values, and not the <code>x</code> and <code>y</code> values."
+                  ],
                   "flags": [
                     {
                       "type": "preference",

--- a/css/properties/scroll-timeline.json
+++ b/css/properties/scroll-timeline.json
@@ -42,6 +42,7 @@
                 "version_added": "111",
                 "notes": [
                   "The syntax of the shorthand property uses the fixed order of name and then the axis.",
+                  "Supports the deprecated <code>horizontal</code> and <code>vertical</code> axis values, and not the <code>x</code> and <code>y</code> values.",
                   "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`."
                 ],
                 "flags": [

--- a/css/properties/view-timeline.json
+++ b/css/properties/view-timeline.json
@@ -15,6 +15,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "111",
+              "notes": "Supports the deprecated <code>horizontal</code> and <code>vertical</code> axis values, and not the <code>x</code> and <code>y</code> values.",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Hah, it's another CSS scroll-driven animations BCD PR ;-)

So, previously in the corresponding content update (https://github.com/mdn/content/pull/27075) I had a couple of pages that listed the standard scroll axis values alongside the deprecated non-logical axis values, which are still supported in Firefox as the implementation is a bit out of date.

I ended up removing the deprecated values from the content, as it seemed a bit strange to list them there. This PR adds notes to the BCD to cover that value support instead, as it seemed like a better place to include it. 

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
