### PR TITLE
Update Firefox data for OVR_multiview2 API

### DIFF
--- a/api/OVR_multiview2.json
+++ b/api/OVR_multiview2.json
@@ -8,14 +8,16 @@
           "chrome": {
             "version_added": "93",
             "partial_implementation": true,
-            "notes": "Not supported on macOS."
+            "notes": "Only supported on Windows with ANGLE."
           },
           "chrome_android": {
             "version_added": "93"
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "71"
+            "version_added": "71",
+            "partial_implementation": true,
+            "notes": "Only supported on Windows with ANGLE."
           },
           "firefox_android": "mirror",
           "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `OVR_multiview2` API. This marks Firefox as partial_implementation as the interface is only supported on certain OSes.

Additional Notes: Additionally, this updates the Chrome note to specify Linux isn't supported either.
