### PR TITLE
Update Safari data for WEBGL_compressed_texture_etc API

### DIFF
--- a/api/WEBGL_compressed_texture_etc.json
+++ b/api/WEBGL_compressed_texture_etc.json
@@ -23,11 +23,9 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "16.2"
+            "version_added": "13.1"
           },
-          "safari_ios": {
-            "version_added": "14"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },

--- a/api/WEBGL_compressed_texture_etc1.json
+++ b/api/WEBGL_compressed_texture_etc1.json
@@ -23,11 +23,9 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "16.2"
+            "version_added": "13.1"
           },
-          "safari_ios": {
-            "version_added": "14"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `WEBGL_compressed_texture_etc` API. The data comes from a commit in the browser's source code, mapped to a version number using available tooling or via the commit timestamp.

Commit: https://github.com/WebKit/WebKit/commit/e992b6b77baf88e2a99248cb091cefcf12d9b7f1
