### PR TITLE
Edge supports desynchronized parameter since first Chromium

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -402,7 +402,7 @@
                   "version_added": "75"
                 },
                 "edge": {
-                  "version_added": "81"
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -599,7 +599,7 @@
                   "version_added": "75"
                 },
                 "edge": {
-                  "version_added": "81"
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false
@@ -869,7 +869,7 @@
                   "version_added": "75"
                 },
                 "edge": {
-                  "version_added": "81"
+                  "version_added": "79"
                 },
                 "firefox": {
                   "version_added": false


### PR DESCRIPTION
Based on results from the mdn-bcd-collector project and manual testing, it was determined that Microsoft Edge supported the `desynchronized` parameter when creating a rendering context since Edge 79.