### PR TITLE
Update Chromium data for DragEvent API

### DIFF
--- a/api/DragEvent.json
+++ b/api/DragEvent.json
@@ -6,7 +6,7 @@
         "spec_url": "https://html.spec.whatwg.org/multipage/dnd.html#the-dragevent-interface",
         "support": {
           "chrome": {
-            "version_added": "3"
+            "version_added": "46"
           },
           "chrome_android": {
             "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `DragEvent` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.3).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/DragEvent
