### PR TITLE
Update Safari data for DragEvent API

### DIFF
--- a/api/DragEvent.json
+++ b/api/DragEvent.json
@@ -28,7 +28,7 @@
           },
           "opera_android": "mirror",
           "safari": {
-            "version_added": "3.1"
+            "version_added": "14"
           },
           "safari_ios": {
             "version_added": false
@@ -70,7 +70,7 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": "3.1"
+              "version_added": "14"
             },
             "safari_ios": {
               "version_added": false
@@ -112,7 +112,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "3.1"
+              "version_added": "14"
             },
             "safari_ios": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `DragEvent` API. The data comes from a commit in the browser's source code, mapped to a version number using available tooling or via the commit timestamp.

Commit: https://github.com/WebKit/WebKit/commit/974932c8c8a4e3121648546281650d2d3b0f695a
