### PR TITLE
Remove api.Request.Request.navigate_mode from BCD

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -228,48 +228,6 @@
             }
           }
         },
-        "navigate_mode": {
-          "__compat": {
-            "description": "<code>navigate</code> mode",
-            "support": {
-              "chrome": {
-                "version_added": "49"
-              },
-              "chrome_android": "mirror",
-              "deno": {
-                "version_added": "1.7"
-              },
-              "edge": {
-                "version_added": "15"
-              },
-              "firefox": {
-                "version_added": "46"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": "10.1"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": false
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "request_body_readablestream": {
           "__compat": {
             "description": "Send <code>ReadableStream</code> in request body",


### PR DESCRIPTION
This PR removes the `Request.navigate_mode` member of the `Request` API from BCD. No browser supports construction of a request when `mode` is set to `navigate`.

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Request/Request/navigate_mode
