### PR TITLE
Update Firefox data for Touch API

### DIFF
--- a/api/Touch.json
+++ b/api/Touch.json
@@ -14,7 +14,9 @@
           },
           "firefox": [
             {
-              "version_added": "52"
+              "version_added": "52",
+              "partial_implementation": true,
+              "notes": "This interface is only exposed if a touch input device is detected."
             },
             {
               "version_added": "18",

--- a/api/Touch.json
+++ b/api/Touch.json
@@ -60,7 +60,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "46"
+              "version_added": "52",
+              "partial_implementation": true,
+              "notes": "This interface is only exposed if a touch input device is detected."
             },
             "firefox_android": {
               "version_added": "6"
@@ -171,7 +173,9 @@
             },
             "firefox": [
               {
-                "version_added": "52"
+                "version_added": "52",
+                "partial_implementation": true,
+                "notes": "This interface is only exposed if a touch input device is detected."
               },
               {
                 "version_added": "18",
@@ -218,7 +222,9 @@
             },
             "firefox": [
               {
-                "version_added": "52"
+                "version_added": "52",
+                "partial_implementation": true,
+                "notes": "This interface is only exposed if a touch input device is detected."
               },
               {
                 "version_added": "18",
@@ -272,7 +278,9 @@
             },
             "firefox": [
               {
-                "version_added": "52"
+                "version_added": "52",
+                "partial_implementation": true,
+                "notes": "This interface is only exposed if a touch input device is detected."
               },
               {
                 "version_added": "18",
@@ -319,7 +327,9 @@
             },
             "firefox": [
               {
-                "version_added": "52"
+                "version_added": "52",
+                "partial_implementation": true,
+                "notes": "This interface is only exposed if a touch input device is detected."
               },
               {
                 "version_added": "18",
@@ -366,7 +376,9 @@
             },
             "firefox": [
               {
-                "version_added": "52"
+                "version_added": "52",
+                "partial_implementation": true,
+                "notes": "This interface is only exposed if a touch input device is detected."
               },
               {
                 "version_added": "18",
@@ -413,7 +425,9 @@
             },
             "firefox": [
               {
-                "version_added": "52"
+                "version_added": "52",
+                "partial_implementation": true,
+                "notes": "This interface is only exposed if a touch input device is detected."
               },
               {
                 "version_added": "18",
@@ -467,7 +481,9 @@
             },
             "firefox": [
               {
-                "version_added": "52"
+                "version_added": "52",
+                "partial_implementation": true,
+                "notes": "This interface is only exposed if a touch input device is detected."
               },
               {
                 "version_added": "18",
@@ -521,7 +537,9 @@
             },
             "firefox": [
               {
-                "version_added": "52"
+                "version_added": "52",
+                "partial_implementation": true,
+                "notes": "This interface is only exposed if a touch input device is detected."
               },
               {
                 "version_added": "18",
@@ -575,7 +593,9 @@
             },
             "firefox": [
               {
-                "version_added": "52"
+                "version_added": "52",
+                "partial_implementation": true,
+                "notes": "This interface is only exposed if a touch input device is detected."
               },
               {
                 "version_added": "18",
@@ -622,7 +642,9 @@
             },
             "firefox": [
               {
-                "version_added": "52"
+                "version_added": "52",
+                "partial_implementation": true,
+                "notes": "This interface is only exposed if a touch input device is detected."
               },
               {
                 "version_added": "18",
@@ -669,7 +691,9 @@
             },
             "firefox": [
               {
-                "version_added": "52"
+                "version_added": "52",
+                "partial_implementation": true,
+                "notes": "This interface is only exposed if a touch input device is detected."
               },
               {
                 "version_added": "18",
@@ -716,7 +740,9 @@
             },
             "firefox": [
               {
-                "version_added": "52"
+                "version_added": "52",
+                "partial_implementation": true,
+                "notes": "This interface is only exposed if a touch input device is detected."
               },
               {
                 "version_added": "18",

--- a/api/TouchList.json
+++ b/api/TouchList.json
@@ -14,7 +14,9 @@
           },
           "firefox": [
             {
-              "version_added": "52"
+              "version_added": "52",
+              "partial_implementation": true,
+              "notes": "This interface is only exposed if a touch input device is detected."
             },
             {
               "version_added": "18",
@@ -60,7 +62,9 @@
             },
             "firefox": [
               {
-                "version_added": "52"
+                "version_added": "52",
+                "partial_implementation": true,
+                "notes": "This interface is only exposed if a touch input device is detected."
               },
               {
                 "version_added": "18",
@@ -107,7 +111,9 @@
             },
             "firefox": [
               {
-                "version_added": "52"
+                "version_added": "52",
+                "partial_implementation": true,
+                "notes": "This interface is only exposed if a touch input device is detected."
               },
               {
                 "version_added": "18",


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `Touch` API. During testing, it was found that this interface is only available if there is hardware touch support (as per `dom.w3c_touch_events.enabled` being set to `2` (auto-detect) in Windows and Linux).
