### PR TITLE
Update Safari data for TouchList API

### DIFF
--- a/api/TouchList.json
+++ b/api/TouchList.json
@@ -32,7 +32,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "10.1"
+            "version_added": false
           },
           "safari_ios": {
             "version_added": "2"
@@ -78,7 +78,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10.1"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "2"
@@ -125,7 +125,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10.1"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "2"


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `TouchList` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.3).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/TouchList

Additional Notes: (Discussed during a 1-on-1 call with Florian.  The original data comes from Apple's developer docs which has incorrect version numbers.  Also, the Touch interface itself isn't supported in Safari Desktop.
