### PR TITLE
Update Safari data for api.RTCPeerConnection.setLocalDescription.description_parameter_optional

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -2494,7 +2494,7 @@
                 "version_added": "66"
               },
               "safari": {
-                "version_added": "14.1"
+                "version_added": "≤13.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `setLocalDescription.description_parameter_optional` member of the `RTCPeerConnection` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.3).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/RTCPeerConnection/setLocalDescription/description_parameter_optional
