### PR TITLE
Update Chromium data for css.properties.list-style-type.symbols

### DIFF
--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -3049,7 +3049,7 @@
             "spec_url": "https://drafts.csswg.org/css-counter-styles/#symbols-function",
             "support": {
               "chrome": {
-                "version_added": "91"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `symbols` member of the `list-style-type` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.3).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/list-style-type/symbols
