### PR TITLE
Update Safari data for css.properties.list-style-type.ethiopic-halehame-am

### DIFF
--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -1213,7 +1213,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "5"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `ethiopic-halehame-am` member of the `list-style-type` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.3).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/list-style-type/ethiopic-halehame-am
