### PR TITLE
Update Safari data for WEBGL_compressed_texture_astc API

### DIFF
--- a/api/WEBGL_compressed_texture_astc.json
+++ b/api/WEBGL_compressed_texture_astc.json
@@ -21,7 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "16.2"
+            "version_added": "12"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -54,7 +54,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16.2"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `WEBGL_compressed_texture_astc` API. The data comes from a commit in the browser's source code, mapped to a version number using available tooling or via the commit timestamp.

Commit: https://github.com/WebKit/WebKit/commit/6d5219cebd6cf31fb1761f97edba5bbf265d0935
