### PR TITLE
Update Firefox data for css.properties.appearance.compat-auto

### DIFF
--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -116,7 +116,9 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "partial_implementation": true,
+                "notes": "<code>push-button</code> is not supported."
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `compat-auto` member of the `appearance` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.3).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/appearance/compat-auto
