### PR TITLE
Update Safari data for api.SpeechSynthesisEvent.charLength

### DIFF
--- a/api/SpeechSynthesisEvent.json
+++ b/api/SpeechSynthesisEvent.json
@@ -162,7 +162,7 @@
               "version_added": false
             },
             "safari": {
-              "version_added": "preview"
+              "version_added": "16"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `charLength` member of the `SpeechSynthesisEvent` API. The data comes from a commit in the browser's source code, mapped to a version number using available tooling or via the commit timestamp.

Commit: https://github.com/WebKit/WebKit/commit/c8a7a8619b280e32eff4e077992d5a7c67e31a5c
