### PR TITLE
CSS display property multi-keyword support in Chrome 115

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -627,7 +627,7 @@
             "description": "Multi-keyword values",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "115"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Add support for multi-keyword syntax on CSS `display` property in Chrome 115. 

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
[Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=995106)
[Announcement in Chrome Dev Blog](https://developer.chrome.com/blog/chrome-115-beta/)

