### PR TITLE
Update Chromium data for css.properties.list-style-type.upper-greek

### DIFF
--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -3578,13 +3578,25 @@
           "__compat": {
             "description": "<code>upper-greek</code>",
             "support": {
-              "chrome": {
-                "version_added": "1"
-              },
+              "chrome": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "1",
+                  "version_removed": "45"
+                }
+              ],
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
+              "edge": [
+                {
+                  "version_added": "91"
+                },
+                {
+                  "version_added": "12",
+                  "version_removed": "79"
+                }
+              ],
               "firefox": {
                 "version_added": "1"
               },


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `upper-greek` member of the `list-style-type` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.4).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/list-style-type/upper-greek
