### PR TITLE
Chrome support for safe/unsafe alignment in flexbox

### DIFF
--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -235,8 +235,8 @@
               "description": "<code>safe</code> and <code>unsafe</code>",
               "support": {
                 "chrome": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "115",
+                  "notes": "Before version 115, this value is recognized, but has no effect."
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",

--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -227,8 +227,8 @@
               "description": "<code>safe</code> and <code>unsafe</code>",
               "support": {
                 "chrome": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "115",
+                  "notes": "Before version 115, this value is recognized, but has no effect."
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -234,8 +234,8 @@
               "description": "<code>safe</code> and <code>unsafe</code>",
               "support": {
                 "chrome": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "115",
+                  "notes": "Before version 115, this value is recognized, but has no effect."
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",

--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -160,8 +160,8 @@
               "description": "<code>safe</code> and <code>unsafe</code>",
               "support": {
                 "chrome": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
+                  "version_added": "115",
+                  "notes": "Before version 115, this value is recognized, but has no effect."
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome recently added support for the `safe`/`unsafe` alignment keywords in flexbox layouts. It's currently in Chrome Beta, or version 115.

<img width="481" alt="image" src="https://github.com/mdn/browser-compat-data/assets/9437625/9586ffd6-dbd1-43ba-b056-f313c5570635">

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

`npm run test` passed 👍 

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

* Chromium bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1121601
* WPT results for `align-content`, `justify-content`, and `align-items` (pictured above): https://wpt.fyi/results/css/css-flexbox/flexbox-safe-overflow-position-001.html
* WPT results for `align-self`: https://wpt.fyi/results/css/css-align/self-alignment/self-align-safe-unsafe-flex-001.html

#### Related issues

None that I could find
