### PR TITLE
Update: Deno supports resizable ArrayBuffers since 1.33

### DIFF
--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -110,7 +110,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "1.33"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -286,7 +286,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.33"
               },
               "edge": "mirror",
               "firefox": {
@@ -326,7 +326,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.33"
               },
               "edge": "mirror",
               "firefox": {
@@ -366,7 +366,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.33"
               },
               "edge": "mirror",
               "firefox": {

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -98,7 +98,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "1.33"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -185,7 +185,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.33"
               },
               "edge": "mirror",
               "firefox": {
@@ -227,7 +227,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.33"
               },
               "edge": "mirror",
               "firefox": {
@@ -269,7 +269,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.33"
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
#### Summary
Update ArrayBuffer data to reflect Deno's support for `resize()` method, `resizable` property, etc.

#### Test results and supporting details
https://deno.com/blog/v1.33

#### Related issues
Closes #20208
