### PR TITLE
Update Chromium data for api.RTCPeerConnection.RTCPeerConnection.configuration_peerIdentity_parameter

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -335,14 +335,10 @@
             "description": "<code>configuration.peerIdentity</code> parameter",
             "support": {
               "chrome": {
-                "version_added": "23"
+                "version_added": false
               },
-              "chrome_android": {
-                "version_added": "57"
-              },
-              "edge": {
-                "version_added": "≤79"
-              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
               "firefox": {
                 "version_added": "32"
               },
@@ -352,9 +348,7 @@
               },
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": {
-                "version_added": "44"
-              },
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "12.1"
               },


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `RTCPeerConnection.configuration_peerIdentity_parameter` member of the `RTCPeerConnection` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.5).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/RTCPeerConnection/RTCPeerConnection/configuration_peerIdentity_parameter

Additional Notes: In the IDL in Chrome, the parameter is commented out with TODO: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/peerconnection/rtc_configuration.idl;l=39;drc=047c7dc4ee1ce908d7fea38ca063fa2f80f92c77
