### PR TITLE
Update Safari data for api.RTCPeerConnection.RTCPeerConnection.configuration_peerIdentity_parameter

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -356,7 +356,7 @@
                 "version_added": "44"
               },
               "safari": {
-                "version_added": "12.1"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `RTCPeerConnection.configuration_peerIdentity_parameter` member of the `RTCPeerConnection` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.5).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/RTCPeerConnection/RTCPeerConnection/configuration_peerIdentity_parameter

Additional Notes: In WebKit's source code, the property is commented out as a TODO: https://github.com/WebKit/WebKit/blob/7cc365707c03970445cec23ec9a2c2be6a80eedd/Source/WebCore/Modules/mediastream/RTCConfiguration.idl#L63
