### PR TITLE
Update Firefox data for api.RTCPeerConnection.createDTMFSender

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1035,11 +1035,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "22"
+              "version_added": false
             },
-            "firefox_android": {
-              "version_added": "24"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `createDTMFSender` member of the `RTCPeerConnection` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.5).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/RTCPeerConnection/createDTMFSender

Additional Notes: Searching through the source code reveals that this property is not implemented.
