### PR TITLE
Fix URLs that point to old "master" branch

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -8,14 +8,14 @@
       "releases": {
         "0.10.0": {
           "release_date": "2013-03-11",
-          "release_notes": "https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V010.md",
+          "release_notes": "https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V010.md",
           "status": "retired",
           "engine": "V8",
           "engine_version": "3.14"
         },
         "0.12.0": {
           "release_date": "2015-02-06",
-          "release_notes": "https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V012.md",
+          "release_notes": "https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V012.md",
           "status": "retired",
           "engine": "V8",
           "engine_version": "3.28"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,7 +34,7 @@ By default, the script will traverse and print the dotted path to every feature.
 
 Run `npm run traverse -- --help` for a complete list of options and examples.
 
-The `-b` or `--browser` argument may be any browser in the [`browsers/` folder](https://github.com/mdn/browser-compat-data/blob/master/browsers/). This argument may be repeated to traverse multiple browsers. By default, the script will traverse all browsers.
+The `-b` or `--browser` argument may be any browser in the [`browsers/` folder](https://github.com/mdn/browser-compat-data/blob/main/browsers/). This argument may be repeated to traverse multiple browsers. By default, the script will traverse all browsers.
 
 The `-f` or `--filter` argument may be any value accepted by `version_added` or `version_removed`. This argument may be repeated to test multiple values. By default, the script will traverse all features regardless of their value. The `-n` or `--non-real` argument may be included as a convenience alias for `-f null -f true`.
 


### PR DESCRIPTION
This PR fixes a few URLs that still refer to the `master` branch even though the repositories have already renamed them to `main`.  Note: the ESLint governance doc is the only URL referencing `master` left, but that is because the repository has been archived.