### PR TITLE
Update Firefox data for css.properties.list-style-type.upper-greek

### DIFF
--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -3598,7 +3598,7 @@
                 }
               ],
               "firefox": {
-                "version_added": "1"
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `upper-greek` member of the `list-style-type` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.5).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/list-style-type/upper-greek

Additional Notes: There are very few results in SearchFox for `upper-greek`: https://searchfox.org/mozilla-central/search?q=upper-greek&path=&case=false&regexp=false
