### PR TITLE
Update Chrome/Safari data for api.Element.animate.options_composite_parameter

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -300,13 +300,7 @@
             "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-keyframeeffectoptions-composite",
             "support": {
               "chrome": {
-                "version_added": "79",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features"
-                  }
-                ]
+                "version_added": "84"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -321,14 +315,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `animate.options_composite_parameter` member of the `Element` API. This mirrors the values from api.KeyframeEffect.composite
