### PR TITLE
Update Firefox data for api.PushManager.supportedContentEncodings_static

### DIFF
--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -353,7 +353,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": false
             },
             "firefox_android": {
               "version_added": "48"

--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -355,9 +355,7 @@
             "firefox": {
               "version_added": false
             },
-            "firefox_android": {
-              "version_added": "48"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `supportedContentEncodings_static` member of the `PushManager` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.0.5).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/PushManager/supportedContentEncodings_static
