### PR TITLE
Update Edge data for api.PushSubscription.subscriptionId

### DIFF
--- a/api/PushSubscription.json
+++ b/api/PushSubscription.json
@@ -228,7 +228,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤18"
+              "version_added": "17"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `subscriptionId` member of the `PushSubscription` API. This is honestly a guess, but it seems likely that this feature was supported since the entire interface was supported.
