### PR TITLE
fix: add a specs URL to css.properties.caption-side to cover all values

### DIFF
--- a/css/properties/caption-side.json
+++ b/css/properties/caption-side.json
@@ -4,7 +4,10 @@
       "caption-side": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/caption-side",
-          "spec_url": "https://drafts.csswg.org/css-logical/#caption-side",
+          "spec_url": [
+            "https://drafts.csswg.org/css2/#propdef-caption-side",
+            "https://drafts.csswg.org/css-logical/#caption-side"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/22271

As discussed on the issue page, we need both the spec URLs to cover all the values.