### PR TITLE
relnote(Fx115): isWellFormed and toWellFormed behind pref in 115

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -912,7 +912,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -2583,7 +2583,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
Nightly provides the pref `javascript.options.experimental.well_formed_unicode_strings` set to false (disabled) by default.

This allows for using the following methods:

- [`String.prototype.isWellFormed()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/isWellFormed)
- [`String.prototype.toWellFormed()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toWellFormed)


__Related issues and pull requests:__
- [ ] Parent issue https://github.com/mdn/content/issues/27173
- [ ] Content: https://github.com/mdn/content/pull/27600

__Bugzilla:__
- [BUG-1825005](https://bugzilla.mozilla.org/show_bug.cgi?id=1825005)
