### PR TITLE
CSS "offset-position": Update support in Firefox116 and Chrome

### DIFF
--- a/css/properties/offset-position.json
+++ b/css/properties/offset-position.json
@@ -48,9 +48,9 @@
             "deprecated": false
           }
         },
-        "normal-support": {
+        "normal": {
           "__compat": {
-            "description": "Support for <code>normal</code> keyword value",
+            "description": "<code>normal</code> keyword value",
             "support": {
               "chrome": {
                 "version_added": false

--- a/css/properties/offset-position.json
+++ b/css/properties/offset-position.json
@@ -7,14 +7,27 @@
           "spec_url": "https://drafts.fxtf.org/motion/#offset-position-property",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/638055'>bug 638055</a>."
+              "version_added": "115",
+              "notes": "The keyword `normal` is not part of the syntax.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1559232'>bug 1559232</a>."
+              "version_added": "115",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.motion-path-offset-position.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/offset-position.json
+++ b/css/properties/offset-position.json
@@ -8,7 +8,6 @@
           "support": {
             "chrome": {
               "version_added": "115",
-              "notes": "The keyword `normal` is not part of the syntax.",
               "flags": [
                 {
                   "type": "preference",
@@ -20,7 +19,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "115",
+              "version_added": "116",
               "flags": [
                 {
                   "type": "preference",
@@ -47,6 +46,46 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "normal-support": {
+          "__compat": {
+            "description": "Support for <code>normal</code> keyword value",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "116",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.motion-path-offset-position.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/css/properties/offset-position.json
+++ b/css/properties/offset-position.json
@@ -75,7 +75,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

1. Firefox 115 now supports the [`offset-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/offset-position) property behind the flag `layout.css.motion-path-offset-position.enabled`. I am working on creating the content PR to reflect the syntax changes on the property page.
Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1559232

2. The syntax for `offset-position` property has changed.
A new keyword (`normal`) has been added: https://drafts.fxtf.org/motion/#offset-position-property.
    - Firefox supports the new syntax
    - Chrome seems to support the `offset-position` property now but the new keyword is not yet supported.

#### Test results and supporting details

1. Screenshots
<details>
<summary>In Firefox 115 beta, behind the flag</summary>

![fx115-firefox-beta-behind-flag](https://github.com/mdn/browser-compat-data/assets/23019147/a408d28c-a960-4995-b930-2b9f69c95bba)

</details>

<details>
<summary>In Chrome beta (Version 115.0.5790.56 (Official Build) beta (x86_64)), experimental is enabled</summary>

![fx115-chrome-beta-flagonbydefault](https://github.com/mdn/browser-compat-data/assets/23019147/330ca05a-2480-4b0c-bdcc-5a3a338d7617)

</details>

<details>
<summary>In Chrome Canary</summary>

![fc115-chrome-canary](https://github.com/mdn/browser-compat-data/assets/23019147/dac1cbe0-6fb3-4dfb-b96b-0774825fe746)

</details>

2. WPT: https://wpt.fyi/results/css/motion/parsing/offset-position-parsing-valid.html?label=master&product=chrome-116%5Bexperimental%5D&product=chrome-115%5Bbeta%5D&product=firefox-115%5Bexperimental%5D&product=safari%5Bbeta%5D

#### Questions

1. Do I need to indicate in some way that the Chrome version in BCD is the beta version?
2. Canary does support the `normal` keyword in syntax. But both Canary and Beta versions don't seem to support keyword `<position>` values like `bottom`, `left`, `right`. Should I be adding a note to that effect? Should I add Canary instead of Beta info to the BCD table?
3. Not sure if I should retain the chrome bug link: https://crbug.com/638055. I am assuming there would be another bug (that I could not find) to track the syntax update.

#### Related issues

Doc tracker for this update: https://github.com/mdn/content/issues/27174

