### PR TITLE
Update Chromium-based browser release data

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -787,28 +787,41 @@
         },
         "113": {
           "release_date": "2023-05-02",
-           "release_notes": "https://chromereleases.googleblog.com/2023/05/stable-channel-update-for-desktop.html",
-          "status": "current",
+          "release_notes": "https://chromereleases.googleblog.com/2023/05/stable-channel-update-for-desktop.html",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "113"
         },
         "114": {
-          "release_date": "2023-05-24",
-          "status": "beta",
+          "release_date": "2023-05-30",
+          "release_notes": "https://chromereleases.googleblog.com/2023/05/stable-channel-update-for-desktop_30.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "114"
         },
         "115": {
-          "release_date": "2023-07-12",
-          "status": "nightly",
+          "release_date": "2023-07-18",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "115"
         },
         "116": {
-          "release_date": "2023-08-09",
-          "status": "planned",
+          "release_date": "2023-08-15",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "116"
+        },
+        "117": {
+          "release_date": "2023-09-12",
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "117"
+        },
+        "118": {
+          "release_date": "2023-10-10",
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "118"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -624,27 +624,40 @@
         "113": {
           "release_date": "2023-05-02",
           "release_notes": "https://chromereleases.googleblog.com/2023/05/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "113"
         },
         "114": {
-          "release_date": "2023-05-24",
-          "status": "beta",
+          "release_date": "2023-05-30",
+          "release_notes": "https://chromereleases.googleblog.com/2023/05/chrome-for-android-update_01893263616.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "114"
         },
         "115": {
-          "release_date": "2023-07-12",
-          "status": "nightly",
+          "release_date": "2023-07-18",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "115"
         },
         "116": {
-          "release_date": "2023-08-09",
-          "status": "planned",
+          "release_date": "2023-08-15",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "116"
+        },
+        "117": {
+          "release_date": "2023-09-12",
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "117"
+        },
+        "118": {
+          "release_date": "2023-10-10",
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "118"
         }
       }
     }

--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -291,21 +291,40 @@
         "113": {
           "release_date": "2023-05-05",
           "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1130177435-may-5-2023",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "113"
         },
         "114": {
-          "release_date": "2023-06-01",
-          "status": "beta",
+          "release_date": "2023-06-02",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1140182337-june-2-2023",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "114"
         },
         "115": {
           "release_date": "2023-07-20",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "115"
+        },
+        "116": {
+          "release_date": "2023-08-10",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "116"
+        },
+        "117": {
+          "release_date": "2023-09-14",
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "116"
+        },
+        "118": {
+          "release_date": "2023-10-12",
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "118"
         }
       }
     }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -588,27 +588,40 @@
         "113": {
           "release_date": "2023-05-02",
           "release_notes": "https://chromereleases.googleblog.com/2023/05/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "113"
         },
         "114": {
-          "release_date": "2023-05-24",
-          "status": "beta",
+          "release_date": "2023-05-30",
+          "release_notes": "https://chromereleases.googleblog.com/2023/05/chrome-for-android-update_01893263616.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "114"
         },
         "115": {
-          "release_date": "2023-07-12",
-          "status": "nightly",
+          "release_date": "2023-07-18",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "115"
         },
         "116": {
-          "release_date": "2023-08-09",
-          "status": "planned",
+          "release_date": "2023-08-15",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "116"
+        },
+        "117": {
+          "release_date": "2023-09-12",
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "117"
+        },
+        "118": {
+          "release_date": "2023-10-10",
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "118"
         }
       }
     }


### PR DESCRIPTION
See https://chromiumdash.appspot.com/schedule and https://learn.microsoft.com/en-us/deployedge/microsoft-edge-release-schedule

For the dates, I'm using "Stable Release" and not "Early Stable Release".