### PR TITLE
FF115 link element supports rel=modulepreload

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -819,7 +819,7 @@
                   "version_added": "≤79"
                 },
                 "firefox": {
-                  "version_added": null
+                  "version_added": "115"
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
FF115 supports `<link>` elements with [`rel="modulepreload"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/modulepreload) in https://bugzilla.mozilla.org/show_bug.cgi?id=1425310

Other docs work for this can be tracked in https://github.com/mdn/content/issues/27177