### PR TITLE
Update image-set() data for Safari

### DIFF
--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -194,13 +194,13 @@
               "opera_android": "mirror",
               "safari": [
                 {
-                  "version_added": "10"
+                  "version_added": "14"
                 },
                 {
                   "prefix": "-webkit-",
                   "version_added": "6",
                   "partial_implementation": true,
-                  "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit. See <a href='https://webkit.org/b/160934'>bug 160934</a>."
+                  "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit."
                 }
               ],
               "safari_ios": "mirror",

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1834,12 +1834,17 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": {
-                "prefix": "-webkit-",
-                "version_added": "6",
-                "partial_implementation": true,
-                "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit. See <a href='https://webkit.org/b/160934'>bug 160934</a>."
-              },
+              "safari": [
+                {
+                  "version_added": "14"
+                },
+                {
+                  "prefix": "-webkit-",
+                  "version_added": "6",
+                  "partial_implementation": true,
+                  "notes": "Support for <code>url</code> images only and <code>x</code> is the only supported resolution unit."
+                }
+              ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"


### PR DESCRIPTION
Fix https://github.com/mdn/browser-compat-data/issues/20246

See https://bugs.webkit.org/show_bug.cgi?id=160934 and which https://github.com/WebKit/WebKit/commit/52692677632e50f8d0e3a4b0f62c94e5520a47d9 which is tagged with Safari 14 as the earliest release.