### PR TITLE
Safari 13.1 supports CSS Q unit

### DIFF
--- a/css/types/length.json
+++ b/css/types/length.json
@@ -63,7 +63,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "13.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
Fix https://github.com/mdn/browser-compat-data/issues/20261

> Done in: https://trac.webkit.org/changeset/251662/webkit
> This revision was part of Safari 13.1 and later (See also GitHub's tag inclusion history [WebKit/WebKit@f158f1c](https://github.com/WebKit/WebKit/commit/f158f1c46209e61ab185d7729aa9146e322d03fb) )