### PR TITLE
Safari supports module import syntax in service workers

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1514,7 +1514,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
Fix https://github.com/mdn/browser-compat-data/issues/20219

Putting Safari 15 because https://github.com/WebKit/WebKit/commit/2433e3b41df9c903a64aa8a017541d80ec72d888 is tagged with "releases/Apple/Safari-15-iOS-15.0" as the earliest release.