### PR TITLE
Fix css-typed-om spec URLs

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -529,7 +529,7 @@
         "__compat": {
           "description": "<code>dvb()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-dvb",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-dvb",
           "support": {
             "chrome": {
               "version_added": "108"
@@ -564,7 +564,7 @@
         "__compat": {
           "description": "<code>dvh()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-dvh",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-dvh",
           "support": {
             "chrome": {
               "version_added": "108"
@@ -599,7 +599,7 @@
         "__compat": {
           "description": "<code>dvi()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-dvi",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-dvi",
           "support": {
             "chrome": {
               "version_added": "108"
@@ -634,7 +634,7 @@
         "__compat": {
           "description": "<code>dvmax()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-dvmax",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-dvmax",
           "support": {
             "chrome": {
               "version_added": "108"
@@ -669,7 +669,7 @@
         "__compat": {
           "description": "<code>dvmin()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-dvmin",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-dvmin",
           "support": {
             "chrome": {
               "version_added": "108"
@@ -704,7 +704,7 @@
         "__compat": {
           "description": "<code>dvw()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-dvw",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-dvw",
           "support": {
             "chrome": {
               "version_added": "108"
@@ -1019,7 +1019,7 @@
         "__compat": {
           "description": "<code>lvb()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-lvb",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-lvb",
           "support": {
             "chrome": {
               "version_added": "108"
@@ -1054,7 +1054,7 @@
         "__compat": {
           "description": "<code>lvh()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-lvh",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-lvh",
           "support": {
             "chrome": {
               "version_added": "108"
@@ -1089,7 +1089,7 @@
         "__compat": {
           "description": "<code>lvi()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-lvi",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-lvi",
           "support": {
             "chrome": {
               "version_added": "108"
@@ -1124,7 +1124,7 @@
         "__compat": {
           "description": "<code>lvmax()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-lvmax",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-lvmax",
           "support": {
             "chrome": {
               "version_added": "108"
@@ -1159,7 +1159,7 @@
         "__compat": {
           "description": "<code>lvmin()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-lvmin",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-lvmin",
           "support": {
             "chrome": {
               "version_added": "108"
@@ -1194,7 +1194,7 @@
         "__compat": {
           "description": "<code>lvw()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-lvw",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-lvw",
           "support": {
             "chrome": {
               "version_added": "108"
@@ -1718,7 +1718,7 @@
         "__compat": {
           "description": "<code>svb()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-svb",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-svb",
           "support": {
             "chrome": {
               "version_added": "108"
@@ -1753,7 +1753,7 @@
         "__compat": {
           "description": "<code>svh()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-svh",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-svh",
           "support": {
             "chrome": {
               "version_added": "108"
@@ -1788,7 +1788,7 @@
         "__compat": {
           "description": "<code>svi()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-svi",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-svi",
           "support": {
             "chrome": {
               "version_added": "108"
@@ -1823,7 +1823,7 @@
         "__compat": {
           "description": "<code>svmax()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-svmax",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-svmax",
           "support": {
             "chrome": {
               "version_added": "108"
@@ -1858,7 +1858,7 @@
         "__compat": {
           "description": "<code>svmin()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-svmin",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-svmin",
           "support": {
             "chrome": {
               "version_added": "108"
@@ -1893,7 +1893,7 @@
         "__compat": {
           "description": "<code>svw()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSS/factory_functions_static",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-css-svw",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-svw",
           "support": {
             "chrome": {
               "version_added": "108"

--- a/api/CSSMathClamp.json
+++ b/api/CSSMathClamp.json
@@ -2,7 +2,7 @@
   "api": {
     "CSSMathClamp": {
       "__compat": {
-        "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#cssmathclamp",
+        "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssmathclamp",
         "support": {
           "chrome": {
             "version_added": "100"
@@ -35,7 +35,7 @@
       "CSSMathClamp": {
         "__compat": {
           "description": "<code>CSSMathClamp()</code> constructor",
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-cssmathclamp-cssmathclamp",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssmathclamp-cssmathclamp",
           "support": {
             "chrome": {
               "version_added": "100"
@@ -68,7 +68,7 @@
       },
       "lower": {
         "__compat": {
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-cssmathclamp-lower",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssmathclamp-lower",
           "support": {
             "chrome": {
               "version_added": "100"
@@ -101,7 +101,7 @@
       },
       "upper": {
         "__compat": {
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-cssmathclamp-upper",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssmathclamp-upper",
           "support": {
             "chrome": {
               "version_added": "100"
@@ -134,7 +134,7 @@
       },
       "value": {
         "__compat": {
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-cssmathclamp-value",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-cssmathclamp-value",
           "support": {
             "chrome": {
               "version_added": "100"

--- a/api/MathMLElement.json
+++ b/api/MathMLElement.json
@@ -47,7 +47,7 @@
       },
       "attributeStyleMap": {
         "__compat": {
-          "spec_url": "https://drafts.css-houdini.org/css-typed-om-1/#dom-elementcssinlinestyle-attributestylemap",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-elementcssinlinestyle-attributestylemap",
           "support": {
             "chrome": {
               "version_added": "109"


### PR DESCRIPTION
These should all be using the unversioned URLs