### PR TITLE
Fix various CSS spec URLs

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -448,7 +448,7 @@
         "options_rangeEnd_parameter": {
           "__compat": {
             "description": "<code>options.rangeEnd</code> parameter",
-            "spec_url": "https://w3c.github.io/csswg-drafts/web-animations-2/#dom-keyframeanimationoptions-rangeend",
+            "spec_url": "https://drafts.csswg.org/web-animations-2/#dom-keyframeanimationoptions-rangeend",
             "support": {
               "chrome": {
                 "version_added": "115"
@@ -482,7 +482,7 @@
         "options_rangeStart_parameter": {
           "__compat": {
             "description": "<code>options.rangeStart</code> parameter",
-            "spec_url": "https://w3c.github.io/csswg-drafts/web-animations-2/#dom-keyframeanimationoptions-rangestart",
+            "spec_url": "https://drafts.csswg.org/web-animations-2/#dom-keyframeanimationoptions-rangestart",
             "support": {
               "chrome": {
                 "version_added": "115"

--- a/api/ScrollTimeline.json
+++ b/api/ScrollTimeline.json
@@ -3,7 +3,7 @@
     "ScrollTimeline": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScrollTimeline",
-        "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#scrolltimeline-interface",
+        "spec_url": "https://drafts.csswg.org/scroll-animations-1/#scrolltimeline-interface",
         "support": {
           "chrome": {
             "version_added": "115"
@@ -37,7 +37,7 @@
         "__compat": {
           "description": "<code>ScrollTimeline()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScrollTimeline/ScrollTimeline",
-          "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#dom-scrolltimeline-scrolltimeline",
+          "spec_url": "https://drafts.csswg.org/scroll-animations-1/#dom-scrolltimeline-scrolltimeline",
           "support": {
             "chrome": {
               "version_added": "115"
@@ -71,7 +71,7 @@
       "axis": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScrollTimeline/axis",
-          "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#dom-scrolltimeline-axis",
+          "spec_url": "https://drafts.csswg.org/scroll-animations-1/#dom-scrolltimeline-axis",
           "support": {
             "chrome": {
               "version_added": "115"
@@ -105,7 +105,7 @@
       "source": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScrollTimeline/scroll",
-          "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#dom-scrolltimeline-source",
+          "spec_url": "https://drafts.csswg.org/scroll-animations-1/#dom-scrolltimeline-source",
           "support": {
             "chrome": {
               "version_added": "115"

--- a/api/ViewTimeline.json
+++ b/api/ViewTimeline.json
@@ -3,7 +3,7 @@
     "ViewTimeline": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/ViewTimeline",
-        "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#viewtimeline-interface",
+        "spec_url": "https://drafts.csswg.org/scroll-animations-1/#viewtimeline-interface",
         "support": {
           "chrome": {
             "version_added": "115"
@@ -37,7 +37,7 @@
         "__compat": {
           "description": "<code>ViewTimeline()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ViewTimeline/ViewTimeline",
-          "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#dom-viewtimeline-viewtimeline",
+          "spec_url": "https://drafts.csswg.org/scroll-animations-1/#dom-viewtimeline-viewtimeline",
           "support": {
             "chrome": {
               "version_added": "115"
@@ -71,7 +71,7 @@
       "endOffset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ViewTimeline/endOffset",
-          "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#dom-viewtimeline-endoffset",
+          "spec_url": "https://drafts.csswg.org/scroll-animations-1/#dom-viewtimeline-endoffset",
           "support": {
             "chrome": {
               "version_added": "115"
@@ -105,7 +105,7 @@
       "startOffset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScrollTimeline/startOffset",
-          "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#dom-viewtimeline-startoffset",
+          "spec_url": "https://drafts.csswg.org/scroll-animations-1/#dom-viewtimeline-startoffset",
           "support": {
             "chrome": {
               "version_added": "115"
@@ -139,7 +139,7 @@
       "subject": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ScrollTimeline/subject",
-          "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#dom-viewtimeline-subject",
+          "spec_url": "https://drafts.csswg.org/scroll-animations-1/#dom-viewtimeline-subject",
           "support": {
             "chrome": {
               "version_added": "115"

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -137,7 +137,7 @@
         "named_range_keyframes": {
           "__compat": {
             "description": "Named timeline range keyframe selectors",
-            "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#named-range-keyframes",
+            "spec_url": "https://drafts.csswg.org/scroll-animations-1/#named-range-keyframes",
             "support": {
               "chrome": {
                 "version_added": "115"

--- a/css/properties/animation-range-end.json
+++ b/css/properties/animation-range-end.json
@@ -4,7 +4,7 @@
       "animation-range-end": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-range-end",
-          "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#animation-range-end",
+          "spec_url": "https://drafts.csswg.org/scroll-animations-1/#animation-range-end",
           "support": {
             "chrome": {
               "version_added": "115"

--- a/css/properties/animation-range-start.json
+++ b/css/properties/animation-range-start.json
@@ -4,7 +4,7 @@
       "animation-range-start": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-range-start",
-          "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#animation-range-start",
+          "spec_url": "https://drafts.csswg.org/scroll-animations-1/#animation-range-start",
           "support": {
             "chrome": {
               "version_added": "115"

--- a/css/properties/animation-range.json
+++ b/css/properties/animation-range.json
@@ -4,7 +4,7 @@
       "animation-range": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-range",
-          "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#animation-range",
+          "spec_url": "https://drafts.csswg.org/scroll-animations-1/#animation-range",
           "support": {
             "chrome": {
               "version_added": "115"

--- a/css/properties/animation-timeline.json
+++ b/css/properties/animation-timeline.json
@@ -70,7 +70,7 @@
           "__compat": {
             "description": "<code>scroll()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-timeline/scroll",
-            "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#scroll-notation",
+            "spec_url": "https://drafts.csswg.org/scroll-animations-1/#scroll-notation",
             "support": {
               "chrome": {
                 "version_added": "115"
@@ -133,7 +133,7 @@
           "__compat": {
             "description": "<code>view()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-timeline/view",
-            "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#view-notation",
+            "spec_url": "https://drafts.csswg.org/scroll-animations-1/#view-notation",
             "support": {
               "chrome": {
                 "version_added": "115"

--- a/css/properties/view-timeline-axis.json
+++ b/css/properties/view-timeline-axis.json
@@ -4,7 +4,7 @@
       "view-timeline-axis": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/view-timeline-axis",
-          "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#view-timeline-axis",
+          "spec_url": "https://drafts.csswg.org/scroll-animations-1/#view-timeline-axis",
           "support": {
             "chrome": {
               "version_added": "115"

--- a/css/properties/view-timeline-inset.json
+++ b/css/properties/view-timeline-inset.json
@@ -4,7 +4,7 @@
       "view-timeline-inset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/view-timeline-inset",
-          "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#view-timeline-inset",
+          "spec_url": "https://drafts.csswg.org/scroll-animations-1/#view-timeline-inset",
           "support": {
             "chrome": {
               "version_added": "115"

--- a/css/properties/view-timeline-name.json
+++ b/css/properties/view-timeline-name.json
@@ -4,7 +4,7 @@
       "view-timeline-name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/view-timeline-name",
-          "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#view-timeline-name",
+          "spec_url": "https://drafts.csswg.org/scroll-animations-1/#view-timeline-name",
           "support": {
             "chrome": {
               "version_added": "115"

--- a/css/properties/view-timeline.json
+++ b/css/properties/view-timeline.json
@@ -4,7 +4,7 @@
       "view-timeline": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/view-timeline",
-          "spec_url": "https://w3c.github.io/csswg-drafts/scroll-animations-1/#view-timeline-shorthand",
+          "spec_url": "https://drafts.csswg.org/scroll-animations-1/#view-timeline-shorthand",
           "support": {
             "chrome": {
               "version_added": "115",

--- a/css/types/line-style.json
+++ b/css/types/line-style.json
@@ -4,7 +4,7 @@
       "line-style": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/line-style",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-backgrounds/#typedef-line-style",
+          "spec_url": "https://drafts.csswg.org/css-backgrounds/#typedef-line-style",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/css/types/overflow.json
+++ b/css/types/overflow.json
@@ -4,7 +4,7 @@
       "overflow": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/overflow_value",
-          "spec_url": "https://w3c.github.io/csswg-drafts/css-overflow/#propdef-overflow",
+          "spec_url": "https://drafts.csswg.org/css-overflow/#propdef-overflow",
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
These should all now (once again) be using the drafts.csswg.org URLs