### PR TITLE
New WebGPU support items Chrome 113-115

### DIFF
--- a/api/GPU.json
+++ b/api/GPU.json
@@ -120,6 +120,42 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "discrete_adapter_default_ac": {
+          "__compat": {
+            "description": "On AC power, discrete GPU returned if no <code>powerPreference</code> set.",
+            "support": {
+              "chrome": {
+                "version_added": "115",
+                "notes": "Currently supported on dual GPU macOS devices only."
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "wgslLanguageFeatures": {

--- a/api/GPURenderBundleEncoder.json
+++ b/api/GPURenderBundleEncoder.json
@@ -577,6 +577,42 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "unset_vertex_buffer": {
+          "__compat": {
+            "description": "Pass <code>null</code> to unset vertex buffer",
+            "support": {
+              "chrome": {
+                "version_added": "115",
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/api/GPURenderPassEncoder.json
+++ b/api/GPURenderPassEncoder.json
@@ -819,6 +819,42 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "unset_vertex_buffer": {
+          "__compat": {
+            "description": "Pass <code>null</code> to unset vertex buffer",
+            "support": {
+              "chrome": {
+                "version_added": "115",
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "setViewport": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

There are a few changes in Chrome's WebGPU implementation between 113 and 115. See @beaufortfrancois 's update articles at https://developer.chrome.com/tags/new-in-webgpu/. The ones that need compat data additions, IMO, are:

- https://developer.chrome.com/blog/new-in-webgpu-115/#unset-vertex-buffer
- https://developer.chrome.com/blog/new-in-webgpu-115/#get-discrete-gpu-by-default-on-ac-power

I'll make changes in the docs for these as well.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
