### PR TITLE
Fix view-transition-image-pair.json spec URLs

### DIFF
--- a/css/selectors/view-transition-image-pair.json
+++ b/css/selectors/view-transition-image-pair.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "<code>::view-transition-image-pair()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/::view-transition-image-pair",
-          "spec_url": "https://drafts.csswg.org/css-view-transitions/#::view-transition-old",
+          "spec_url": "https://drafts.csswg.org/css-view-transitions/#::view-transition-image-pair",
           "support": {
             "chrome": {
               "version_added": "111"


### PR DESCRIPTION
Flubbed this one in an earlier commit. This cleans it up.