### PR TITLE
added the release and flag for view() in firefox

### DIFF
--- a/css/properties/animation-timeline.json
+++ b/css/properties/animation-timeline.json
@@ -145,7 +145,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "layout.css.scroll-linked-animations.enabled",
+                    "name": "layout.css.scroll-driven-animations.enabled",
                     "value_to_set": "true"
                   }
                 ]

--- a/css/properties/animation-timeline.json
+++ b/css/properties/animation-timeline.json
@@ -141,7 +141,14 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "114",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-linked-animations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
#### Summary

Added the version added to firefox for `view()` and the associated feature flag

#### Test results and supporting details

#### Related issues

- [bugzilla 1808410](https://bugzilla.mozilla.org/show_bug.cgi?id=1808410)
- Associated MDN Content issues: [26685](https://github.com/mdn/content/issues/26685) & [26687](https://github.com/mdn/content/issues/26687)
- Associated MDN Content PR - [27075](https://github.com/mdn/content/pull/27075)