### PR TITLE
updated the view-timeline-axis values for firefox

### DIFF
--- a/css/properties/view-timeline-axis.json
+++ b/css/properties/view-timeline-axis.json
@@ -11,17 +11,31 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "111",
-              "notes": "Supports the deprecated <code>horizontal</code> and <code>vertical</code> values, and not the <code>x</code> and <code>y</code> values.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.scroll-driven-animations.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "114",
+                "notes": "Now supports the <code>x</code> and <code>y</code> values, and also the deprecated <code>horizontal</code> and <code>vertical</code> values.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-driven-animations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "111",
+                "version_removed": "114",
+                "notes": "Supports the deprecated <code>horizontal</code> and <code>vertical</code> values, and not the <code>x</code> and <code>y</code> values.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-driven-animations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/css/properties/view-timeline.json
+++ b/css/properties/view-timeline.json
@@ -13,17 +13,31 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "111",
-              "notes": "Supports the deprecated <code>horizontal</code> and <code>vertical</code> axis values, and not the <code>x</code> and <code>y</code> values.",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.scroll-driven-animations.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "114",
+                "notes": "Now supports the <code>x</code> and <code>y</code> values, and also the deprecated <code>horizontal</code> and <code>vertical</code> values.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-driven-animations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              {
+                "version_added": "111",
+                "version_removed": "114",
+                "notes": "Supports the deprecated <code>horizontal</code> and <code>vertical</code> values, and not the <code>x</code> and <code>y</code> values.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-driven-animations.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
#### Summary

Updated the notes for firefox for the `view-timeline-axis` so that it shows support for `x` & `y`.

#### Test results and supporting details

[codepen](https://codepen.io/CodeRedDigital/pen/KKGOXqQ?editors=1100) showing:
- `view-timeline-axis: y;`
- `view-timeline-axis: vertical;`

#### Related issues

- [bugzilla 1737920](https://bugzilla.mozilla.org/show_bug.cgi?id=1737920)
- Associated MDN Content issues: [26685](https://github.com/mdn/content/issues/26685) & [26687](https://github.com/mdn/content/issues/26687)
- Associated MDN Content PR - [27075](https://github.com/mdn/content/pull/27075)