### PR TITLE
Update for Deno v1.35

### DIFF
--- a/api/Headers.json
+++ b/api/Headers.json
@@ -334,7 +334,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "1.35"
             },
             "edge": "mirror",
             "firefox": {

--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -317,7 +317,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.35"
               },
               "edge": "mirror",
               "firefox": {
@@ -566,7 +566,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.35"
               },
               "edge": "mirror",
               "firefox": {

--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -247,9 +247,16 @@
         "1.34": {
           "release_date": "2023-05-24",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.34.0",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "11.5"
+        },
+        "1.35": {
+          "release_date": "2023-07-05",
+          "release_notes": "https://github.com/denoland/deno/releases/tag/v1.35.0",
+          "status": "current",
+          "engine": "V8",
+          "engine_version": "11.6"
         }
       }
     }


### PR DESCRIPTION
#### Summary

Update `Headers.getSetCookie`, `URLSearchParams.delete` and `URLSearchParams.has` for Deno v1.35.

https://deno.com/blog/v1.35

