### PR TITLE
Firefox supports CanvasCaptureMediaStreamTrack

### DIFF
--- a/api/CanvasCaptureMediaStreamTrack.json
+++ b/api/CanvasCaptureMediaStreamTrack.json
@@ -11,14 +11,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "41",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "canvas.capturestream.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "43"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -51,14 +44,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "41",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "canvas.capturestream.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "43"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -92,14 +78,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "41",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "canvas.capturestream.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "43"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
Firefox has supported this feature since v43

https://bugzilla.mozilla.org/show_bug.cgi?id=1177276