### PR TITLE
FF116 supports audio output API

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2754,22 +2754,13 @@
             "edge": {
               "version_added": "17"
             },
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "64",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.setsinkid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": "mirror",
+            "firefox": {
+              "version_added": "116"
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Not available due to a limitation in Android (see <a href='https://bugzil.la/1473346'>bug 1473346</a>)."
+            },
             "ie": {
               "version_added": false
             },
@@ -2805,22 +2796,13 @@
             "edge": {
               "version_added": "17"
             },
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "64",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.setsinkid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": "mirror",
+            "firefox": {
+              "version_added": "116"
+            },
+            "firefox_android": {
+              "version_added": false,
+              "notes": "Not available due to a limitation in Android (see <a href='https://bugzil.la/1473346'>bug 1473346</a>)."
+            },
             "ie": {
               "version_added": false
             },
@@ -2835,7 +2817,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -101,24 +101,13 @@
             },
             "firefox": [
               {
-                "version_added": "preview",
+                "version_added": "116",
                 "notes": "<code>enumerateDevices()</code> enumerates both input and output devices. Previously only input devices were returned."
               },
               {
                 "version_added": "39",
                 "partial_implementation": true,
                 "notes": "<code>enumerateDevices()</code> only returns input devices."
-              },
-              {
-                "version_added": "63",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.setsinkid.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Before Firefox 63, <code>enumerateDevices()</code> only returned input devices. Starting with Firefox 63, output devices are also included if the <code>media.setsinkid.enabled</code> preference is enabled."
               }
             ],
             "firefox_android": "mirror",
@@ -567,22 +556,12 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "88",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "media.setsinkid.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
-            "firefox_android": "mirror",
+            "firefox": {
+              "version_added": "116"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },

--- a/http/headers/Feature-Policy.json
+++ b/http/headers/Feature-Policy.json
@@ -924,26 +924,15 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "preview",
-                  "partial_implementation": true,
-                  "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
-                },
-                {
-                  "version_added": "92",
-                  "partial_implementation": true,
-                  "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements.",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.setsinkid.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "116",
+                "partial_implementation": true,
+                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "Not available due to a limitation in Android (see <a href='https://bugzil.la/1473346'>bug 1473346</a>)."
+              },
               "ie": {
                 "version_added": false
               },

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -1245,28 +1245,16 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "preview",
-                  "alternative_name": "Feature-Policy: speaker-selection",
-                  "partial_implementation": true,
-                  "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
-                },
-                {
-                  "version_added": "92",
-                  "alternative_name": "Feature-Policy: speaker-selection",
-                  "partial_implementation": true,
-                  "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements.",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "media.setsinkid.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
-              "firefox_android": "mirror",
+              "firefox": {
+                "version_added": "116",
+                "alternative_name": "Feature-Policy: speaker-selection",
+                "partial_implementation": true,
+                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+              },
+              "firefox_android": {
+                "version_added": false,
+                "notes": "Not available due to a limitation in Android (see <a href='https://bugzil.la/1473346'>bug 1473346</a>)."
+              },
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
FF116 supports the audio output API in https://bugzilla.mozilla.org/show_bug.cgi?id=1498512 - by enabling `media.setsinkid.enabled` by default, except on Android. On android there is a bug which means it might not be implementable https://bugzilla.mozilla.org/show_bug.cgi?id=1473346

This finds all instances of the preference, sets the release version to match the old preview, removes preferenced version, sets firefox-android to false with a Note/bug link.

This is part of work in https://github.com/mdn/content/issues/27748