### PR TITLE
Fix description of `URL.canParse()`

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -131,6 +131,7 @@
       },
       "canParse_static": {
         "__compat": {
+          "description": "<code>canParse()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/canParse_static",
           "spec_url": "https://url.spec.whatwg.org/#ref-for-dom-url-canparse",
           "support": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Fix the description of `URL.canParse()` from "`canParse_static`" to "`canParse()` static method", matching the other static methods of the `URL`.