### PR TITLE
Fix message displayed when invalid browser version found

### DIFF
--- a/test/linter/test-versions.ts
+++ b/test/linter/test-versions.ts
@@ -170,7 +170,7 @@ const checkVersions = (
         if (!isValidVersion(browser, category, version)) {
           logger.error(
             chalk`{bold ${property}: "${version}"} is {bold NOT} a valid version number for {bold ${browser}}\n    Valid {bold ${browser}} versions are: ${Object.keys(
-              browsers[browser],
+              browsers[browser].releases,
             ).join(', ')}`,
             { tip: browserTips[browser] },
           );


### PR DESCRIPTION
This PR fixes a bug found in https://github.com/mdn/browser-compat-data/actions/runs/5458481317/jobs/9933610824?pr=20295 where the keys of the browser object are listed off, rather than all the version numbers.
