### PR TITLE
release firefox 115

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -823,28 +823,28 @@
         "114": {
           "release_date": "2023-06-06",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/114",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "114"
         },
         "115": {
           "release_date": "2023-07-04",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/115",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "116"
         },
         "116": {
           "release_date": "2023-08-01",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/116",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "116"
         },
         "117": {
           "release_date": "2023-08-29",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/117",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "117"
         },

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -690,28 +690,28 @@
         "114": {
           "release_date": "2023-06-06",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/114",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "114"
         },
         "115": {
           "release_date": "2023-07-04",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/115",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "116"
         },
         "116": {
           "release_date": "2023-08-01",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/116",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "116"
         },
         "117": {
           "release_date": "2023-08-29",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/117",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "117"
         },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 115 got released

#### Test results and supporting details

Release Notes: https://www.mozilla.org/en-US/firefox/115.0/releasenotes/
