### PR TITLE
fix firefox 115 engine_version

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -832,7 +832,7 @@
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/115",
           "status": "beta",
           "engine": "Gecko",
-          "engine_version": "116"
+          "engine_version": "115"
         },
         "116": {
           "release_date": "2023-08-01",

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -699,7 +699,7 @@
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/115",
           "status": "beta",
           "engine": "Gecko",
-          "engine_version": "116"
+          "engine_version": "115"
         },
         "116": {
           "release_date": "2023-08-01",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 115 should have `engine_version` 115. Think this was a copy/paste error
