### PR TITLE
Update Safari iOS data for api.Notification.tag

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -1045,7 +1045,8 @@
               "version_added": "7"
             },
             "safari_ios": {
-              "version_added": "16.4"
+              "version_added": false,
+              "notes": "This property is exposed but is not implemented. See <a href='https://webkit.org/b/258922'>WebKit bug 258922</a>."
             },
             "samsunginternet_android": "mirror",
             "webview_android": {


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `tag` member of the `Notification` API. The data comes from a bug in the web browser's bug tracker.

Bug: https://webkit.org/b/258922

Additional Notes: Fixes #20305.
