### PR TITLE
Update Edge data for IdleDetector API

### DIFF
--- a/api/IdleDetector.json
+++ b/api/IdleDetector.json
@@ -9,10 +9,15 @@
             "version_added": "94"
           },
           "chrome_android": "mirror",
-          "edge": {
-            "version_added": "94",
-            "version_removed": "96"
-          },
+          "edge": [
+            {
+              "version_added": "114"
+            },
+            {
+              "version_added": "94",
+              "version_removed": "96"
+            }
+          ],
           "firefox": {
             "version_added": false
           },
@@ -46,10 +51,15 @@
               "version_added": "94"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "94",
-              "version_removed": "96"
-            },
+            "edge": [
+              {
+                "version_added": "114"
+              },
+              {
+                "version_added": "94",
+                "version_removed": "96"
+              }
+            ],
             "firefox": {
               "version_added": false
             },
@@ -84,10 +94,15 @@
               "version_added": "94"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "94",
-              "version_removed": "96"
-            },
+            "edge": [
+              {
+                "version_added": "114"
+              },
+              {
+                "version_added": "94",
+                "version_removed": "96"
+              }
+            ],
             "firefox": {
               "version_added": false
             },
@@ -122,10 +137,15 @@
               "version_added": "94"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "94",
-              "version_removed": "96"
-            },
+            "edge": [
+              {
+                "version_added": "114"
+              },
+              {
+                "version_added": "94",
+                "version_removed": "96"
+              }
+            ],
             "firefox": {
               "version_added": false
             },
@@ -159,10 +179,15 @@
               "version_added": "94"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "94",
-              "version_removed": "96"
-            },
+            "edge": [
+              {
+                "version_added": "114"
+              },
+              {
+                "version_added": "94",
+                "version_removed": "96"
+              }
+            ],
             "firefox": {
               "version_added": false
             },
@@ -196,10 +221,15 @@
               "version_added": "94"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "94",
-              "version_removed": "96"
-            },
+            "edge": [
+              {
+                "version_added": "114"
+              },
+              {
+                "version_added": "94",
+                "version_removed": "96"
+              }
+            ],
             "firefox": {
               "version_added": false
             },
@@ -233,10 +263,15 @@
               "version_added": "94"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "94",
-              "version_removed": "96"
-            },
+            "edge": [
+              {
+                "version_added": "114"
+              },
+              {
+                "version_added": "94",
+                "version_removed": "96"
+              }
+            ],
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `IdleDetector` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.1.0).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/IdleDetector

Additional Notes: Fixes #20288.
