### PR TITLE
Update Firefox data for api.Event.composed

### DIFF
--- a/api/Event.json
+++ b/api/Event.json
@@ -274,7 +274,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "52"
+              "version_added": "52",
+              "notes": "Before Firefox 95, this property was incorrectly set to <code>false</code> on <code>&lt;select&gt;</code> and <code>&lt;input type='checkbox'&gt;</code> elements."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `composed` member of the `Event` API. This adds a note that fixes #16770; details for testingand information in the linked issue.
