### PR TITLE
Update Chromium data for FontFaceSet API

### DIFF
--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -6,7 +6,8 @@
         "spec_url": "https://drafts.csswg.org/css-font-loading/#FontFaceSet-interface",
         "support": {
           "chrome": {
-            "version_added": "35"
+            "version_added": "35",
+            "notes": "Chrome does not expose the <code>FontFaceSet</code> interface directly, and is only available through <a href='https://developer.mozilla.org/docs/Web/API/Document/fonts'><code>Document.fonts</code></a> or <a href='https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/fonts'><code>WorkerGlobalScope.fonts</code></a>."
           },
           "chrome_android": "mirror",
           "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `FontFaceSet` API. This fixes #7662 by adding a note as requested.
