### PR TITLE
FF116 CSP script-src support external file with hash

### DIFF
--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -985,6 +985,7 @@
           "external_scripts": {
             "__compat": {
               "description": "External scripts with hash",
+              "spec_url": "https://w3c.github.io/webappsec-csp/#external-hash",
               "support": {
                 "chrome": {
                   "version_added": "59"

--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -984,7 +984,7 @@
           },
           "external_scripts": {
             "__compat": {
-              "description": "With external scripts",
+              "description": "External scripts with hash",
               "support": {
                 "chrome": {
                   "version_added": "59"
@@ -994,7 +994,7 @@
                   "version_added": "≤79"
                 },
                 "firefox": {
-                  "version_added": null
+                  "version_added": "116"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -1004,7 +1004,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": null
+                  "version_added": "15.6"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
FF116 supports the CSP3 feature of allowing hash source expressions to match external scripts, rather than just inline scripts, in https://bugzilla.mozilla.org/show_bug.cgi?id=1409200. This adds the entry.

I've also modified the description  for the feature because "external scripts" wasn't sufficient to be able to work out what the feature is for. Even knowing what it was "probably" for I wasn't certain until I found https://chromestatus.com/feature/4626666856906752 which had a matching release number.
Not just me - lots of questions about why this does not work on the net, so clearly people did not see it on the page as "not supported"

Other docs work for this can be tracked in https://github.com/mdn/content/issues/27749