### PR TITLE
Update Firefox data for api.Window.prompt

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3939,7 +3939,8 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "Firefox strips newline characters from the prompt response; see <a href='https://bugzil.la/1716229'>bug 1716229</a>."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `prompt` member of the `Window` API. This fixes #10994 by adding a note regarding Firefox's behavior regarding newlines.
