### PR TITLE
Update Safari data for api.URL.searchParams

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -729,7 +729,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10"
+              "version_added": "10.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `searchParams` member of the `URL` API. This fixes #11330 by synchronizing the data with URLSearchParams.
