### PR TITLE
Remove css.properties.column-width.intrinsic_sizes from BCD

### DIFF
--- a/css/properties/column-width.json
+++ b/css/properties/column-width.json
@@ -105,40 +105,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "intrinsic_sizes": {
-          "__compat": {
-            "description": "Intrinsic sizes",
-            "support": {
-              "chrome": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/964183'>bug 964183</a>."
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
This PR removes the `intrinsic_sizes` member of the `column-width` CSS property from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.1.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/column-width/intrinsic_sizes

Additional Notes: The MDN article makes no mention of these sizes, and none of them are supported in browsers.
