### PR TITLE
Update word-break.json

### DIFF
--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -1,7 +1,7 @@
 {
   "css": {
     "properties": {
-      "break-all": {
+      "word-break": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/word-break",
           "spec_url": "https://drafts.csswg.org/css-text/#word-break-property",
@@ -115,6 +115,9 @@
               "deprecated": false
             }
           }
+        },
+        "break-all": {
+          
         }
       }
     }

--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -1,7 +1,7 @@
 {
   "css": {
     "properties": {
-      "word-break": {
+      "break-all": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/word-break",
           "spec_url": "https://drafts.csswg.org/css-text/#word-break-property",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
![image](https://github.com/mdn/browser-compat-data/assets/21235555/a82cf10c-26cc-4cbb-89b6-049df45b610d)

missing `break-all` prop



#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
