### PR TITLE
relnote(116): CSSPropertyRule enabled in Fx nightly by default

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -1552,7 +1552,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/CSSPropertyRule.json
+++ b/api/CSSPropertyRule.json
@@ -11,7 +11,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -44,7 +44,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -78,7 +78,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -112,7 +112,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -146,7 +146,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/at-rules/property.json
+++ b/css/at-rules/property.json
@@ -13,8 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1684605'>bug 1684605</a>."
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -48,7 +47,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -83,7 +82,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -118,7 +117,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
The pref `layout.css.properties-and-values.enabled` is set to true (enabled) on Nightly in 116. This allows for using the following APIs:

- [`CSSPropertyRule`](https://developer.mozilla.org/en-US/docs/Web/API/CSSPropertyRule)
- [`CSSPropertyRule.inherits`](https://developer.mozilla.org/en-US/docs/Web/API/CSSPropertyRule/inherits)
- [`CSSPropertyRule.initialvalue`](https://developer.mozilla.org/en-US/docs/Web/API/CSSPropertyRule/initialvalue)
- [`CSSPropertyRule.name`](https://developer.mozilla.org/en-US/docs/Web/API/CSSPropertyRule/name)
- [`CSSPropertyRule.syntax`](https://developer.mozilla.org/en-US/docs/Web/API/CSSPropertyRule/syntax)

- [`registerProperty()`](https://developer.mozilla.org/en-US/docs/Web/API/CSS/registerProperty_static)

And the following CSS syntax:

```css
@property --item-size {
  syntax: "<percentage>";
  inherits: true;
  initial-value: 40%;
}
```

__pen/demo:__
https://codepen.io/bsmth/pen/xxQpVow?editors=0111


__Related issues and pull requests:__
- [ ] Parent issue https://github.com/mdn/content/issues/27756
- [x] Content (Exp Features): https://github.com/mdn/content/pull/27902

__Bugzilla:__
- [BUG-1840480](https://bugzilla.mozilla.org/show_bug.cgi?id=1840480)
