### PR TITLE
Fix MDN URLs for WebAssembly JS API

### DIFF
--- a/javascript/builtins/WebAssembly.json
+++ b/javascript/builtins/WebAssembly.json
@@ -3,7 +3,7 @@
     "builtins": {
       "WebAssembly": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface",
           "spec_url": "https://webassembly.github.io/spec/js-api/#webassembly-namespace",
           "support": {
             "chrome": {
@@ -44,7 +44,7 @@
         },
         "compile": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/compile",
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/compile",
             "spec_url": "https://webassembly.github.io/spec/js-api/#dom-webassembly-compile",
             "support": {
               "chrome": {
@@ -86,7 +86,7 @@
         },
         "compileStreaming": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/compileStreaming",
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/compileStreaming",
             "spec_url": "https://webassembly.github.io/spec/web-api/#dom-webassembly-compilestreaming",
             "support": {
               "chrome": {
@@ -130,7 +130,7 @@
         },
         "instantiate": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiate",
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/instantiate",
             "spec_url": "https://webassembly.github.io/spec/js-api/#dom-webassembly-instantiate",
             "support": {
               "chrome": {
@@ -172,7 +172,7 @@
         },
         "instantiateStreaming": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming",
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/instantiateStreaming",
             "spec_url": "https://webassembly.github.io/spec/web-api/#dom-webassembly-instantiatestreaming",
             "support": {
               "chrome": {
@@ -216,7 +216,7 @@
         },
         "validate": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/validate",
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/validate",
             "spec_url": "https://webassembly.github.io/spec/js-api/#dom-webassembly-validate",
             "support": {
               "chrome": {

--- a/javascript/builtins/WebAssembly/CompileError.json
+++ b/javascript/builtins/WebAssembly/CompileError.json
@@ -4,7 +4,7 @@
       "WebAssembly": {
         "CompileError": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError",
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/CompileError",
             "spec_url": [
               "https://webassembly.github.io/spec/js-api/#exceptiondef-compileerror",
               "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-native-error-types-used-in-this-standard"
@@ -49,7 +49,7 @@
           "CompileError": {
             "__compat": {
               "description": "<code>CompileError()</code> constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/CompileError/CompileError",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/CompileError/CompileError",
               "spec_url": [
                 "https://webassembly.github.io/spec/js-api/#exceptiondef-compileerror",
                 "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-nativeerror-constructors"

--- a/javascript/builtins/WebAssembly/Exception.json
+++ b/javascript/builtins/WebAssembly/Exception.json
@@ -4,7 +4,7 @@
       "WebAssembly": {
         "Exception": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception",
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Exception",
             "spec_url": "https://webassembly.github.io/exception-handling/js-api/#runtime-exceptions",
             "support": {
               "chrome": {
@@ -44,7 +44,7 @@
           "Exception": {
             "__compat": {
               "description": "<code>Exception()</code> constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/Exception",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Exception/Exception",
               "spec_url": "https://webassembly.github.io/exception-handling/js-api/#dom-exception-exception",
               "support": {
                 "chrome": {
@@ -84,7 +84,7 @@
             "options_parameter_traceStack": {
               "__compat": {
                 "description": "<code>options.traceStack</code> parameter",
-                "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/Exception",
+                "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Exception/Exception",
                 "support": {
                   "chrome": {
                     "version_added": "95"
@@ -124,7 +124,7 @@
           },
           "getArg": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/getArg",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Exception/getArg",
               "spec_url": "https://webassembly.github.io/exception-handling/js-api/#dom-exception-getarg",
               "support": {
                 "chrome": {
@@ -164,7 +164,7 @@
           },
           "is": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/is",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Exception/is",
               "spec_url": "https://webassembly.github.io/exception-handling/js-api/#dom-exception-is",
               "support": {
                 "chrome": {
@@ -205,7 +205,7 @@
           "stack": {
             "__compat": {
               "description": "Stack trace",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Exception",
               "support": {
                 "chrome": {
                   "version_added": "95"

--- a/javascript/builtins/WebAssembly/Global.json
+++ b/javascript/builtins/WebAssembly/Global.json
@@ -4,7 +4,7 @@
       "WebAssembly": {
         "Global": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Global",
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Global",
             "spec_url": "https://webassembly.github.io/spec/js-api/#globals",
             "support": {
               "chrome": {
@@ -44,7 +44,7 @@
           "Global": {
             "__compat": {
               "description": "<code>Global()</code> constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Global/Global",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Global/Global",
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-global-global",
               "support": {
                 "chrome": {
@@ -87,7 +87,7 @@
           },
           "value": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Global/value",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Global/value",
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-global-value",
               "support": {
                 "chrome": {
@@ -127,7 +127,7 @@
           },
           "valueOf": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Global/valueOf",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Global/valueOf",
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-global-valueof",
               "support": {
                 "chrome": {

--- a/javascript/builtins/WebAssembly/Instance.json
+++ b/javascript/builtins/WebAssembly/Instance.json
@@ -4,7 +4,7 @@
       "WebAssembly": {
         "Instance": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance",
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Instance",
             "spec_url": "https://webassembly.github.io/spec/js-api/#instances",
             "support": {
               "chrome": {
@@ -46,7 +46,7 @@
           "Instance": {
             "__compat": {
               "description": "<code>Instance()</code> constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/Instance",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Instance/Instance",
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-instance-instance",
               "support": {
                 "chrome": {
@@ -88,7 +88,7 @@
           },
           "exports": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Instance/exports",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Instance/exports",
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-instance-exports",
               "support": {
                 "chrome": {

--- a/javascript/builtins/WebAssembly/LinkError.json
+++ b/javascript/builtins/WebAssembly/LinkError.json
@@ -4,7 +4,7 @@
       "WebAssembly": {
         "LinkError": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError",
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/LinkError",
             "spec_url": [
               "https://webassembly.github.io/spec/js-api/#exceptiondef-linkerror",
               "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-native-error-types-used-in-this-standard"
@@ -49,7 +49,7 @@
           "LinkError": {
             "__compat": {
               "description": "<code>LinkError()</code> constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/LinkError/LinkError",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/LinkError/LinkError",
               "spec_url": [
                 "https://webassembly.github.io/spec/js-api/#exceptiondef-linkerror",
                 "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-nativeerror-constructors"

--- a/javascript/builtins/WebAssembly/Memory.json
+++ b/javascript/builtins/WebAssembly/Memory.json
@@ -4,7 +4,7 @@
       "WebAssembly": {
         "Memory": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory",
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Memory",
             "spec_url": "https://webassembly.github.io/spec/js-api/#memories",
             "support": {
               "chrome": {
@@ -46,7 +46,7 @@
           "Memory": {
             "__compat": {
               "description": "<code>Memory()</code> constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/Memory",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Memory/Memory",
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-memory-memory",
               "support": {
                 "chrome": {
@@ -139,7 +139,7 @@
           },
           "buffer": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/buffer",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Memory/buffer",
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-memory-buffer",
               "support": {
                 "chrome": {
@@ -181,7 +181,7 @@
           },
           "grow": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/grow",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Memory/grow",
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-memory-grow",
               "support": {
                 "chrome": {

--- a/javascript/builtins/WebAssembly/Module.json
+++ b/javascript/builtins/WebAssembly/Module.json
@@ -4,7 +4,7 @@
       "WebAssembly": {
         "Module": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module",
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Module",
             "spec_url": "https://webassembly.github.io/spec/js-api/#modules",
             "support": {
               "chrome": {
@@ -46,7 +46,7 @@
           "Module": {
             "__compat": {
               "description": "<code>Module()</code> constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/Module",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Module/Module",
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-module-module",
               "support": {
                 "chrome": {
@@ -88,7 +88,7 @@
           },
           "customSections": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/customSections",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Module/customSections",
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-module-customsections",
               "support": {
                 "chrome": {
@@ -130,7 +130,7 @@
           },
           "exports": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/exports",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Module/exports",
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-module-exports",
               "support": {
                 "chrome": {
@@ -172,7 +172,7 @@
           },
           "imports": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Module/imports",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Module/imports",
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-module-imports",
               "support": {
                 "chrome": {

--- a/javascript/builtins/WebAssembly/RuntimeError.json
+++ b/javascript/builtins/WebAssembly/RuntimeError.json
@@ -4,7 +4,7 @@
       "WebAssembly": {
         "RuntimeError": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError",
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/RuntimeError",
             "spec_url": [
               "https://webassembly.github.io/spec/js-api/#exceptiondef-runtimeerror",
               "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-native-error-types-used-in-this-standard"
@@ -49,7 +49,7 @@
           "RuntimeError": {
             "__compat": {
               "description": "<code>RuntimeError()</code> constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/RuntimeError/RuntimeError",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/RuntimeError/RuntimeError",
               "spec_url": [
                 "https://webassembly.github.io/spec/js-api/#exceptiondef-runtimeerror",
                 "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-nativeerror-constructors"

--- a/javascript/builtins/WebAssembly/Table.json
+++ b/javascript/builtins/WebAssembly/Table.json
@@ -4,7 +4,7 @@
       "WebAssembly": {
         "Table": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table",
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Table",
             "spec_url": "https://webassembly.github.io/spec/js-api/#tables",
             "support": {
               "chrome": {
@@ -46,7 +46,7 @@
           "Table": {
             "__compat": {
               "description": "<code>Table()</code> constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/Table",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Table/Table",
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-table-table",
               "support": {
                 "chrome": {
@@ -88,7 +88,7 @@
           },
           "get": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/get",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Table/get",
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-table-get",
               "support": {
                 "chrome": {
@@ -130,7 +130,7 @@
           },
           "grow": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/grow",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Table/grow",
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-table-grow",
               "support": {
                 "chrome": {
@@ -172,7 +172,7 @@
           },
           "length": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/length",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Table/length",
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-table-length",
               "support": {
                 "chrome": {
@@ -214,7 +214,7 @@
           },
           "set": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/set",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Table/set",
               "spec_url": "https://webassembly.github.io/spec/js-api/#dom-table-set",
               "support": {
                 "chrome": {

--- a/javascript/builtins/WebAssembly/Tag.json
+++ b/javascript/builtins/WebAssembly/Tag.json
@@ -4,7 +4,7 @@
       "WebAssembly": {
         "Tag": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag",
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Tag",
             "spec_url": "https://webassembly.github.io/exception-handling/js-api/#tags",
             "support": {
               "chrome": {
@@ -44,7 +44,7 @@
           "Tag": {
             "__compat": {
               "description": "<code>Tag()</code> constructor",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag/Tag",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Tag/Tag",
               "spec_url": "https://webassembly.github.io/exception-handling/js-api/#dom-tag-tag",
               "support": {
                 "chrome": {
@@ -84,7 +84,7 @@
           },
           "type": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag/type",
+              "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Tag/type",
               "spec_url": "https://webassembly.github.io/exception-handling/js-api/#dom-tag-type",
               "support": {
                 "chrome": {


### PR DESCRIPTION
This PR fixes the MDN URLs for the WebAssembly JavaScript API to match the URLs that you are redirected to when going to the old URLs.
