### PR TITLE
Temporal.now -> Temporal.Now

### DIFF
--- a/javascript/builtins/Temporal/Now.json
+++ b/javascript/builtins/Temporal/Now.json
@@ -2,10 +2,10 @@
   "javascript": {
     "builtins": {
       "Temporal": {
-        "now": {
+        "Now": {
           "__compat": {
-            "description": "Temporal.now interface",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/now",
+            "description": "Temporal.Now interface",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Temporal/Now",
             "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal-now-object",
             "support": {
               "chrome": {
@@ -41,7 +41,7 @@
           },
           "instant": {
             "__compat": {
-              "description": "Temporal.now.instant()",
+              "description": "Temporal.Now.instant()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/instant",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.instant",
               "support": {
@@ -79,7 +79,7 @@
           },
           "plainDate": {
             "__compat": {
-              "description": "Temporal.now.plainDate()",
+              "description": "Temporal.Now.plainDate()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/plaindate",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.plaindate",
               "support": {
@@ -117,7 +117,7 @@
           },
           "plainDateISO": {
             "__compat": {
-              "description": "Temporal.now.plainDateISO()",
+              "description": "Temporal.Now.plainDateISO()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/plaindateiso",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.plaindateiso",
               "support": {
@@ -155,7 +155,7 @@
           },
           "plainDateTime": {
             "__compat": {
-              "description": "Temporal.now.plainDateTime()",
+              "description": "Temporal.Now.plainDateTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/plaindatetime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.plaindatetime",
               "support": {
@@ -193,7 +193,7 @@
           },
           "plainDateTimeISO": {
             "__compat": {
-              "description": "Temporal.now.plainDateTimeISO()",
+              "description": "Temporal.Now.plainDateTimeISO()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/plaindatetimeiso",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.plaindatetimeiso",
               "support": {
@@ -231,7 +231,7 @@
           },
           "timeZone": {
             "__compat": {
-              "description": "Temporal.now.timeZone()",
+              "description": "Temporal.Now.timeZone()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/timezone",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.timezone",
               "support": {
@@ -269,7 +269,7 @@
           },
           "zonedDateTime": {
             "__compat": {
-              "description": "Temporal.now.zonedDateTime()",
+              "description": "Temporal.Now.zonedDateTime()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/zoneddatetime",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.zoneddatetime",
               "support": {
@@ -307,7 +307,7 @@
           },
           "zonedDateTimeISO": {
             "__compat": {
-              "description": "Temporal.now.zonedDateTimeISO()",
+              "description": "Temporal.Now.zonedDateTimeISO()",
               "mdn_url": "https://developer.mozilla.org/docs/web/javascript/reference/global_objects/temporal/now/zoneddatetimeiso",
               "spec_url": "https://tc39.es/proposal-temporal/#sec-temporal.now.zoneddatetimeiso",
               "support": {


### PR DESCRIPTION
This PR corrects the capitalization of `Temporal.Now` to match the capitalization defined in the spec.
