### PR TITLE
FF116 TextMetrics.fontBoundingBoxAscent/Descent supported

### DIFF
--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -325,14 +325,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "74",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.textMetrics.fontBoundingBox.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "116"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -366,14 +359,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "74",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.textMetrics.fontBoundingBox.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "116"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF116 supports [TextMetrics.fontBoundingBoxAscent](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics/fontBoundingBoxAscent) and [TextMetrics.fontBoundingBoxDescent](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics/fontBoundingBoxDescent) in https://bugzilla.mozilla.org/show_bug.cgi?id=1801198

This updates the two records. 

Other docs work can be tracked in https://github.com/mdn/content/issues/27758

FYI @queengooborg 