### PR TITLE
Add support for HTMLDialogElement.close_event in Chrome Android

### DIFF
--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -116,9 +116,7 @@
             "chrome": {
               "version_added": "37"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": "98"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updated HTMLDialogElement.json because HTMLDialogElement.close_event is already supported in Chrome Android v37.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

https://chromestatus.com/feature/5770237022568448
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
Fixes #20351 
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
