### PR TITLE
Add flagged Chrome support for prefers-reduced-transparency

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1307,7 +1307,15 @@
             "spec_url": "https://drafts.csswg.org/mediaqueries-5/#prefers-reduced-transparency",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "preview",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "impl_url": "https://crbug.com/1424879"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1330,7 +1338,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/175497"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add flagged Chrome support for prefers-reduced-transparency

Also add link to WebKit bug tracking its implementation

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

https://chromium-review.googlesource.com/c/chromium/src/+/4671150 - Here's my merged Chromium patch that adds this media query behind the experimental web platform features flag.

https://goose.icu/prefers-reduced-transparency in latest canary should show this as supported

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
