### PR TITLE
WebGPU updates for Chrome 116

### DIFF
--- a/api/GPUAdapter.json
+++ b/api/GPUAdapter.json
@@ -243,6 +243,41 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "lost_device_on_duplicate": {
+          "__compat": {
+            "description": "Lost <code>GPUDevice</code> returned on duplicate calls.",
+            "support": {
+              "chrome": {
+                "version_added": "116"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -731,6 +731,41 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "videoframe_source": {
+          "__compat": {
+            "description": "<code>VideoFrame</code> object as source",
+            "support": {
+              "chrome": {
+                "version_added": "116"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "label": {

--- a/api/GPUPipelineError.json
+++ b/api/GPUPipelineError.json
@@ -72,6 +72,41 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "message_optional": {
+          "__compat": {
+            "description": "<code>message</code> parameter is optional",
+            "support": {
+              "chrome": {
+                "version_added": "116"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "reason": {

--- a/api/GPUQueue.json
+++ b/api/GPUQueue.json
@@ -79,6 +79,41 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "videoframe_source": {
+          "__compat": {
+            "description": "<code>VideoFrame</code> object as source",
+            "support": {
+              "chrome": {
+                "version_added": "116"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "label": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR adds some data points for [Chromium 116 WebGPU updates](https://pr-6763-static-dot-dcc-staging.uc.r.appspot.com/blog/new-in-webgpu-116), namely:

- `GPUDevice.importExternalTexture()` and `GPUQueue.copyExternalImageToTexture()` can now use a `VideoFrame` object as a source. Data point added for each.

- `GPUAdapter.requestDevice()` now returns a device that is immediately lost, if it has already been used to create a device (i.e. `requestDevice()` was already called.) rather than the promise being rejected with `null`. You can then get lost info from it via `GPUDevice.lost`. This needs to be added to the return value section. Data point added.

- `GPUPipelineError.GPUPipelineError()` message argument is now optional. Data point added.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
