### PR TITLE
Add data for Performance.interactionCount

### DIFF
--- a/api/Performance.json
+++ b/api/Performance.json
@@ -412,6 +412,46 @@
           }
         }
       },
+      "interactionCount": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Performance/interactionCount",
+          "spec_url": "https://w3c.github.io/event-timing/#dom-performance-interactioncount",
+          "support": {
+            "chrome": {
+              "version_added": "111"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "mark": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Performance/mark",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

[`Performance.interactionCount`](https://w3c.github.io/event-timing/#dom-performance-interactioncount) was added in Chrome 111; this PR adds data for it.

I'm leaving this as a draft for now; it is supposed to be available in Chrome 111+, but upon testing, I found that it wasn't available by default in release yet (it is available in Chrome Canary). I've asked Chrome engineering for an update on this.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
