### PR TITLE
FF116 Intl NumberFormat and PluralRules NumberFormat v3 updates

### DIFF
--- a/javascript/builtins/Intl/NumberFormat.json
+++ b/javascript/builtins/Intl/NumberFormat.json
@@ -962,6 +962,192 @@
                 "deprecated": false
               }
             },
+            "result_roundingIncrement_property": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "116"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "19.0.0"
+                  },
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "16.4"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "result_roundingMode_property": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "116"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "19.0.0"
+                  },
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "16.4"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "result_roundingPriority_property": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "116"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "19.0.0"
+                  },
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "16.4"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "result_signDisplay_property": {
+              "__compat": {
+                "description": "The result <code>signDisplay</code> parameter may contain <code>'auto'</code>, <code>'always'</code>, <code>'exceptZero'</code>, <code>negative</code> and <code>never</code> (previous versions did not allow <code>negative</code>)",
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "116"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "19.0.0"
+                  },
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "16.4"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "result_trailingZeroDisplay_property": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "116"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": "19.0.0"
+                  },
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "16.4"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
             "result_useGrouping_property": {
               "__compat": {
                 "description": "The result <code>useGrouping</code> parameter may contain <code>'always'</code>, <code>'auto'</code>, <code>'min2'</code>, <code>true</code> and <code>false</code> (previous versions may only contain <code>true</code> and <code>false</code>)",

--- a/javascript/builtins/Intl/NumberFormat.json
+++ b/javascript/builtins/Intl/NumberFormat.json
@@ -964,6 +964,7 @@
             },
             "result_roundingIncrement_property": {
               "__compat": {
+                "description": "The result <code>roundingMode</code> parameter with possible integer values:<code>'1'</code>, <code>'2'</code>, <code>'5'</code>, <code>'10'</code>, <code>'20'</code>, <code>'25'</code>, <code>'50'</code>, <code>'100'</code>, <code>'2000'</code>, <code>'2500'</code>, <code>'5000'</code>.",
                 "support": {
                   "chrome": {
                     "version_added": "106"
@@ -1001,6 +1002,7 @@
             },
             "result_roundingMode_property": {
               "__compat": {
+                "description": "The result <code>roundingMode</code> parameter with possible values:<code>'ceil'</code>, <code>'floor'</code>, <code>'expand'</code>, <code>'trunc'</code>, <code>'halfCeil'</code>, <code>'halfFloor'</code>, <code>'halfExpand'</code>, <code>'halfTrunc'</code>, <code>'halfEven'</code>.",
                 "support": {
                   "chrome": {
                     "version_added": "106"
@@ -1038,6 +1040,7 @@
             },
             "result_roundingPriority_property": {
               "__compat": {
+                "description": "The result <code>roundingPriority</code> parameter with possible values: <code>'auto'</code>, <code>'morePrecision'</code>, <code>'lessPrecision'</code>.",
                 "support": {
                   "chrome": {
                     "version_added": "106"
@@ -1113,6 +1116,7 @@
             },
             "result_trailingZeroDisplay_property": {
               "__compat": {
+                "description": "The result <code>trailingZeroDisplay</code> parameter with possible values: <code>'auto'</code>, <code>'stripIfInteger'</code>.",
                 "support": {
                   "chrome": {
                     "version_added": "106"

--- a/javascript/builtins/Intl/PluralRules.json
+++ b/javascript/builtins/Intl/PluralRules.json
@@ -92,6 +92,158 @@
                 "standard_track": true,
                 "deprecated": false
               }
+            },
+            "options_roundingIncrement_parameter": {
+              "__compat": {
+                "description": "<code>options.roundingIncrement</code> parameter",
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "116"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": false
+                  },
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "options_roundingMode_parameter": {
+              "__compat": {
+                "description": "<code>options.roundingMode</code> parameter",
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "116"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": false
+                  },
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "options_roundingPriority_parameter": {
+              "__compat": {
+                "description": "<code>options.roundingPriority</code> parameter",
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "116"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": false
+                  },
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "options_trailingZeroDisplay_parameter": {
+              "__compat": {
+                "description": "<code>options.trailingZeroDisplay</code> parameter",
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "116"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": false
+                  },
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
             }
           },
           "resolvedOptions": {
@@ -134,6 +286,158 @@
                 "experimental": false,
                 "standard_track": true,
                 "deprecated": false
+              }
+            },
+            "result_roundingIncrement_property": {
+              "__compat": {
+                "description": "The result <code>roundingMode</code> parameter with possible integer values:<code>'1'</code>, <code>'2'</code>, <code>'5'</code>, <code>'10'</code>, <code>'20'</code>, <code>'25'</code>, <code>'50'</code>, <code>'100'</code>, <code>'2000'</code>, <code>'2500'</code>, <code>'5000'</code>.",
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "116"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": false
+                  },
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "result_roundingMode_property": {
+              "__compat": {
+                "description": "The result <code>roundingMode</code> parameter with possible values:<code>'ceil'</code>, <code>'floor'</code>, <code>'expand'</code>, <code>'trunc'</code>, <code>'halfCeil'</code>, <code>'halfFloor'</code>, <code>'halfExpand'</code>, <code>'halfTrunc'</code>, <code>'halfEven'</code>.",
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "116"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": false
+                  },
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "result_roundingPriority_property": {
+              "__compat": {
+                "description": "The result <code>roundingPriority</code> parameter with possible values: <code>'auto'</code>, <code>'morePrecision'</code>, <code>'lessPrecision'</code>.",
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "116"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": false
+                  },
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "result_trailingZeroDisplay_property": {
+              "__compat": {
+                "description": "The result <code>trailingZeroDisplay</code> parameter with possible values: <code>'auto'</code>, <code>'stripIfInteger'</code>.",
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "116"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "nodejs": {
+                    "version_added": false
+                  },
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
               }
             }
           },


### PR DESCRIPTION
This updates the
- `NumberFormat.resolvedOptions()` to reflect all the changes to options, not just the `useGrouping` option.
- `PluralRules` - constructor and `resolvedOptions()` to add the NumberFormat v3 updates.

Follow on from #20262

Related docs work can be tracked in https://github.com/mdn/content/issues/27746