### PR TITLE
Chrome for Android doesn't support the Badging API

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4009,7 +4009,7 @@
               "notes": "Windows and macOS only."
             },
             "chrome_android": {
-              "version_added": "81"
+              "version_added": false
             },
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
#### Summary

Chrome for Android doesn't support the Badging API

