### PR TITLE
Update Firefox data for ImageCapture API

### DIFF
--- a/api/ImageCapture.json
+++ b/api/ImageCapture.json
@@ -11,8 +11,14 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
-            "notes": "See <a href='https://bugzil.la/888177'>bug 888177</a>."
+            "version_added": "35",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.imagecapture.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": "mirror",
           "ie": {
@@ -46,8 +52,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/888177'>bug 888177</a>."
+              "version_added": "35",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.imagecapture.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -81,8 +93,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/888177'>bug 888177</a>."
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
@@ -116,8 +127,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/888177'>bug 888177</a>."
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
@@ -155,8 +165,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/888177'>bug 888177</a>."
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
@@ -198,8 +207,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/888177'>bug 888177</a>."
+              "version_added": "35",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.imagecapture.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -233,8 +248,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/888177'>bug 888177</a>."
+              "version_added": "35",
+              "alternative_name": "videoStreamTrack",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.imagecapture.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `ImageCapture` API. This fixes #9720 by updating the data based on the bug (https://bugzil.la/916643) and the source code (https://searchfox.org/mozilla-central/source/dom/webidl/ImageCapture.webidl#21).
