### PR TITLE
Update Firefox Android data for Headers API

### DIFF
--- a/api/Headers.json
+++ b/api/Headers.json
@@ -18,9 +18,7 @@
           "firefox": {
             "version_added": "39"
           },
-          "firefox_android": {
-            "version_added": "44"
-          },
+          "firefox_android": "mirror",
           "ie": {
             "version_added": false
           },
@@ -82,9 +80,7 @@
             "firefox": {
               "version_added": "39"
             },
-            "firefox_android": {
-              "version_added": "44"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -126,9 +122,7 @@
             "firefox": {
               "version_added": "39"
             },
-            "firefox_android": {
-              "version_added": "44"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -170,9 +164,7 @@
             "firefox": {
               "version_added": "39"
             },
-            "firefox_android": {
-              "version_added": "44"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -297,10 +289,7 @@
               "version_added": "39",
               "notes": "Before version 52, <code>get()</code> returns only the first value for the specified header."
             },
-            "firefox_android": {
-              "version_added": "44",
-              "notes": "Before version 52, <code>get()</code> returns only the first value for the specified header."
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -382,9 +371,7 @@
             "firefox": {
               "version_added": "39"
             },
-            "firefox_android": {
-              "version_added": "44"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
@@ -503,9 +490,7 @@
             "firefox": {
               "version_added": "39"
             },
-            "firefox_android": {
-              "version_added": "44"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox Android for the `Headers` API. This sets Firefox Android to mirror from upstream, as it seems very, very unlikely that FxA support came later.  Fixes #9880.
