### PR TITLE
Update all browsers data for api.HTMLMediaElement.playbackRate

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2087,14 +2087,20 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/media.html#dom-media-playbackrate-dev",
           "support": {
             "chrome": {
-              "version_added": "3"
+              "version_added": "3",
+              "partial_implementation": true,
+              "notes": "Setting the <code>playbackRate</code> to a negative value will throw an error."
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "partial_implementation": true,
+              "notes": "Setting the <code>playbackRate</code> to a negative value will throw an error."
             },
             "firefox": {
-              "version_added": "20"
+              "version_added": "20",
+              "partial_implementation": true,
+              "notes": "Setting the <code>playbackRate</code> to a negative value will throw an error."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2102,10 +2108,14 @@
             },
             "oculus": "mirror",
             "opera": {
-              "version_added": "≤12.1"
+              "version_added": "≤12.1",
+              "partial_implementation": true,
+              "notes": "Setting the <code>playbackRate</code> to a negative value will throw an error."
             },
             "opera_android": {
-              "version_added": "≤12.1"
+              "version_added": "≤12.1",
+              "partial_implementation": true,
+              "notes": "Setting the <code>playbackRate</code> to a negative value will throw an error."
             },
             "safari": {
               "version_added": "3.1"
@@ -2114,9 +2124,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `playbackRate` member of the `HTMLMediaElement` API. This fixes #10139 by adding a note (confirmed to be accurate) about Chrome's and Firefox's behavior with negative values.
