### PR TITLE
Update Firefox data for css.grid-template.fit-content feature

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -96,9 +96,15 @@
               "edge": {
                 "version_added": "16"
               },
-              "firefox": {
-                "version_added": "52"
-              },
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "52"
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -96,9 +96,15 @@
               "edge": {
                 "version_added": "16"
               },
-              "firefox": {
-                "version_added": "52"
-              },
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "52"
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `css.grid-template.fit-content` feature. This fixes #10171 by mirroring the prefix data from `width: fit-content;`.
