### PR TITLE
Update Chromium data for api.SpeechSynthesisUtterance.boundary_event

### DIFF
--- a/api/SpeechSynthesisUtterance.json
+++ b/api/SpeechSynthesisUtterance.json
@@ -103,13 +103,11 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "33"
-            },
-            "chrome_android": {
               "version_added": "33",
               "partial_implementation": true,
               "notes": "The <code>boundary</code> event does not fire as expected. See <a href='https://crbug.com/1122143'>bug 1122143</a>."
             },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "14"
             },


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `boundary_event` member of the `SpeechSynthesisUtterance` API. This fixes #10303 by copying the note from Chrome Android to Chrome Desktop.
