### PR TITLE
Update Chrome Android data for api.ServiceWorkerRegistration.showNotification

### DIFF
--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -720,7 +720,10 @@
               "chrome": {
                 "version_added": "45"
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false,
+                "notes": "In Android Oreo and above, setting this parameter has no effect."
+              },
               "edge": {
                 "version_added": "≤79"
               },


### PR DESCRIPTION
This PR updates and corrects version values for Chrome Android for the `showNotification` member of the `ServiceWorkerRegistration` API. This PR fixes #10407 by setting Chrome Android to `false`, and adds a note explaining that it has no effect.
