### PR TITLE
Update Chromium data for fieldset HTML element

### DIFF
--- a/html/elements/fieldset.json
+++ b/html/elements/fieldset.json
@@ -8,12 +8,12 @@
           "support": {
             "chrome": {
               "version_added": "1",
-              "notes": "Does not support <code>flexbox</code> and <code>grid</code> layouts within this element. See <a href='https://crbug.com/262679'>bug 262679</a>."
+              "notes": "Before version 86, this element did not support <code>flexbox</code> and <code>grid</code> layouts within this element. See <a href='https://crbug.com/262679'>bug 262679</a>."
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12",
-              "notes": "Does not support <code>flexbox</code> and <code>grid</code> layouts within this element. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/4511145/'>bug 4511145</a>."
+              "notes": "Before version 86, this element did not support <code>flexbox</code> and <code>grid</code> layouts within this element. See <a href='https://developer.microsoft.com/microsoft-edge/platform/issues/4511145/'>bug 4511145</a>."
             },
             "firefox": {
               "version_added": "1"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `fieldset` HTML element. This fixes #10530 by updating the note accordingly.
