### PR TITLE
Update Firefox Android data for css.at-rules.media.display-mode

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -467,7 +467,11 @@
                 "version_added": "47",
                 "notes": "Firefox 47 and later support <code>display-mode</code> values <code>fullscreen</code> and <code>browser</code>. Firefox 57 added support for <code>minimal-ui</code> and <code>standalone</code> values."
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "47",
+                "partial_implementation": true,
+                "notes": "Only supports the <code>browser</code> value, which always reports <code>true</code>."
+              },
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox Android for the `display-mode` member of the `media` CSS at-rule. This adds a note which fixes #10540.
