### PR TITLE
Add Safari 17 support for scripting media query

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1480,14 +1480,14 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
# Summary
Add Safari 17 support for scripting media query

# Test results and supporting details
https://github.com/WebKit/WebKit/pull/15076 - is the PR where it was added. And i manually tested using https://mq5.goose.icu/ on iPadOS 17

# Related Issues

Fixes #20318 
