### PR TITLE
Add Chrome 98 flagged support for video-dynamic-range media query

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1535,7 +1535,14 @@
             "spec_url": "https://drafts.csswg.org/mediaqueries-5/#video-dynamic-range",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "98",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add Chrome 98 flagged support for video-dynamic-range media query

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

This Chrome patch moved it under a different flag from the "dynamic-range" query. https://chromium.googlesource.com/chromium/src/+/055410a19d8631f3343146e712a784edf68aa5e6

And https://storage.googleapis.com/chromium-find-releases-static/055.html#055410a19d8631f3343146e712a784edf68aa5e6 shows that was launched in 98.

It may have been available in earlier versions but the exact version is unimportant that many releases ago.
