### PR TITLE
Update chrome browser to version 115

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -800,8 +800,8 @@
           "engine_version": "114"
         },
         "115": {
-          "release_date": "2023-07-21",
-          "release_notes": "https://chromereleases.googleblog.com/2023/07/chrome-for-android-update.html",
+          "release_date": "2023-07-18",
+          "release_notes": "https://chromereleases.googleblog.com/2023/07/stable-channel-update-for-desktop_20.html",
           "status": "current",
           "engine": "Blink",
           "engine_version": "115"

--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -795,25 +795,26 @@
         "114": {
           "release_date": "2023-05-30",
           "release_notes": "https://chromereleases.googleblog.com/2023/05/stable-channel-update-for-desktop_30.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "114"
         },
         "115": {
-          "release_date": "2023-07-18",
-          "status": "beta",
+          "release_date": "2023-07-21",
+          "release_notes": "https://chromereleases.googleblog.com/2023/07/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "115"
         },
         "116": {
           "release_date": "2023-08-15",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "116"
         },
         "117": {
           "release_date": "2023-09-12",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "117"
         },

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -631,25 +631,26 @@
         "114": {
           "release_date": "2023-05-30",
           "release_notes": "https://chromereleases.googleblog.com/2023/05/chrome-for-android-update_01893263616.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "114"
         },
         "115": {
           "release_date": "2023-07-18",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2023/05/chrome-for-android-update_01893263616.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "115"
         },
         "116": {
           "release_date": "2023-08-15",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "116"
         },
         "117": {
           "release_date": "2023-09-12",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "117"
         },

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -636,8 +636,8 @@
           "engine_version": "114"
         },
         "115": {
-          "release_date": "2023-07-18",
-          "release_notes": "https://chromereleases.googleblog.com/2023/05/chrome-for-android-update_01893263616.html",
+          "release_date": "2023-07-21",
+          "release_notes": "https://chromereleases.googleblog.com/2023/07/chrome-for-android-update.html",
           "status": "current",
           "engine": "Blink",
           "engine_version": "115"

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -595,25 +595,26 @@
         "114": {
           "release_date": "2023-05-30",
           "release_notes": "https://chromereleases.googleblog.com/2023/05/chrome-for-android-update_01893263616.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "114"
         },
         "115": {
-          "release_date": "2023-07-18",
-          "status": "beta",
+          "release_date": "2023-07-21",
+          "release_notes": "https://chromereleases.googleblog.com/2023/07/chrome-for-android-update.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "115"
         },
         "116": {
           "release_date": "2023-08-15",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "116"
         },
         "117": {
           "release_date": "2023-09-12",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "117"
         },


### PR DESCRIPTION
Hello!

Updating chrome browser to version 115.

Chrome for Android was released on July 21.