### PR TITLE
[mathml] Update compat data for math-depth and font-size: math

### DIFF
--- a/css/properties/font-size.json
+++ b/css/properties/font-size.json
@@ -64,8 +64,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1667090"
+                "version_added": "117"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -84,7 +83,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/math-depth.json
+++ b/css/properties/math-depth.json
@@ -23,18 +23,23 @@
             ],
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "83",
-              "impl_url": "https://bugzil.la/1667090",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.math-depth.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "Implementation lacks support for <code>font-size: math</code> to be complete."
-            },
+            "firefox": [
+              {
+                "version_added": "117"
+              },
+              {
+                "version_added": "83",
+                "impl_url": "https://bugzil.la/1667090",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.math-depth.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "notes": "Implementation lacks support for <code>font-size: math</code> to be complete."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -51,7 +56,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
#### Summary

math-depth and font-size: math are supported in Firefox 117. They are supported in Chrome 109, so make them non-experimental features.

#### Test results and supporting details

See https://bugzilla.mozilla.org/show_bug.cgi?id=1667090#c11

#### Related issues

N/A