### PR TITLE
Add Safari 16 support for forced-colors

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -538,10 +538,7 @@
               "chrome": {
                 "version_added": "89"
               },
-              "chrome_android": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/970285'>bug 970285</a>."
-              },
+              "chrome_android": "mirror",
               "edge": {
                 "version_added": "79"
               },
@@ -553,14 +550,10 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add Safari 16 support for forced-colors

Also clean up non-mirrored data that should be mirrored

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

The commit where it was added to WebKit: https://github.com/WebKit/WebKit/commit/46513cc172ce079baedb34e890803058b9158b35

The release notes where it was added to Safari TP 153: https://webkit.org/blog/13148/release-notes-for-safari-technology-preview-153/

Based on the the timing I'm assuming it made it for 16.0.

It always equates to false so the exact version is arguably unimportant.


I've also tested Chrome for Android and it's supported so I believe the false data is just erroenous. So they're all made to mirror now.
