### PR TITLE
Update Safari `outline` support to full

### DIFF
--- a/css/properties/outline.json
+++ b/css/properties/outline.json
@@ -64,11 +64,17 @@
             "opera_android": {
               "version_added": "10.1"
             },
-            "safari": {
-              "version_added": "1.2",
-              "partial_implementation": true,
-              "notes": "<code>outline</code> does not follow the shape of <code>border-radius</code>. See <a href='https://webkit.org/b/20807'>bug 20807</a>."
-            },
+            "safari": [
+              {
+                "version_added": "16.4"
+              },
+              {
+                "version_added": "1.2",
+                "version_removed": "16.4",
+                "partial_implementation": true,
+                "notes": "Before Safari 16.4, <code>outline</code> does not follow the shape of <code>border-radius</code>. See <a href='https://webkit.org/b/20807'>bug 20807</a>."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "1.0"


### PR DESCRIPTION
#### Summary

The caveat on CSS `outline` support for Safari no longer applies: it follows `border-radius` as of 16.4!

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
* [Closed WebKit bug](https://bugs.webkit.org/show_bug.cgi?id=20807)
* [WPT results](https://wpt.fyi/results/css/css-ui/outline-005.html?label=experimental&label=master&aligned)
* [Safari beta announcement blog post here](https://webkit.org/blog/13966/webkit-features-in-safari-16-4/#outline-border-radius)

#### Related issues

Related to: https://github.com/mdn/browser-compat-data/pull/17598, https://github.com/mdn/browser-compat-data/issues/12760, https://github.com/Fyrd/caniuse/issues/6099
