### PR TITLE
Update Firefox support for math-style

### DIFF
--- a/css/properties/math-style.json
+++ b/css/properties/math-style.json
@@ -22,16 +22,21 @@
             ],
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "83",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.math-style.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "117"
+              },
+              {
+                "version_added": "83",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.math-style.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
#### Summary

Indicate math-style is supported for Firefox 117.

#### Test results and supporting details

https://groups.google.com/a/mozilla.org/g/dev-platform/c/Uk39hvO910w/m/rBwWIfmLCAAJ
https://bugzilla.mozilla.org/show_bug.cgi?id=1845516

#### Related issues

math-depth/font-size already handled in https://github.com/mdn/browser-compat-data/pull/20417