### PR TITLE
Update 103 Early Hints support information

### DIFF
--- a/http/status.json
+++ b/http/status.json
@@ -44,32 +44,26 @@
           "support": {
             "chrome": {
               "version_added": "103",
-              "notes": "Supported in HTTP/2 and later (SPDY/QUIC)"
+              "notes": "Supported in HTTP/2 and later for preconnect and preload."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview",
-                "notes": "Supported in HTTP1.0 and later"
-              },
-              {
-                "version_added": "102",
-                "notes": "Supported in HTTP1.0 and later",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "network.early-hints.enabled",
-                    "value_to_set": "true"
-                  },
-                  {
-                    "type": "preference",
-                    "name": "network.early-hints.preconnect.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "102",
+              "notes": "Supported in HTTP1.0 and later for preconnect.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "network.early-hints.enabled",
+                  "value_to_set": "true"
+                },
+                {
+                  "type": "preference",
+                  "name": "network.early-hints.preconnect.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "ie": {
               "version_added": false
             },
@@ -78,7 +72,8 @@
               "version_added": false
             },
             "safari": {
-              "version_added": false
+              "version_added": "preview",
+              "notes": "Supported in HTTP/2 and later for preconnect."
             }
           },
           "status": {

--- a/http/status.json
+++ b/http/status.json
@@ -44,7 +44,7 @@
           "support": {
             "chrome": {
               "version_added": "103",
-              "notes": "Supported in HTTP/2 and later for preconnect and preload."
+              "notes": "Supported in <a href='https://developer.chrome.com/blog/early-hints/'>HTTP/2 and later for preconnect and preload</a>."
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Drop support for Firefox beta after testing locally.

Added support for Safari preview.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Firefox beta shows this is still disabled by default:

<img width="888" alt="image" src="https://github.com/mdn/browser-compat-data/assets/10931297/c004a5a9-eb55-46bb-99c1-631b4c846d1d">

The [code config](https://hg.mozilla.org/integration/autoland/file/tip/modules/libpref/init/StaticPrefList.yaml#:~:text=Enable%20103%20Early%20Hint%20status%20code%20(RFC%208297)) is still set to `IS_EARLY_BETA` rather than `RELEASE_OR_BETA`. Also the [main issue for implementing it is still open](https://bugzilla.mozilla.org/show_bug.cgi?id=1407355).

[Safari release notes](https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes#:~:text=Added%20support%20for%20preconnect%20via%20HTTP%20early%20hints) and [PR](https://github.com/WebKit/WebKit/pull/10836) (which notes support is limited to HTTP/2 and preconnect).

Screenshot from Safari Tech Preview:

<img width="909" alt="image" src="https://github.com/mdn/browser-compat-data/assets/10931297/21968d36-c502-43df-9bb9-2a7dcab1a57a">


#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Corrects #19027 which set this to true for Firefox beta (which [only set this for the Next beta](https://bugzilla.mozilla.org/show_bug.cgi?id=1813035) but this was never switched for current beta as discussed above).

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
