### PR TITLE
Add Chrome/Safari versions for api.HTMLInputElement.cancel_event

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -207,8 +207,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/1227424'>bug 1227424</a>."
+              "version_added": "113"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -223,15 +222,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/227799'>bug 227799</a>."
+              "version_added": "16.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Chrome & Safari has supported input `cancel` event.
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details
test: add a `cancel` event listener on the input element and print a log.
https://codesandbox.io/s/file-cancel-event-2qwspv
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
| Browser | version | test result | release notes or docs |
|--------|--------|--------|--------|
| Chrome | 113.0.5672.163 |   ✅  | https://chromiumdash.appspot.com/commits?commit=3cee6dd4bef608ab05a8b6a69fee5c00204b85ef&platform=Android |
| Safari | 16.4 |  ✅  | https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes#Forms | 

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #20342 
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
