### PR TITLE
mark nesting as partial implementation

### DIFF
--- a/css/selectors/nesting.json
+++ b/css/selectors/nesting.json
@@ -8,7 +8,9 @@
           "spec_url": "https://drafts.csswg.org/css-nesting/#nesting-selector",
           "support": {
             "chrome": {
-              "version_added": "112"
+              "version_added": "112",
+              "partial_implementation": true,
+              "notes": "Does not support nested rules that start with a type selector."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -23,7 +25,9 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16.5"
+              "version_added": "16.5",
+              "partial_implementation": true,
+              "notes": "Does not support nested rules that start with a type selector."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

CSS nesting in Chrome and Safari are only partial implementations.
As late change/addition to the specification was nesting with a leading type selector.

Firefox does implement this specification entirely and will ship this in version 117.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

https://wpt.fyi/results/css/css-nesting/nesting-type-selector.html?label=master&label=experimental&aligned&q=nesting

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixes https://github.com/mdn/browser-compat-data/issues/20433

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
