### PR TITLE
FF117 HTMLElement.togglePopover() returns boolean behind pref

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2238,6 +2238,7 @@
         },
         "returns_boolean": {
           "__compat": {
+            "description": "Returns <code>true</code> or <code>false</code>",
             "support": {
               "chrome": {
                 "version_added": false

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2235,6 +2235,45 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "returns_boolean": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "117",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.element.popover.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "translate": {


### PR DESCRIPTION
FF117 `HTMLElement.togglePopover()` returns `boolean` (behind pref) instead of None in https://bugzilla.mozilla.org/show_bug.cgi?id=1842845. This is due to a spec change.

Other browsers do not implement this yet, but it is worth adding the subfeature now - it will be needed when the pref is removed.

Related docs work can be tracked in https://github.com/mdn/content/issues/27417