### PR TITLE
FF117 moz-preservesPitch fully removed

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2279,7 +2279,7 @@
                 "prefix": "moz",
                 "version_added": "20",
                 "version_removed": "115",
-                "notes": "Disable by default in version 115 (behind preference <code>dom.media.mozPreservesPitch.enabled</code>). May be fully removed in a future release (see <a href='https://bugzil.la/1765201'>bug 1765201</a>)."
+                "notes": "Disabled by default in version 115 (behind preference <code>dom.media.mozPreservesPitch.enabled</code>). Removed in version 117 (see <a href='https://bugzil.la/1765201'>bug 1765201</a>)."
               }
             ],
             "firefox_android": "mirror",


### PR DESCRIPTION
FF117 removes the moz-prefixed alias of preservesPitch, which was disabled by default in FF115. This just changes the note to indicate has been fully removed. Version is kept at 115 since that is the version at which you couldn't use it by default.

Related docs work can be tracked in https://github.com/mdn/content/issues/28284