### PR TITLE
FF117 CanvasRenderingContext2D.getContextAttributes() supported

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1258,7 +1258,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF117 supports [`FF117 CanvasRenderingContext2D.getContextAttributes()`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/getContextAttributes) in https://bugzilla.mozilla.org/show_bug.cgi?id=1517786

This just updates to 117. Note that attributes are set in [`HTMLCanvasElement: getContext()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext) when you create a context, and this new method returns the values as actually supported by the browser. 

FF doesn't support 'desynchronized' and 'colorSpace' attributes, so it doesn't return them. NOTE, however I have not specified the supported returned options. My reasoning is that you will only get back supported values, so it doesn't matter. I can update if there is strong disagreement - should be possible to work out for other browsers (which is main reason I have not done this)

Related docs work can be tracked in https://github.com/mdn/content/issues/28283