### PR TITLE
FF117 Nightly CSS highlight API

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -922,7 +922,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Highlight.json
+++ b/api/Highlight.json
@@ -10,7 +10,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -43,7 +43,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -75,7 +75,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -107,7 +107,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -139,7 +139,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -171,7 +171,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -203,7 +203,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -235,7 +235,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -267,7 +267,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -300,7 +300,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -332,7 +332,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -365,7 +365,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -397,7 +397,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -429,7 +429,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HighlightRegistry.json
+++ b/api/HighlightRegistry.json
@@ -10,7 +10,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -41,7 +41,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -73,7 +73,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -105,7 +105,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -137,7 +137,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -169,7 +169,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -201,7 +201,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -233,7 +233,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -265,7 +265,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -297,7 +297,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -329,7 +329,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -361,7 +361,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/highlight.json
+++ b/css/selectors/highlight.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/highlight.json
+++ b/css/selectors/highlight.json
@@ -13,7 +13,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "partial_implementation": true,
+              "notes": "Cannot yet be used with <code>text-decoration</code> and <code>text-shadow</code> (see <a href='https://bugzil.la/1845446'>bug 1845446</a>, <a href='https://bugzil.la/1845447'>bug 1845447</a>)."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/highlight.json
+++ b/css/selectors/highlight.json
@@ -15,7 +15,7 @@
             "firefox": {
               "version_added": "preview",
               "partial_implementation": true,
-              "notes": "Cannot yet be used with <code>text-decoration</code> and <code>text-shadow</code> (see <a href='https://bugzil.la/1845446'>bug 1845446</a>, <a href='https://bugzil.la/1845447'>bug 1845447</a>)."
+              "notes": "Cannot yet be used with <code>text-decoration</code> and <code>text-shadow</code>. See <a href='https://bugzil.la/1703961'>bug 1703961</a>."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF117 supports the [CSS Custom Highlight API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Custom_Highlight_API) in nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=1840818 (behind  a pref `dom.customHighlightAPI.enabled` since FF111 and now enabled in nightly).

This adds "preview" to all parts of the API. As far as I can tell the created objects match the spec.
Decided not to add second entry that includes the preference since once something is in preview that is really the latest and greatest that you want people to try.

Other docs work associated with this can be tracked in https://github.com/mdn/content/issues/28291

