### PR TITLE
FF117 ReadableStream: from() static method

### DIFF
--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -134,6 +134,47 @@
           }
         }
       },
+      "from_static": {
+        "__compat": {
+          "description": "<code>from()</code> static method",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStream/from_static",
+          "spec_url": "https://streams.spec.whatwg.org/#ref-for-rs-from",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "117"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "nodejs": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getReader": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ReadableStream/getReader",


### PR DESCRIPTION
FF117 supports the `ReadableStream: from()` static method in https://bugzilla.mozilla.org/show_bug.cgi?id=1772772 . 

This is new to the spec 
- testing using https://wpt.live/streams/readable-streams/from.any.html shows it is not in Safari or Chrome.
- It is not in latest deno docs https://deno.land/api@v1.35.3?s=ReadableStream&unstable=
- Node doesn't show it in docs: https://nodejs.org/api/webstreams.html#class-readablestream (though node has something similar in native https://www.geeksforgeeks.org/node-js-stream-readable-from-method/).

Other docs work can be tracked in https://github.com/mdn/content/issues/28282

FYI @queengooborg 