### PR TITLE
Add BCD for Topics API

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -753,6 +753,40 @@
           }
         }
       },
+      "browsingTopics": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/browsingTopics",
+          "spec_url": "https://patcg-individual-drafts.github.io/topics/#dom-document-browsingtopics",
+          "support": {
+            "chrome": {
+              "version_added": "115"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "captureEvents": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/captureEvents",

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -204,6 +204,40 @@
           }
         }
       },
+      "browsingTopics": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/browsingTopics",
+          "spec_url": "https://patcg-individual-drafts.github.io/topics/#dom-htmliframeelement-browsingtopics",
+          "support": {
+            "chrome": {
+              "version_added": "115"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "contentDocument": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/contentDocument",

--- a/api/Request.json
+++ b/api/Request.json
@@ -152,6 +152,40 @@
             }
           }
         },
+        "init_browsingTopics_parameter": {
+          "__compat": {
+            "description": "<code>init.browsingTopics</code> parameter",
+            "spec_url": "https://patcg-individual-drafts.github.io/topics/#dom-requestinit-browsingtopics",
+            "support": {
+              "chrome": {
+                "version_added": "115"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "init_priority_parameter": {
           "__compat": {
             "description": "<code>init.priority</code> parameter",

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -175,6 +175,40 @@
           }
         }
       },
+      "init_browsingTopics_parameter": {
+        "__compat": {
+          "description": "<code>init.browsingTopics</code> parameter",
+          "spec_url": "https://patcg-individual-drafts.github.io/topics/#dom-requestinit-browsingtopics",
+          "support": {
+            "chrome": {
+              "version_added": "115"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "init_keepalive_parameter": {
         "__compat": {
           "description": "<code>init.keepalive</code> parameter",

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -204,6 +204,39 @@
             }
           }
         },
+        "browsingtopics": {
+          "__compat": {
+            "spec_url": "https://patcg-individual-drafts.github.io/topics/#dom-htmliframeelement-browsingtopics",
+            "support": {
+              "chrome": {
+                "version_added": "115"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "credentialless": {
           "__compat": {
             "support": {

--- a/http/headers/Observe-Browsing-Topics.json
+++ b/http/headers/Observe-Browsing-Topics.json
@@ -1,0 +1,40 @@
+{
+  "http": {
+    "headers": {
+      "Observe-Browsing-Topics": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Observe-Browsing-Topics",
+          "spec_url": "https://patcg-individual-drafts.github.io/topics/#the-observe-browsing-topics-http-response-header-header",
+          "support": {
+            "chrome": {
+              "version_added": "115"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -208,6 +208,40 @@
             }
           }
         },
+        "browsing-topics": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/browsing-topics",
+            "spec_url": "https://patcg-individual-drafts.github.io/topics/#permissions-policy-integration-header",
+            "support": {
+              "chrome": {
+                "version_added": "115"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "camera": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/camera",

--- a/http/headers/Sec-Browsing-Topics.json
+++ b/http/headers/Sec-Browsing-Topics.json
@@ -1,0 +1,40 @@
+{
+  "http": {
+    "headers": {
+      "Sec-Browsing-Topics": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-Browsing-Topics",
+          "spec_url": "https://patcg-individual-drafts.github.io/topics/#the-sec-browsing-topics-http-request-header-header",
+          "support": {
+            "chrome": {
+              "version_added": "115"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

[The Topics API](https://wicg.github.io/fenced-frame/) is an integral part of Google's [privacy sandbox](https://developer.chrome.com/docs/privacy-sandbox/) technologies. Many parts of this set are being made available by default in Chrome 115 (depending on a gradual ramp-up to 100% of userbase over the 115 release period).

This PR provides BCD for the Topics API and its related HTTP headers and other features.

See my [research document](https://docs.google.com/document/d/1gfp8Ey6nfGTo4cOlq1Knbhz0kSopbBUc69BF0JCSmq4/edit) for more details of exactly what changes are expected in the PR.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
