### PR TITLE
Update mdn_urls and spec_urls for the Navigation API

### DIFF
--- a/api/NavigateEvent.json
+++ b/api/NavigateEvent.json
@@ -2,7 +2,8 @@
   "api": {
     "NavigateEvent": {
       "__compat": {
-        "spec_url": "https://wicg.github.io/navigation-api/#navigate-event-class",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigateEvent",
+        "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-navigateevent-interface",
         "support": {
           "chrome": {
             "version_added": "102"
@@ -37,7 +38,8 @@
       "NavigateEvent": {
         "__compat": {
           "description": "<code>NavigateEvent()</code> constructor",
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigateevent-navigateevent",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigateEvent/NavigateEvent",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-navigateevent-interface",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -72,7 +74,8 @@
       },
       "canIntercept": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigateevent-canintercept",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigateEvent/canIntercept",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-canintercept-dev",
           "support": {
             "chrome": {
               "version_added": "105"
@@ -142,7 +145,8 @@
       },
       "destination": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigateevent-destination",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigateEvent/destination",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-destination-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -177,7 +181,8 @@
       },
       "downloadRequest": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigateevent-downloadrequest",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigateEvent/downloadRequest",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-downloadrequest-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -212,7 +217,8 @@
       },
       "formData": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigateevent-formdata",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigateEvent/formData",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-formdata-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -247,7 +253,8 @@
       },
       "hashChange": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigateevent-hashchange",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigateEvent/hashChange",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-hashchange-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -282,7 +289,8 @@
       },
       "info": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigateevent-info",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigateEvent/info",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-info-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -317,7 +325,8 @@
       },
       "intercept": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigateevent-intercept",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigateEvent/intercept",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-intercept-dev",
           "support": {
             "chrome": {
               "version_added": "105"
@@ -352,7 +361,8 @@
       },
       "navigationType": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigateevent-navigationtype",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigateEvent/navigationType",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-navigationtype-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -422,7 +432,8 @@
       },
       "scroll": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigateevent-scroll",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigateEvent/scroll",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-scroll-dev",
           "support": {
             "chrome": {
               "version_added": "105"
@@ -457,7 +468,8 @@
       },
       "signal": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigateevent-signal",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigateEvent/signal",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-signal-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -527,7 +539,8 @@
       },
       "userInitiated": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigateevent-userinitiated",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigateEvent/userInitiated",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-userinitiated-dev",
           "support": {
             "chrome": {
               "version_added": "102"

--- a/api/Navigation.json
+++ b/api/Navigation.json
@@ -2,7 +2,8 @@
   "api": {
     "Navigation": {
       "__compat": {
-        "spec_url": "https://wicg.github.io/navigation-api/#global",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigation",
+        "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-interface",
         "support": {
           "chrome": {
             "version_added": "102"
@@ -34,7 +35,8 @@
       },
       "back": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigation-back",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigation/back",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-back-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -67,7 +69,8 @@
       },
       "canGoBack": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigation-cangoback",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigation/canGoBack",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-cangoback-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -100,7 +103,8 @@
       },
       "canGoForward": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigation-cangoforward",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigation/canGoForward",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-cangoforward-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -133,7 +137,8 @@
       },
       "currentEntry": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigation-currententry",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigation/currentEntry",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-currententry-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -167,7 +172,8 @@
       "currententrychange_event": {
         "__compat": {
           "description": "<code>currententrychange</code> event",
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigation-oncurrententrychange",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigation/currententrychange_event",
+          "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-currententrychange",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -200,7 +206,8 @@
       },
       "entries": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigation-entries",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigation/entries",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-entries-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -233,7 +240,8 @@
       },
       "forward": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigation-forward",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigation/forward",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-forward-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -266,7 +274,8 @@
       },
       "navigate": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigation-navigate",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigation/navigate",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-navigate-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -300,7 +309,8 @@
       "navigate_event": {
         "__compat": {
           "description": "<code>navigate</code> event",
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigation-onnavigate",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigation/navigate_event",
+          "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-navigate",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -334,7 +344,8 @@
       "navigateerror_event": {
         "__compat": {
           "description": "<code>navigateerror</code> event",
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigation-onnavigateerror",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigation/navigateerror_event",
+          "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-navigateerror",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -368,7 +379,8 @@
       "navigatesuccess_event": {
         "__compat": {
           "description": "<code>navigatesuccess</code> event",
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigation-onnavigatesuccess",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigation/navigatesuccess_event",
+          "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-navigatesuccess",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -401,7 +413,8 @@
       },
       "reload": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigation-reload",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigation/reload",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-reload-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -434,7 +447,8 @@
       },
       "transition": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigation-transition",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigation/transition",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-transition-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -467,7 +481,8 @@
       },
       "traverseTo": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigation-traverseto",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigation/traverseTo",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-traverseto-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -500,7 +515,8 @@
       },
       "updateCurrentEntry": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigation-updatecurrententry",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigation/updateCurrentEntry",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation-updatecurrententry-dev",
           "support": {
             "chrome": {
               "version_added": "102"

--- a/api/NavigationCurrentEntryChangeEvent.json
+++ b/api/NavigationCurrentEntryChangeEvent.json
@@ -2,7 +2,8 @@
   "api": {
     "NavigationCurrentEntryChangeEvent": {
       "__compat": {
-        "spec_url": "https://wicg.github.io/navigation-api/#navigationcurrententrychangeevent",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationCurrentEntryChangeEvent/",
+        "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-navigationcurrententrychangeevent-interface",
         "support": {
           "chrome": {
             "version_added": "102"
@@ -35,7 +36,8 @@
       "NavigationCurrentEntryChangeEvent": {
         "__compat": {
           "description": "<code>NavigationCurrentEntryChangeEvent()</code> constructor",
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigationcurrententrychangeevent-navigationcurrententrychangeevent",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationCurrentEntryChangeEvent/NavigationCurrentEntryChangeEvent",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-navigationcurrententrychangeevent-interface",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -68,7 +70,8 @@
       },
       "from": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigationcurrententrychangeevent-from",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationCurrentEntryChangeEvent/from",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationcurrententrychangeevent-from-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -101,7 +104,8 @@
       },
       "navigationType": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigationcurrententrychangeevent-navigationtype",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationCurrentEntryChangeEvent/navigationType",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationcurrententrychangeevent-navigationtype-dev",
           "support": {
             "chrome": {
               "version_added": "102"

--- a/api/NavigationDestination.json
+++ b/api/NavigationDestination.json
@@ -2,7 +2,8 @@
   "api": {
     "NavigationDestination": {
       "__compat": {
-        "spec_url": "https://wicg.github.io/navigation-api/#navigationdestination",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationDestination",
+        "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-navigationdestination-interface",
         "support": {
           "chrome": {
             "version_added": "102"
@@ -34,7 +35,8 @@
       },
       "getState": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigationdestination-getstate",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationDestination/getState",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-navigationdestination-interface:dom-navigationdestination-getstate-2",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -67,7 +69,8 @@
       },
       "id": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigationdestination-id",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationDestination/id",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-navigationdestination-interface:dom-navigationdestination-id-2",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -100,7 +103,8 @@
       },
       "index": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigationdestination-index",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationDestination/index",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-navigationdestination-interface:dom-navigationdestination-index-2",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -133,7 +137,8 @@
       },
       "key": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigationdestination-key",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationDestination/key",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-navigationdestination-interface:dom-navigationdestination-key-2",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -166,7 +171,8 @@
       },
       "sameDocument": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigationdestination-samedocument",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationDestination/sameDocument",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-navigationdestination-interface:dom-navigationdestination-samedocument-2",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -199,7 +205,8 @@
       },
       "url": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigationdestination-url",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationDestination/url",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-navigationdestination-interface:dom-navigationdestination-url-2",
           "support": {
             "chrome": {
               "version_added": "102"

--- a/api/NavigationHistoryEntry.json
+++ b/api/NavigationHistoryEntry.json
@@ -2,7 +2,8 @@
   "api": {
     "NavigationHistoryEntry": {
       "__compat": {
-        "spec_url": "https://wicg.github.io/navigation-api/#navigationhistoryentry",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationHistoryEntry",
+        "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-navigationhistoryentry-interface",
         "support": {
           "chrome": {
             "version_added": "102"
@@ -35,7 +36,8 @@
       "dispose_event": {
         "__compat": {
           "description": "<code>dispose</code> event",
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigationhistoryentry-ondispose",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationHistoryEntry/dispose_event",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#handler-navigationhistoryentry-ondispose",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -68,7 +70,8 @@
       },
       "getState": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigationhistoryentry-getstate",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationHistoryEntry/getState",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationhistoryentry-getstate-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -101,7 +104,8 @@
       },
       "id": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigationhistoryentry-id",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationHistoryEntry/id",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationhistoryentry-id-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -134,7 +138,8 @@
       },
       "index": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigationhistoryentry-index",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationHistoryEntry/index",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationhistoryentry-index-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -167,7 +172,8 @@
       },
       "key": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigationhistoryentry-key",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationHistoryEntry/key",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationhistoryentry-key-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -200,7 +206,8 @@
       },
       "sameDocument": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigationhistoryentry-samedocument",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationHistoryEntry/sameDocument",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationhistoryentry-samedocument-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -233,7 +240,8 @@
       },
       "url": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigationhistoryentry-url",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationHistoryEntry/url",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationhistoryentry-url-dev",
           "support": {
             "chrome": {
               "version_added": "102"

--- a/api/NavigationTransition.json
+++ b/api/NavigationTransition.json
@@ -2,7 +2,8 @@
   "api": {
     "NavigationTransition": {
       "__compat": {
-        "spec_url": "https://wicg.github.io/navigation-api/#navigationtransition",
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationTransition",
+        "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigationtransition",
         "support": {
           "chrome": {
             "version_added": "102"
@@ -34,7 +35,8 @@
       },
       "finished": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigationtransition-finished",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationTransition/finished",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationtransition-finished-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -67,7 +69,8 @@
       },
       "from": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigationtransition-from",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationTransition/from",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationtransition-from-dev",
           "support": {
             "chrome": {
               "version_added": "102"
@@ -100,7 +103,8 @@
       },
       "navigationType": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#dom-navigationtransition-navigationtype",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigationTransition/navigationType",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationtransition-navigationtype-dev",
           "support": {
             "chrome": {
               "version_added": "102"

--- a/api/Window.json
+++ b/api/Window.json
@@ -2883,7 +2883,8 @@
       },
       "navigation": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/navigation-api/#global",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/navigation",
+          "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigation",
           "support": {
             "chrome": {
               "version_added": "102"

--- a/test/linter/test-spec-urls.ts
+++ b/test/linter/test-spec-urls.ts
@@ -35,10 +35,6 @@ const specsExceptions = [
   // if they have been integrated into a real spec
   'https://w3c.github.io/webrtc-extensions/',
 
-  // Remove once https://github.com/whatwg/html/pull/8502
-  // is merged and the new URL is live
-  'https://wicg.github.io/navigation-api',
-
   // Proposals for WebAssembly
   'https://github.com/WebAssembly/spec/blob/main/proposals',
   'https://github.com/WebAssembly/exception-handling/blob/main/proposals',


### PR DESCRIPTION
The Navigation API is now part of the HTML specification and MDN pages exist.