### PR TITLE
relnote(117): sign() and abs() functions available

### DIFF
--- a/css/types/abs.json
+++ b/css/types/abs.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -30,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/types/sign.json
+++ b/css/types/sign.json
@@ -30,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/types/sign.json
+++ b/css/types/sign.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
The `abs()` and `sign()` functions are supported in 117.

Docs:

- [`abs()`](https://developer.mozilla.org/en-US/docs/Web/CSS/abs)
- [`sign()`](https://developer.mozilla.org/en-US/docs/Web/CSS/sign)

__pen/demo:__
TODO


__Related issues and pull requests:__
- [x] Parent issue https://github.com/mdn/content/issues/28293

__Bugzilla:__
- [BUG-1814588](https://bugzilla.mozilla.org/show_bug.cgi?id=1814588)
