### PR TITLE
Safari 16.6 is released

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -258,9 +258,16 @@
         "16.5": {
           "release_date": "2023-05-18",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_5-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "615.2.9"
+        },
+        "16.6": {
+          "release_date": "2023-07-24",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_6-release-notes",
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "615.3.12"
         },
         "17": {
           "status": "beta",

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -230,9 +230,16 @@
         "16.5": {
           "release_date": "2023-05-18",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_5-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "615.2.9"
+        },
+        "16.6": {
+          "release_date": "2023-07-24",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_6-release-notes",
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "615.3.12"
         },
         "17": {
           "status": "beta",


### PR DESCRIPTION
This PR adds Safari 16.6 to the browser data and marks it as the current version.  The release date comes from https://mrmacintosh.com/macos-ventura-13-full-installer-database-download-directly-from-apple/, and the engine version comes from Safari 16.6 itself.
