### PR TITLE
relnote(117): sign() and abs() functions in nightly only (planned Fx118)

### DIFF
--- a/css/types/abs.json
+++ b/css/types/abs.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/sign.json
+++ b/css/types/sign.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
My mistake, target branch for flipping the pref is Fx118 for these features. Currently these are nightly-only.

__prefs:__
- https://hg.mozilla.org/integration/autoland/file/tip/modules/libpref/init/StaticPrefList.yaml#l8186
  - `layout.css.abs-sign.enabled`

__pen:__
https://codepen.io/bsmth/pen/KKrEMZr

__Amends:__
- [x] https://github.com/mdn/browser-compat-data/pull/20465

__Bugzilla:__
- (117) Sign-Related Functions: abs() and sign() https://bugzilla.mozilla.org/show_bug.cgi?id=1814588
- (118) Enable css-values-4 math functions by default https://bugzilla.mozilla.org/show_bug.cgi?id=1814589