### PR TITLE
CSS ray() function: Add "at <position>" feature row for Firefox116

### DIFF
--- a/css/types/ray.json
+++ b/css/types/ray.json
@@ -49,7 +49,50 @@
             "deprecated": false
           }
         },
-        "size-support": {
+        "position": {
+          "__compat": {
+            "description": "<code>&lt;at-position&gt;</code>",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": [
+                {
+                  "version_added": "116",
+                  "notes": "<code>&lt;at-position&gt;</code> is optional. If omitted, the <code>offset-position</code> of the element is used.",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.motion-path-ray.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                }
+              ],
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "size": {
           "__compat": {
             "description": "<code>&lt;ray-size&gt;</code>",
             "support": {
@@ -98,15 +141,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview",
-                "notes": "<code>&lt;ray-size&gt;</code> is required."
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/types/ray.json
+++ b/css/types/ray.json
@@ -58,19 +58,17 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "116",
-                  "notes": "<code>&lt;at-position&gt;</code> is optional. If omitted, the <code>offset-position</code> of the element is used.",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.motion-path-ray.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "116",
+                "notes": "<code>&lt;at-position&gt;</code> is optional. If omitted, the <code>offset-position</code> of the element is used.",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.motion-path-ray.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/css/types/ray.json
+++ b/css/types/ray.json
@@ -92,11 +92,11 @@
         },
         "size": {
           "__compat": {
-            "description": "<code>&lt;ray-size&gt;</code>",
+            "description": "<code>&lt;size&gt;</code>",
             "support": {
               "chrome": {
                 "version_added": "64",
-                "notes": "<code>&lt;ray-size&gt;</code> is required.",
+                "notes": "<code>&lt;size&gt;</code> is required.",
                 "flags": [
                   {
                     "type": "preference",
@@ -110,7 +110,7 @@
               "firefox": [
                 {
                   "version_added": "112",
-                  "notes": "<code>&lt;ray-size&gt;</code> is optional. If omitted, the value <code>closest-side</code> is used.",
+                  "notes": "<code>&lt;size&gt;</code> is optional. If omitted, the value <code>closest-side</code> is used.",
                   "flags": [
                     {
                       "type": "preference",
@@ -121,7 +121,7 @@
                 },
                 {
                   "version_added": "72",
-                  "notes": "<code>&lt;ray-size&gt;</code> is required.",
+                  "notes": "<code>&lt;size&gt;</code> is required.",
                   "flags": [
                     {
                       "type": "preference",

--- a/css/types/ray.json
+++ b/css/types/ray.json
@@ -51,7 +51,7 @@
         },
         "position": {
           "__compat": {
-            "description": "<code>&lt;at-position&gt;</code>",
+            "description": "<code>at &lt;position&gt;</code>",
             "support": {
               "chrome": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Fx116 adds support for specifying initial starting position of the ray. The [`ray()`](https://developer.mozilla.org/en-US/docs/Web/CSS/ray) function itself is still available behind the preference `layout.css.motion-path-ray.enabled`.

The new syntax:
`ray( <angle> && <size>? && contain? && [at <position>]? )`

This PR:
- adds the feature row "position" for `at <position>`.
- renames the "size-support" row to "size" for `<ray-size>`.
- renames `<ray-size>` to `<size>`: (update in [content page](https://pr28348.content.dev.mdn.mozit.cloud/en-US/docs/Web/CSS/ray#size))

Safari TP does not support `<ray-size>`, so removed the value for that feature row for Safari.

#### Test results and supporting details

Codepen: updated ray syntax (https://codepen.io/dipikabh/pen/yLReQaZ)
- Fx116 stable version: `at <position>` is supported behind pref and is optional.
- Chrome 116: `at <position>` is not supported even behind the flag Experimental Web Platform features (115).
- Safari TP (Safari 17.0): `at <position>` is not supported.

#### Related issues

Doc issue: https://github.com/mdn/content/issues/27751
Content PR: https://github.com/mdn/content/pull/28348
