### PR TITLE
Remove html.elements.col.valign from BCD

### DIFF
--- a/html/elements/col.json
+++ b/html/elements/col.json
@@ -209,41 +209,6 @@
             }
           }
         },
-        "valign": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": false,
-                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>."
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": true
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "3"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
-            }
-          }
-        },
         "width": {
           "__compat": {
             "support": {


### PR DESCRIPTION
This PR removes the `valign` member of the `col` HTML element from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/col/valign
