### PR TITLE
browser_style:true removed from MV3

### DIFF
--- a/webextensions/manifest/action.json
+++ b/webextensions/manifest/action.json
@@ -29,7 +29,8 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "109",
-                "notes": "Deprecated. See <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles'>Browser styles</a> for more details."
+                "version_removed": "118",
+                "notes": "See <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles'>Browser styles</a> for more details."
               },
               "firefox_android": {
                 "version_added": false

--- a/webextensions/manifest/browser_action.json
+++ b/webextensions/manifest/browser_action.json
@@ -49,8 +49,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "48",
-                "notes": "Deprecated in Manifest V3. See <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles'>Browser styles</a> for more details."
+                "version_added": "48"
               },
               "firefox_android": {
                 "version_added": false

--- a/webextensions/manifest/options_ui.json
+++ b/webextensions/manifest/options_ui.json
@@ -33,7 +33,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "55",
-                "notes": "Deprecated in Manifest V3. See <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles'>Browser styles</a> for more details."
+                "notes": "Removed from Manifest V3 in Firefox 118. See <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles'>Browser styles</a> for more details."
               },
               "firefox_android": {
                 "version_added": false

--- a/webextensions/manifest/page_action.json
+++ b/webextensions/manifest/page_action.json
@@ -44,7 +44,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "48",
-                "notes": "Deprecated in Manifest V3. See <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles'>Browser styles</a> for more details."
+                "notes": "Removed from Manifest V3 in Firefox 118. See <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles'>Browser styles</a> for more details."
               },
               "firefox_android": {
                 "version_added": false

--- a/webextensions/manifest/sidebar_action.json
+++ b/webextensions/manifest/sidebar_action.json
@@ -33,7 +33,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "55",
-                "notes": "Deprecated in Manifest V3. See <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles'>Browser styles</a> for more details."
+                "notes": "Removed from Manifest V3 in Firefox 118. See <a href='https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles'>Browser styles</a> for more details."
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
### Description

Updated relevant notes to indicate that 'browser_style:true' removed from MV3 in release 118.

### Related issues and pull requests

Provide documentation for [Bug 1830711](https://bugzilla.mozilla.org/show_bug.cgi?id=1830711) Turn off support for browser_style:true in MV3
Content changes made in [#28415](https://github.com/mdn/content/pull/28415)