### PR TITLE
CSSStyleSheet() constructor baseURL option not supported in Chrome

### DIFF
--- a/api/CSSStyleSheet.json
+++ b/api/CSSStyleSheet.json
@@ -46,7 +46,9 @@
           "spec_url": "https://drafts.csswg.org/cssom/#dom-cssstylesheet-cssstylesheet",
           "support": {
             "chrome": {
-              "version_added": "73"
+              "version_added": "73",
+              "partial_implementation": true,
+              "notes": "The <code>baseURL</code> option property is not supported. See <a href='https://crbug.com/1275639'>bug 1275639</a>."
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
See https://wpt.fyi/results/css/cssom/CSSStyleSheet-constructable-baseURL.tentative.html