### PR TITLE
CSS offset-path: Add rows for <basic-shape> and <coord-box> for Firefox 116

### DIFF
--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -65,9 +65,9 @@
             "deprecated": false
           }
         },
-        "path-support": {
+        "path": {
           "__compat": {
-            "description": "Support for <code>path()</code> function as a value",
+            "description": "Support for <a href='https://developer.mozilla.org/en-US/docs/Web/CSS/path'><code>path()</code></a> function as a value",
             "support": {
               "chrome": {
                 "version_added": "64"
@@ -98,9 +98,9 @@
             }
           }
         },
-        "ray-support": {
+        "ray": {
           "__compat": {
-            "description": "Support for <code>ray()</code> function as a value",
+            "description": "Support for <a href='https://developer.mozilla.org/en-US/docs/Web/CSS/ray'><code>ray()</code></a> function as a value",
             "support": {
               "chrome": {
                 "version_added": "64",

--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -145,7 +145,7 @@
             }
           }
         },
-        "path": {
+        "path-support": {
           "__compat": {
             "description": "Support for <a href='https://developer.mozilla.org/en-US/docs/Web/CSS/path'><code>path()</code></a> function as a value",
             "support": {
@@ -178,7 +178,7 @@
             }
           }
         },
-        "ray": {
+        "ray-support": {
           "__compat": {
             "description": "Support for <a href='https://developer.mozilla.org/en-US/docs/Web/CSS/ray'><code>ray()</code></a> function as a value",
             "support": {

--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -65,6 +65,86 @@
             "deprecated": false
           }
         },
+        "basic-shape": {
+          "__compat": {
+            "description": "<code>&lt;basic-shape&gt;</code>",
+            "support": {
+              "chrome": {
+                "version_added": "preview"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "116",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.motion-path-basic-shapes.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "coord-box": {
+          "__compat": {
+            "description": "<code>&lt;coord-box&gt;</code>",
+            "support": {
+              "chrome": {
+                "version_added": "preview"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "116",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.motion-path-coord-box.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "path": {
           "__compat": {
             "description": "Support for <a href='https://developer.mozilla.org/en-US/docs/Web/CSS/path'><code>path()</code></a> function as a value",
@@ -117,7 +197,7 @@
               "firefox": [
                 {
                   "version_added": "112",
-                  "notes": "<code>&lt;ray-size&gt;</code> is optional with the default value <code>closest-side</code>.",
+                  "notes": "<code>&lt;size&gt;</code> is optional with the default value <code>closest-side</code>.",
                   "flags": [
                     {
                       "type": "preference",

--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -145,9 +145,9 @@
             }
           }
         },
-        "path-support": {
+        "path": {
           "__compat": {
-            "description": "Support for <a href='https://developer.mozilla.org/en-US/docs/Web/CSS/path'><code>path()</code></a> function as a value",
+            "description": "Support for <a href='https://developer.mozilla.org/docs/Web/CSS/path'><code>path()</code></a> function as a value",
             "support": {
               "chrome": {
                 "version_added": "64"
@@ -178,9 +178,9 @@
             }
           }
         },
-        "ray-support": {
+        "ray": {
           "__compat": {
-            "description": "Support for <a href='https://developer.mozilla.org/en-US/docs/Web/CSS/ray'><code>ray()</code></a> function as a value",
+            "description": "Support for <a href='https://developer.mozilla.org/docs/Web/CSS/ray'><code>ray()</code></a> function as a value",
             "support": {
               "chrome": {
                 "version_added": "64",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

In the `offset-path` property ([page being updated](https://pr28348.content.dev.mdn.mozit.cloud/en-US/docs/Web/CSS/offset-path)), Fx116 adds support for `<basic-shape>` and `<coord-box>` behind the preferences `layout.css.motion-path-basic-shapes.enabled` and `layout.css.motion-path-coord-box.enabled`, respectively.

The new syntax:
`offset-path: none | <offset-path> || <coord-box>`

This PR:
- adds rows for `<basic-shape>` and `<coord-box>`.
- adds links to `path` and `ray()` pages in the existing path and ray rows.
- renames `<ray-size>` to `<size>`: (update in [content page](https://pr28348.content.dev.mdn.mozit.cloud/en-US/docs/Web/CSS/ray#size)).

#### Test results and supporting details

Codepen: https://codepen.io/dipikabh/pen/JjexYPo

- Fx116 stable version: Supported behind pref and are optional
- Chrome Canary: Supported behind pref and are optional
- Safari TP (Safari 17.0): Not supported


#### Related issues

Doc issue: https://github.com/mdn/content/issues/27747
Content PR: https://github.com/mdn/content/pull/28348
