### PR TITLE
Remove svg.elements.a.referrerpolicy from BCD

### DIFF
--- a/svg/elements/a.json
+++ b/svg/elements/a.json
@@ -180,40 +180,6 @@
             }
           }
         },
-        "referrerpolicy": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "51"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "52"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "14"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": {
-                "version_added": "7.2"
-              },
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "rel": {
           "__compat": {
             "support": {


### PR DESCRIPTION
This PR removes the `referrerpolicy` member of the `a` SVG element from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/svg/elements/a/referrerpolicy

Additional Notes: This attribute is only available on HTML anchor elements, not SVG anchor elements.
