### PR TITLE
Add missing features for html.elements.textarea.wrap.hard

### DIFF
--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -623,6 +623,41 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "hard": {
+            "__compat": {
+              "description": "<code>hard</code> value",
+              "support": {
+                "chrome": {
+                  "version_added": "16"
+                },
+                "chrome_android": "mirror",
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing features of the `wrap.hard` member of the `textarea` HTML element. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code: http://wpt.live/html/semantics/forms/the-textarea-element/wrap-enumerated-ascii-case-insensitive.html

Additional Notes: This fixes #10164.  (In that PR, the attribute is inaccurately described as "unsupported", but it is just the `hard` value that is unsupported in Firefox and Safari.)
