### PR TITLE
Remove css.selectors.hover.pseudo_elements from BCD

### DIFF
--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -133,43 +133,6 @@
               "deprecated": false
             }
           }
-        },
-        "pseudo_elements": {
-          "__compat": {
-            "description": "Pseudo-element support",
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "28"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "11"
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "2"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
This PR removes the `pseudo_elements` member of the `hover` CSS selector from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.0).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/selectors/hover/pseudo_elements

Additional Notes: This fixes #10778.
