### PR TITLE
Update Firefox data for api.KeyboardEvent.key.dead_key

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -825,7 +825,7 @@
                 "version_added": "≤79"
               },
               "firefox": {
-                "version_added": false
+                "version_added": "37"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `key.dead_key` member of the `KeyboardEvent` API. The data comes from a bug in the web browser's bug tracker.

Bug: https://bugzil.la/938987

Additional Notes: This fixes #11523.
