### PR TITLE
Update Safari iOS data for OES_texture_float_linear API

### DIFF
--- a/api/OES_texture_float_linear.json
+++ b/api/OES_texture_float_linear.json
@@ -25,7 +25,10 @@
           "safari": {
             "version_added": "8"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "8",
+            "notes": "Only supported on iPadOS."
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `OES_texture_float_linear` API. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code: https://mdn-bcd-collector.gooborg.com/tests/api/OES_texture_float_linear

Additional Notes: This fixes #11536.
