### PR TITLE
Update Safari data for MediaRecorder API

### DIFF
--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -26,9 +26,11 @@
             "version_added": "36"
           },
           "safari": {
+            "version_added": "14.1"
+          },
+          "safari_ios": {
             "version_added": "14"
           },
-          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -64,9 +66,11 @@
               "version_added": "36"
             },
             "safari": {
+              "version_added": "14.1"
+            },
+            "safari_ios": {
               "version_added": "14"
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -96,9 +100,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
+                "version_added": "14.1"
+              },
+              "safari_ios": {
                 "version_added": "14"
               },
-              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -199,9 +205,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
+              "version_added": "14.1"
+            },
+            "safari_ios": {
               "version_added": "14"
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -236,9 +244,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
+              "version_added": "14.1"
+            },
+            "safari_ios": {
               "version_added": "14"
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -275,9 +285,11 @@
               "version_added": "36"
             },
             "safari": {
+              "version_added": "14.1"
+            },
+            "safari_ios": {
               "version_added": "14"
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -324,9 +336,11 @@
               "version_added": "36"
             },
             "safari": {
+              "version_added": "14.1"
+            },
+            "safari_ios": {
               "version_added": "14"
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -427,9 +441,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
+              "version_added": "14.1"
+            },
+            "safari_ios": {
               "version_added": "14"
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -534,9 +550,11 @@
               "version_added": "36"
             },
             "safari": {
+              "version_added": "14.1"
+            },
+            "safari_ios": {
               "version_added": "14"
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -569,9 +587,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
+              "version_added": "14.1"
+            },
+            "safari_ios": {
               "version_added": "14"
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -615,9 +635,11 @@
               "version_added": "36"
             },
             "safari": {
+              "version_added": "14.1"
+            },
+            "safari_ios": {
               "version_added": "14"
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -649,9 +671,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
+              "version_added": "14.1"
+            },
+            "safari_ios": {
               "version_added": "14"
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -684,9 +708,11 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
+              "version_added": "14.1"
+            },
+            "safari_ios": {
               "version_added": "14"
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -730,9 +756,11 @@
               "version_added": "36"
             },
             "safari": {
+              "version_added": "14.1"
+            },
+            "safari_ios": {
               "version_added": "14"
             },
-            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "49"


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `MediaRecorder` API. This fixes #11998.
