### PR TITLE
Update Firefox Android data for css.properties.grid-template-columns.subgrid

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -283,9 +283,7 @@
               "firefox": {
                 "version_added": "71"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox Android for the `subgrid` member of the `grid-template-columns` CSS property. This fixes #12128 by setting Firefox Android to mirror.
