### PR TITLE
Update Chrome Android data for api.HTMLCanvasElement.toBlob

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -1059,9 +1059,7 @@
               "chrome": {
                 "version_added": "50"
               },
-              "chrome_android": {
-                "version_added": false
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": "25"
@@ -1078,9 +1076,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "50"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
This PR updates and corrects version values for Chrome Android for the `toBlob` member of the `HTMLCanvasElement` API. This fixes #12192 by setting Chrome Android to mirror.
