### PR TITLE
Combine console "substitution strings" features

### DIFF
--- a/api/_globals/console.json
+++ b/api/_globals/console.json
@@ -331,70 +331,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "substitution_strings": {
-          "__compat": {
-            "description": "Substitution strings",
-            "support": {
-              "chrome": {
-                "version_added": "2",
-                "notes": "In version 28, if a negative value is passed to <code>%d</code>, it will be rounded down to the closest negative integer. For example, -0.1 becomes -1."
-              },
-              "chrome_android": "mirror",
-              "deno": {
-                "version_added": "1.0",
-                "notes": [
-                  "Before Deno 1.4, <code>%c</code> is not supported.",
-                  "<code>%c</code> only supports CSS properties <code>color</code>, <code>background-color</code>, <code>font-weight</code>, <code>font-style</code>, <code>text-decoration-color</code>, and <code>text-decoration-line</code>."
-                ]
-              },
-              "edge": {
-                "version_added": "12",
-                "notes": [
-                  "Before Edge 79, <code>%c</code> is not supported.",
-                  "Before Edge 79, <code>%d</code> outputs a 0 if the specified value isn't a number."
-                ]
-              },
-              "firefox": {
-                "version_added": "9"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "10",
-                "notes": [
-                  "<code>%c</code> is not supported.",
-                  "<code>%d</code> outputs a 0 if the specified value isn't a number."
-                ]
-              },
-              "nodejs": {
-                "version_added": "8.10.0"
-              },
-              "oculus": "mirror",
-              "opera": {
-                "version_added": "15"
-              },
-              "opera_android": {
-                "version_added": "14"
-              },
-              "safari": {
-                "version_added": "4"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": {
-                "version_added": "1.0",
-                "notes": "In Samsung Internet 1.5, if a negative value is passed to <code>%d</code>, it will be rounded down to the closest negative integer. For example, -0.1 becomes -1."
-              },
-              "webview_android": {
-                "version_added": "≤37",
-                "notes": "In version 28, if a negative value is passed to <code>%d</code>, it will be rounded down to the closest negative integer. For example, -0.1 becomes -1."
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "dir": {
@@ -546,61 +482,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "substitution_strings": {
-          "__compat": {
-            "description": "Substitution strings",
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "deno": {
-                "version_added": "1.0",
-                "notes": [
-                  "Before Deno 1.4, <code>%c</code> is not supported.",
-                  "<code>%c</code> only supports CSS properties <code>color</code>, <code>background-color</code>, <code>font-weight</code>, <code>font-style</code>, <code>text-decoration-color</code>, and <code>text-decoration-line</code>."
-                ]
-              },
-              "edge": {
-                "version_added": "12",
-                "notes": [
-                  "Before Edge 79, <code>%c</code> is not supported.",
-                  "Before Edge 79, <code>%d</code> outputs a 0 if the specified value isn't a number."
-                ]
-              },
-              "firefox": {
-                "version_added": "9"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "10",
-                "notes": [
-                  "<code>%c</code> is not supported.",
-                  "<code>%d</code> outputs a 0 if the specified value isn't a number."
-                ]
-              },
-              "nodejs": {
-                "version_added": "0.10.0"
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "3"
-              },
-              "safari_ios": {
-                "version_added": "1"
-              },
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "exception": {
@@ -642,48 +523,6 @@
             "experimental": false,
             "standard_track": false,
             "deprecated": true
-          }
-        },
-        "substitution_strings": {
-          "__compat": {
-            "description": "Substitution strings",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "deno": {
-                "version_added": false
-              },
-              "edge": {
-                "version_added": "≤18",
-                "version_removed": "79"
-              },
-              "firefox": {
-                "version_added": "28"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "nodejs": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
           }
         }
       },
@@ -879,61 +718,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "substitution_strings": {
-          "__compat": {
-            "description": "Substitution strings",
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "deno": {
-                "version_added": "1.0",
-                "notes": [
-                  "Before Deno 1.4, <code>%c</code> is not supported.",
-                  "<code>%c</code> only supports CSS properties <code>color</code>, <code>background-color</code>, <code>font-weight</code>, <code>font-style</code>, <code>text-decoration-color</code>, and <code>text-decoration-line</code>."
-                ]
-              },
-              "edge": {
-                "version_added": "12",
-                "notes": [
-                  "Before Edge 79, <code>%c</code> is not supported.",
-                  "Before Edge 79, <code>%d</code> outputs a 0 if the specified value isn't a number."
-                ]
-              },
-              "firefox": {
-                "version_added": "9"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "10",
-                "notes": [
-                  "<code>%c</code> is not supported.",
-                  "<code>%d</code> outputs a 0 if the specified value isn't a number."
-                ]
-              },
-              "nodejs": {
-                "version_added": "0.10.0"
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "3"
-              },
-              "safari_ios": {
-                "version_added": "1"
-              },
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "log": {
@@ -981,72 +765,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "substitution_strings": {
-          "__compat": {
-            "description": "Substitution strings",
-            "support": {
-              "chrome": {
-                "version_added": "1",
-                "notes": "In version 28, if a negative value is passed to %d, it will be rounded down to the closest negative integer, so -0.1 becomes -1."
-              },
-              "chrome_android": "mirror",
-              "deno": {
-                "version_added": "1.0",
-                "notes": [
-                  "Before Deno 1.4, <code>%c</code> is not supported.",
-                  "<code>%c</code> only supports CSS properties <code>color</code>, <code>background-color</code>, <code>font-weight</code>, <code>font-style</code>, <code>text-decoration-color</code>, and <code>text-decoration-line</code>."
-                ]
-              },
-              "edge": {
-                "version_added": "12",
-                "notes": [
-                  "Before Edge 79, <code>%c</code> is not supported.",
-                  "Before Edge 79, <code>%d</code> outputs a 0 if the specified value isn't a number."
-                ]
-              },
-              "firefox": {
-                "version_added": "9"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "10",
-                "notes": [
-                  "<code>%c</code> is not supported.",
-                  "<code>%d</code> outputs a 0 if the specified value isn't a number."
-                ]
-              },
-              "nodejs": {
-                "version_added": "0.10.0"
-              },
-              "oculus": "mirror",
-              "opera": {
-                "version_added": "15"
-              },
-              "opera_android": {
-                "version_added": "14"
-              },
-              "safari": {
-                "version_added": "3"
-              },
-              "safari_ios": {
-                "version_added": "1"
-              },
-              "samsunginternet_android": {
-                "version_added": "1.0",
-                "notes": "In Samsung Internet 1.5, if a negative value is passed to %d, it will be rounded down to the closest negative integer, so -0.1 becomes -1."
-              },
-              "webview_android": {
-                "version_added": "≤37",
-                "notes": "In version 28, if a negative value is passed to %d, it will be rounded down to the closest negative integer, so -0.1 becomes -1."
-              }
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },
@@ -1153,6 +871,72 @@
           "status": {
             "experimental": false,
             "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "substitution_strings": {
+        "__compat": {
+          "description": "Substitution strings",
+          "support": {
+            "chrome": {
+              "version_added": "1",
+              "notes": "In version 28, if a negative value is passed to %d, it will be rounded down to the closest negative integer, so -0.1 becomes -1."
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.0",
+              "notes": [
+                "Before Deno 1.4, <code>%c</code> is not supported.",
+                "<code>%c</code> only supports CSS properties <code>color</code>, <code>background-color</code>, <code>font-weight</code>, <code>font-style</code>, <code>text-decoration-color</code>, and <code>text-decoration-line</code>."
+              ]
+            },
+            "edge": {
+              "version_added": "12",
+              "notes": [
+                "Before Edge 79, <code>%c</code> is not supported.",
+                "Before Edge 79, <code>%d</code> outputs a 0 if the specified value isn't a number."
+              ]
+            },
+            "firefox": {
+              "version_added": "9"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": "10",
+              "notes": [
+                "<code>%c</code> is not supported.",
+                "<code>%d</code> outputs a 0 if the specified value isn't a number."
+              ]
+            },
+            "nodejs": {
+              "version_added": "0.10.0"
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": "15"
+            },
+            "opera_android": {
+              "version_added": "14"
+            },
+            "safari": {
+              "version_added": "3"
+            },
+            "safari_ios": {
+              "version_added": "1"
+            },
+            "samsunginternet_android": {
+              "version_added": "1.0",
+              "notes": "In Samsung Internet 1.5, if a negative value is passed to %d, it will be rounded down to the closest negative integer, so -0.1 becomes -1."
+            },
+            "webview_android": {
+              "version_added": "≤37",
+              "notes": "In version 28, if a negative value is passed to %d, it will be rounded down to the closest negative integer, so -0.1 becomes -1."
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
@@ -1484,61 +1268,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "substitution_strings": {
-          "__compat": {
-            "description": "Substitution strings",
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "deno": {
-                "version_added": "1.0",
-                "notes": [
-                  "Before Deno 1.4, <code>%c</code> is not supported.",
-                  "<code>%c</code> only supports CSS properties <code>color</code>, <code>background-color</code>, <code>font-weight</code>, <code>font-style</code>, <code>text-decoration-color</code>, and <code>text-decoration-line</code>."
-                ]
-              },
-              "edge": {
-                "version_added": "12",
-                "notes": [
-                  "Before Edge 79, <code>%c</code> is not supported.",
-                  "Before Edge 79, <code>%d</code> outputs a 0 if the specified value isn't a number."
-                ]
-              },
-              "firefox": {
-                "version_added": "9"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "10",
-                "notes": [
-                  "<code>%c</code> is not supported.",
-                  "<code>%d</code> outputs a 0 if the specified value isn't a number."
-                ]
-              },
-              "nodejs": {
-                "version_added": "0.10.0"
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "3"
-              },
-              "safari_ios": {
-                "version_added": "1"
-              },
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       }


### PR DESCRIPTION
This PR combines the "substitution strings" subfeatures of the Console API.  This fixes #12607.
