### PR TITLE
Update Edge data for webextensions.manifest.background.persistent

### DIFF
--- a/webextensions/manifest/background.json
+++ b/webextensions/manifest/background.json
@@ -58,7 +58,11 @@
                 "notes": "Available for use in Manifest V2 only."
               },
               "edge": {
-                "version_added": "14"
+                "version_added": "14",
+                "notes": [
+                  "Available for use in Manifest V2 only.",
+                  "Before Edge 79, this property was required."
+                ]
               },
               "firefox": {
                 "version_added": "48",

--- a/webextensions/manifest/background.json
+++ b/webextensions/manifest/background.json
@@ -58,8 +58,7 @@
                 "notes": "Available for use in Manifest V2 only."
               },
               "edge": {
-                "version_added": "14",
-                "notes": "This property is required."
+                "version_added": "14"
               },
               "firefox": {
                 "version_added": "48",


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `persistent` member of the `background` Web Extensions manifest property. This fixes #12702.
