### PR TITLE
Update Safari data for javascript.statements.for_await_of

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -759,7 +759,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11"
+              "version_added": "12"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `for_await_of` member of the `statements` JavaScript feature. This fixes #14522.
