### PR TITLE
Update Chromium data for html.elements.link.rel.alternate_stylesheet

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -640,12 +640,8 @@
                   "version_added": "1",
                   "version_removed": "48"
                 },
-                "chrome_android": {
-                  "version_added": null
-                },
-                "edge": {
-                  "version_added": null
-                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "3"
                 },
@@ -654,9 +650,7 @@
                   "version_added": "8"
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": true
-                },
+                "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": null


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `rel.alternate_stylesheet` member of the `link` HTML element. This fixes #14987 by setting all Chromium browsers to mirror from upstream.
