### PR TITLE
Add browser support for search element

### DIFF
--- a/html/elements/search.json
+++ b/html/elements/search.json
@@ -10,28 +10,20 @@
               "version_added": false,
               "notes": "See <a href='https://crbug.com/937101'>bug 1294294</a> and <a href='https://crbug.com/1277435'>bug 1277435</a>."
             },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1824121'>bug 1824121</a>."
+              "version_added": "118"
             },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
-              "notes": "See <a href=' https://webkit.org/b/254327'>bug 254327</a>."
+              "version_added": "17"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
Also clean up non-mirrored data that should be mirrored

#### Summary
Add Safari and Firefox support for search element

#### Test results and supporting details

https://groups.google.com/a/mozilla.org/g/dev-platform/c/1Eoh9zcTt08/m/xdir_heoAQAJ - Firefox Intent to Ship

Safari manually tested on latest 16.x version it's not supported, and 17 beta it is.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
