### PR TITLE
FF117 WebRTC encoded transform API

### DIFF
--- a/api/DedicatedWorkerGlobalScope.json
+++ b/api/DedicatedWorkerGlobalScope.json
@@ -381,7 +381,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -398,7 +398,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/DedicatedWorkerGlobalScope.json
+++ b/api/DedicatedWorkerGlobalScope.json
@@ -373,6 +373,7 @@
       "rtctransform_event": {
         "__compat": {
           "description": "<code>rtctransform</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/rtctransform_event",
           "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-dedicatedworkerglobalscope-onrtctransform",
           "support": {
             "chrome": {

--- a/api/RTCEncodedAudioFrame.json
+++ b/api/RTCEncodedAudioFrame.json
@@ -2,6 +2,8 @@
   "api": {
     "RTCEncodedAudioFrame": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCEncodedAudioFrame",
+        "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#RTCEncodedAudioFrame-interface",
         "support": {
           "chrome": {
             "version_added": "86"
@@ -33,6 +35,7 @@
       },
       "data": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCEncodedAudioFrame/data",
           "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcencodedaudioframe-data",
           "support": {
             "chrome": {
@@ -66,6 +69,7 @@
       },
       "getMetadata": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCEncodedAudioFrame/getMetadata",
           "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcencodedaudioframe-getmetadata",
           "support": {
             "chrome": {
@@ -99,6 +103,7 @@
       },
       "timestamp": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCEncodedAudioFrame/timestamp",
           "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcencodedaudioframe-timestamp",
           "support": {
             "chrome": {

--- a/api/RTCEncodedAudioFrame.json
+++ b/api/RTCEncodedAudioFrame.json
@@ -9,7 +9,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "117"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -41,7 +41,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -74,7 +74,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -107,7 +107,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/RTCEncodedVideoFrame.json
+++ b/api/RTCEncodedVideoFrame.json
@@ -2,6 +2,8 @@
   "api": {
     "RTCEncodedVideoFrame": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCEncodedVideoFrame",
+        "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#RTCEncodedVideoFrame-interface",
         "support": {
           "chrome": {
             "version_added": "86"
@@ -33,6 +35,7 @@
       },
       "data": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCEncodedVideoFrame/data",
           "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcencodedvideoframe-data",
           "support": {
             "chrome": {
@@ -66,6 +69,7 @@
       },
       "getMetadata": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCEncodedVideoFrame/getMetadata",
           "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcencodedvideoframe-getmetadata",
           "support": {
             "chrome": {
@@ -99,6 +103,7 @@
       },
       "timestamp": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCEncodedVideoFrame/timestamp",
           "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcencodedvideoframe-timestamp",
           "support": {
             "chrome": {
@@ -132,6 +137,7 @@
       },
       "type": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCEncodedVideoFrame/type",
           "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcencodedvideoframe-type",
           "support": {
             "chrome": {

--- a/api/RTCEncodedVideoFrame.json
+++ b/api/RTCEncodedVideoFrame.json
@@ -9,7 +9,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "117"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -41,7 +41,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -74,7 +74,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -107,7 +107,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -140,7 +140,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -568,6 +568,7 @@
       },
       "transform": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpReceiver/transform",
           "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcrtpsender-transform",
           "support": {
             "chrome": {

--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -576,7 +576,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -593,7 +593,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/RTCRtpScriptTransform.json
+++ b/api/RTCRtpScriptTransform.json
@@ -2,6 +2,7 @@
   "api": {
     "RTCRtpScriptTransform": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpScriptTransform",
         "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#rtcrtpscripttransform",
         "support": {
           "chrome": {
@@ -35,6 +36,7 @@
       "RTCRtpScriptTransform": {
         "__compat": {
           "description": "<code>RTCRtpScriptTransform()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpScriptTransform/RTCRtpScriptTransform",
           "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcrtpscripttransform-rtcrtpscripttransform",
           "support": {
             "chrome": {

--- a/api/RTCRtpScriptTransform.json
+++ b/api/RTCRtpScriptTransform.json
@@ -10,7 +10,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "117"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -27,7 +27,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -43,7 +43,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -60,7 +60,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/RTCRtpScriptTransformer.json
+++ b/api/RTCRtpScriptTransformer.json
@@ -2,6 +2,7 @@
   "api": {
     "RTCRtpScriptTransformer": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpScriptTransformer",
         "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#rtcrtpscripttransformer",
         "support": {
           "chrome": {
@@ -34,6 +35,7 @@
       },
       "generateKeyFrame": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpScriptTransformer/generateKeyFrame",
           "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcrtpscripttransformer-generatekeyframe",
           "support": {
             "chrome": {
@@ -67,6 +69,7 @@
       },
       "options": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpScriptTransformer/options",
           "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcrtpscripttransformer-options",
           "support": {
             "chrome": {
@@ -100,6 +103,7 @@
       },
       "readable": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpScriptTransformer/readable",
           "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcrtpscripttransformer-readable",
           "support": {
             "chrome": {
@@ -133,6 +137,7 @@
       },
       "sendKeyFrameRequest": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpScriptTransformer/sendKeyFrameRequest",
           "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcrtpscripttransformer-sendkeyframerequest",
           "support": {
             "chrome": {
@@ -166,6 +171,7 @@
       },
       "writable": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpScriptTransformer/writable",
           "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcrtpscripttransformer-writable",
           "support": {
             "chrome": {

--- a/api/RTCRtpScriptTransformer.json
+++ b/api/RTCRtpScriptTransformer.json
@@ -10,7 +10,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "117"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -27,7 +27,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -42,7 +42,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -59,7 +59,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -75,7 +75,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -92,7 +92,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -108,7 +108,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -125,7 +125,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -141,7 +141,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -158,7 +158,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -174,7 +174,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -191,7 +191,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -859,7 +859,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -876,7 +876,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -851,6 +851,7 @@
       },
       "transform": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpSender/transform",
           "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtcrtpsender-transform",
           "support": {
             "chrome": {

--- a/api/RTCTransformEvent.json
+++ b/api/RTCTransformEvent.json
@@ -10,7 +10,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "117"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -27,7 +27,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -42,7 +42,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -59,7 +59,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/RTCTransformEvent.json
+++ b/api/RTCTransformEvent.json
@@ -2,6 +2,7 @@
   "api": {
     "RTCTransformEvent": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCTransformEvent",
         "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#rtctransformevent",
         "support": {
           "chrome": {
@@ -34,6 +35,7 @@
       },
       "transformer": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCTransformEvent/transformer",
           "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#dom-rtctransformevent-transformer",
           "support": {
             "chrome": {


### PR DESCRIPTION
FF117 adds support for the [WebRTC encoded transform API](https://w3c.github.io/webrtc-encoded-transform/) in https://bugzilla.mozilla.org/show_bug.cgi?id=1631263.

Specifically `RTCRtpScriptTransform` and friends, but not `SFrameTransform`.

This updates all the supported members, as tested by review of WebIDL and testing using https://mdn-bcd-collector.gooborg.com/tests/api/ 

Related docs work can be tracked in https://github.com/mdn/content/issues/28280