### PR TITLE
Remove irrelevant  flag data for scroll-timeline CSS property

### DIFF
--- a/css/properties/scroll-timeline.json
+++ b/css/properties/scroll-timeline.json
@@ -6,66 +6,28 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-timeline",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#scroll-timeline-shorthand",
           "support": {
-            "chrome": [
-              {
-                "version_added": "115",
-                "partial_implementation": true,
-                "notes": "<code>scroll-timeline-attachment</code> not included in shorthand."
-              },
-              {
-                "version_added": "111",
-                "notes": "The syntax of the shorthand property `scroll-timeline` uses the fixed order of name and then the axis.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "108",
-                "notes": "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "115",
+              "partial_implementation": true,
+              "notes": "<code>scroll-timeline-attachment</code> not included in shorthand."
+            },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "111",
-                "notes": [
-                  "The syntax of the shorthand property uses the fixed order of name and then the axis.",
-                  "Supports the deprecated <code>horizontal</code> and <code>vertical</code> axis values, and not the <code>x</code> and <code>y</code> values.",
-                  "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`."
-                ],
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.scroll-driven-animations.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "103",
-                "version_removed": "110",
-                "notes": "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.scroll-linked-animations.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "111",
+              "notes": [
+                "The syntax of the shorthand property uses the fixed order of name and then the axis.",
+                "Supports the deprecated <code>horizontal</code> and <code>vertical</code> axis values, and not the <code>x</code> and <code>y</code> values.",
+                "The <code>@scroll-timeline</code> at-rule is replaced with the longhand properties <code>scroll-timeline-name</code> and <code>scroll-timeline-axis</code> and the shorthand property <code>scroll-timeline</code>."
+              ],
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.scroll-driven-animations.enabled",
+                  "value_to_set": "true"
+                }
+              ]
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for  for the `scroll-timeline` CSS property as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-flag-data). This PR was created from results of the `remove-redundant-flags` script.

Additional Notes: This also fixes the notes that were incorrectly formatted with Markdown rather than HTML.
