### PR TITLE
Update Firefox data for webextensions.api.menus.OnClickData.srcUrl

### DIFF
--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -421,16 +421,10 @@
                   "version_added": true
                 },
                 "edge": "mirror",
-                "firefox": [
-                  {
-                    "version_added": "48"
-                  },
-                  {
-                    "version_added": "59",
-                    "version_removed": "94",
-                    "notes": "Returns a post-redirect URL rather than the raw value of the <code>src</code> attribute of the clicked element."
-                  }
-                ],
+                "firefox": {
+                  "version_added": "48",
+                  "notes": "Between Firefox 59 and Firefox 94, this returns a post-redirect URL rather than the raw value of the <code>src</code> attribute of the clicked element."
+                },
                 "firefox_android": {
                   "version_added": false
                 },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `OnClickData.srcUrl` member of the `menus` Web Extensions interface. This fixes #15848 by removing the separate statement for the note and instead simply combining it with the above statement.
