### PR TITLE
Remove mention of Array.group[ToMap]

### DIFF
--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -506,17 +506,9 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": [
-                {
-                  "version_added": "preview"
-                },
-                {
-                  "version_added": "16.4",
-                  "version_removed": "16.6",
-                  "partial_implementation": true,
-                  "notes": "This feature was originally supported via <code>Array.prototype.groupToMap</code>."
-                }
-              ],
+              "safari": {
+                "version_added": "preview"
+              },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -512,8 +512,9 @@
                 },
                 {
                   "version_added": "16.4",
-                  "version_removed": "preview",
-                  "alternative_name": "Array.prototype.groupToMap"
+                  "version_removed": "16.6",
+                  "partial_implementation": true,
+                  "notes": "This feature was originally supported via <code>Array.prototype.groupToMap</code>."
                 }
               ],
               "safari_ios": "mirror",

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -856,17 +856,9 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": [
-                {
-                  "version_added": "preview"
-                },
-                {
-                  "version_added": "16.4",
-                  "version_removed": "16.6",
-                  "partial_implementation": true,
-                  "notes": "This feature was originally supported via <code>Array.prototype.group</code>."
-                }
-              ],
+              "safari": {
+                "version_added": "preview"
+              },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -862,8 +862,9 @@
                 },
                 {
                   "version_added": "16.4",
-                  "version_removed": "preview",
-                  "alternative_name": "Array.prototype.groupToMap"
+                  "version_removed": "16.6",
+                  "partial_implementation": true,
+                  "notes": "This feature was originally supported via <code>Array.prototype.group</code>."
                 }
               ],
               "safari_ios": "mirror",


### PR DESCRIPTION
This PR is a follow-up to #20497 which fixes the data by ~~replacing the improper `alternative_name` with notes and adding a `version_removed` (as confirmed locally).~~ removing all mention of the former methods available on the Array prototype.