### PR TITLE
Remove anachronistic proxy details

### DIFF
--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -387,34 +387,6 @@
             }
           }
         },
-        "register": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/proxy/register",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "56",
-                  "version_removed": "71"
-                },
-                {
-                  "alternative_name": "registerProxyScript",
-                  "version_added": "55",
-                  "version_removed": "71"
-                }
-              ],
-              "firefox_android": "mirror",
-              "opera": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror"
-            }
-          }
-        },
         "settings": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/proxy/settings",
@@ -430,27 +402,6 @@
               "firefox_android": {
                 "version_added": false
               },
-              "opera": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror"
-            }
-          }
-        },
-        "unregister": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/proxy/unregister",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "56",
-                "version_removed": "71"
-              },
-              "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
                 "version_added": false


### PR DESCRIPTION
#### Summary

Documentation for the `proxy,register` and `proxy.unregister` functions removed as part of "proxy API compatibility details update" [#28276](https://github.com/mdn/content/pull/28276)
