### PR TITLE
CSS: add font-display descriptor

### DIFF
--- a/css/at-rules/font-feature-values.json
+++ b/css/at-rules/font-feature-values.json
@@ -105,7 +105,7 @@
         },
         "font-display": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-featur-values/font-display",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-feature-values/font-display",
             "spec_url": "https://drafts.csswg.org/css-fonts/#font-display-font-feature-values",
             "support": {
               "chrome": {

--- a/css/at-rules/font-feature-values.json
+++ b/css/at-rules/font-feature-values.json
@@ -103,6 +103,42 @@
             }
           }
         },
+        "font-display": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/@font-featur-values/font-display",
+            "spec_url": "https://drafts.csswg.org/css-fonts/#font-display-font-feature-values",
+            "support": {
+              "chrome": {
+                "version_added": "60"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "58"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "11.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": {
+                "version_added": "11.0"
+              },
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "historical-forms": {
           "__compat": {
             "description": "<code>@historical-forms</code>",


### PR DESCRIPTION
Part of https://github.com/openwebdocs/project/issues/176
Creating a page at https://developer.mozilla.org/en-US/docs/Web/CSS/@font-feature-values/font-display (no pr yet)
https://drafts.csswg.org/css-fonts/#font-display-font-feature-values

The `display-font` descriptor is the same for `@font-feature-values` as for `@font-face`.