### PR TITLE
Safari 10 supports :indeterminate with <input type=radio>

### DIFF
--- a/css/selectors/indeterminate.json
+++ b/css/selectors/indeterminate.json
@@ -148,8 +148,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/156270'>WebKit bug 156270</a>."
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
See https://github.com/WebKit/WebKit/commit/e8eecf8527fbf9bc9f3984d7e42d9a2ad9dbf233

Fixes https://github.com/mdn/browser-compat-data/issues/20503