### PR TITLE
Firefox 115 supports Canvas {letter,word}Spacing

### DIFF
--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1732,7 +1732,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "115"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1749,7 +1749,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -3182,7 +3182,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "115"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3199,7 +3199,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -1232,7 +1232,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "115"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1249,7 +1249,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -2355,7 +2355,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "115"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2372,7 +2372,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1778909

(Looks like part of interop2023)