### PR TITLE
Add data for Clear-Site-Data clientHints type

### DIFF
--- a/http/headers/Clear-Site-Data.json
+++ b/http/headers/Clear-Site-Data.json
@@ -116,15 +116,12 @@
             "spec_url": "https://w3c.github.io/webappsec-clear-site-data/#grammardef-clienthints",
             "support": {
               "chrome": {
-                "version_added": "61"
+                "version_added": "117"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤79"
-              },
+              "edge": "mirror",
               "firefox": {
-                "version_added": "63",
-                "version_removed": "94"
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {

--- a/http/headers/Clear-Site-Data.json
+++ b/http/headers/Clear-Site-Data.json
@@ -75,6 +75,45 @@
           "__compat": {
             "description": "<code>&quot;cache&quot;</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data#cache",
+            "spec_url": "https://w3c.github.io/webappsec-clear-site-data/#grammardef-cache",
+            "support": {
+              "chrome": {
+                "version_added": "61"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "≤79"
+              },
+              "firefox": {
+                "version_added": "63",
+                "version_removed": "94"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "clientHints": {
+          "__compat": {
+            "description": "<code>&quot;clientHints&quot;</code>",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data#clientHints",
+            "spec_url": "https://w3c.github.io/webappsec-clear-site-data/#grammardef-clienthints",
             "support": {
               "chrome": {
                 "version_added": "61"
@@ -112,6 +151,7 @@
           "__compat": {
             "description": "<code>&quot;cookies&quot;</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data#cookies",
+            "spec_url": "https://w3c.github.io/webappsec-clear-site-data/#grammardef-cookies",
             "support": {
               "chrome": {
                 "version_added": "61"
@@ -148,6 +188,7 @@
           "__compat": {
             "description": "<code>&quot;executionContexts&quot;</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data#executionContexts",
+            "spec_url": "https://w3c.github.io/webappsec-clear-site-data/#grammardef-executioncontexts",
             "support": {
               "chrome": {
                 "version_added": false,
@@ -186,6 +227,7 @@
           "__compat": {
             "description": "<code>&quot;storage&quot;</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Clear-Site-Data#storage",
+            "spec_url": "https://w3c.github.io/webappsec-clear-site-data/#grammardef-storage",
             "support": {
               "chrome": {
                 "version_added": "61"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The `Clear-Site-Data` HTTP header [`clientHints` data type](https://w3c.github.io/webappsec-clear-site-data/#grammardef-clienthints) will be supported in Chrome 117 (see [ChromeStatus entry](https://chromestatus.com/feature/5105030738214912)). This PR adds BCD for it.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
