### PR TITLE
Update Firefox Android data for html.global_attributes.part

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1166,9 +1166,7 @@
             "firefox": {
               "version_added": "72"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox Android for the `part` member of the `global_attributes` HTML feature. This fixes #20402 by setting FxA to mirror from upstream.
