### PR TITLE
Add Chrome support data for groupBy()

### DIFF
--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -479,7 +479,7 @@
             "spec_url": "https://tc39.es/proposal-array-grouping/#sec-map.groupby",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "117"
               },
               "chrome_android": "mirror",
               "deno": {

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -829,7 +829,7 @@
             "spec_url": "https://tc39.es/proposal-array-grouping/#sec-object.groupby",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "117"
               },
               "chrome_android": "mirror",
               "deno": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The [`Map.groupBy()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/groupBy) and [`Object.groupBy()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/groupBy) static methods are supported in Chrome 117 release (see [ChromeStatus entry](https://chromestatus.com/feature/5714791975878656); I also tested them in Canary 117).

This PR updates the BCD to suit.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
