### PR TITLE
Add BCD for Document Picture-In-Picture API

### DIFF
--- a/api/DocumentPictureInPicture.json
+++ b/api/DocumentPictureInPicture.json
@@ -1,0 +1,149 @@
+{
+  "api": {
+    "DocumentPictureInPicture": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentPictureInPicture",
+        "spec_url": "https://wicg.github.io/document-picture-in-picture/#documentpictureinpicture",
+        "support": {
+          "chrome": {
+            "version_added": "116"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "enter_event": {
+        "__compat": {
+          "description": "<code>enter</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentPictureInPicture/enter_event",
+          "spec_url": "https://wicg.github.io/document-picture-in-picture/#dom-documentpictureinpicture-onenter",
+          "support": {
+            "chrome": {
+              "version_added": "116"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "requestWindow": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentPictureInPicture/requestWindow",
+          "spec_url": "https://wicg.github.io/document-picture-in-picture/#dom-documentpictureinpicture-requestwindow",
+          "support": {
+            "chrome": {
+              "version_added": "116"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "window": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentPictureInPicture/window",
+          "spec_url": "https://wicg.github.io/document-picture-in-picture/#dom-documentpictureinpicture-window",
+          "support": {
+            "chrome": {
+              "version_added": "116"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/DocumentPictureInPictureEvent.json
+++ b/api/DocumentPictureInPictureEvent.json
@@ -1,0 +1,113 @@
+{
+  "api": {
+    "DocumentPictureInPictureEvent": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentPictureInPictureEvent",
+        "spec_url": "https://wicg.github.io/document-picture-in-picture/#documentpictureinpictureevent",
+        "support": {
+          "chrome": {
+            "version_added": "116"
+          },
+          "chrome_android": {
+            "version_added": false
+          },
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "DocumentPictureInPictureEvent": {
+        "__compat": {
+          "description": "<code>DocumentPictureInPictureEvent()</code> constructor",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentPictureInPictureEvent/DocumentPictureInPictureEvent",
+          "spec_url": "https://wicg.github.io/document-picture-in-picture/#dom-documentpictureinpictureevent-documentpictureinpictureevent",
+          "support": {
+            "chrome": {
+              "version_added": "116"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "window": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/DocumentPictureInPictureEvent/window",
+          "spec_url": "https://wicg.github.io/document-picture-in-picture/#dom-documentpictureinpictureevent-window",
+          "support": {
+            "chrome": {
+              "version_added": "116"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/Window.json
+++ b/api/Window.json
@@ -1188,6 +1188,42 @@
           }
         }
       },
+      "documentPictureInPicture": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/documentPictureInPicture",
+          "spec_url": "https://wicg.github.io/document-picture-in-picture/#dom-window-documentpictureinpicture",
+          "support": {
+            "chrome": {
+              "version_added": "116"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "dump": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/dump",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The [Document Picture-In-Picture API](https://wicg.github.io/document-picture-in-picture/) is supported in release Chrome version 116 (see [ChromeStatus entry](https://chromestatus.com/feature/5755179560337408)). This PR adds BCD for this API.

See my [research document](https://docs.google.com/document/d/1YGFqgYX8nqOQYAh8hgMfjmTJUrxBe932q4aicXdM8qo/edit) for more details of exactly what has been added.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
