### PR TITLE
relnote(117): 'auto none' allowed for 'contain-intrinsic-size' CSS prop

### DIFF
--- a/css/properties/contain-intrinsic-size.json
+++ b/css/properties/contain-intrinsic-size.json
@@ -50,9 +50,6 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "false"
-              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/css/properties/contain-intrinsic-size.json
+++ b/css/properties/contain-intrinsic-size.json
@@ -39,7 +39,7 @@
             "description": "<code>auto none</code> value",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "117"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/contain-intrinsic-size.json
+++ b/css/properties/contain-intrinsic-size.json
@@ -33,6 +33,42 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "auto_none": {
+          "__compat": {
+            "description": "<code>auto none</code> value",
+            "support": {
+              "chrome": {
+                "version_added": "preview"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "117"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "false"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "false"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/contain-intrinsic-size.json
+++ b/css/properties/contain-intrinsic-size.json
@@ -54,7 +54,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "false"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
The declaration `contain-intrinsic-size: auto none` is now supported.

__Docs:__

- [`contain-intrinsic-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/contain-intrinsic-size)


__Related issues and pull requests:__
- [ ] Parent issue https://github.com/mdn/content/issues/28292
- [x] Relnote: https://github.com/mdn/content/pull/28522

__Bugzilla:__
- https://bugzilla.mozilla.org/show_bug.cgi?id=1835813

__WPT:__
- https://wpt.fyi/results/css/css-sizing/contain-intrinsic-size/auto-014.html?label=experimental&label=master&aligned

__Resources:__
- https://phabricator.services.mozilla.com/D174583#inline-985747
- https://chromestatus.com/feature/6203168806928384
- https://wicg.github.io/display-locking/sample-code/contain-intrinsic-size-examples.html