### PR TITLE
The transition-behavior property

### DIFF
--- a/css/properties/transition-behavior.json
+++ b/css/properties/transition-behavior.json
@@ -7,7 +7,7 @@
           "spec_url": "https://drafts.csswg.org/css-transitions-2/#transition-behavior-property",
           "support": {
             "chrome": {
-              "version_added": "117",
+              "version_added": "117"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/transition-behavior.json
+++ b/css/properties/transition-behavior.json
@@ -1,0 +1,40 @@
+{
+  "css": {
+    "properties": {
+      "transition-behavior": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/transition-behavior",
+          "spec_url": "https://drafts.csswg.org/css-transitions-2/#transition-behavior-property",
+          "support": {
+            "chrome": {
+              "version_added": "116",
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/transition-behavior.json
+++ b/css/properties/transition-behavior.json
@@ -7,7 +7,7 @@
           "spec_url": "https://drafts.csswg.org/css-transitions-2/#transition-behavior-property",
           "support": {
             "chrome": {
-              "version_added": "116",
+              "version_added": "117",
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -150,7 +150,7 @@
             "description": "transition-behavior",
             "support": {
               "chrome": {
-                "version_added": "116"
+                "version_added": "117"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -147,7 +147,7 @@
         },
         "transition_behavior_value": {
           "__compat": {
-            "description": "transition-behavior",
+            "description": "<code>transition-behavior</code> value",
             "support": {
               "chrome": {
                 "version_added": "117"

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -144,6 +144,39 @@
               "deprecated": false
             }
           }
+        },
+        "transition_behavior_value": {
+          "__compat": {
+            "description": "transition-behavior",
+            "support": {
+              "chrome": {
+                "version_added": "116"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Adding the `transition-behavior` property and updating the shorthand which also includes this property.

This is part of the [CSS Transitions 2 spec](https://drafts.csswg.org/css-transitions-2/#transition-behavior-property), and implemented in Chrome 117.
