### PR TITLE
Update Chrome Support for CSS Scrollbars

### DIFF
--- a/css/properties/scrollbar-color.json
+++ b/css/properties/scrollbar-color.json
@@ -7,8 +7,15 @@
           "spec_url": "https://drafts.csswg.org/css-scrollbars/#scrollbar-color",
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "See <a href='https://crbug.com/891944'>bug 891944</a>."
+              "version_added": "118",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ],
+              "impl_url": "https://crbug.com/891944"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/scrollbar-width.json
+++ b/css/properties/scrollbar-width.json
@@ -7,7 +7,7 @@
           "spec_url": "https://drafts.csswg.org/css-scrollbars/#scrollbar-width",
           "support": {
             "chrome": {
-              "version_added": "preview",
+              "version_added": "115",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Update Chrome support data for CSS Scrollbars

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

https://chromium-review.googlesource.com/c/chromium/src/+/4777120?tab=checks - My patch to move scrollbar-color under experimental just merged so will be in 118 canary tomorrow.

Scrollbar width was moved to experimental in 115.

![image](https://github.com/mdn/browser-compat-data/assets/32498324/69207599-1030-44be-82eb-d8025c1ed66f)

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
