### PR TITLE
Remove html.elements.area.hreflang from BCD

### DIFF
--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -206,40 +206,6 @@
             }
           }
         },
-        "hreflang": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": true
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "≤4"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
-            }
-          }
-        },
         "implicit_noopener": {
           "__compat": {
             "description": "<code>target=\"_blank\"</code> implies <code>rel=\"noopener\"</code> behavior",


### PR DESCRIPTION
This PR removes the `hreflang` member of the `area` HTML element from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.1).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/area/hreflang
