### PR TITLE
Add BCD for FedCM extensions

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -476,6 +476,74 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "context_option": {
+            "__compat": {
+              "description": "<code>context</code> option",
+              "spec_url": "https://fedidcg.github.io/FedCM/#dom-identitycredentialrequestoptions-context",
+              "support": {
+                "chrome": {
+                  "version_added": "116"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "loginHint": {
+            "__compat": {
+              "description": "<code>loginHint/code> option",
+              "spec_url": "https://fedidcg.github.io/FedCM/#dom-identityproviderconfig-loginhint",
+              "support": {
+                "chrome": {
+                  "version_added": "116"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "otp_option": {

--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -479,7 +479,7 @@
           },
           "context_option": {
             "__compat": {
-              "description": "<code>context</code> option",
+              "description": "<code>identity.context</code>",
               "spec_url": "https://fedidcg.github.io/FedCM/#dom-identitycredentialrequestoptions-context",
               "support": {
                 "chrome": {
@@ -513,7 +513,7 @@
           },
           "loginHint": {
             "__compat": {
-              "description": "<code>loginHint/code> option",
+              "description": "<code>identity.providers.loginHint</code>",
               "spec_url": "https://fedidcg.github.io/FedCM/#dom-identityproviderconfig-loginhint",
               "support": {
                 "chrome": {

--- a/api/IdentityProvider.json
+++ b/api/IdentityProvider.json
@@ -1,0 +1,72 @@
+{
+  "api": {
+    "IdentityProvider": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdentityProvider",
+        "spec_url": "https://fedidcg.github.io/FedCM/#browser-api-identity-provider-interface",
+        "support": {
+          "chrome": {
+            "version_added": "116"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "getUserInfo": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdentityProvider/getUserInfo",
+          "spec_url": "https://fedidcg.github.io/FedCM/#dom-identityprovider-getuserinfo",
+          "support": {
+            "chrome": {
+              "version_added": "116"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 116 supports various [Fed CM API](https://developer.mozilla.org/en-US/docs/Web/API/FedCM_API) extensions (see [ChromeStatus entry](https://chromestatus.com/feature/5166718178033664))

See my [research document](https://docs.google.com/document/d/1cvLL7euxUeoLvQk6oLy5a6b7KlySmorJIqCYOngGPoA/edit) for more details of what the extensions are.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
