### PR TITLE
Update Edge data for api.RTCRtpEncodingParameters.scaleResolutionDownBy

### DIFF
--- a/api/RTCRtpEncodingParameters.json
+++ b/api/RTCRtpEncodingParameters.json
@@ -317,9 +317,7 @@
               "version_added": "74"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "46"
             },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `scaleResolutionDownBy` member of the `RTCRtpEncodingParameters` API. This sets Edge to mirror, which fixes #20529.
