### PR TITLE
Subgrid support in Chrome

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -268,15 +268,7 @@
             "spec_url": "https://drafts.csswg.org/css-grid/#subgrids",
             "support": {
               "chrome": {
-                "version_added": "114",
-                "impl_url": "https://crbug.com/618969",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "117"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -269,15 +269,7 @@
             "spec_url": "https://drafts.csswg.org/css-grid/#subgrids",
             "support": {
               "chrome": {
-                "version_added": "114",
-                "impl_url": "https://crbug.com/618969",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "117"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
The `subgrid` value for `grid-template-columns` and `grid-template-rows` is in Chrome 117. 

https://chromestatus.com/feature/5663795354533888
