### PR TITLE
fix(ci): Trigger mdn/bcd-util API deployment after release

### DIFF
--- a/.github/workflows/update_bcd-utils_api.yml
+++ b/.github/workflows/update_bcd-utils_api.yml
@@ -1,0 +1,23 @@
+name: Trigger mdn/bcd-utils API update
+
+on:
+  workflow_run:
+    workflows: ["Release package"]
+    types:
+      - completed
+
+jobs:
+  send_repo_dispatch_event:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.DISPATCH_PAT }}
+          script: |
+            const result = await github.rest.repos.createDispatchEvent({
+              owner: 'mdn',
+              repo: 'bcd-utils',
+              event_type: 'bcd_release',
+              client_payload: {}
+            })
+            console.log(result);

--- a/.github/workflows/update_bcd-utils_api.yml
+++ b/.github/workflows/update_bcd-utils_api.yml
@@ -5,6 +5,7 @@ on:
     workflows: ["Release package"]
     types:
       - completed
+  workflow_dispatch:
 
 jobs:
   send_repo_dispatch_event:


### PR DESCRIPTION
- This is the other half of https://github.com/mdn/bcd-utils/pull/24 .

This PR creates a workflow that will trigger the API deployment workflow in `mdn/bcd-util` repo.

Note: this will need a special `secrets.DISPATCH_PAT` token to be created.