### PR TITLE
Resolve Safari differences between html/ and api/ where one has false

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -92,7 +92,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -568,7 +568,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -1063,7 +1063,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "6"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This deals with the following:

html.elements.a.coords v. api.HTMLAnchorElement.coords: `{'version_added': false} v. {'version_added': '1'}`

html.elements.a.shape v. api.HTMLAnchorElement.shape: `{'version_added': false} v. {'version_added': '1'}`

html.elements.link.sizes v. api.HTMLLinkElement.sizes: `{'version_added': false} v. {'version_added': '6'}`

In all these cases, the version given in api/ appears to be correct.

Note this _doesn't_ try to fix all differences—merely the cases where one has `false`.

#### Test results and supporting details

The `a` element attributes are supported from the KHTML import: https://github.com/WebKit/WebKit/blob/a063c2b75ddebd1edfe9c54c428d762bdb61f794/WebCore/khtml/html/html_imageimpl.cpp#L345-L372

The `sizes` attribute was implemented as both an HTML attribute and an IDL attribute at the same time: https://github.com/WebKit/WebKit/commit/79e39b932a8130d3f0ae90f37b341f8068c3c880

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Kinda related to #18368, which would mitigate this whole problem.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
