### PR TITLE
Release Firefox 116

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -830,28 +830,28 @@
         "115": {
           "release_date": "2023-07-04",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/115",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "115"
         },
         "116": {
           "release_date": "2023-08-01",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/116",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "116"
         },
         "117": {
           "release_date": "2023-08-29",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/117",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "117"
         },
         "118": {
           "release_date": "2023-09-26",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/118",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "118"
         },

--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -739,7 +739,7 @@
         "102": {
           "release_date": "2022-06-28",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/102",
-          "status": "esr",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "102"
         },
@@ -830,7 +830,7 @@
         "115": {
           "release_date": "2023-07-04",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/115",
-          "status": "retired",
+          "status": "esr",
           "engine": "Gecko",
           "engine_version": "115"
         },

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -697,28 +697,28 @@
         "115": {
           "release_date": "2023-07-04",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/115",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "115"
         },
         "116": {
           "release_date": "2023-08-01",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/116",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "116"
         },
         "117": {
           "release_date": "2023-08-29",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/117",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "117"
         },
         "118": {
           "release_date": "2023-09-26",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/118",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "118"
         },


### PR DESCRIPTION
**Summary**

Firefox 116 got released

**Test results and supporting details**

Release Notes: https://www.mozilla.org/en-US/firefox/116.0/releasenotes/
