### PR TITLE
Automatically label WASM pull requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,6 +16,8 @@ data:mathml :heavy_division_sign::
   - "mathml/**"
 data:svg :paintbrush::
   - "svg/**"
+data:wasm :mechanical_arm::
+  - "webassembly/**"
 data:webdriver :racing_car::
   - "webdriver/**"
 data:webext :game_die::


### PR DESCRIPTION
This PR updates the labeler config to automatically label WebAssembly pull requests.