### PR TITLE
Chrome 116 is released

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -802,25 +802,26 @@
         "115": {
           "release_date": "2023-07-18",
           "release_notes": "https://chromereleases.googleblog.com/2023/07/stable-channel-update-for-desktop_20.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "115"
         },
         "116": {
           "release_date": "2023-08-15",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2023/08/stable-channel-update-for-desktop_15.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "116"
         },
         "117": {
           "release_date": "2023-09-12",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "117"
         },
         "118": {
           "release_date": "2023-10-10",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "118"
         }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -644,19 +644,20 @@
         },
         "116": {
           "release_date": "2023-08-15",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2023/08/chrome-for-android-update_0776151896.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "116"
         },
         "117": {
           "release_date": "2023-09-12",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "117"
         },
         "118": {
           "release_date": "2023-10-10",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "118"
         }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -638,7 +638,7 @@
         "115": {
           "release_date": "2023-07-21",
           "release_notes": "https://chromereleases.googleblog.com/2023/07/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "115"
         },

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -608,19 +608,20 @@
         },
         "116": {
           "release_date": "2023-08-15",
-          "status": "beta",
+          "release_notes": "https://chromereleases.googleblog.com/2023/08/chrome-for-android-update_0776151896.html",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "116"
         },
         "117": {
           "release_date": "2023-09-12",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "117"
         },
         "118": {
           "release_date": "2023-10-10",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "118"
         }

--- a/browsers/webview_android.json
+++ b/browsers/webview_android.json
@@ -602,7 +602,7 @@
         "115": {
           "release_date": "2023-07-21",
           "release_notes": "https://chromereleases.googleblog.com/2023/07/chrome-for-android-update.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "115"
         },


### PR DESCRIPTION
This PR marks Chrome 116 as the current version of Chrome.
