### PR TITLE
Deno 1.36 is released

### DIFF
--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -254,6 +254,13 @@
         "1.35": {
           "release_date": "2023-07-05",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.35.0",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "11.6"
+        },
+        "1.36": {
+          "release_date": "2023-08-03",
+          "release_notes": "https://github.com/denoland/deno/releases/tag/v1.36.0",
           "status": "current",
           "engine": "V8",
           "engine_version": "11.6"


### PR DESCRIPTION
This PR marks Deno 1.36 as released and adds it to our data.
