### PR TITLE
Add BCD data for Secure Payment Confirmation

### DIFF
--- a/api/SecurePaymentConfirmation.json
+++ b/api/SecurePaymentConfirmation.json
@@ -1,0 +1,258 @@
+{
+  "api": {
+    "SecurePaymentConfirmation": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/TODO",
+        "support": {
+          "chrome": {
+            "version_added": "95"
+          },
+          "chrome_android": {
+            "version_added": "109"
+          },
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": {
+            "version_added": false
+          }
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "PaymentCredentialInstrument": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/secure-payment-confirmation/#dictdef-paymentcredentialinstrument",
+          "support": {
+            "chrome": {
+              "version_added": "95"
+            },
+            "chrome_android": {
+              "version_added": "109"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "payment-extension": {
+        "__compat": {
+          "description": "<code>payment</code> WebAuthn extension",
+          "spec_url": "https://w3c.github.io/secure-payment-confirmation/#sctn-payment-extension-registration",
+          "support": {
+            "chrome": {
+              "version_added": "95"
+            },
+            "chrome_android": {
+              "version_added": "109"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "CollectedClientAdditionalPaymentData": {
+          "__compat": {
+            "spec_url": "https://w3c.github.io/secure-payment-confirmation/#dictdef-collectedclientadditionalpaymentdata",
+            "support": {
+              "chrome": {
+                "version_added": "95"
+              },
+              "chrome_android": {
+                "version_added": "109"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "CollectedClientPaymentData": {
+          "__compat": {
+            "spec_url": "https://w3c.github.io/secure-payment-confirmation/#dictdef-collectedclientpaymentdata",
+            "support": {
+              "chrome": {
+                "version_added": "95"
+              },
+              "chrome_android": {
+                "version_added": "109"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      },
+      "secure-payment-confirmation": {
+        "__compat": {
+          "description": "<code>secure-payment-confirmation</code> payment method",
+          "spec_url": "https://w3c.github.io/secure-payment-confirmation/#sctn-payment-method-spc",
+          "support": {
+            "chrome": {
+              "version_added": "95"
+            },
+            "chrome_android": {
+              "version_added": "109"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "SecurePaymentConfirmationRequest": {
+          "__compat": {
+            "spec_url": "https://w3c.github.io/secure-payment-confirmation/#sctn-securepaymentconfirmationrequest-dictionary",
+            "support": {
+              "chrome": {
+                "version_added": "95"
+              },
+              "chrome_android": {
+                "version_added": "109"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Summary

Add an `api/` entry for [Secure Payment Confirmation](https://w3c.github.io/secure-payment-confirmation/). It consists of three main sub-features: 

1. PaymentCredentialInstrument, a dictionary (minor)
2. payment-extension, a WebAuthn extension that the SPC spec defines
3. secure-payment-confirmation, a Payment Request payment method that the SPC spec defines

#### Test results and supporting details

Data was written using the author's knowledge of when SPC released on Chrome, and which other browsers inherit from Chrome. Some of this still needs to be manually verified, such as the status on Opera and Samsung Internet Browser.
