### PR TITLE
Add "or" syntax to @media at-rule

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -906,7 +906,7 @@
         "or_syntax": {
           "__compat": {
             "description": "<code>or</code> syntax from Media Queries Level 4",
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries#testing_for_multiple_features_with_or",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/CSS_media_queries/Using_media_queries#testing_for_multiple_features_with_or",
             "support": {
               "chrome": {
                 "version_added": "104"

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -903,6 +903,40 @@
             }
           }
         },
+        "or_syntax": {
+          "__compat": {
+            "description": "<code>or</code> syntax from Media Queries Level 4",
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_media_queries/Using_media_queries#testing_for_multiple_features_with_or",
+            "support": {
+              "chrome": {
+                "version_added": "104"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "64"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "16.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "orientation": {
           "__compat": {
             "description": "<code>orientation</code> media feature",
@@ -1352,7 +1386,7 @@
         "range_syntax": {
           "__compat": {
             "description": "Range syntax from Media Queries Level 4",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Media_Queries/Using_media_queries#syntax_improvements_in_level_4",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/CSS_media_queries/Using_media_queries#syntax_improvements_in_level_4",
             "support": {
               "chrome": {
                 "version_added": "104"


### PR DESCRIPTION
This PR adds the "or" syntax to the `@media` at-rule.  This fixes #6033.  Test code used is in the issue.
