### PR TITLE
Add missing features for javascript.builtins.Intl.NumberFormat

### DIFF
--- a/javascript/builtins/Intl/NumberFormat.json
+++ b/javascript/builtins/Intl/NumberFormat.json
@@ -71,16 +71,9 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "nodejs": [
-                  {
-                    "version_added": "13.0.0"
-                  },
-                  {
-                    "version_added": "0.12.0",
-                    "partial_implementation": true,
-                    "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>NumberFormat</code> instance silently falls back to <code>en-US</code>. To make full ICU (locale) data available before version 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
-                  }
-                ],
+                "nodejs": {
+                  "version_added": "0.12.0"
+                },
                 "oculus": "mirror",
                 "opera": "mirror",
                 "opera_android": "mirror",
@@ -149,6 +142,56 @@
                 }
               }
             },
+            "locales_parameter": {
+              "__compat": {
+                "description": "<code>locales</code> parameter",
+                "support": {
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": "1.8"
+                  },
+                  "edge": {
+                    "version_added": "12"
+                  },
+                  "firefox": {
+                    "version_added": "29"
+                  },
+                  "firefox_android": {
+                    "version_added": "56"
+                  },
+                  "ie": {
+                    "version_added": "11"
+                  },
+                  "nodejs": [
+                    {
+                      "version_added": "13.0.0"
+                    },
+                    {
+                      "version_added": "0.12.0",
+                      "partial_implementation": true,
+                      "notes": "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. When other locales are specified, the <code>NumberFormat</code> instance silently falls back to <code>en-US</code>. To make full ICU (locale) data available before version 13, see <a href='https://nodejs.org/docs/latest/api/intl.html#intl_options_for_building_node_js'>Node.js documentation on the <code>--with-intl</code> option</a> and how to provide the data."
+                    }
+                  ],
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "10"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
             "options_compactDisplay_parameter": {
               "__compat": {
                 "description": "<code>options.compactDisplay</code> parameter",
@@ -176,6 +219,49 @@
                   "opera_android": "mirror",
                   "safari": {
                     "version_added": "14.1"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "options_currency_parameter": {
+              "__compat": {
+                "description": "<code>options.currency</code> parameter",
+                "support": {
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": "1.8"
+                  },
+                  "edge": {
+                    "version_added": "12"
+                  },
+                  "firefox": {
+                    "version_added": "29"
+                  },
+                  "firefox_android": {
+                    "version_added": "56"
+                  },
+                  "ie": {
+                    "version_added": "11"
+                  },
+                  "nodejs": {
+                    "version_added": "0.12.0"
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "10"
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
@@ -274,6 +360,264 @@
                 }
               }
             },
+            "options_localeMatcher_parameter": {
+              "__compat": {
+                "description": "<code>options.localeMatcher</code> parameter",
+                "support": {
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": "1.8"
+                  },
+                  "edge": {
+                    "version_added": "12"
+                  },
+                  "firefox": {
+                    "version_added": "29"
+                  },
+                  "firefox_android": {
+                    "version_added": "56"
+                  },
+                  "ie": {
+                    "version_added": "11"
+                  },
+                  "nodejs": {
+                    "version_added": "0.12.0"
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "10"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "options_maximumFractionDigits_parameter": {
+              "__compat": {
+                "description": "<code>options.maximumFractionDigits</code> parameter",
+                "support": {
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": "1.8"
+                  },
+                  "edge": {
+                    "version_added": "12"
+                  },
+                  "firefox": {
+                    "version_added": "29"
+                  },
+                  "firefox_android": {
+                    "version_added": "56"
+                  },
+                  "ie": {
+                    "version_added": "11"
+                  },
+                  "nodejs": {
+                    "version_added": "0.12.0"
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "10"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "options_maximumSignificantDigits_parameter": {
+              "__compat": {
+                "description": "<code>options.maximumSignificantDigits</code> parameter",
+                "support": {
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": "1.8"
+                  },
+                  "edge": {
+                    "version_added": "12"
+                  },
+                  "firefox": {
+                    "version_added": "29"
+                  },
+                  "firefox_android": {
+                    "version_added": "56"
+                  },
+                  "ie": {
+                    "version_added": "11"
+                  },
+                  "nodejs": {
+                    "version_added": "0.12.0"
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "10"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "options_minimumFractionDigits_parameter": {
+              "__compat": {
+                "description": "<code>options.minimumFractionDigits</code> parameter",
+                "support": {
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": "1.8"
+                  },
+                  "edge": {
+                    "version_added": "12"
+                  },
+                  "firefox": {
+                    "version_added": "29"
+                  },
+                  "firefox_android": {
+                    "version_added": "56"
+                  },
+                  "ie": {
+                    "version_added": "11"
+                  },
+                  "nodejs": {
+                    "version_added": "0.12.0"
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "10"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "options_minimumIntegerDigits_parameter": {
+              "__compat": {
+                "description": "<code>options.minimumIntegerDigits</code> parameter",
+                "support": {
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": "1.8"
+                  },
+                  "edge": {
+                    "version_added": "12"
+                  },
+                  "firefox": {
+                    "version_added": "29"
+                  },
+                  "firefox_android": {
+                    "version_added": "56"
+                  },
+                  "ie": {
+                    "version_added": "11"
+                  },
+                  "nodejs": {
+                    "version_added": "0.12.0"
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "10"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "options_minimumSignificantDigits_parameter": {
+              "__compat": {
+                "description": "<code>options.minimumSignificantDigits</code> parameter",
+                "support": {
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": "1.8"
+                  },
+                  "edge": {
+                    "version_added": "12"
+                  },
+                  "firefox": {
+                    "version_added": "29"
+                  },
+                  "firefox_android": {
+                    "version_added": "56"
+                  },
+                  "ie": {
+                    "version_added": "11"
+                  },
+                  "nodejs": {
+                    "version_added": "0.12.0"
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "10"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
             "options_notation_parameter": {
               "__compat": {
                 "description": "<code>options.notation</code> parameter",
@@ -301,6 +645,49 @@
                   "opera_android": "mirror",
                   "safari": {
                     "version_added": "14.1"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "options_numberingSystem_parameter": {
+              "__compat": {
+                "description": "<code>options.numberingSystem</code> parameter",
+                "support": {
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": "1.8"
+                  },
+                  "edge": {
+                    "version_added": "12"
+                  },
+                  "firefox": {
+                    "version_added": "29"
+                  },
+                  "firefox_android": {
+                    "version_added": "56"
+                  },
+                  "ie": {
+                    "version_added": "11"
+                  },
+                  "nodejs": {
+                    "version_added": "0.12.0"
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "10"
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",
@@ -502,6 +889,49 @@
                     "standard_track": true,
                     "deprecated": false
                   }
+                }
+              }
+            },
+            "options_style_parameter": {
+              "__compat": {
+                "description": "<code>options.style</code> parameter",
+                "support": {
+                  "chrome": {
+                    "version_added": "24"
+                  },
+                  "chrome_android": "mirror",
+                  "deno": {
+                    "version_added": "1.8"
+                  },
+                  "edge": {
+                    "version_added": "12"
+                  },
+                  "firefox": {
+                    "version_added": "29"
+                  },
+                  "firefox_android": {
+                    "version_added": "56"
+                  },
+                  "ie": {
+                    "version_added": "11"
+                  },
+                  "nodejs": {
+                    "version_added": "0.12.0"
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "10"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
                 }
               }
             },


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing features of the `NumberFormat` member of the `Intl` JavaScript builtin. This fixes #6046 by adding the missing arguments.  Note: all data was simply mirrored from the main constructor's data, assuming they are all features that were supported since the constructor was introduced.
