### PR TITLE
Add Chrome unload event deprecation

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6203,7 +6203,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "117"
             },
             "chrome_android": "mirror",
             "deno": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds Chrome `unload` event deprecation starting in 117 (see https://developer.chrome.com/blog/deprecating-unload/)
