### PR TITLE
Convert simple "See bug" notes to impl_url keys

### DIFF
--- a/api/BlobEvent.json
+++ b/api/BlobEvent.json
@@ -114,7 +114,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1573299'>bug 1573299</a>."
+              "impl_url": "https://bugzil.la/1573299"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -61,7 +61,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/1100993'>bug 1100993</a>."
+            "impl_url": "https://crbug.com/1100993"
           }
         },
         "status": {

--- a/api/BluetoothCharacteristicProperties.json
+++ b/api/BluetoothCharacteristicProperties.json
@@ -61,7 +61,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/1100993'>bug 1100993</a>."
+            "impl_url": "https://crbug.com/1100993"
           }
         },
         "status": {

--- a/api/BluetoothDevice.json
+++ b/api/BluetoothDevice.json
@@ -61,7 +61,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/1100993'>bug 1100993</a>."
+            "impl_url": "https://crbug.com/1100993"
           }
         },
         "status": {

--- a/api/BluetoothRemoteGATTCharacteristic.json
+++ b/api/BluetoothRemoteGATTCharacteristic.json
@@ -61,7 +61,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/1100993'>bug 1100993</a>."
+            "impl_url": "https://crbug.com/1100993"
           }
         },
         "status": {

--- a/api/BluetoothRemoteGATTDescriptor.json
+++ b/api/BluetoothRemoteGATTDescriptor.json
@@ -63,7 +63,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/1100993'>bug 1100993</a>."
+            "impl_url": "https://crbug.com/1100993"
           }
         },
         "status": {

--- a/api/BluetoothRemoteGATTServer.json
+++ b/api/BluetoothRemoteGATTServer.json
@@ -61,7 +61,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/1100993'>bug 1100993</a>."
+            "impl_url": "https://crbug.com/1100993"
           }
         },
         "status": {

--- a/api/BluetoothRemoteGATTService.json
+++ b/api/BluetoothRemoteGATTService.json
@@ -61,7 +61,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/1100993'>bug 1100993</a>."
+            "impl_url": "https://crbug.com/1100993"
           }
         },
         "status": {

--- a/api/BluetoothUUID.json
+++ b/api/BluetoothUUID.json
@@ -61,7 +61,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/1100993'>bug 1100993</a>."
+            "impl_url": "https://crbug.com/1100993"
           }
         },
         "status": {

--- a/api/CSS.json
+++ b/api/CSS.json
@@ -1972,7 +1972,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1287034'>bug 1287034</a>."
+              "impl_url": "https://bugzil.la/1287034"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1983,7 +1983,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "16.4",
-              "notes": "See <a href='https://webkit.org/b/159801'>bug 159801</a>."
+              "impl_url": "https://webkit.org/b/159801"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2044,7 +2044,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1287034'>bug 1287034</a>."
+              "impl_url": "https://bugzil.la/1287034"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2055,7 +2055,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "16.4",
-              "notes": "See <a href='https://webkit.org/b/159801'>bug 159801</a>."
+              "impl_url": "https://webkit.org/b/159801"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/CSSStyleDeclaration.json
+++ b/api/CSSStyleDeclaration.json
@@ -127,12 +127,12 @@
             "chrome": {
               "version_added": "1",
               "version_removed": "40",
-              "notes": "See <a href='https://crbug.com/331608'>bug 331608</a>."
+              "impl_url": "https://crbug.com/331608"
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/331608'>bug 331608</a>."
+              "impl_url": "https://crbug.com/331608"
             },
             "firefox": {
               "version_added": "1",
@@ -157,7 +157,7 @@
             "webview_android": {
               "version_added": "4.4",
               "version_removed": "41",
-              "notes": "See <a href='https://crbug.com/331608'>bug 331608</a>."
+              "impl_url": "https://crbug.com/331608"
             }
           },
           "status": {

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -1084,7 +1084,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/198416'>bug 198416</a>."
+              "impl_url": "https://webkit.org/b/198416"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/CookieStore.json
+++ b/api/CookieStore.json
@@ -12,7 +12,7 @@
           "edge": "mirror",
           "firefox": {
             "version_added": false,
-            "notes": "See <a href='https://bugzil.la/1475599'>bug 1475599</a>."
+            "impl_url": "https://bugzil.la/1475599"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -23,7 +23,7 @@
           "opera_android": "mirror",
           "safari": {
             "version_added": false,
-            "notes": "See <a href='https://webkit.org/b/231750'>bug 231750</a>."
+            "impl_url": "https://webkit.org/b/231750"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",

--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -54,7 +54,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/182671'>bug 182671</a>."
+              "impl_url": "https://webkit.org/b/182671"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/DedicatedWorkerGlobalScope.json
+++ b/api/DedicatedWorkerGlobalScope.json
@@ -208,7 +208,7 @@
             },
             "safari": {
               "version_added": "16.4",
-              "notes": "See <a href='https://webkit.org/b/171216'>bug 171216</a>."
+              "impl_url": "https://webkit.org/b/171216"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -2359,7 +2359,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1675847'>bug 1675847</a>."
+                "impl_url": "https://bugzil.la/1675847"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -2370,7 +2370,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/218665'>bug 218665</a>."
+                "impl_url": "https://webkit.org/b/218665"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -2888,7 +2888,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1675847'>bug 1675847</a>."
+                "impl_url": "https://bugzil.la/1675847"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -2899,7 +2899,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/218665'>bug 218665</a>."
+                "impl_url": "https://webkit.org/b/218665"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -3358,7 +3358,7 @@
             },
             "safari_ios": {
               "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/213953'>bug 213953</a>."
+              "impl_url": "https://webkit.org/b/213953"
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -3380,7 +3380,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1675847'>bug 1675847</a>."
+                "impl_url": "https://bugzil.la/1675847"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -3391,7 +3391,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/218665'>bug 218665</a>."
+                "impl_url": "https://webkit.org/b/218665"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -22,7 +22,7 @@
           "opera_android": "mirror",
           "safari": {
             "version_added": "16.4",
-            "notes": "See <a href='https://webkit.org/b/197960'>bug 197960</a>."
+            "impl_url": "https://webkit.org/b/197960"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",

--- a/api/FetchEvent.json
+++ b/api/FetchEvent.json
@@ -247,7 +247,7 @@
               "alternative_name": "targetClientId",
               "version_added": "11.1",
               "version_removed": "16",
-              "notes": "See <a href='https://webkit.org/b/226638'>bug 226638</a>."
+              "impl_url": "https://webkit.org/b/226638"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -919,7 +919,7 @@
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": false,
-                  "notes": "See <a href='https://webkit.org/b/244117'>bug 244117</a>."
+                  "impl_url": "https://webkit.org/b/244117"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -88,7 +88,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/393466'>bug 393466</a>."
+              "impl_url": "https://crbug.com/393466"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -138,7 +138,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "16.4",
-              "notes": "See <a href='https://webkit.org/b/197960'>bug 197960</a>."
+              "impl_url": "https://webkit.org/b/197960"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1241,7 +1241,7 @@
               },
               "chrome_android": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/953169'>bug 953169</a>."
+                "impl_url": "https://crbug.com/953169"
               },
               "edge": {
                 "version_added": "17"
@@ -1251,7 +1251,7 @@
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1544660'>bug 1544660</a>."
+                "impl_url": "https://bugzil.la/1544660"
               },
               "ie": {
                 "version_added": false

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1732,7 +1732,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/234348'>bug 234348</a>."
+              "impl_url": "https://webkit.org/b/234348"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2037,7 +2037,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+                "impl_url": "https://webkit.org/b/234009"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -2071,7 +2071,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+                "impl_url": "https://webkit.org/b/234009"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -2105,7 +2105,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+                "impl_url": "https://webkit.org/b/234009"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -2139,7 +2139,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+                "impl_url": "https://webkit.org/b/234009"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -2173,7 +2173,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+                "impl_url": "https://webkit.org/b/234009"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -2207,7 +2207,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+                "impl_url": "https://webkit.org/b/234009"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -2241,7 +2241,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+                "impl_url": "https://webkit.org/b/234009"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -2275,7 +2275,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+                "impl_url": "https://webkit.org/b/234009"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -2309,7 +2309,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/234009'>bug 234009</a>."
+                "impl_url": "https://webkit.org/b/234009"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -854,7 +854,7 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/521319'>bug 521319</a>."
+              "impl_url": "https://crbug.com/521319"
             }
           },
           "status": {
@@ -1233,7 +1233,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/648207'>bug 648207</a>."
+              "impl_url": "https://crbug.com/648207"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -2292,12 +2292,12 @@
             "safari": {
               "prefix": "webkit",
               "version_added": "4",
-              "notes": "See <a href='https://webkit.org/b/214922'>bug 214922</a>."
+              "impl_url": "https://webkit.org/b/214922"
             },
             "safari_ios": {
               "prefix": "webkit",
               "version_added": "4",
-              "notes": "See <a href='https://webkit.org/b/214922'>bug 214922</a>."
+              "impl_url": "https://webkit.org/b/214922"
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -2473,7 +2473,7 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/521319'>bug 521319</a>."
+              "impl_url": "https://crbug.com/521319"
             }
           },
           "status": {

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -819,7 +819,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/234348'>bug 234348</a>."
+              "impl_url": "https://webkit.org/b/234348"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -149,7 +149,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/934640'>bug 934640</a>."
+              "impl_url": "https://bugzil.la/934640"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/MIDIOutput.json
+++ b/api/MIDIOutput.json
@@ -57,7 +57,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/471798'>bug 471798</a>."
+              "impl_url": "https://crbug.com/471798"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/MediaRecorderErrorEvent.json
+++ b/api/MediaRecorderErrorEvent.json
@@ -6,7 +6,7 @@
         "support": {
           "chrome": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/1250432'>bug 1250432</a>."
+            "impl_url": "https://crbug.com/1250432"
           },
           "chrome_android": "mirror",
           "edge": "mirror",

--- a/api/MediaStreamEvent.json
+++ b/api/MediaStreamEvent.json
@@ -6,7 +6,7 @@
         "support": {
           "chrome": {
             "version_added": "26",
-            "notes": "See <a href='https://crbug.com/697059'>bug 697059</a>."
+            "impl_url": "https://crbug.com/697059"
           },
           "chrome_android": "mirror",
           "edge": {

--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -259,7 +259,7 @@
             },
             "safari": {
               "version_added": "16.4",
-              "notes": "See <a href='https://webkit.org/b/171216'>bug 171216</a>."
+              "impl_url": "https://webkit.org/b/171216"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -363,7 +363,7 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/1100993'>bug 1100993</a>."
+              "impl_url": "https://crbug.com/1100993"
             }
           },
           "status": {
@@ -655,7 +655,7 @@
             },
             "safari": {
               "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/185697'>bug 185697</a>."
+              "impl_url": "https://webkit.org/b/185697"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2196,7 +2196,7 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/490120'>bug 490120</a>."
+              "impl_url": "https://crbug.com/490120"
             }
           },
           "status": {
@@ -2365,7 +2365,7 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/521319'>bug 521319</a>."
+              "impl_url": "https://crbug.com/521319"
             }
           },
           "status": {
@@ -4447,7 +4447,7 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/921655'>bug 921655</a>."
+              "impl_url": "https://crbug.com/921655"
             }
           },
           "status": {

--- a/api/NavigatorUAData.json
+++ b/api/NavigatorUAData.json
@@ -29,7 +29,7 @@
           },
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/921655'>bug 921655</a>."
+            "impl_url": "https://crbug.com/921655"
           }
         },
         "status": {

--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -28,7 +28,7 @@
           "opera_android": "mirror",
           "safari": {
             "version_added": false,
-            "notes": "See <a href='https://webkit.org/b/185697'>bug 185697</a>."
+            "impl_url": "https://webkit.org/b/185697"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -68,7 +68,7 @@
           },
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/551446'>bug 551446</a>."
+            "impl_url": "https://crbug.com/551446"
           }
         },
         "status": {

--- a/api/NotificationEvent.json
+++ b/api/NotificationEvent.json
@@ -37,7 +37,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/551446'>bug 551446</a>."
+            "impl_url": "https://crbug.com/551446"
           }
         },
         "status": {

--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -332,7 +332,7 @@
             },
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1265406'>bug 1265406</a>."
+              "impl_url": "https://bugzil.la/1265406"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/PerformanceLongTaskTiming.json
+++ b/api/PerformanceLongTaskTiming.json
@@ -12,7 +12,7 @@
           "edge": "mirror",
           "firefox": {
             "version_added": false,
-            "notes": "See <a href='https://bugzil.la/1348405'>bug 1348405</a>."
+            "impl_url": "https://bugzil.la/1348405"
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -382,7 +382,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1811291'>bug 1811291</a>"
+              "impl_url": "https://bugzil.la/1811291"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/PermissionStatus.json
+++ b/api/PermissionStatus.json
@@ -27,7 +27,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/490120'>bug 490120</a>."
+            "impl_url": "https://crbug.com/490120"
           }
         },
         "status": {

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -27,7 +27,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/490120'>bug 490120</a>."
+            "impl_url": "https://crbug.com/490120"
           }
         },
         "status": {

--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -419,7 +419,7 @@
               ],
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1680669'>bug 1680669</a>."
+                "impl_url": "https://bugzil.la/1680669"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -432,7 +432,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/133180'>bug 133180</a>."
+                "impl_url": "https://webkit.org/b/133180"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/api/PushEvent.json
+++ b/api/PushEvent.json
@@ -39,7 +39,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/421921'>bug 421921</a>."
+            "impl_url": "https://crbug.com/421921"
           }
         },
         "status": {

--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -35,7 +35,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/421921'>bug 421921</a>."
+            "impl_url": "https://crbug.com/421921"
           }
         },
         "status": {

--- a/api/PushMessageData.json
+++ b/api/PushMessageData.json
@@ -35,7 +35,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/421921'>bug 421921</a>."
+            "impl_url": "https://crbug.com/421921"
           }
         },
         "status": {

--- a/api/PushSubscription.json
+++ b/api/PushSubscription.json
@@ -35,7 +35,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/421921'>bug 421921</a>."
+            "impl_url": "https://crbug.com/421921"
           }
         },
         "status": {

--- a/api/PushSubscriptionOptions.json
+++ b/api/PushSubscriptionOptions.json
@@ -35,7 +35,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/421921'>bug 421921</a>."
+            "impl_url": "https://crbug.com/421921"
           }
         },
         "status": {

--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -111,13 +111,10 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</a>."
+                "impl_url": "https://crbug.com/webrtc/2276"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</a>."
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "22"
               },
@@ -128,22 +125,13 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</a>."
-              },
-              "opera_android": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</a>."
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "11"
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": {
-                "version_added": false,
-                "notes": "See <a href='https://crbug.com/webrtc/2276'>Chrome WebRTC bug 2276</a>."
-              },
+              "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
@@ -923,13 +911,13 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/1244165'>bug 1244165</a>"
+              "impl_url": "https://crbug.com/1244165"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1209163'>bug 1209163</a>"
+              "impl_url": "https://bugzil.la/1209163"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -484,7 +484,7 @@
           "support": {
             "chrome": {
               "version_added": "24",
-              "notes": "See <a href='https://crbug.com/697059'>bug 697059</a>."
+              "impl_url": "https://crbug.com/697059"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -532,7 +532,7 @@
           "support": {
             "chrome": {
               "version_added": "24",
-              "notes": "See <a href='https://crbug.com/697059'>bug 697059</a>."
+              "impl_url": "https://crbug.com/697059"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -1356,7 +1356,7 @@
           "support": {
             "chrome": {
               "version_added": "27",
-              "notes": "See <a href='https://crbug.com/697059'>bug 697059</a>."
+              "impl_url": "https://crbug.com/697059"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -1437,7 +1437,7 @@
           "support": {
             "chrome": {
               "version_added": "27",
-              "notes": "See <a href='https://crbug.com/697059'>bug 697059</a>."
+              "impl_url": "https://crbug.com/697059"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -1704,7 +1704,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1561441'>bug 1561441</a>."
+              "impl_url": "https://bugzil.la/1561441"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2146,7 +2146,7 @@
           "support": {
             "chrome": {
               "version_added": "24",
-              "notes": "See <a href='https://crbug.com/697059'>bug 697059</a>."
+              "impl_url": "https://crbug.com/697059"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -2196,7 +2196,7 @@
           "support": {
             "chrome": {
               "version_added": "24",
-              "notes": "See <a href='https://crbug.com/697059'>bug 697059</a>."
+              "impl_url": "https://crbug.com/697059"
             },
             "chrome_android": "mirror",
             "edge": {

--- a/api/RemotePlayback.json
+++ b/api/RemotePlayback.json
@@ -27,7 +27,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/521319'>bug 521319</a>."
+            "impl_url": "https://crbug.com/521319"
           }
         },
         "status": {

--- a/api/Request.json
+++ b/api/Request.json
@@ -401,7 +401,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1387483'>bug 1387483</a>."
+              "impl_url": "https://bugzil.la/1387483"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -224,7 +224,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/873988'>bug 873988</a>."
+              "impl_url": "https://crbug.com/873988"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -258,7 +258,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/873988'>bug 873988</a>."
+              "impl_url": "https://crbug.com/873988"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -623,7 +623,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "7",
-              "notes": "See <a href='https://webkit.org/b/226721'>bug 226721</a>."
+              "impl_url": "https://webkit.org/b/226721"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1260,11 +1260,11 @@
             },
             "safari": {
               "version_added": "3",
-              "notes": "See <a href='https://webkit.org/b/226721'>bug 226721</a>."
+              "impl_url": "https://webkit.org/b/226721"
             },
             "safari_ios": {
               "version_added": "1",
-              "notes": "See <a href='https://webkit.org/b/226721'>bug 226721</a>."
+              "impl_url": "https://webkit.org/b/226721"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/api/ServiceWorkerContainer.json
+++ b/api/ServiceWorkerContainer.json
@@ -121,7 +121,7 @@
             "firefox": {
               "version_added": "44",
               "version_removed": "106",
-              "notes": "See <a href='https://bugzil.la/1714533'>bug 1714533</a>."
+              "impl_url": "https://bugzil.la/1714533"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -176,7 +176,7 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/551446'>bug 551446</a>."
+              "impl_url": "https://crbug.com/551446"
             }
           },
           "status": {
@@ -401,7 +401,7 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/421921'>bug 421921</a>."
+              "impl_url": "https://crbug.com/421921"
             }
           },
           "status": {
@@ -480,7 +480,7 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/421921'>bug 421921</a>."
+              "impl_url": "https://crbug.com/421921"
             }
           },
           "status": {

--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -10,7 +10,7 @@
           },
           "chrome_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/154571'>bug 154571</a>."
+            "impl_url": "https://crbug.com/154571"
           },
           "edge": "mirror",
           "firefox": {
@@ -173,7 +173,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/794548'>Chromium bug 794548</a>."
+                "impl_url": "https://crbug.com/794548"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/api/SpeechSynthesis.json
+++ b/api/SpeechSynthesis.json
@@ -37,7 +37,7 @@
           },
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/487255'>bug 487255</a>."
+            "impl_url": "https://crbug.com/487255"
           }
         },
         "status": {

--- a/api/SpeechSynthesisErrorEvent.json
+++ b/api/SpeechSynthesisErrorEvent.json
@@ -37,7 +37,7 @@
           },
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/487255'>bug 487255</a>."
+            "impl_url": "https://crbug.com/487255"
           }
         },
         "status": {

--- a/api/SpeechSynthesisEvent.json
+++ b/api/SpeechSynthesisEvent.json
@@ -37,7 +37,7 @@
           },
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/487255'>bug 487255</a>."
+            "impl_url": "https://crbug.com/487255"
           }
         },
         "status": {

--- a/api/SpeechSynthesisUtterance.json
+++ b/api/SpeechSynthesisUtterance.json
@@ -37,7 +37,7 @@
           },
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/487255'>bug 487255</a>."
+            "impl_url": "https://crbug.com/487255"
           }
         },
         "status": {

--- a/api/SpeechSynthesisVoice.json
+++ b/api/SpeechSynthesisVoice.json
@@ -38,7 +38,7 @@
           },
           "webview_android": {
             "version_added": false,
-            "notes": "See <a href='https://crbug.com/487255'>bug 487255</a>."
+            "impl_url": "https://crbug.com/487255"
           }
         },
         "status": {

--- a/api/TaskAttributionTiming.json
+++ b/api/TaskAttributionTiming.json
@@ -12,7 +12,7 @@
           "edge": "mirror",
           "firefox": {
             "version_added": false,
-            "notes": "See <a href='https://bugzil.la/1348405'>bug 1348405</a>."
+            "impl_url": "https://bugzil.la/1348405"
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/TextTrack.json
+++ b/api/TextTrack.json
@@ -265,7 +265,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/754093'>bug 754093</a>."
+              "impl_url": "https://crbug.com/754093"
             },
             "chrome_android": "mirror",
             "edge": {

--- a/api/VTTCue.json
+++ b/api/VTTCue.json
@@ -205,7 +205,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/633690'>bug 633690</a>."
+              "impl_url": "https://crbug.com/633690"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -280,7 +280,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/633690'>bug 633690</a>."
+              "impl_url": "https://crbug.com/633690"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -647,7 +647,7 @@
             "firefox": [
               {
                 "version_added": "18",
-                "notes": "See <a href='https://bugzil.la/775368'>bug 775368</a>."
+                "impl_url": "https://bugzil.la/775368"
               },
               {
                 "version_added": "11",

--- a/api/Window.json
+++ b/api/Window.json
@@ -884,7 +884,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1475599'>bug 1475599</a>."
+              "impl_url": "https://bugzil.la/1475599"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -895,7 +895,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/231750'>bug 231750</a>."
+              "impl_url": "https://webkit.org/b/231750"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2717,7 +2717,7 @@
             },
             "safari": {
               "version_added": "16.4",
-              "notes": "See <a href='https://webkit.org/b/171216'>bug 171216</a>."
+              "impl_url": "https://webkit.org/b/171216"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -5855,7 +5855,7 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/487255'>bug 487255</a>."
+              "impl_url": "https://crbug.com/487255"
             }
           },
           "status": {

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -198,7 +198,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/794548'>Chromium bug 794548</a>."
+                "impl_url": "https://crbug.com/794548"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -464,7 +464,7 @@
             },
             "safari": {
               "version_added": "16.4",
-              "notes": "See <a href='https://webkit.org/b/171216'>bug 171216</a>."
+              "impl_url": "https://webkit.org/b/171216"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -382,7 +382,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/114475'>bug 114475</a>."
+              "impl_url": "https://crbug.com/114475"
             },
             "chrome_android": "mirror",
             "deno": {
@@ -421,7 +421,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/114475'>bug 114475</a>."
+              "impl_url": "https://crbug.com/114475"
             },
             "chrome_android": "mirror",
             "deno": {

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -196,7 +196,7 @@
             },
             "safari": {
               "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/185697'>bug 185697</a>."
+              "impl_url": "https://webkit.org/b/185697"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -565,7 +565,7 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/490120'>bug 490120</a>."
+              "impl_url": "https://crbug.com/490120"
             }
           },
           "status": {
@@ -872,7 +872,7 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/921655'>bug 921655</a>."
+              "impl_url": "https://crbug.com/921655"
             }
           },
           "status": {

--- a/api/_globals/createImageBitmap.json
+++ b/api/_globals/createImageBitmap.json
@@ -25,7 +25,7 @@
           "opera_android": "mirror",
           "safari": {
             "version_added": "15",
-            "notes": "See <a href='https://webkit.org/b/182424'>bug 182424</a>."
+            "impl_url": "https://webkit.org/b/182424"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1222,7 +1222,7 @@
             "support": {
               "chrome": {
                 "version_added": "85",
-                "notes": "See <a href='https://crbug.com/1051189'>bug 1051189</a>.",
+                "impl_url": "https://crbug.com/1051189",
                 "flags": [
                   {
                     "type": "preference",
@@ -1250,7 +1250,7 @@
               "samsunginternet_android": "mirror",
               "webview_android": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/1051189'>bug 1051189</a>."
+                "impl_url": "https://crbug.com/1051189"
               }
             },
             "status": {
@@ -1458,7 +1458,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/489957'>bug 489957</a>."
+                "impl_url": "https://crbug.com/489957"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -130,7 +130,7 @@
               "opera": "mirror",
               "opera_android": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/979041'>bug 979041</a>."
+                "impl_url": "https://crbug.com/979041"
               },
               "safari": {
                 "version_added": "14.1"

--- a/css/properties/break-after.json
+++ b/css/properties/break-after.json
@@ -482,7 +482,7 @@
               "support": {
                 "chrome": {
                   "version_added": false,
-                  "notes": "See <a href='https://crbug.com/538475'>bug 538475</a>."
+                  "impl_url": "https://crbug.com/538475"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",

--- a/css/properties/break-before.json
+++ b/css/properties/break-before.json
@@ -430,7 +430,7 @@
               "support": {
                 "chrome": {
                   "version_added": false,
-                  "notes": "See <a href='https://crbug.com/538475'>bug 538475</a>."
+                  "impl_url": "https://crbug.com/538475"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",

--- a/css/properties/column-fill.json
+++ b/css/properties/column-fill.json
@@ -63,7 +63,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/909596'>bug 909596</a>."
+                "impl_url": "https://crbug.com/909596"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/font-variant-position.json
+++ b/css/properties/font-variant-position.json
@@ -8,7 +8,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/1212668'>bug 1212668</a>."
+              "impl_url": "https://crbug.com/1212668"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/initial-letter-align.json
+++ b/css/properties/initial-letter-align.json
@@ -13,7 +13,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1273021'>bug 1273021</a>."
+              "impl_url": "https://bugzil.la/1273021"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/initial-letter.json
+++ b/css/properties/initial-letter.json
@@ -13,7 +13,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1223880'>bug 1223880</a>."
+              "impl_url": "https://bugzil.la/1223880"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/margin-trim.json
+++ b/css/properties/margin-trim.json
@@ -13,7 +13,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1506241'>bug 1506241</a>."
+              "impl_url": "https://bugzil.la/1506241"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/mask-border-outset.json
+++ b/css/properties/mask-border-outset.json
@@ -14,7 +14,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/877294'>bug 877294</a>."
+              "impl_url": "https://bugzil.la/877294"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/mask-border-repeat.json
+++ b/css/properties/mask-border-repeat.json
@@ -14,7 +14,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/877294'>bug 877294</a>."
+              "impl_url": "https://bugzil.la/877294"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/mask-border-slice.json
+++ b/css/properties/mask-border-slice.json
@@ -14,7 +14,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/877294'>bug 877294</a>."
+              "impl_url": "https://bugzil.la/877294"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/mask-border-source.json
+++ b/css/properties/mask-border-source.json
@@ -14,7 +14,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/877294'>bug 877294</a>."
+              "impl_url": "https://bugzil.la/877294"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/mask-border-width.json
+++ b/css/properties/mask-border-width.json
@@ -14,7 +14,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/877294'>bug 877294</a>."
+              "impl_url": "https://bugzil.la/877294"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/mask-border.json
+++ b/css/properties/mask-border.json
@@ -14,7 +14,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/877294'>bug 877294</a>."
+              "impl_url": "https://bugzil.la/877294"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -65,7 +65,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/137293'>bug 137293</a>."
+                "impl_url": "https://webkit.org/b/137293"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -142,7 +142,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/137293'>bug 137293</a>."
+                "impl_url": "https://webkit.org/b/137293"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -176,7 +176,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/137293'>bug 137293</a>."
+                "impl_url": "https://webkit.org/b/137293"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/math-depth.json
+++ b/css/properties/math-depth.json
@@ -49,7 +49,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/202303'>bug 202303</a>."
+              "impl_url": "https://webkit.org/b/202303"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/ruby-position.json
+++ b/css/properties/ruby-position.json
@@ -65,7 +65,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/1191394'>bug 1191394</a>."
+                "impl_url": "https://crbug.com/1191394"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -99,13 +99,13 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/1258284'>bug 1258284</a>."
+                "impl_url": "https://crbug.com/1258284"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1055672'>bug 1055672</a>."
+                "impl_url": "https://bugzil.la/1055672"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/scrollbar-color.json
+++ b/css/properties/scrollbar-color.json
@@ -31,7 +31,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/231590'>bug 231590</a>."
+              "impl_url": "https://webkit.org/b/231590"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/scrollbar-gutter.json
+++ b/css/properties/scrollbar-gutter.json
@@ -23,7 +23,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/167335'>bug 167335</a>."
+              "impl_url": "https://webkit.org/b/167335"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/scrollbar-width.json
+++ b/css/properties/scrollbar-width.json
@@ -30,7 +30,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/231588'>bug 231588</a>."
+              "impl_url": "https://webkit.org/b/231588"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/text-justify.json
+++ b/css/properties/text-justify.json
@@ -49,7 +49,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/99945'>bug 9945</a>."
+              "impl_url": "https://webkit.org/b/99945"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/touch-action.json
+++ b/css/properties/touch-action.json
@@ -275,7 +275,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1285685'>bug 1285685</a>."
+                "impl_url": "https://bugzil.la/1285685"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/zoom.json
+++ b/css/properties/zoom.json
@@ -14,7 +14,7 @@
             },
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/390936'>bug 390936</a>."
+              "impl_url": "https://bugzil.la/390936"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/-moz-only-whitespace.json
+++ b/css/selectors/-moz-only-whitespace.json
@@ -13,7 +13,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "1",
-              "notes": "See <a href='https://bugzil.la/1106296'>bug 1106296</a>."
+              "impl_url": "https://bugzil.la/1106296"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/-webkit-resizer.json
+++ b/css/selectors/-webkit-resizer.json
@@ -13,7 +13,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1432935'>bug 1432935</a>."
+              "impl_url": "https://bugzil.la/1432935"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/-webkit-scrollbar-button.json
+++ b/css/selectors/-webkit-scrollbar-button.json
@@ -13,7 +13,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1432935'>bug 1432935</a>."
+              "impl_url": "https://bugzil.la/1432935"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/-webkit-scrollbar-corner.json
+++ b/css/selectors/-webkit-scrollbar-corner.json
@@ -13,7 +13,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1432935'>bug 1432935</a>."
+              "impl_url": "https://bugzil.la/1432935"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/-webkit-scrollbar-thumb.json
+++ b/css/selectors/-webkit-scrollbar-thumb.json
@@ -13,7 +13,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1432935'>bug 1432935</a>."
+              "impl_url": "https://bugzil.la/1432935"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/-webkit-scrollbar-track-piece.json
+++ b/css/selectors/-webkit-scrollbar-track-piece.json
@@ -13,7 +13,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1432935'>bug 1432935</a>."
+              "impl_url": "https://bugzil.la/1432935"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/-webkit-scrollbar-track.json
+++ b/css/selectors/-webkit-scrollbar-track.json
@@ -13,7 +13,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1432935'>bug 1432935</a>."
+              "impl_url": "https://bugzil.la/1432935"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/-webkit-scrollbar.json
+++ b/css/selectors/-webkit-scrollbar.json
@@ -13,7 +13,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1432935'>bug 1432935</a>."
+              "impl_url": "https://bugzil.la/1432935"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/attribute.json
+++ b/css/selectors/attribute.json
@@ -82,7 +82,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/1041095'>bug 1041095</a>."
+                "impl_url": "https://crbug.com/1041095"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/selectors/blank.json
+++ b/css/selectors/blank.json
@@ -14,7 +14,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1197736'>bug 1197736</a>."
+              "impl_url": "https://bugzil.la/1197736"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/column.json
+++ b/css/selectors/column.json
@@ -14,7 +14,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1605558'>bug 1605558</a>."
+              "impl_url": "https://bugzil.la/1605558"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/empty.json
+++ b/css/selectors/empty.json
@@ -54,7 +54,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1106296'>bug 1106296</a>."
+                "impl_url": "https://bugzil.la/1106296"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/selectors/grammar-error.json
+++ b/css/selectors/grammar-error.json
@@ -24,7 +24,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/175784'>bug 175784</a>."
+              "impl_url": "https://webkit.org/b/175784"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/selectors/host-context.json
+++ b/css/selectors/host-context.json
@@ -14,7 +14,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1082060'>bug 1082060</a>."
+              "impl_url": "https://bugzil.la/1082060"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/nth-last-child.json
+++ b/css/selectors/nth-last-child.json
@@ -82,7 +82,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/304163'>bug 304163</a>."
+                "impl_url": "https://crbug.com/304163"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/selectors/spelling-error.json
+++ b/css/selectors/spelling-error.json
@@ -24,7 +24,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/175784'>bug 175784</a>."
+              "impl_url": "https://webkit.org/b/175784"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/selectors/user-invalid.json
+++ b/css/selectors/user-invalid.json
@@ -9,7 +9,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/1156069'>bug 1156069</a>."
+              "impl_url": "https://crbug.com/1156069"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/selectors/user-valid.json
+++ b/css/selectors/user-valid.json
@@ -9,7 +9,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/1156069'>bug 1156069</a>."
+              "impl_url": "https://crbug.com/1156069"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/types/-moz-image-rect.json
+++ b/css/types/-moz-image-rect.json
@@ -23,7 +23,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/32177'>WebKit bug 32177</a>."
+              "impl_url": "https://webkit.org/b/32177"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/types/attr.json
+++ b/css/types/attr.json
@@ -54,7 +54,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1448248'>bug 1448248</a>."
+                "impl_url": "https://bugzil.la/1448248"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -65,7 +65,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
+                "impl_url": "https://webkit.org/b/204275"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -89,7 +89,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/435426'>bug 435426</a>."
+                "impl_url": "https://bugzil.la/435426"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -100,7 +100,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
+                "impl_url": "https://webkit.org/b/204275"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -123,7 +123,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/435426'>bug 435426</a>."
+                  "impl_url": "https://bugzil.la/435426"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -134,7 +134,7 @@
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": false,
-                  "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
+                  "impl_url": "https://webkit.org/b/204275"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -158,7 +158,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/1448251'>bug 1448251</a>."
+                  "impl_url": "https://bugzil.la/1448251"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -169,7 +169,7 @@
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": false,
-                  "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
+                  "impl_url": "https://webkit.org/b/204275"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -193,7 +193,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/435426'>bug 435426</a>."
+                  "impl_url": "https://bugzil.la/435426"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -204,7 +204,7 @@
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": false,
-                  "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
+                  "impl_url": "https://webkit.org/b/204275"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -228,7 +228,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/435426'>bug 435426</a>."
+                  "impl_url": "https://bugzil.la/435426"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -239,7 +239,7 @@
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": false,
-                  "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
+                  "impl_url": "https://webkit.org/b/204275"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -263,7 +263,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/435426'>bug 435426</a>."
+                  "impl_url": "https://bugzil.la/435426"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -274,7 +274,7 @@
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": false,
-                  "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
+                  "impl_url": "https://webkit.org/b/204275"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -298,7 +298,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/435426'>bug 435426</a>."
+                  "impl_url": "https://bugzil.la/435426"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -309,7 +309,7 @@
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": false,
-                  "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
+                  "impl_url": "https://webkit.org/b/204275"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -333,7 +333,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/435426'>bug 435426</a>."
+                  "impl_url": "https://bugzil.la/435426"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -344,7 +344,7 @@
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": false,
-                  "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
+                  "impl_url": "https://webkit.org/b/204275"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -368,7 +368,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/435426'>bug 435426</a>."
+                  "impl_url": "https://bugzil.la/435426"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -379,7 +379,7 @@
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": false,
-                  "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
+                  "impl_url": "https://webkit.org/b/204275"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -403,7 +403,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/1448252'>bug 1448252</a>."
+                  "impl_url": "https://bugzil.la/1448252"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -414,7 +414,7 @@
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": false,
-                  "notes": "See <a href='https://webkit.org/b/204275'>bug 204275</a>."
+                  "impl_url": "https://webkit.org/b/204275"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/css/types/frequency-percentage.json
+++ b/css/types/frequency-percentage.json
@@ -14,7 +14,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/741643'>bug 741643</a>."
+              "impl_url": "https://bugzil.la/741643"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/frequency.json
+++ b/css/types/frequency.json
@@ -14,7 +14,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/741643'>bug 741643</a>."
+              "impl_url": "https://bugzil.la/741643"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -59,7 +59,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1657516'>bug 1657516</a>."
+                "impl_url": "https://bugzil.la/1657516"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -334,7 +334,7 @@
                   "edge": "mirror",
                   "firefox": {
                     "version_added": false,
-                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
+                    "impl_url": "https://bugzil.la/1824041"
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -368,7 +368,7 @@
                   "edge": "mirror",
                   "firefox": {
                     "version_added": false,
-                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
+                    "impl_url": "https://bugzil.la/1824041"
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -542,7 +542,7 @@
                   "edge": "mirror",
                   "firefox": {
                     "version_added": false,
-                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
+                    "impl_url": "https://bugzil.la/1824041"
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -576,7 +576,7 @@
                   "edge": "mirror",
                   "firefox": {
                     "version_added": false,
-                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
+                    "impl_url": "https://bugzil.la/1824041"
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -927,7 +927,7 @@
                   "edge": "mirror",
                   "firefox": {
                     "version_added": false,
-                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
+                    "impl_url": "https://bugzil.la/1824041"
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -961,7 +961,7 @@
                   "edge": "mirror",
                   "firefox": {
                     "version_added": false,
-                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
+                    "impl_url": "https://bugzil.la/1824041"
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -1063,7 +1063,7 @@
                   "edge": "mirror",
                   "firefox": {
                     "version_added": false,
-                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
+                    "impl_url": "https://bugzil.la/1824041"
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -1097,7 +1097,7 @@
                   "edge": "mirror",
                   "firefox": {
                     "version_added": false,
-                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
+                    "impl_url": "https://bugzil.la/1824041"
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -1271,7 +1271,7 @@
                   "edge": "mirror",
                   "firefox": {
                     "version_added": false,
-                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
+                    "impl_url": "https://bugzil.la/1824041"
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -1305,7 +1305,7 @@
                   "edge": "mirror",
                   "firefox": {
                     "version_added": false,
-                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
+                    "impl_url": "https://bugzil.la/1824041"
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -1661,7 +1661,7 @@
                   "edge": "mirror",
                   "firefox": {
                     "version_added": false,
-                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
+                    "impl_url": "https://bugzil.la/1824041"
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -1695,7 +1695,7 @@
                   "edge": "mirror",
                   "firefox": {
                     "version_added": false,
-                    "notes": "See <a href='https://bugzil.la/1824041'>bug 1824041</a>."
+                    "impl_url": "https://bugzil.la/1824041"
                   },
                   "firefox_android": "mirror",
                   "ie": {

--- a/css/types/length-percentage.json
+++ b/css/types/length-percentage.json
@@ -195,7 +195,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/937101'>bug 937101</a>."
+                "impl_url": "https://crbug.com/937101"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -211,7 +211,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/195176'>bug 195176</a>."
+                "impl_url": "https://webkit.org/b/195176"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -230,13 +230,13 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/937104'>bug 937104</a>."
+                "impl_url": "https://crbug.com/937104"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1310170'>bug 1310170</a>."
+                "impl_url": "https://bugzil.la/1310170"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -342,13 +342,13 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/937104'>bug 937104</a>."
+                "impl_url": "https://crbug.com/937104"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1310170'>bug 1310170</a>."
+                "impl_url": "https://bugzil.la/1310170"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -382,7 +382,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1287034'>bug 1287034</a>."
+                "impl_url": "https://bugzil.la/1287034"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -393,7 +393,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/159801'>bug 159801</a>."
+                "impl_url": "https://webkit.org/b/159801"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -454,7 +454,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1287034'>bug 1287034</a>."
+                "impl_url": "https://bugzil.la/1287034"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -465,7 +465,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/159801'>bug 159801</a>."
+                "impl_url": "https://webkit.org/b/159801"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -267,7 +267,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1310170'>bug 1310170</a>."
+                "impl_url": "https://bugzil.la/1310170"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -340,13 +340,13 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/937104'>bug 937104</a>."
+                "impl_url": "https://crbug.com/937104"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1310170'>bug 1310170</a>."
+                "impl_url": "https://bugzil.la/1310170"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/types/resolution.json
+++ b/css/types/resolution.json
@@ -37,7 +37,7 @@
             },
             "safari": {
               "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/78087'>bug 78087</a>."
+              "impl_url": "https://webkit.org/b/78087"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/html/elements/col.json
+++ b/html/elements/col.json
@@ -48,7 +48,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>."
+                "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -117,7 +117,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>."
+                "impl_url": "https://bugzil.la/2212"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -152,7 +152,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>."
+                "impl_url": "https://bugzil.la/2212"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -221,7 +221,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>."
+                "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/elements/colgroup.json
+++ b/html/elements/colgroup.json
@@ -48,7 +48,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>."
+                "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -117,7 +117,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>."
+                "impl_url": "https://bugzil.la/2212"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -152,7 +152,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>."
+                "impl_url": "https://bugzil.la/2212"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -221,7 +221,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>."
+                "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -348,7 +348,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1622090'>bug 1622090</a>."
+                "impl_url": "https://bugzil.la/1622090"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -58,7 +58,7 @@
                 },
                 "firefox": {
                   "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/960989'>bug 960989</a> for the status of support for the <code>autocomplete</code> attribute in Firefox."
+                  "impl_url": "https://bugzil.la/960989"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -98,7 +98,7 @@
                 },
                 "firefox_android": {
                   "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/1805397'>bug 1805397</a> for the status of support for the list attribute in Firefox."
+                  "impl_url": "https://bugzil.la/1805397"
                 },
                 "ie": {
                   "version_added": false

--- a/html/elements/input/month.json
+++ b/html/elements/input/month.json
@@ -17,7 +17,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/888320'>bug 888320</a>."
+                "impl_url": "https://bugzil.la/888320"
               },
               "firefox_android": {
                 "version_added": "18"

--- a/html/elements/input/range.json
+++ b/html/elements/input/range.json
@@ -108,7 +108,10 @@
                 },
                 "firefox": {
                   "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/840820'>bug 840820</a> and <a href='https://bugzil.la/981916'>bug 981916</a>."
+                  "impl_url": [
+                    "https://bugzil.la/840820",
+                    "https://bugzil.la/981916"
+                  ]
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/html/elements/input/week.json
+++ b/html/elements/input/week.json
@@ -17,7 +17,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/888320'>bug 888320</a>."
+                "impl_url": "https://bugzil.la/888320"
               },
               "firefox_android": {
                 "version_added": "18"
@@ -32,7 +32,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/200416'>bug 200416</a>."
+                "impl_url": "https://webkit.org/b/200416"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -1053,7 +1053,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/441770'>bug 441770</a>."
+                "impl_url": "https://bugzil.la/441770"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/elements/search.json
+++ b/html/elements/search.json
@@ -8,7 +8,10 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/937101'>bug 1294294</a> and <a href='https://crbug.com/1277435'>bug 1277435</a>."
+              "impl_url": [
+                "https://crbug.com/937101",
+                "https://crbug.com/1277435"
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/html/elements/tbody.json
+++ b/html/elements/tbody.json
@@ -52,7 +52,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>."
+                "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -125,7 +125,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>."
+                "impl_url": "https://bugzil.la/2212"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -160,7 +160,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>."
+                "impl_url": "https://bugzil.la/2212"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -195,7 +195,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>."
+                "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/elements/td.json
+++ b/html/elements/td.json
@@ -86,7 +86,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>."
+                "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -193,7 +193,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>."
+                "impl_url": "https://bugzil.la/2212"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -228,7 +228,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>."
+                "impl_url": "https://bugzil.la/2212"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -432,7 +432,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>."
+                "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/elements/tfoot.json
+++ b/html/elements/tfoot.json
@@ -52,7 +52,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>."
+                "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -125,7 +125,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>."
+                "impl_url": "https://bugzil.la/2212"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -160,7 +160,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>."
+                "impl_url": "https://bugzil.la/2212"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -195,7 +195,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>."
+                "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/elements/th.json
+++ b/html/elements/th.json
@@ -86,7 +86,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>."
+                "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -193,7 +193,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>."
+                "impl_url": "https://bugzil.la/2212"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -228,7 +228,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>."
+                "impl_url": "https://bugzil.la/2212"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -432,7 +432,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>."
+                "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/elements/thead.json
+++ b/html/elements/thead.json
@@ -53,7 +53,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>."
+                "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -126,7 +126,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>."
+                "impl_url": "https://bugzil.la/2212"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -161,7 +161,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>."
+                "impl_url": "https://bugzil.la/2212"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -196,7 +196,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>."
+                "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/elements/tr.json
+++ b/html/elements/tr.json
@@ -52,7 +52,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>."
+                "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -125,7 +125,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>."
+                "impl_url": "https://bugzil.la/2212"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -160,7 +160,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/2212'>bug 2212</a>."
+                "impl_url": "https://bugzil.la/2212"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -195,7 +195,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/915'>bug 915</a>."
+                "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -856,7 +856,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/182671'>bug 182671</a>."
+              "impl_url": "https://webkit.org/b/182671"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1139,7 +1139,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/179728'>bug 179728</a>."
+                "impl_url": "https://webkit.org/b/179728"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/manifest/screenshots.json
+++ b/html/manifest/screenshots.json
@@ -32,7 +32,7 @@
             },
             "safari_ios": {
               "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/222356'>bug 222356</a>."
+              "impl_url": "https://webkit.org/b/222356"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/html/manifest/shortcuts.json
+++ b/html/manifest/shortcuts.json
@@ -23,7 +23,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1582341'>bug 1582341</a>."
+              "impl_url": "https://bugzil.la/1582341"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -34,7 +34,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": false,
-              "notes": "See <a href='https://webkit.org/b/201964'>bug 201964</a>."
+              "impl_url": "https://webkit.org/b/201964"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/http/headers/Clear-Site-Data.json
+++ b/http/headers/Clear-Site-Data.json
@@ -189,7 +189,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/898503'>bug 898503</a>."
+                "impl_url": "https://crbug.com/898503"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -702,13 +702,13 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/801561'>bug 801561</a>."
+                "impl_url": "https://crbug.com/801561"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1457204'>bug 1457204</a>."
+                "impl_url": "https://bugzil.la/1457204"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -719,7 +719,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/185070'>bug 185070</a>."
+                "impl_url": "https://webkit.org/b/185070"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/http/headers/Expect-CT.json
+++ b/http/headers/Expect-CT.json
@@ -16,7 +16,7 @@
             },
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1281469'>bug 1281469</a>."
+              "impl_url": "https://bugzil.la/1281469"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/http/headers/Retry-After.json
+++ b/http/headers/Retry-After.json
@@ -15,7 +15,7 @@
             },
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/230260'>bug 230260</a>."
+              "impl_url": "https://bugzil.la/230260"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -58,7 +58,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1568906'>bug 1568906</a>."
+                "impl_url": "https://bugzil.la/1568906"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -72,7 +72,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/248650'>bug 248650</a>."
+                "impl_url": "https://webkit.org/b/248650"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -100,7 +100,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1568906'>bug 1568906</a>."
+                "impl_url": "https://bugzil.la/1568906"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -114,7 +114,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/248650'>bug 248650</a>."
+                "impl_url": "https://webkit.org/b/248650"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -142,7 +142,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1568906'>bug 1568906</a>."
+                "impl_url": "https://bugzil.la/1568906"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -156,7 +156,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/248650'>bug 248650</a>."
+                "impl_url": "https://webkit.org/b/248650"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -184,7 +184,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1568906'>bug 1568906</a>."
+                "impl_url": "https://bugzil.la/1568906"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -198,7 +198,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/248650'>bug 248650</a>."
+                "impl_url": "https://webkit.org/b/248650"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -226,7 +226,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1568906'>bug 1568906</a>."
+                "impl_url": "https://bugzil.la/1568906"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -240,7 +240,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/248650'>bug 248650</a>."
+                "impl_url": "https://webkit.org/b/248650"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -268,7 +268,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1568906'>bug 1568906</a>."
+                "impl_url": "https://bugzil.la/1568906"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -282,7 +282,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/248650'>bug 248650</a>."
+                "impl_url": "https://webkit.org/b/248650"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -310,7 +310,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1568906'>bug 1568906</a>."
+                "impl_url": "https://bugzil.la/1568906"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -324,7 +324,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/248650'>bug 248650</a>."
+                "impl_url": "https://webkit.org/b/248650"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -352,7 +352,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1568906'>bug 1568906</a>."
+                "impl_url": "https://bugzil.la/1568906"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -366,7 +366,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/248650'>bug 248650</a>."
+                "impl_url": "https://webkit.org/b/248650"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -394,7 +394,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1568906'>bug 1568906</a>."
+                "impl_url": "https://bugzil.la/1568906"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -408,7 +408,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/248650'>bug 248650</a>."
+                "impl_url": "https://webkit.org/b/248650"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -436,7 +436,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1568906'>bug 1568906</a>."
+                "impl_url": "https://bugzil.la/1568906"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -450,7 +450,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/248650'>bug 248650</a>."
+                "impl_url": "https://webkit.org/b/248650"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -478,7 +478,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1568906'>bug 1568906</a>."
+                "impl_url": "https://bugzil.la/1568906"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -492,7 +492,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/248650'>bug 248650</a>."
+                "impl_url": "https://webkit.org/b/248650"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -520,7 +520,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1568906'>bug 1568906</a>."
+                "impl_url": "https://bugzil.la/1568906"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -534,7 +534,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/248650'>bug 248650</a>."
+                "impl_url": "https://webkit.org/b/248650"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -562,7 +562,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1568906'>bug 1568906</a>."
+                "impl_url": "https://bugzil.la/1568906"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -576,7 +576,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "See <a href='https://webkit.org/b/248650'>bug 248650</a>."
+                "impl_url": "https://webkit.org/b/248650"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -398,7 +398,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/v8/13556'>bug 13556</a>."
+                "impl_url": "https://crbug.com/v8/13556"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -583,7 +583,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/v8/13556'>bug 13556</a>."
+                "impl_url": "https://crbug.com/v8/13556"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -631,7 +631,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/v8/13556'>bug 13556</a>."
+                "impl_url": "https://crbug.com/v8/13556"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -679,7 +679,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/v8/13556'>bug 13556</a>."
+                "impl_url": "https://crbug.com/v8/13556"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -727,7 +727,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/v8/13556'>bug 13556</a>."
+                "impl_url": "https://crbug.com/v8/13556"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -859,7 +859,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/v8/13556'>bug 13556</a>."
+                "impl_url": "https://crbug.com/v8/13556"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -907,7 +907,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/v8/13556'>bug 13556</a>."
+                "impl_url": "https://crbug.com/v8/13556"
               },
               "chrome_android": "mirror",
               "deno": {

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -875,7 +875,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1736059'>bug 1736059</a>."
+                "impl_url": "https://bugzil.la/1736059"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/operators/import.json
+++ b/javascript/operators/import.json
@@ -107,7 +107,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1736059'>bug 1736059</a>."
+                "impl_url": "https://bugzil.la/1736059"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/regular_expressions.json
+++ b/javascript/regular_expressions.json
@@ -615,7 +615,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/v8/13173'>bug 13173</a>."
+                "impl_url": "https://crbug.com/v8/13173"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -624,7 +624,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1773135'>bug 1773135</a>."
+                "impl_url": "https://bugzil.la/1773135"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1376,7 +1376,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1736059'>bug 1736059</a>."
+                "impl_url": "https://bugzil.la/1736059"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1431,7 +1431,7 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": false,
-                  "notes": "See <a href='https://bugzil.la/1736059'>bug 1736059</a>."
+                  "impl_url": "https://bugzil.la/1736059"
                 },
                 "firefox_android": "mirror",
                 "ie": {

--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -91,7 +91,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "notes": "See <a href='https://crbug.com/825443'>bug 825443</a>.",
+                  "impl_url": "https://crbug.com/825443",
                   "version_added": false
                 },
                 "edge": "mirror",

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -52,7 +52,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/628819'>bug 628819</a>."
+                "impl_url": "https://crbug.com/628819"
               },
               "edge": {
                 "version_added": false
@@ -1366,7 +1366,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See <a href='https://crbug.com/628819'>bug 628819</a>."
+                "impl_url": "https://crbug.com/628819"
               },
               "edge": {
                 "version_added": false

--- a/webextensions/manifest/externally_connectable.json
+++ b/webextensions/manifest/externally_connectable.json
@@ -13,7 +13,7 @@
             },
             "firefox": {
               "version_added": false,
-              "notes": "See <a href='https://bugzil.la/1319168'>bug 1319168</a>."
+              "impl_url": "https://bugzil.la/1319168"
             },
             "firefox_android": {
               "version_added": false

--- a/webextensions/manifest/incognito.json
+++ b/webextensions/manifest/incognito.json
@@ -75,7 +75,7 @@
               },
               "firefox": {
                 "version_added": false,
-                "notes": "See <a href='https://bugzil.la/1380812'>bug 1380812</a>."
+                "impl_url": "https://bugzil.la/1380812"
               },
               "firefox_android": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
This PR converts various "See bug XXXXX" notes into `impl_url` keys instead, which would allow for better machine readability if needed.

This change was primarily performed by the following regex: `"notes": "See <a href='(https://(crbug\.com(/[^/]+)?|bugzil\.la|webkit\.org/b)/(\d+))'>(\w+\s)?bug (\d+)</a>\.?"` -> `"impl_url": "$1"`
Manual changes were then performed as needed.
