### PR TITLE
Fix linter to allow Deno/NodeJS in WASM category

### DIFF
--- a/test/linter/test-browsers-presence.ts
+++ b/test/linter/test-browsers-presence.ts
@@ -33,7 +33,9 @@ const processData = (
           'desktop',
           'mobile',
           'xr',
-          ...(['api', 'javascript'].includes(category) ? ['server'] : []),
+          ...(['api', 'javascript', 'webassembly'].includes(category)
+            ? ['server']
+            : []),
         ].includes(browsers[b].type) &&
         (category !== 'webextensions' || browsers[b].accepts_webextensions),
     );


### PR DESCRIPTION
This PR fixes the browser presence linter to allow server context browsers to be present in the WebAssembly category.
