### PR TITLE
fix 404

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3767,7 +3767,7 @@
             "firefox": [
               {
                 "version_added": "108",
-                "notes": "API access is gated by installation of a <a href='https://support.mozilla.org/en-US/kb/site-permission-addons'>site permission add-on</a> (user prompt), secure context, and <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/midi'>Permission Policy: <code>midi</code></a>."
+                "notes": "API access is gated by installation of a <a href='https://support.mozilla.org/en-US/kb/site-permission-add-ons'>site permission add-on</a> (user prompt), secure context, and <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers/Feature-Policy/midi'>Permission Policy: <code>midi</code></a>."
               },
               {
                 "version_added": "97",


### PR DESCRIPTION
#### Summary

fix 404 for hardcoded implementation note link

#### Test results and supporting details

n/a

#### Related issues

n/a

#### Other

This feature should really be under a "X" or marked as "user-must enable" for firefox... requiring a not-documented extension hack to enable is not the same as "supported".

...Also, if anyone know of a doc page for it, consider replacing the end-user-vague-explanation currently linked to one meant for developers having to implement said extension permission hack instead. thanks!