### PR TITLE
RTCEncodedAudioFrame / Video frame links

### DIFF
--- a/api/RTCEncodedAudioFrame.json
+++ b/api/RTCEncodedAudioFrame.json
@@ -3,7 +3,7 @@
     "RTCEncodedAudioFrame": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCEncodedAudioFrame",
-        "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#RTCEncodedAudioFrame-interface",
+        "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#ref-for-rtcencodedaudioframe%E2%91%A1",
         "support": {
           "chrome": {
             "version_added": "86"

--- a/api/RTCEncodedVideoFrame.json
+++ b/api/RTCEncodedVideoFrame.json
@@ -3,7 +3,7 @@
     "RTCEncodedVideoFrame": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCEncodedVideoFrame",
-        "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#RTCEncodedVideoFrame-interface",
+        "spec_url": "https://w3c.github.io/webrtc-encoded-transform/#rtcencodedvideoframe",
         "support": {
           "chrome": {
             "version_added": "86"


### PR DESCRIPTION
The specification links for RTCEncodedAudioFrame and RTCEncodedVideoFrame wasn't working. This tries a new link to the IDL section rather than nearest heading.

This is related to https://github.com/mdn/content/issues/28280