### PR TITLE
Improve data about async versions of filesystemsyncaccesshandle methods

### DIFF
--- a/api/FileSystemSyncAccessHandle.json
+++ b/api/FileSystemSyncAccessHandle.json
@@ -41,10 +41,10 @@
           "spec_url": "https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-close",
           "support": {
             "chrome": {
-              "version_added": "102"
+              "version_added": "109"
             },
             "chrome_android": {
-              "version_added": "109"
+              "version_added": "110"
             },
             "edge": "mirror",
             "firefox": {
@@ -70,12 +70,13 @@
             "deprecated": false
           }
         },
-        "sync_version": {
+        "async_version": {
           "__compat": {
-            "description": "Synchronous implementation of the <code>close()</code> method",
+            "description": "Asynchronous implementation of the <code>close()</code> method",
             "support": {
               "chrome": {
-                "version_added": "108",
+                "version_added": "102",
+                "version_removed": "108",
                 "flags": [
                   {
                     "type": "preference",
@@ -85,17 +86,27 @@
                 ]
               },
               "chrome_android": {
-                "version_added": "109"
+                "version_added": "102",
+                "version_removed": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Sync Access Handle All Sync Surface",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "111"
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
-              "oculus": "mirror",
+              "oculus": {
+                "version_added": false
+              },
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
@@ -119,10 +130,10 @@
           "spec_url": "https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-flush",
           "support": {
             "chrome": {
-              "version_added": "102"
+              "version_added": "109"
             },
             "chrome_android": {
-              "version_added": "109"
+              "version_added": "110"
             },
             "edge": "mirror",
             "firefox": {
@@ -148,12 +159,13 @@
             "deprecated": false
           }
         },
-        "sync_version": {
+        "async_version": {
           "__compat": {
-            "description": "Synchronous implementation of the <code>flush()</code> method",
+            "description": "Asynchronous implementation of the <code>flush()</code> method",
             "support": {
               "chrome": {
-                "version_added": "108",
+                "version_added": "102",
+                "version_removed": "108",
                 "flags": [
                   {
                     "type": "preference",
@@ -163,17 +175,27 @@
                 ]
               },
               "chrome_android": {
-                "version_added": "109"
+                "version_added": "102",
+                "version_removed": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Sync Access Handle All Sync Surface",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "111"
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
-              "oculus": "mirror",
+              "oculus": {
+                "version_added": false
+              },
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
@@ -197,10 +219,10 @@
           "spec_url": "https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-getsize",
           "support": {
             "chrome": {
-              "version_added": "102"
+              "version_added": "109"
             },
             "chrome_android": {
-              "version_added": "109"
+              "version_added": "110"
             },
             "edge": "mirror",
             "firefox": {
@@ -226,12 +248,13 @@
             "deprecated": false
           }
         },
-        "sync_version": {
+        "async_version": {
           "__compat": {
-            "description": "Synchronous implementation of the <code>getSize()</code> method",
+            "description": "Asynchronous implementation of the <code>getSize()</code> method",
             "support": {
               "chrome": {
-                "version_added": "108",
+                "version_added": "102",
+                "version_removed": "108",
                 "flags": [
                   {
                     "type": "preference",
@@ -241,17 +264,27 @@
                 ]
               },
               "chrome_android": {
-                "version_added": "109"
+                "version_added": "102",
+                "version_removed": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Sync Access Handle All Sync Surface",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "111"
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
-              "oculus": "mirror",
+              "oculus": {
+                "version_added": false
+              },
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
@@ -311,10 +344,10 @@
           "spec_url": "https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-truncate",
           "support": {
             "chrome": {
-              "version_added": "102"
+              "version_added": "109"
             },
             "chrome_android": {
-              "version_added": "109"
+              "version_added": "110"
             },
             "edge": "mirror",
             "firefox": {
@@ -340,12 +373,13 @@
             "deprecated": false
           }
         },
-        "sync_version": {
+        "async_version": {
           "__compat": {
-            "description": "Synchronous implementation of the <code>truncate()</code> method",
+            "description": "Asynchronous implementation of the <code>truncate()</code> method",
             "support": {
               "chrome": {
-                "version_added": "108",
+                "version_added": "102",
+                "version_removed": "108",
                 "flags": [
                   {
                     "type": "preference",
@@ -355,17 +389,27 @@
                 ]
               },
               "chrome_android": {
-                "version_added": "109"
+                "version_added": "102",
+                "version_removed": "109",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "Sync Access Handle All Sync Surface",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "111"
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
-              "oculus": "mirror",
+              "oculus": {
+                "version_added": false
+              },
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

As detailed in https://github.com/mdn/content/issues/28647, the sync support data is misleading/wrong; the incorrect async versions of these methods are no longer supported in any modern browser. This PR improves the data as suggested.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixes https://github.com/mdn/content/issues/28647

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
