### PR TITLE
relnote(117): Windows notifications have requireInteraction set to true by default

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -910,7 +910,15 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "117",
+              "notes": "Enabled on Windows by default in Firefox 117.",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.webnotifications.requireinteraction.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -911,7 +911,7 @@
             },
             "firefox": {
               "version_added": "117",
-              "notes": "Enabled on Windows by default in Firefox 117.",
+              "notes": "Enabled by default on Windows",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
Windows notifications require user interaction (dismiss) by default via `dom.webnotifications.requireinteraction.enabled` pref

__Related issues and pull requests:__
- [ ] Parent issue https://github.com/mdn/content/issues/28756
- [ ] content https://github.com/mdn/content/pull/28855

__Revision:__

- https://hg.mozilla.org/mozilla-central/rev/74f21a0ae212

__Bugzilla:__
- https://bugzilla.mozilla.org/show_bug.cgi?id=1794475

