### PR TITLE
Update Chrome support for scripting media query

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1457,8 +1457,7 @@
             "spec_url": "https://drafts.csswg.org/mediaqueries-5/#scripting",
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/489957"
+                "version_added": "118"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1470,12 +1469,8 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "17"
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Update Chrome support for scripting media query

#### Test results and supporting details

https://chromium-review.googlesource.com/c/chromium/src/+/4827163: My patch to enable this feature by default got merged today so will be in Chrome 118

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
