### PR TITLE
Include Opera 60+ support for `Cross-Origin-Resource-Policy`

### DIFF
--- a/http/headers/Cross-Origin-Resource-Policy.json
+++ b/http/headers/Cross-Origin-Resource-Policy.json
@@ -28,7 +28,7 @@
             },
             "oculus": "mirror",
             "opera": {
-              "version_added": false
+              "version_added": "60"
             },
             "opera_android": {
               "version_added": false


### PR DESCRIPTION
#### Summary

Update Opera's compatibility data for `Cross-Origin-Resource-Policy` (CORP)

#### Test results and supporting details

1. Tested by [running WPT tests on Opera](https://wpt.live/html/cross-origin-embedder-policy/reporting-subresource-corp.https.html) and checked devtools console for CORP related error messages (e.g. `Failed to load resource: net::ERR_BLOCKED_BY_RESPONSE.NotSameOrigin`)
2. [Opera 60](https://blogs.opera.com/desktop/2019/04/opera-60-0-3255-56-stable-update/) is based on Chromium 73, which was the version CORP was added to Chromium.
