### PR TITLE
html base element - forbid href with data or javascript url

### DIFF
--- a/html/elements/base.json
+++ b/html/elements/base.json
@@ -70,6 +70,39 @@
               "deprecated": false
             }
           },
+          "forbid_data_javascript_urls": {
+            "__compat": {
+              "description": "<code>data:</code> and <code>javascript:</code> urls are not allowed",
+              "support": {
+                "chrome": {
+                  "version_added": "58"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "13.1"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "relative_url": {
             "__compat": {
               "description": "Relative URIs.",


### PR DESCRIPTION
The `href` in the [`<base>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) element disallows `data:` and `javascript:` URLs in a recent spec change. Note however that Chrome and Safari already obey this rule. FF does not - but will in https://bugzilla.mozilla.org/show_bug.cgi?id=1850967

This was tested using first test in http://wpt.live/html/semantics/document-metadata/the-base-element/base-javascript.html and http://wpt.live/html/semantics/document-metadata/the-base-element/base-data.html

Note that the dynamic case of using JavaScript to add a new base element is not yet supported by our browsers - this is the third test in the above tests (currently failing). This PR only applies to the HTML base element.

Associated docs: https://github.com/mdn/content/issues/28865