### PR TITLE
Remove incorrect notes on `MediaQueryList.removeListener`

### DIFF
--- a/api/MediaQueryList.json
+++ b/api/MediaQueryList.json
@@ -266,8 +266,7 @@
               "version_added": "12.1"
             },
             "safari": {
-              "version_added": "5.1",
-              "notes": "Before Safari 14, <code>MediaQueryList</code> is based on <code>EventTarget</code>, so you must use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists."
+              "version_added": "5.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Do the same for `removeListener` like this [PR](https://github.com/mdn/browser-compat-data/pull/17246).

But I didn't understand below [comment](https://github.com/mdn/browser-compat-data/pull/17246#pullrequestreview-1061674365).  

> I think we should remove these notes instead. There's already a "EventTarget_inheritance" subfeature that captures this, and all browsers have gone through this change, not just Safari.

Isn't it true that for before Safari 14, you can't use `addEventListener/removeEventListener` and have to use `addListener/removeListener`? The notes seem to be important.

> Before Safari 14, <code>MediaQueryList</code> is not based on <code>EventTarget</code>, so you must use <code>addListener()</code> and <code>removeListener()</code> to observe media query lists.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
