### PR TITLE
Firefox 116 ships CSS :first selector

### DIFF
--- a/css/selectors/first.json
+++ b/css/selectors/first.json
@@ -15,7 +15,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "116"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
Fix https://github.com/mdn/browser-compat-data/issues/20595