### PR TITLE
relnote(118): CSS math functions enabled (CSS Values 4)

### DIFF
--- a/css/types/abs.json
+++ b/css/types/abs.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "118"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/exp.json
+++ b/css/types/exp.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "112"
+              "version_added": "118"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/hypot.json
+++ b/css/types/hypot.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "112"
+              "version_added": "118"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/log.json
+++ b/css/types/log.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "112"
+              "version_added": "118"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/mod.json
+++ b/css/types/mod.json
@@ -13,14 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "109",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.mod-rem.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "118"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -37,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/types/pow.json
+++ b/css/types/pow.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "112"
+              "version_added": "118"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/rem.json
+++ b/css/types/rem.json
@@ -30,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/types/rem.json
+++ b/css/types/rem.json
@@ -13,14 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "109",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.mod-rem.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "118"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/round.json
+++ b/css/types/round.json
@@ -12,14 +12,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "preview"
-              },
-              {
-                "version_added": "118"
-              }
-            ],
+            "firefox": {
+              "version_added": "118"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -35,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/types/round.json
+++ b/css/types/round.json
@@ -17,14 +17,7 @@
                 "version_added": "preview"
               },
               {
-                "version_added": "108",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.round.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "118"
               }
             ],
             "firefox_android": "mirror",

--- a/css/types/sign.json
+++ b/css/types/sign.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "118"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/types/sqrt.json
+++ b/css/types/sqrt.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "112"
+              "version_added": "118"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
There are a few CSS math functions enabled by default in 118.

__Related issues and pull requests:__
- [ ] Parent issue https://github.com/mdn/content/issues/28840
- [x] relnote: https://github.com/mdn/content/pull/28925
- [x] `layout.css.exp.enabled` https://github.com/mdn/browser-compat-data/pull/19366

__Bugzilla:__
- https://bugzilla.mozilla.org/show_bug.cgi?id=1814589


__details:__
>Specifically enabling these prefs (previously nightly only):
> - layout.css.round.enabled
> - layout.css.mod-rem.enabled
> - layout.css.exp.enabled
> - layout.css.abs-sign.enabled
>Specifically these functions: round, mod, rem, pow, sqrt, hypot, log, exp, abs, sign

Revision: https://hg.mozilla.org/integration/autoland/rev/d84e836e47652db87a27a6f4b689c2a34c699685