### PR TITLE
Chrome 116 ships CSS Motion Path

### DIFF
--- a/css/properties/offset-anchor.json
+++ b/css/properties/offset-anchor.json
@@ -7,7 +7,7 @@
           "spec_url": "https://drafts.fxtf.org/motion/#offset-anchor-property",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "116"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -70,7 +70,7 @@
             "description": "<code>&lt;basic-shape&gt;</code>",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "116"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -110,7 +110,7 @@
             "description": "<code>&lt;coord-box&gt;</code>",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "116"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -183,14 +183,7 @@
             "description": "Support for <a href='https://developer.mozilla.org/docs/Web/CSS/ray'><code>ray()</code></a> function as a value",
             "support": {
               "chrome": {
-                "version_added": "64",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "116"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/offset-position.json
+++ b/css/properties/offset-position.json
@@ -7,14 +7,7 @@
           "spec_url": "https://drafts.fxtf.org/motion/#offset-position-property",
           "support": {
             "chrome": {
-              "version_added": "115",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "116"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -53,7 +46,7 @@
             "description": "<code>normal</code> keyword value",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "116"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -180,11 +180,16 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/path",
             "spec_url": "https://drafts.csswg.org/css-shapes/#funcdef-basic-shape-path",
             "support": {
-              "chrome": {
-                "version_added": "46",
-                "partial_implementation": true,
-                "notes": "Only supported on the <code>offset-path</code> property."
-              },
+              "chrome": [
+                {
+                  "version_added": "88"
+                },
+                {
+                  "version_added": "46",
+                  "partial_implementation": true,
+                  "notes": "Only supported on the <code>offset-path</code> property."
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": [
@@ -267,14 +272,9 @@
             "spec_url": "https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-rect",
             "support": {
               "chrome": {
-                "version_added": "115",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "116",
+                "partial_implementation": true,
+                "notes": "Only supported on the <code>offset-path</code> property."
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -316,14 +316,9 @@
             "spec_url": "https://drafts.csswg.org/css-shapes-1/#funcdef-basic-shape-xywh",
             "support": {
               "chrome": {
-                "version_added": "115",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "116",
+                "partial_implementation": true,
+                "notes": "Only supported on the <code>offset-path</code> property."
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/types/ray.json
+++ b/css/types/ray.json
@@ -8,14 +8,7 @@
           "spec_url": "https://drafts.fxtf.org/motion/#ray-function",
           "support": {
             "chrome": {
-              "version_added": "64",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "116"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -54,7 +47,7 @@
             "description": "<code>at &lt;position&gt;</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "116"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -95,15 +88,7 @@
             "description": "<code>&lt;size&gt;</code>",
             "support": {
               "chrome": {
-                "version_added": "64",
-                "notes": "<code>&lt;size&gt;</code> is required.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "116"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
Chrome 116 ships CSS Motion Path per https://chromestatus.com/feature/5124394449371136

https://github.com/web-platform-dx/web-features/pull/333 was useful to determine all features that belong to this group.

The path() function works also on clip-path since version 88, as confirmed by https://chromestatus.com/feature/5633533638868992 and the same data in css.properties.clip-path.path

Fixes https://github.com/mdn/browser-compat-data/issues/20628
Fixes https://github.com/mdn/browser-compat-data/issues/20653