### PR TITLE
Update Chromium data for FileSystemSyncAccessHandle API

### DIFF
--- a/api/FileSystemSyncAccessHandle.json
+++ b/api/FileSystemSyncAccessHandle.json
@@ -41,7 +41,7 @@
           "spec_url": "https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-close",
           "support": {
             "chrome": {
-              "version_added": "109"
+              "version_added": "102"
             },
             "chrome_android": {
               "version_added": "110"
@@ -130,7 +130,7 @@
           "spec_url": "https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-flush",
           "support": {
             "chrome": {
-              "version_added": "109"
+              "version_added": "102"
             },
             "chrome_android": {
               "version_added": "110"
@@ -219,7 +219,7 @@
           "spec_url": "https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-getsize",
           "support": {
             "chrome": {
-              "version_added": "109"
+              "version_added": "102"
             },
             "chrome_android": {
               "version_added": "110"
@@ -344,7 +344,7 @@
           "spec_url": "https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-truncate",
           "support": {
             "chrome": {
-              "version_added": "109"
+              "version_added": "102"
             },
             "chrome_android": {
               "version_added": "110"


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `FileSystemSyncAccessHandle` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.3).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/FileSystemSyncAccessHandle
