### PR TITLE
Update Firefox data for api.OffscreenCanvasRenderingContext2D.textRendering

### DIFF
--- a/api/OffscreenCanvasRenderingContext2D.json
+++ b/api/OffscreenCanvasRenderingContext2D.json
@@ -2256,7 +2256,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "116"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -2273,7 +2273,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `textRendering` member of the `OffscreenCanvasRenderingContext2D` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.3).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/OffscreenCanvasRenderingContext2D/textRendering
