### PR TITLE
Update Firefox data for TextMetrics API

### DIFF
--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -190,14 +190,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "74",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.textMetrics.baselines.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "116"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -214,7 +207,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -393,14 +386,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "74",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.textMetrics.baselines.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "116"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -417,7 +403,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -434,14 +420,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "74",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.textMetrics.baselines.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "116"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -458,7 +437,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `TextMetrics` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.3).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/TextMetrics
