### PR TITLE
Update Chromium data for offset-anchor CSS property

### DIFF
--- a/css/properties/offset-anchor.json
+++ b/css/properties/offset-anchor.json
@@ -7,7 +7,7 @@
           "spec_url": "https://drafts.fxtf.org/motion/#offset-anchor-property",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "116"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `offset-anchor` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.3).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/offset-anchor
