### PR TITLE
Update Chromium data for offset-position CSS property

### DIFF
--- a/css/properties/offset-position.json
+++ b/css/properties/offset-position.json
@@ -7,14 +7,7 @@
           "spec_url": "https://drafts.fxtf.org/motion/#offset-position-property",
           "support": {
             "chrome": {
-              "version_added": "115",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "116"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `offset-position` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.3).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/offset-position
