### PR TITLE
Update Chrome support for Sec-CH-Prefers-Reduced-Transparency header

### DIFF
--- a/http/headers/Sec-CH-Prefers-Reduced-Transparency.json
+++ b/http/headers/Sec-CH-Prefers-Reduced-Transparency.json
@@ -8,15 +8,7 @@
           "spec_url": "https://wicg.github.io/user-preference-media-features-headers/#sec-ch-prefers-reduced-transparency",
           "support": {
             "chrome": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ],
-              "impl_url": "https://crbug.com/1466423"
+              "version_added": "118"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Update Chrome support for Sec-CH-Prefers-Reduced-Transparency header to reflect it releasing in 118

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

https://chromium-review.googlesource.com/c/chromium/src/+/4846931 - is my patch to enable this by default which got merged into 118.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
