### PR TITLE
Correct Chrome support for Sec-CH-Prefers-Reduced-Transparency header

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -824,6 +824,11 @@
           "status": "nightly",
           "engine": "Blink",
           "engine_version": "118"
+        },
+        "119": {
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "119"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -660,6 +660,11 @@
           "status": "nightly",
           "engine": "Blink",
           "engine_version": "118"
+        },
+        "119": {
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "119"
         }
       }
     }

--- a/http/headers/Sec-CH-Prefers-Reduced-Transparency.json
+++ b/http/headers/Sec-CH-Prefers-Reduced-Transparency.json
@@ -8,7 +8,7 @@
           "spec_url": "https://wicg.github.io/user-preference-media-features-headers/#sec-ch-prefers-reduced-transparency",
           "support": {
             "chrome": {
-              "version_added": "118"
+              "version_added": "119"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Correct Chrome support for Sec-CH-Prefers-Reduced-Transparency header

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

In #20672 I incorrectly marked this as released in 118. However, it seems I just missed the cut off for 118 so it's in fact in 119. Apologies for this mistake here's the correction.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
