### PR TITLE
RTCRtpTranceiver - current/currentDirection support stopped value

### DIFF
--- a/api/RTCRtpTransceiver.json
+++ b/api/RTCRtpTransceiver.json
@@ -68,9 +68,9 @@
             "deprecated": false
           }
         },
-        "value_stopped": {
+        "stopped_value": {
           "__compat": {
-            "description": "<code>\"stopped\"</code> value supported",
+            "description": "<code>\"stopped\"</code> value",
             "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiverdirection-stopped",
             "support": {
               "chrome": {
@@ -138,7 +138,7 @@
         },
         "value_stopped": {
           "__compat": {
-            "description": "<code>\"stopped\"</code> value supported",
+            "description": "<code>\"stopped\"</code> value",
             "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiverdirection-stopped",
             "support": {
               "chrome": {

--- a/api/RTCRtpTransceiver.json
+++ b/api/RTCRtpTransceiver.json
@@ -67,6 +67,40 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "value_stopped": {
+          "__compat": {
+            "description": "<code>\"stopped\"</code> value supported",
+            "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiverdirection-stopped",
+            "support": {
+              "chrome": {
+                "version_added": "103"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "118"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "direction": {
@@ -100,6 +134,40 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "value_stopped": {
+          "__compat": {
+            "description": "<code>\"stopped\"</code> value supported",
+            "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcrtptransceiverdirection-stopped",
+            "support": {
+              "chrome": {
+                "version_added": "103"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "118"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },


### PR DESCRIPTION
[`RTCRtpTransceiver.currentDirection`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpTransceiver/currentDirection) and [`RTCRtpTransceiver.direction`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpTransceiver/direction) now support a new value `stopped` in https://bugzilla.mozilla.org/show_bug.cgi?id=1568296. I also tested in Chrome and Safari using the last result in the first test of https://wpt.live/webrtc/RTCRtpTransceiver-stopping.https.html

Note, I call this "supports" not "returns" for the value because the `direction` also can be set with the value some circumstances, but I don't want to go into that level of detail in BCD.

Related docs work can be tracked in https://github.com/mdn/content/issues/28845