### PR TITLE
FF118 TextMetrics.emHeightAscent/Descent supported

### DIFF
--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -219,25 +219,12 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-emheightascent-dev",
           "support": {
             "chrome": {
-              "version_added": "35",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features"
-                }
-              ]
+              "version_added": "77"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "74",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.textMetrics.emHeight.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "118"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -254,7 +241,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -266,25 +253,12 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-emheightdescent-dev",
           "support": {
             "chrome": {
-              "version_added": "35",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features"
-                }
-              ]
+              "version_added": "77"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "74",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.textMetrics.emHeight.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "118"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -301,7 +275,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
FF118 supports [`TextMetrics.emHeightDescent`](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics/emHeightDescent) and [`TextMetrics.emHeightDescent`](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics/emHeightDescent) in https://bugzilla.mozilla.org/show_bug.cgi?id=1841692

This adds a BCD entry, and that also makes this no longer experimental.

Note, this is also present in Chrome - which can be tested using these tests:
 [2d.text.measure.emHeights-low-ascent.html](http://wpt.live/html/canvas/offscreen/text/2d.text.measure.emHeights-low-ascent.html)
[2d.text.measure.emHeights-low-ascent.worker.js](http://wpt.live/html/canvas/offscreen/text/2d.text.measure.emHeights-low-ascent.worker.js)
[2d.text.measure.emHeights-zero-descent.html](http://wpt.live/html/canvas/offscreen/text/2d.text.measure.emHeights-zero-descent.html)
[2d.text.measure.emHeights-zero-descent.worker.js](http://wpt.live/html/canvas/offscreen/text/2d.text.measure.emHeights-zero-descent.worker.js)
[2d.text.measure.emHeights.html](http://wpt.live/html/canvas/offscreen/text/2d.text.measure.emHeights.html)
[2d.text.measure.emHeights.worker.js](http://wpt.live/html/canvas/offscreen/text/2d.text.measure.emHeights.worker.js)

Note however that I couldn't bisect for a version because they fail on browserstack live for me in all versions. However Chromestatus indicates a bunch of stuff when in on Chrome 77 to do with this https://chromestatus.com/feature/5307344997056512. Chasing down the various bugs, and then comparing changes lists I am _fairly_ confident that it was version 77 this particular change went in as.

Related docs work can be tracked in https://github.com/mdn/content/issues/28852