### PR TITLE
Update Chromium data for api.TextMetrics.emHeightAscent/Descent

### DIFF
--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -219,7 +219,13 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-emheightascent-dev",
           "support": {
             "chrome": {
-              "version_added": "77"
+              "version_added": "35",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -253,7 +259,13 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-emheightdescent-dev",
           "support": {
             "chrome": {
-              "version_added": "77"
+              "version_added": "35",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `emHeightAscent` and `emHeightDescent` members of the `TextMetrics` API. The mdn-bcd-collector (v10.2.3) disagreed with the changes made to Chrome in #20682, so this reverts them.  Flag support was manually confirmed in Chrome 116.
