### PR TITLE
Chrome supports TextMetrics.emHeightAscent/Descent behind pref

### DIFF
--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -219,7 +219,13 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-emheightascent-dev",
           "support": {
             "chrome": {
-              "version_added": "77"
+              "version_added": "77",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -253,7 +259,13 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-emheightdescent-dev",
           "support": {
             "chrome": {
-              "version_added": "77"
+              "version_added": "77",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
Fixes error injected in #20682