### PR TITLE
Firefox 118 supports "from-font" keyword in CSS "font-size-adjust" property

### DIFF
--- a/css/properties/font-size-adjust.json
+++ b/css/properties/font-size-adjust.json
@@ -43,11 +43,42 @@
             "deprecated": false
           }
         },
+        "from-font": {
+          "__compat": {
+            "description": "<code>from-font</code> keyword",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "118"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "two-values": {
           "__compat": {
             "description": "Two-value syntax",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-size-adjust",
-            "spec_url": "https://drafts.csswg.org/css-fonts-5/#font-size-adjust-prop",
             "support": {
               "chrome": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Fx118 adds support for `from-font` keyword in CSS [`font-size-adjust`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size-adjust#browser_compatibility) property.

#### Test results and supporting details

https://codepen.io/dipikabh/pen/OJrpmBO
- Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1708240. Tested in Nightly 119 and 118 beta (browserstack).
- Safari TP: Tested in version 17
- Chromestatus: Still no support. Tested in 117 beta and supported there, so coming soon
  - https://chromestatus.com/feature/5720910061371392
  - https://chromestatus.com/feature/5170570175447040

#### Related issues

Doc issue tracker: https://github.com/mdn/content/issues/28842
Content update PR: https://github.com/mdn/content/pull/29052
