### PR TITLE
Transceivers, senders, receivers not included in returned arrays if stopped

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -1429,6 +1429,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "stopped_transceivers_removed": {
+          "__compat": {
+            "description": "Receivers for stopped transceivers not returned",
+            "support": {
+              "chrome": {
+                "version_added": "88"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "118"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "getRemoteStreams": {
@@ -1509,6 +1542,39 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "stopped_transceivers_removed": {
+          "__compat": {
+            "description": "Senders for stopped transceivers not returned",
+            "support": {
+              "chrome": {
+                "version_added": "88"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "118"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },
@@ -1649,6 +1715,39 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "stopped_transceivers_removed": {
+          "__compat": {
+            "description": "Stopped transcievers not returned",
+            "support": {
+              "chrome": {
+                "version_added": "88"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "118"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },


### PR DESCRIPTION
FF118 - [`RTCPeerConnection.getTransceivers()`](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/getTransceivers) returns only non-stopped transceivers according to https://bugzilla.mozilla.org/show_bug.cgi?id=1568296#c3. I tested this using the test in http://wpt.live/webrtc/RTCRtpTransceiver-stop.html with text "If a transceiver is stopped, transceivers, senders and receivers should disappear after offer/answer", which further indicates (as does the spec) that the receivers/senders are also removed from the lists if a transceiver is stopped.

The test fails in FF117 and passes in FF118. I also tested on Safari and that fails in all cases. Chrome passes in all versions from the point at which it first supports `stop()` - which is Chrome 88.

Related to https://github.com/mdn/content/issues/28845
