### PR TITLE
add sms protocol to a element

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -255,7 +255,7 @@
               "standard_track": true,
               "deprecated": false
             }
-          },
+          }
         },
         "hreflang": {
           "__compat": {

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -153,76 +153,6 @@
             }
           }
         },
-        "href_sms": {
-          "__compat": {
-            "description": "<code>href = 'sms:'</code>",
-            "support": {
-              "chrome": {
-                "version_added": "false"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "false"
-              },
-              "firefox": {
-                "version_added": "12"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "false"
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "false"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          },
-          "href_top": {
-            "__compat": {
-              "description": "<code>href = '#top'</code>",
-              "support": {
-                "chrome": {
-                  "version_added": "1"
-                },
-                "chrome_android": "mirror",
-                "edge": {
-                  "version_added": "12"
-                },
-                "firefox": {
-                  "version_added": "10"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": true
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "≤4"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
-          }
-        },
         "href": {
           "__compat": {
             "support": {
@@ -291,6 +221,41 @@
               }
             }
           }
+        },
+        "href_sms": {
+          "__compat": {
+            "description": "<code>href = 'sms:'</code>",
+            "support": {
+              "chrome": {
+                "version_added": "false"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "false"
+              },
+              "firefox": {
+                "version_added": "12"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "false"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "false"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
         },
         "hreflang": {
           "__compat": {

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -153,6 +153,76 @@
             }
           }
         },
+        "href_sms": {
+          "__compat": {
+            "description": "<code>href = 'sms:'</code>",
+            "support": {
+              "chrome": {
+                "version_added": "false"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "false"
+              },
+              "firefox": {
+                "version_added": "12"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "false"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "false"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "href_top": {
+            "__compat": {
+              "description": "<code>href = '#top'</code>",
+              "support": {
+                "chrome": {
+                  "version_added": "1"
+                },
+                "chrome_android": "mirror",
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "10"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": true
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "≤4"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        },
         "href": {
           "__compat": {
             "support": {

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -230,9 +230,7 @@
                 "version_added": false
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "12"
               },

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -227,24 +227,24 @@
             "description": "<code>href = 'sms:'</code>",
             "support": {
               "chrome": {
-                "version_added": "false"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "false"
+                "version_added": false
               },
               "firefox": {
                 "version_added": "12"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": "false"
+                "version_added": false
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "false"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
tested https://codepen.io/estelle/live/ExGXoGw on real devices and browser stack.

href="sms:5534234234234" only works in Firefox (android, mac, windows)

related to https://github.com/mdn/content/pull/29101

standard: https://html.spec.whatwg.org/#sms-protocol