### PR TITLE
Fix content issue 24453: Response.body is a readable byte stream

### DIFF
--- a/api/Response.json
+++ b/api/Response.json
@@ -305,7 +305,7 @@
         },
         "readable_byte_stream": {
           "__compat": {
-            "description": "<code>body</code> is a readable byte stream.",
+            "description": "<code>body</code> is a readable byte stream",
             "support": {
               "chrome": {
                 "version_added": "116"

--- a/api/Response.json
+++ b/api/Response.json
@@ -302,6 +302,42 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "readable_byte_stream": {
+          "__compat": {
+            "description": "<code>body</code> is a readable byte stream.",
+            "support": {
+              "chrome": {
+                "version_added": "116"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "102"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "bodyUsed": {


### PR DESCRIPTION
BCD side of https://github.com/mdn/content/issues/24453.

- Chromium shipped in 116: https://chromestatus.com/feature/5192003450568704
- Firefox shipped in 102: https://github.com/whatwg/fetch/issues/267#issuecomment-1350303670
- Safari apparently does not support this yet: https://bugs.webkit.org/show_bug.cgi?id=250549
- Deno apparently does not support this yet: https://github.com/denoland/deno/issues/17386