### PR TITLE
Fix issue 23837: compat data for generic string display

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -394,6 +394,41 @@
             }
           }
         },
+        "generic_string_displayed": {
+          "__compat": {
+            "description": "Dialog displays a generic string, not event handler return value",
+            "support": {
+              "chrome": {
+                "version_added": "51"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "44"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "11"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "9.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
         "preventdefault_activation": {
           "__compat": {
             "description": "Activation using <code>event.preventDefault()</code>",


### PR DESCRIPTION
Part of the fix for https://github.com/mdn/content/issues/23837: add a subfeature describing compat for browsers displaying a generic string in the confirmation dialog, rather than one under the site's control.