### PR TITLE
CSS "offset-path" can use url() to specify reference to SVG shape (Fx118)

### DIFF
--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -230,6 +230,46 @@
               "deprecated": false
             }
           }
+        },
+        "url": {
+          "__compat": {
+            "description": "<code>&lt;url()</code>",
+            "support": {
+              "chrome": {
+                "version_added": "116"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "118",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.motion-path-url.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -233,7 +233,7 @@
         },
         "url": {
           "__compat": {
-            "description": "<code>&lt;url()</code>",
+            "description": "<code>&lt;url()&gt;</code>",
             "support": {
               "chrome": {
                 "version_added": "116"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The CSS `offset-path` property can use the `url()` function to specify the ID of the SVG shape element to be used as a path.

#### Test results and supporting details

- Firefox - Tested in **118** (https://bugzilla.mozilla.org/show_bug.cgi?id=1598158).
Available behind the flag  `layout.css.motion-path-url.enabled`.

- Chrome - Tested in **116** (https://bugs.chromium.org/p/chromium/issues/detail?id=654666, https://chromestatus.com/feature/5124394449371136)

- Safari - Tested in TP version 17 (but also working in version 16.6, though I was not able to determine the exact version in which the feature support was added)
   - Only have the link to this bug https://bugs.webkit.org/show_bug.cgi?id=139127
   - Also, for reference: https://github.com/WebKit/WebKit/blob/47fbfbce93f42fd200567a124d8ffe7922b3331b/LayoutTests/imported/w3c/web-platform-tests/css/motion/w3c-import.log#L212

#### Related issues

Doc issue tracker: https://github.com/mdn/content/issues/28846
