### PR TITLE
Ff118 Permissions-Policy: publickey-credentials-get supported

### DIFF
--- a/http/headers/Feature-Policy.json
+++ b/http/headers/Feature-Policy.json
@@ -853,7 +853,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "118",
+                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
               },
               "firefox_android": "mirror",
               "ie": {
@@ -874,7 +875,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/http/headers/Feature-Policy.json
+++ b/http/headers/Feature-Policy.json
@@ -854,6 +854,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "118",
+                "partial_implementation": true,
                 "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
               },
               "firefox_android": "mirror",

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -1136,6 +1136,7 @@
               "firefox": {
                 "version_added": "118",
                 "alternative_name": "Feature-Policy: publickey-credentials-get",
+                "partial_implementation": true,
                 "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
               },
               "firefox_android": "mirror",

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -1134,7 +1134,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "118",
+                "alternative_name": "Feature-Policy: publickey-credentials-get"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -1135,7 +1135,8 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "118",
-                "alternative_name": "Feature-Policy: publickey-credentials-get"
+                "alternative_name": "Feature-Policy: publickey-credentials-get",
+                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1156,7 +1157,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
[`Permissions-Policy: publickey-credentials-get`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-get) is supported in FF118 in https://bugzilla.mozilla.org/show_bug.cgi?id=1460986 under Feature-Policy alternative name. This is also therefore not experimental.

Have followed same pattern as other entries.

Associated docs work can be tracked in https://github.com/mdn/content/issues/28848

