### PR TITLE
HTML `<search>` element - Chrome 118 support

### DIFF
--- a/html/elements/search.json
+++ b/html/elements/search.json
@@ -7,11 +7,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/grouping-content.html#the-search-element",
           "support": {
             "chrome": {
-              "version_added": false,
-              "impl_url": [
-                "https://crbug.com/937101",
-                "https://crbug.com/1277435"
-              ]
+              "version_added": "118",
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/html/elements/search.json
+++ b/html/elements/search.json
@@ -7,7 +7,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/grouping-content.html#the-search-element",
           "support": {
             "chrome": {
-              "version_added": "118",
+              "version_added": "118"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
#### Summary

According to [chromestatus](https://chromestatus.com/roadmap), the [HTML `<search>` element](https://chromestatus.com/feature/5126108151808000) is shipping in Chrome 118.

#### Related issues

https://github.com/mdn/browser-compat-data/pull/19357
