### PR TITLE
Fix notes replacement in mirroring

### DIFF
--- a/scripts/release/mirror.test.ts
+++ b/scripts/release/mirror.test.ts
@@ -142,16 +142,20 @@ describe('mirror', () => {
         const support = {
           chrome: {
             version_added: '65',
-            notes:
+            notes: [
               'Before Chrome 70, this method always returned <code>true</code> even if the webcam was not connected. Since version 70, this method correctly returns the webcam state.',
+              'Google Chrome will always use the default webcam.',
+            ],
           },
         };
 
         const mirrored = mirrorSupport('opera', support);
         assert.deepEqual(mirrored, {
           version_added: '52',
-          notes:
+          notes: [
             'Before Opera 57, this method always returned <code>true</code> even if the webcam was not connected. Since version 57, this method correctly returns the webcam state.',
+            'Opera will always use the default webcam.',
+          ],
         });
       });
 

--- a/scripts/release/mirror.ts
+++ b/scripts/release/mirror.ts
@@ -196,11 +196,11 @@ export const bumpSupport = (
 
   let notesRepl: [RegExp, string] | undefined;
   if (destination === 'edge') {
-    notesRepl = [/Chrome(?!OS)/g, 'Edge'];
+    notesRepl = [/(Google )?Chrome(?!OS)/g, 'Edge'];
   } else if (destination.includes('opera')) {
-    notesRepl = [/Chrome(?!OS)/g, 'Opera'];
+    notesRepl = [/(Google )?Chrome(?!OS)/g, 'Opera'];
   } else if (destination === 'samsunginternet_android') {
-    notesRepl = [/Chrome(?!OS)/g, 'Samsung Internet'];
+    notesRepl = [/(Google )?Chrome(?!OS)/g, 'Samsung Internet'];
   }
 
   const newData: SimpleSupportStatement = copyStatement(sourceData);


### PR DESCRIPTION
This PR fixes #20712 by catching "Google Chrome" in notes replacement, rather than just "Chrome".
