### PR TITLE
Chrome 118 CSS logical flow-relative values

### DIFF
--- a/css/properties/clear.json
+++ b/css/properties/clear.json
@@ -48,14 +48,7 @@
             "description": "Flow-relative values <code>inline-start</code> and <code>inline-end</code>",
             "support": {
               "chrome": {
-                "version_added": "70",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
+                "version_added": "118"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/float.json
+++ b/css/properties/float.json
@@ -48,14 +48,7 @@
             "description": "Flow-relative values <code>inline-start</code> and <code>inline-end</code>",
             "support": {
               "chrome": {
-                "version_added": "70",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
+                "version_added": "118"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/resize.json
+++ b/css/properties/resize.json
@@ -81,14 +81,7 @@
             "description": "Support for flow-relative values <code>block</code> and <code>inline</code>",
             "support": {
               "chrome": {
-                "version_added": "70",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
+                "version_added": "118"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
#### Summary

Chrome 118 adds support for CSS logical flow-relative values.

Ref: https://chromestatus.com/feature/6237096230518784

