### PR TITLE
Revert "Update Firefox data for css.grid-template.fit-content feature"

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -96,15 +96,9 @@
               "edge": {
                 "version_added": "16"
               },
-              "firefox": [
-                {
-                  "version_added": "94"
-                },
-                {
-                  "prefix": "-moz-",
-                  "version_added": "52"
-                }
-              ],
+              "firefox": {
+                "version_added": "52"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -96,15 +96,9 @@
               "edge": {
                 "version_added": "16"
               },
-              "firefox": [
-                {
-                  "version_added": "94"
-                },
-                {
-                  "prefix": "-moz-",
-                  "version_added": "52"
-                }
-              ],
+              "firefox": {
+                "version_added": "52"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false


### PR DESCRIPTION
Reverts mdn/browser-compat-data#20387.  Turns out, the original report was actually incorrect, and the collector confirms that the value works as intended.  Tested with the following code in Firefox 51 and 52:

```html
<style id="test-style">
	.example-element {
		border: 1px solid #c5c5c5;
		display: grid;
		grid-auto-rows: 40px;
		grid-gap: 10px;
		width: 200px
	}

	.example-element>div {
		background-color: rgba(0,0,255,.2);
		border: 3px solid #00f
	}
</style>

<p>grid-template-columns: fit-content(100%);</p>
<div class="example-element" style="grid-template-columns: fit-content(100%);">
	<div>One</div>
	<div>Two</div>
	<div>Three</div>
	<div>Four</div>
	<div>Five</div>
</div>

<p>grid-template-columns: -moz-fit-content(100%);</p>
<div class="example-element" style="grid-template-columns: -moz-fit-content(100%);">
	<div>One</div>
	<div>Two</div>
	<div>Three</div>
	<div>Four</div>
	<div>Five</div>
</div>

<p>Control</p>
<div class="example-element">
	<div>One</div>
	<div>Two</div>
	<div>Three</div>
	<div>Four</div>
	<div>Five</div>
</div>
```

Result (in Firefox 52 and 117):
<img width="294" alt="image" src="https://github.com/mdn/browser-compat-data/assets/5179191/f3a952b0-e980-41ad-9f6f-792044f63553">

You can see that the first div looks different than the second (prefixed) and final (control) divs.  In Firefox 51, all three divs look the same.