### PR TITLE
Add Node.js v18.1.0

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -408,6 +408,13 @@
         "18.0.0": {
           "release_date": "2022-04-19",
           "release_notes": "https://nodejs.org/en/blog/release/v18.0.0/",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "10.1"
+        },
+        "18.1.0": {
+          "release_date": "2022-05-03",
+          "release_notes": "https://nodejs.org/en/blog/release/v18.1.0/",
           "status": "esr",
           "engine": "V8",
           "engine_version": "10.1"


### PR DESCRIPTION
This PR adds Node.js v18.1.0 to the browser data.
