### PR TITLE
Add Bun server runtime to BCD

### DIFF
--- a/browsers/bun.json
+++ b/browsers/bun.json
@@ -1,0 +1,18 @@
+{
+  "browsers": {
+    "bun": {
+      "name": "Bun",
+      "type": "server",
+      "accepts_flags": true,
+      "accepts_webextensions": false,
+      "releases": {
+        "1.0": {
+          "release_date": "2023-09-08",
+          "release_notes": "https://bun.sh/blog/bun-v1.0",
+          "status": "current",
+          "engine": "WebKit"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the [Bun](https://bun.sh) runtime to BCD as requrested in https://github.com/mdn/browser-compat-data/issues/18484.  Fixes #18484.
