### PR TITLE
Mark (synchronous) `import.meta.resolve(…)` as implemented in `node` v20.6.0

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -460,6 +460,13 @@
           "status": "retired",
           "engine": "V8",
           "engine_version": "11.3"
+        },
+        "20.6.0": {
+          "release_date": "2023-09-04",
+          "release_notes": "https://nodejs.org/en/blog/release/v20.6.0",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "11.3"
         }
       }
     }

--- a/javascript/operators/import_meta.json
+++ b/javascript/operators/import_meta.json
@@ -67,9 +67,33 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": {
-                "version_added": "20.6.0"
-              },
+              "nodejs": [
+                {
+                  "version_added": "20.6.0",
+                  "notes": "Returns a URL object instead of a string."
+                },
+                {
+                  "version_added": "20.0.0",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--experimental-import-meta-resolve"
+                    }
+                  ],
+                  "notes": "Returns a URL object instead of a string."
+                },
+                {
+                  "version_added": "12.6.0",
+                  "partial_implementation": true,
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--experimental-import-meta-resolve"
+                    }
+                  ],
+                  "notes": "Returns a Promise resolving to a URL object, instead of a string."
+                }
+              ],
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/operators/import_meta.json
+++ b/javascript/operators/import_meta.json
@@ -68,15 +68,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "12.6.0",
-                "partial_implementation": true,
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--experimental-import-meta-resolve"
-                  }
-                ],
-                "notes": "Returns a Promise."
+                "version_added": "20.6.0"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
Release notes documenting that this is now available without a flag: https://nodejs.org/en/blog/release/v20.6.0

Note that the experimental version became synchronous in v20.0.0 (still behind a flag at the time): https://nodejs.org/en/blog/release/v20.0.0
