### PR TITLE
update Chrome version for css.selectors.user-valid/user-invalid

### DIFF
--- a/css/selectors/user-invalid.json
+++ b/css/selectors/user-invalid.json
@@ -8,7 +8,7 @@
           "spec_url": "https://drafts.csswg.org/selectors/#user-invalid-pseudo",
           "support": {
             "chrome": {
-              "version_added": false,
+              "version_added": "119",
               "impl_url": "https://crbug.com/1156069"
             },
             "chrome_android": "mirror",

--- a/css/selectors/user-valid.json
+++ b/css/selectors/user-valid.json
@@ -8,7 +8,7 @@
           "spec_url": "https://drafts.csswg.org/selectors/#user-valid-pseudo",
           "support": {
             "chrome": {
-              "version_added": false,
+              "version_added": "119",
               "impl_url": "https://crbug.com/1156069"
             },
             "chrome_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR updates the versions for the :user-valid and :user-invalid selectors based on manual testing. This fixes https://github.com/mdn/browser-compat-data/issues/20727
