### PR TITLE
FF Clarify Feature-Policy header not sent

### DIFF
--- a/http/headers/Feature-Policy.json
+++ b/http/headers/Feature-Policy.json
@@ -14,7 +14,7 @@
             "firefox": {
               "version_added": "74",
               "partial_implementation": true,
-              "notes": "Header not sent but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
+              "notes": "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -26,7 +26,7 @@
             "safari": {
               "version_added": "11.1",
               "partial_implementation": true,
-              "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+              "notes": "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -118,15 +118,13 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "74",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "partial_implementation": true,
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false,
+                "notes": "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
+              },
               "ie": {
                 "version_added": false
               },
@@ -141,7 +139,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -195,7 +193,7 @@
               "firefox": {
                 "version_added": "74",
                 "partial_implementation": true,
-                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                "notes": "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -237,7 +235,7 @@
               "firefox": {
                 "version_added": "74",
                 "partial_implementation": true,
-                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                "notes": "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
               },
               "firefox_android": {
                 "version_added": false
@@ -251,7 +249,7 @@
               "safari": {
                 "version_added": "13",
                 "partial_implementation": true,
-                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                "notes": "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
               },
               "safari_ios": {
                 "version_added": false
@@ -367,7 +365,7 @@
                 "version_added": "74",
                 "partial_implementation": true,
                 "notes": [
-                  "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements.",
+                  "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>).",
                   "Before Firefox 80, applying <code>fullscreen</code> to an <code>&lt;iframe&gt;</code> (i.e. via the <code>allow</code> attribute) does not work unless the <code>allowfullscreen</code> attribute is also present."
                 ]
               },
@@ -413,7 +411,7 @@
                 "version_added": "91",
                 "partial_implementation": true,
                 "notes": [
-                  "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements.",
+                  "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>).",
                   "The default allowlist is <code>*</code> instead of <code>self</code> (as required by the specification)."
                 ]
               },
@@ -451,7 +449,7 @@
               "firefox": {
                 "version_added": "74",
                 "partial_implementation": true,
-                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                "notes": "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -660,7 +658,7 @@
               "firefox": {
                 "version_added": "74",
                 "partial_implementation": true,
-                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                "notes": "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -927,7 +925,7 @@
               "firefox": {
                 "version_added": "116",
                 "partial_implementation": true,
-                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                "notes": "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
               },
               "firefox_android": {
                 "version_added": false,
@@ -1102,14 +1100,14 @@
                 "version_added": "81",
                 "partial_implementation": true,
                 "notes": [
-                  "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements.",
+                  "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>).",
                   "Firefox recognizes the <code>web-share</code> permissions policy, but this has no effect in versions of Firefox that do not support the <a href='https://developer.mozilla.org/docs/Web/API/Navigator/share'><code>share()</code></a> method."
                 ]
               },
               "firefox_android": {
                 "version_added": "81",
                 "partial_implementation": true,
-                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                "notes": "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
               },
               "ie": {
                 "version_added": false

--- a/http/headers/Feature-Policy.json
+++ b/http/headers/Feature-Policy.json
@@ -14,7 +14,7 @@
             "firefox": {
               "version_added": "74",
               "partial_implementation": true,
-              "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+              "notes": "Header not sent but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/http/headers/Feature-Policy.json
+++ b/http/headers/Feature-Policy.json
@@ -14,7 +14,7 @@
             "firefox": {
               "version_added": "74",
               "partial_implementation": true,
-              "notes": "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
+              "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -26,7 +26,7 @@
             "safari": {
               "version_added": "11.1",
               "partial_implementation": true,
-              "notes": "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
+              "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -123,7 +123,7 @@
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
               },
               "ie": {
                 "version_added": false
@@ -193,7 +193,7 @@
               "firefox": {
                 "version_added": "74",
                 "partial_implementation": true,
-                "notes": "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -235,7 +235,7 @@
               "firefox": {
                 "version_added": "74",
                 "partial_implementation": true,
-                "notes": "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
               },
               "firefox_android": {
                 "version_added": false
@@ -249,7 +249,7 @@
               "safari": {
                 "version_added": "13",
                 "partial_implementation": true,
-                "notes": "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
               },
               "safari_ios": {
                 "version_added": false
@@ -365,7 +365,7 @@
                 "version_added": "74",
                 "partial_implementation": true,
                 "notes": [
-                  "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>).",
+                  "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>).",
                   "Before Firefox 80, applying <code>fullscreen</code> to an <code>&lt;iframe&gt;</code> (i.e. via the <code>allow</code> attribute) does not work unless the <code>allowfullscreen</code> attribute is also present."
                 ]
               },
@@ -411,7 +411,7 @@
                 "version_added": "91",
                 "partial_implementation": true,
                 "notes": [
-                  "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>).",
+                  "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>).",
                   "The default allowlist is <code>*</code> instead of <code>self</code> (as required by the specification)."
                 ]
               },
@@ -449,7 +449,7 @@
               "firefox": {
                 "version_added": "74",
                 "partial_implementation": true,
-                "notes": "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -658,7 +658,7 @@
               "firefox": {
                 "version_added": "74",
                 "partial_implementation": true,
-                "notes": "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -925,7 +925,7 @@
               "firefox": {
                 "version_added": "116",
                 "partial_implementation": true,
-                "notes": "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
               },
               "firefox_android": {
                 "version_added": false,
@@ -1100,14 +1100,14 @@
                 "version_added": "81",
                 "partial_implementation": true,
                 "notes": [
-                  "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>).",
+                  "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>).",
                   "Firefox recognizes the <code>web-share</code> permissions policy, but this has no effect in versions of Firefox that do not support the <a href='https://developer.mozilla.org/docs/Web/API/Navigator/share'><code>share()</code></a> method."
                 ]
               },
               "firefox_android": {
                 "version_added": "81",
                 "partial_implementation": true,
-                "notes": "Header not recognised but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"
               },
               "ie": {
                 "version_added": false

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -21,7 +21,7 @@
               "version_added": "74",
               "alternative_name": "Feature-Policy",
               "partial_implementation": true,
-              "notes": "Header not sent but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
+              "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -34,7 +34,7 @@
               "version_added": "11.1",
               "alternative_name": "Feature-Policy",
               "partial_implementation": true,
-              "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+              "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -145,13 +145,8 @@
               "firefox": {
                 "version_added": "74",
                 "alternative_name": "Feature-Policy: autoplay",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.security.featurePolicy.header.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "partial_implementation": true,
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -228,7 +223,7 @@
                 "version_added": "74",
                 "alternative_name": "Feature-Policy: camera",
                 "partial_implementation": true,
-                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -270,7 +265,7 @@
                 "version_added": "74",
                 "alternative_name": "Feature-Policy: display-capture",
                 "partial_implementation": true,
-                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
               },
               "firefox_android": {
                 "version_added": false
@@ -285,7 +280,7 @@
                 "version_added": "13",
                 "alternative_name": "Feature-Policy: display-capture",
                 "partial_implementation": true,
-                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
               },
               "safari_ios": {
                 "version_added": false
@@ -515,7 +510,7 @@
                 "alternative_name": "Feature-Policy: fullscreen",
                 "partial_implementation": true,
                 "notes": [
-                  "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements.",
+                  "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>).",
                   "Before Firefox 80, applying <code>fullscreen</code> to an <code>&lt;iframe&gt;</code> (i.e. via the <code>allow</code> attribute) does not work unless the <code>allowfullscreen</code> attribute is also present."
                 ]
               },
@@ -555,7 +550,7 @@
                 "alternative_name": "Feature-Policy: gamepad",
                 "partial_implementation": true,
                 "notes": [
-                  "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements.",
+                  "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>).",
                   "The default allowlist is <code>*</code> instead of <code>self</code> (as required by the specification)."
                 ]
               },
@@ -600,7 +595,7 @@
                 "version_added": "74",
                 "alternative_name": "Feature-Policy: geolocation",
                 "partial_implementation": true,
-                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)."
               },
               "firefox_android": "mirror",
               "ie": {
@@ -865,7 +860,7 @@
                 "version_added": "74",
                 "alternative_name": "Feature-Policy: microphone",
                 "partial_implementation": true,
-                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1249,7 +1244,7 @@
                 "version_added": "116",
                 "alternative_name": "Feature-Policy: speaker-selection",
                 "partial_implementation": true,
-                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
               },
               "firefox_android": {
                 "version_added": false,
@@ -1372,14 +1367,14 @@
                 "alternative_name": "Feature-Policy: web-share",
                 "partial_implementation": true,
                 "notes": [
-                  "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements.",
+                  "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>).",
                   "Firefox recognizes the <code>web-share</code> permissions policy, but this has no effect in versions of Firefox that do not support the <a href='https://developer.mozilla.org/docs/Web/API/Navigator/share'><code>share()</code></a> method."
                 ]
               },
               "firefox_android": {
                 "version_added": "81",
                 "partial_implementation": true,
-                "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
               },
               "ie": {
                 "version_added": false

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -21,7 +21,7 @@
               "version_added": "74",
               "alternative_name": "Feature-Policy",
               "partial_implementation": true,
-              "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
+              "notes": "Header not sent but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
The Permissions-Policy and Feature-Policy for FF confused me because it said partial support of the header and indicated 

> "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."

So the header isn't actually supported, just the functionality that the header provides. Someone who knows how this all works might not be confused, but I was. So what I have done is change the note text to:

> Header not sent but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1627890'>bug 1627890</a>)"

The bug links are different - for Feature-Policy I link to the bug where the header was disabled by default. For `Permissions-Policy` I link to the bug where the header is intended to be updated to `Permissions-Policy` and be sent. I think that makes sense for the later case, because you mostly want to be able to track when this will be fixed.

This fell out of work done for https://github.com/mdn/content/issues/28848

