### PR TITLE
Ff118 Nightly enables globalprivacy

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1372,17 +1372,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "95",
+              "version_added": "preview",
               "impl_url": "https://hg.mozilla.org/mozilla-central/rev/09e51e6d4a7e",
               "flags": [
                 {
                   "type": "preference",
                   "name": "privacy.globalprivacycontrol.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "type": "preference",
-                  "name": "privacy.globalprivacycontrol.functionality.enabled",
                   "value_to_set": "true"
                 }
               ]

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1373,14 +1373,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "preview",
-              "impl_url": "https://hg.mozilla.org/mozilla-central/rev/09e51e6d4a7e",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "privacy.globalprivacycontrol.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "impl_url": "https://hg.mozilla.org/mozilla-central/rev/09e51e6d4a7e"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1374,7 +1374,6 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "preview",
-              "impl_url": "https://hg.mozilla.org/mozilla-central/rev/09e51e6d4a7e",
               "notes": "Opt-in to GPC by setting the preference <code>privacy.globalprivacycontrol.enabled</code> to <code>true</code>."
             },
             "firefox_android": "mirror",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1365,6 +1365,7 @@
       "globalPrivacyControl": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/globalPrivacyControl",
+          "spec_url": "https://privacycg.github.io/gpc-spec/#dom-globalprivacycontrol",
           "support": {
             "chrome": {
               "version_added": false
@@ -1392,7 +1393,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1373,7 +1373,8 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "preview",
-              "impl_url": "https://hg.mozilla.org/mozilla-central/rev/09e51e6d4a7e"
+              "impl_url": "https://hg.mozilla.org/mozilla-central/rev/09e51e6d4a7e",
+              "notes": "Opt-in to GPC by setting the preference <code>privacy.globalprivacycontrol.enabled</code> to <code>true</code>."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -247,6 +247,40 @@
           }
         }
       },
+      "globalPrivacyControl": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerNavigator/globalPrivacyControl",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview",
+              "notes": "Opt-in to GPC by setting the preference <code>privacy.globalprivacycontrol.enabled</code> to <code>true</code>."
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "gpu": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerNavigator/gpu",

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -250,6 +250,7 @@
       "globalPrivacyControl": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerNavigator/globalPrivacyControl",
+          "spec_url": "https://privacycg.github.io/gpc-spec/#dom-globalprivacycontrol",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -277,7 +277,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/http/headers/Sec-GPC.json
+++ b/http/headers/Sec-GPC.json
@@ -38,7 +38,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/http/headers/Sec-GPC.json
+++ b/http/headers/Sec-GPC.json
@@ -13,7 +13,6 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "preview",
-              "impl_url": "https://hg.mozilla.org/mozilla-central/rev/09e51e6d4a7e",
               "notes": "Opt-in to GPC by setting the preference <code>privacy.globalprivacycontrol.enabled</code> to <code>true</code>.",
               "flags": [
                 {

--- a/http/headers/Sec-GPC.json
+++ b/http/headers/Sec-GPC.json
@@ -39,7 +39,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/http/headers/Sec-GPC.json
+++ b/http/headers/Sec-GPC.json
@@ -14,6 +14,7 @@
             "firefox": {
               "version_added": "preview",
               "impl_url": "https://hg.mozilla.org/mozilla-central/rev/09e51e6d4a7e",
+              "notes": "Opt-in to GPC by setting the preference <code>privacy.globalprivacycontrol.enabled</code> to <code>true</code>.",
               "flags": [
                 {
                   "type": "preference",

--- a/http/headers/Sec-GPC.json
+++ b/http/headers/Sec-GPC.json
@@ -12,17 +12,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "95",
+              "version_added": "preview",
               "impl_url": "https://hg.mozilla.org/mozilla-central/rev/09e51e6d4a7e",
               "flags": [
                 {
                   "type": "preference",
                   "name": "privacy.globalprivacycontrol.enabled",
-                  "value_to_set": "true"
-                },
-                {
-                  "type": "preference",
-                  "name": "privacy.globalprivacycontrol.functionality.enabled",
                   "value_to_set": "true"
                 }
               ]


### PR DESCRIPTION
Back in FF95 global privacy control (https://globalprivacycontrol.org/) was implemented behind two prefs `privacy.globalprivacycontrol.functionality.enabled` and `privacy.globalprivacycontrol.enabled`.

FF118 has now enabled the preference `privacy.globalprivacycontrol.functionality.enabled` in nightly/preview in https://bugzilla.mozilla.org/show_bug.cgi?id=1830623 

- The newly turned on pref  `privacy.globalprivacycontrol.functionality.enabled` turns on [`Navigator.globalPrivacyControl`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/globalPrivacyControl) and `WorkerNavigator.globalPrivacyControl`. 
- The second pref `privacy.globalprivacycontrol.enabled` causes FF to send the [Sec-GPC](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-GPC) HTTP header with a value of 1. This means "I opt out of getting my services sold". In other words this is like the UI trigger for turning the opt in and opt out. Yes you're enabling the header, but that's how the signaling is done.

The intent is for an `about:preferences` to be added instead of that config pref. In the meantime for `Navigator/WorkerNavigator.globalPrivacyControl` I have removed both flags since this is enabled all the time (it exists). For the `Sec-GPC` header I left the flag present since this is off by default and it won't exist on release.

I added a **note** in both cases about how to enable GPC using the flag., since that's the only way to do it right now.

THoughts on this approach? @Elchi3 @queengooborg 


This is part of https://github.com/mdn/content/issues/28854






