### PR TITLE
Update all browsers data for FileSystemSyncAccessHandle API

### DIFF
--- a/api/FileSystemSyncAccessHandle.json
+++ b/api/FileSystemSyncAccessHandle.json
@@ -41,10 +41,10 @@
           "spec_url": "https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-close",
           "support": {
             "chrome": {
-              "version_added": "109"
+              "version_added": "102"
             },
             "chrome_android": {
-              "version_added": "110"
+              "version_added": "109"
             },
             "edge": "mirror",
             "firefox": {
@@ -70,47 +70,29 @@
             "deprecated": false
           }
         },
-        "async_version": {
+        "sync_version": {
           "__compat": {
-            "description": "Asynchronous implementation of the <code>close()</code> method",
+            "description": "Synchronous implementation of the <code>close()</code> method",
             "support": {
               "chrome": {
-                "version_added": "102",
-                "version_removed": "108",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Sync Access Handle All Sync Surface",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "108"
               },
               "chrome_android": {
-                "version_added": "102",
-                "version_removed": "109",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Sync Access Handle All Sync Surface",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "109"
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "111"
               },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
-              "oculus": {
-                "version_added": false
-              },
+              "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -130,10 +112,10 @@
           "spec_url": "https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-flush",
           "support": {
             "chrome": {
-              "version_added": "109"
+              "version_added": "102"
             },
             "chrome_android": {
-              "version_added": "110"
+              "version_added": "109"
             },
             "edge": "mirror",
             "firefox": {
@@ -159,47 +141,29 @@
             "deprecated": false
           }
         },
-        "async_version": {
+        "sync_version": {
           "__compat": {
-            "description": "Asynchronous implementation of the <code>flush()</code> method",
+            "description": "Synchronous implementation of the <code>flush()</code> method",
             "support": {
               "chrome": {
-                "version_added": "102",
-                "version_removed": "108",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Sync Access Handle All Sync Surface",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "108"
               },
               "chrome_android": {
-                "version_added": "102",
-                "version_removed": "109",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Sync Access Handle All Sync Surface",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "109"
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "111"
               },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
-              "oculus": {
-                "version_added": false
-              },
+              "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -219,10 +183,10 @@
           "spec_url": "https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-getsize",
           "support": {
             "chrome": {
-              "version_added": "109"
+              "version_added": "102"
             },
             "chrome_android": {
-              "version_added": "110"
+              "version_added": "109"
             },
             "edge": "mirror",
             "firefox": {
@@ -248,47 +212,29 @@
             "deprecated": false
           }
         },
-        "async_version": {
+        "sync_version": {
           "__compat": {
-            "description": "Asynchronous implementation of the <code>getSize()</code> method",
+            "description": "Synchronous implementation of the <code>getSize()</code> method",
             "support": {
               "chrome": {
-                "version_added": "102",
-                "version_removed": "108",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Sync Access Handle All Sync Surface",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "108"
               },
               "chrome_android": {
-                "version_added": "102",
-                "version_removed": "109",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Sync Access Handle All Sync Surface",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "109"
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "111"
               },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
-              "oculus": {
-                "version_added": false
-              },
+              "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -344,10 +290,10 @@
           "spec_url": "https://fs.spec.whatwg.org/#api-filesystemsyncaccesshandle-truncate",
           "support": {
             "chrome": {
-              "version_added": "109"
+              "version_added": "102"
             },
             "chrome_android": {
-              "version_added": "110"
+              "version_added": "109"
             },
             "edge": "mirror",
             "firefox": {
@@ -373,47 +319,29 @@
             "deprecated": false
           }
         },
-        "async_version": {
+        "sync_version": {
           "__compat": {
-            "description": "Asynchronous implementation of the <code>truncate()</code> method",
+            "description": "Synchronous implementation of the <code>truncate()</code> method",
             "support": {
               "chrome": {
-                "version_added": "102",
-                "version_removed": "108",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Sync Access Handle All Sync Surface",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "108"
               },
               "chrome_android": {
-                "version_added": "102",
-                "version_removed": "109",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "Sync Access Handle All Sync Surface",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "109"
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "111"
               },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
-              "oculus": {
-                "version_added": false
-              },
+              "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `FileSystemSyncAccessHandle` API. This effectively reverts #20621 first, and then fixes the data.  (Chrome supported the synchronous version since 108 without a flag, and Safari since 16.4.)
