### PR TITLE
FF118 CSSStyleRule inherits from CSSGroupingRule - add props

### DIFF
--- a/api/CSSStyleRule.json
+++ b/api/CSSStyleRule.json
@@ -41,6 +41,7 @@
       },
       "cssRules": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSGroupingRule/cssRules",
           "spec_url": "https://drafts.csswg.org/css-nesting-1/#dom-cssstylerule-cssrules",
           "support": {
             "chrome": {
@@ -49,7 +50,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "118"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -74,6 +75,7 @@
       },
       "deleteRule": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSGroupingRule/deleteRule",
           "spec_url": "https://drafts.csswg.org/css-nesting-1/#dom-cssstylerule-deleterule",
           "support": {
             "chrome": {
@@ -82,7 +84,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "118"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -107,6 +109,7 @@
       },
       "insertRule": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSGroupingRule/insertRule",
           "spec_url": "https://drafts.csswg.org/css-nesting-1/#dom-cssstylerule-insertrule",
           "support": {
             "chrome": {
@@ -115,7 +118,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "118"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF118 supports now matches spec so [`CSSStyleRule`](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleRule) inherits from [`CSSGroupingRule`](https://developer.mozilla.org/en-US/docs/Web/API/CSSGroupingRule) instead of directly from  [`CSSRule`](https://developer.mozilla.org/en-US/docs/Web/API/CSSRule). See https://bugzilla.mozilla.org/show_bug.cgi?id=1846251.

This means that `CSSStyleRule` now supports the cssRules property + deleteRule and insertRule from `CSSGroupingRule`.
I have checked these are supported in `CSSGroupingRule` on the bcd collector. Also manually showed they exist in FF119 nightly. 

This adds support from version 118 and also links to the MDN docs.

Other docs work can be tracked in https://github.com/mdn/content/issues/28853