### PR TITLE
Add missing features for api.GamepadHapticActuator.canPlayEffectType

### DIFF
--- a/api/GamepadHapticActuator.json
+++ b/api/GamepadHapticActuator.json
@@ -75,6 +75,39 @@
           }
         }
       },
+      "canPlayEffectType": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/gamepad/extensions.html#dom-gamepadhapticactuator-canplayeffecttype",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "playEffect": {
         "__compat": {
           "support": {


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing features of the `canPlayEffectType` member of the `GamepadHapticActuator` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.3).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/GamepadHapticActuator/canPlayEffectType
