### PR TITLE
Add "_static" suffix to api.IdentityProvier.getUserInfo

### DIFF
--- a/api/IdentityProvider.json
+++ b/api/IdentityProvider.json
@@ -33,9 +33,9 @@
           "deprecated": false
         }
       },
-      "getUserInfo": {
+      "getUserInfo_static": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdentityProvider/getUserInfo",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdentityProvider/getUserInfo_static",
           "spec_url": "https://fedidcg.github.io/FedCM/#dom-identityprovider-getuserinfo",
           "support": {
             "chrome": {


### PR DESCRIPTION
This PR adds the `_static` suffix to the `getUserInfo` member of the `IdentityProvider` API.  Note: the MDN page doesn't exist so no content update is needed.
