### PR TITLE
Add missing features for api.TaskSignal.any_static

### DIFF
--- a/api/TaskSignal.json
+++ b/api/TaskSignal.json
@@ -40,6 +40,41 @@
           "deprecated": false
         }
       },
+      "any_static": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/scheduling-apis/#dom-tasksignal-any",
+          "support": {
+            "chrome": {
+              "version_added": "116"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "priority": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TaskSignal/priority",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing features of the `any_static` member of the `TaskSignal` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.3).

_Check out the [collector's guide on how to review this PR](https://github.com/GooborgStudios/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/TaskSignal/any_static
