### PR TITLE
Release Firefox 117

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -837,28 +837,28 @@
         "116": {
           "release_date": "2023-08-01",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/116",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "116"
         },
         "117": {
           "release_date": "2023-08-29",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/117",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "117"
         },
         "118": {
           "release_date": "2023-09-26",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/118",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "118"
         },
         "119": {
           "release_date": "2023-10-24",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/119",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "119"
         },

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -704,28 +704,28 @@
         "116": {
           "release_date": "2023-08-01",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/116",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "116"
         },
         "117": {
           "release_date": "2023-08-29",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/117",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "117"
         },
         "118": {
           "release_date": "2023-09-26",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/118",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "118"
         },
         "119": {
           "release_date": "2023-10-24",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/119",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "119"
         },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The Firefox versions haven't been updated since 117 got released about 3 weeks ago. This PR updates all the current versions.

#### Test results and supporting details

https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/117
