### PR TITLE
CSS Math Functions: Add crbug.com URLs

### DIFF
--- a/css/types/abs.json
+++ b/css/types/abs.json
@@ -8,7 +8,8 @@
           "spec_url": "https://drafts.csswg.org/css-values/#sign-funcs",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://crbug.com/1407476"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/types/exp.json
+++ b/css/types/exp.json
@@ -8,7 +8,8 @@
           "spec_url": "https://drafts.csswg.org/css-values/#exponent-funcs",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://crbug.com/1407474"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/types/hypot.json
+++ b/css/types/hypot.json
@@ -8,7 +8,8 @@
           "spec_url": "https://drafts.csswg.org/css-values/#exponent-funcs",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://crbug.com/1407474"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/types/log.json
+++ b/css/types/log.json
@@ -8,7 +8,8 @@
           "spec_url": "https://drafts.csswg.org/css-values/#exponent-funcs",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://crbug.com/1407474"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/types/mod.json
+++ b/css/types/mod.json
@@ -8,7 +8,8 @@
           "spec_url": "https://drafts.csswg.org/css-values/#funcdef-mod",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://crbug.com/1407473"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/types/pow.json
+++ b/css/types/pow.json
@@ -8,7 +8,8 @@
           "spec_url": "https://drafts.csswg.org/css-values/#exponent-funcs",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://crbug.com/1407474"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/types/rem.json
+++ b/css/types/rem.json
@@ -8,7 +8,8 @@
           "spec_url": "https://drafts.csswg.org/css-values/#funcdef-rem",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://crbug.com/1407473"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/types/round.json
+++ b/css/types/round.json
@@ -8,7 +8,8 @@
           "spec_url": "https://drafts.csswg.org/css-values/#funcdef-round",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://crbug.com/1407473"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/types/sign.json
+++ b/css/types/sign.json
@@ -8,7 +8,8 @@
           "spec_url": "https://drafts.csswg.org/css-values/#sign-funcs",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://crbug.com/1407476"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/types/sqrt.json
+++ b/css/types/sqrt.json
@@ -8,7 +8,8 @@
           "spec_url": "https://drafts.csswg.org/css-values/#exponent-funcs",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://crbug.com/1407474"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
#### Summary

Add [crbug.com](https://crbug.com/) URLs to different [CSS math functions](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Functions#math_functions).
