### PR TITLE
Add Deno 1.37, add support data for groupBy()

### DIFF
--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -261,9 +261,16 @@
         "1.36": {
           "release_date": "2023-08-03",
           "release_notes": "https://github.com/denoland/deno/releases/tag/v1.36.0",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "11.6"
+        },
+        "1.37": {
+          "release_date": "2023-09-20",
+          "release_notes": "https://github.com/denoland/deno/releases/tag/v1.37.0",
+          "status": "current",
+          "engine": "V8",
+          "engine_version": "11.8"
         }
       }
     }

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -483,7 +483,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.37"
               },
               "edge": "mirror",
               "firefox": {

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -833,7 +833,7 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": false
+                "version_added": "1.37"
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
#### Summary

Deno v1.37 has been released https://deno.com/blog/v1.37

Deno added support of `Object.groupBy` and `Map.groupBy` in version 1.37.0.

#### Test results and supporting details

You can check the support in the specific version with the commands:
```sh
curl -fsSL https://deno.land/install.sh | sh -s v1.37.0
deno --version
deno eval -p "Object.groupBy" # Or any other JS expression to check
```

The result of the above commands:
```shellsession
$ curl -fsSL https://deno.land/install.sh | sh -s v1.37.0
######################################################################## 100.0%
Deno was installed successfully to /Users/kt3k/.deno/bin/deno
$ deno --version    
deno 1.37.0 (release, aarch64-apple-darwin)
v8 11.8.172.3
typescript 5.2.2
$ deno eval -p "Object.groupBy"
[Function: groupBy]
$ curl -fsSL https://deno.land/install.sh | sh -s v1.36.4
######################################################################## 100.0%
Deno was installed successfully to /Users/kt3k/.deno/bin/deno
$ deno --version                                            
deno 1.36.4 (release, aarch64-apple-darwin)
v8 11.6.189.12
typescript 5.1.6
$ deno eval -p "Object.groupBy"                          
undefined
```

### Other links

v1.37 blog post mentions about upgrade of V8 to version 11.8 https://deno.com/blog/v1.37#v8-118-and-typescript-522

