### PR TITLE
Remove irrelevant `layout.css.math-style.enabled` flag in Firefox

### DIFF
--- a/css/properties/math-depth.json
+++ b/css/properties/math-depth.json
@@ -23,23 +23,9 @@
             ],
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "117"
-              },
-              {
-                "version_added": "83",
-                "impl_url": "https://bugzil.la/1667090",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.math-depth.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "Implementation lacks support for <code>font-size: math</code> to be complete."
-              }
-            ],
+            "firefox": {
+              "version_added": "117"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false

--- a/css/properties/math-style.json
+++ b/css/properties/math-style.json
@@ -22,21 +22,9 @@
             ],
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "117"
-              },
-              {
-                "version_added": "83",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.math-style.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              }
-            ],
+            "firefox": {
+              "version_added": "117"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for the `layout.css.math-style.enabled` flag of Firefox and Firefox Android as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-flag-data). This PR was created from results of the `remove-redundant-flags` script.
