### PR TITLE
Remove irrelevant `enable-experimental-web-platform-features` flag in Chromium

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -401,22 +401,9 @@
             "description": "<code>options.pseudoElement</code> parameter",
             "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-keyframeeffectoptions-pseudoelement",
             "support": {
-              "chrome": [
-                {
-                  "version_added": "84"
-                },
-                {
-                  "version_added": "81",
-                  "partial_implementation": true,
-                  "notes": "A valid animation object is returned but the targeted pseudoelement is not visually animated.",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-experimental-web-platform-features"
-                    }
-                  ]
-                }
-              ],
+              "chrome": {
+                "version_added": "84"
+              },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -5,22 +5,9 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sanitizer",
         "spec_url": "https://wicg.github.io/sanitizer-api/#sanitizer-api",
         "support": {
-          "chrome": [
-            {
-              "version_added": "105"
-            },
-            {
-              "version_added": "93",
-              "version_removed": "105",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            }
-          ],
+          "chrome": {
+            "version_added": "105"
+          },
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
@@ -68,22 +55,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sanitizer/Sanitizer",
           "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-sanitizer",
           "support": {
-            "chrome": [
-              {
-                "version_added": "105"
-              },
-              {
-                "version_added": "93",
-                "version_removed": "105",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "105"
+            },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -204,7 +204,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": {
               "version_added": "79",
               "flags": [
@@ -254,7 +256,9 @@
             "ie": {
               "version_added": false
             },
-            "oculus": "mirror",
+            "oculus": {
+              "version_added": false
+            },
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {

--- a/css/properties/animation-timeline.json
+++ b/css/properties/animation-timeline.json
@@ -6,21 +6,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/animation-timeline",
           "spec_url": "https://drafts.csswg.org/css-animations-2/#animation-timeline",
           "support": {
-            "chrome": [
-              {
-                "version_added": "115"
-              },
-              {
-                "version_added": "85",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "enable-experimental-web-platform-features",
-                    "value_to_set": "enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "115"
+            },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": [

--- a/css/properties/scroll-timeline-axis.json
+++ b/css/properties/scroll-timeline-axis.json
@@ -6,33 +6,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-timeline-axis",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#propdef-scroll-timeline-axis",
           "support": {
-            "chrome": [
-              {
-                "version_added": "115"
-              },
-              {
-                "version_added": "111",
-                "notes": "The syntax of the shorthand property `scroll-timeline` uses the fixed order of name and then the axis.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "108",
-                "notes": "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "115"
+            },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": [

--- a/css/properties/scroll-timeline-name.json
+++ b/css/properties/scroll-timeline-name.json
@@ -6,33 +6,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/scroll-timeline-name",
           "spec_url": "https://drafts.csswg.org/scroll-animations/#scroll-timeline-name",
           "support": {
-            "chrome": [
-              {
-                "version_added": "115"
-              },
-              {
-                "version_added": "111",
-                "notes": "The syntax of the shorthand property `scroll-timeline` uses the fixed order of name and then the axis.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "108",
-                "notes": "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`.",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "115"
+            },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": [


### PR DESCRIPTION
This PR removes irrelevant flag data for the `enable-experimental-web-platform-features` flag of Chromium (Chrome, Opera, Samsung Internet, WebView Android) as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-flag-data). This PR was created from results of the `remove-redundant-flags` script.
