### PR TITLE
Remove irrelevant `--experimental-worker` flag in NodeJS

### DIFF
--- a/api/Worker.json
+++ b/api/Worker.json
@@ -40,21 +40,6 @@
                 "Worker script environment expects CommonJS modules.",
                 "Must be imported from the <code>worker_threads</code> module."
               ]
-            },
-            {
-              "version_added": "10.5.0",
-              "partial_implementation": true,
-              "notes": [
-                "Is a Node <code>EventEmitter</code> instead of DOM <code>EventTarget</code>.",
-                "Worker script environment expects CommonJS modules.",
-                "Must be imported from the <code>worker_threads</code> module."
-              ],
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--experimental-worker"
-                }
-              ]
             }
           ],
           "oculus": "mirror",
@@ -112,17 +97,6 @@
                 "version_added": "11.7.0",
                 "partial_implementation": true,
                 "notes": "Takes entirely different options."
-              },
-              {
-                "version_added": "10.5.0",
-                "partial_implementation": true,
-                "notes": "Takes entirely different options.",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--experimental-worker"
-                  }
-                ]
               }
             ],
             "oculus": "mirror",
@@ -395,17 +369,6 @@
                 "version_added": "11.7.0",
                 "partial_implementation": true,
                 "notes": "Supports the event, but only via Node <code>EventEmitter</code>."
-              },
-              {
-                "version_added": "10.5.0",
-                "partial_implementation": true,
-                "notes": "Supports the event, but only via Node <code>EventEmitter</code>.",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--experimental-worker"
-                  }
-                ]
               }
             ],
             "oculus": "mirror",
@@ -540,17 +503,6 @@
                 "version_added": "11.7.0",
                 "notes": "Supports <code>transferList</code> argument for transferring <code>ArrayBuffer</code> and <code>MessagePort</code> objects",
                 "partial_implementation": true
-              },
-              {
-                "version_added": "10.5.0",
-                "notes": "Supports <code>transferList</code> argument for transferring <code>ArrayBuffer</code> and <code>MessagePort</code> objects",
-                "partial_implementation": true,
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--experimental-worker"
-                  }
-                ]
               }
             ],
             "oculus": "mirror",
@@ -608,17 +560,6 @@
                 "version_added": "11.7.0",
                 "partial_implementation": true,
                 "notes": "Also takes an optional callback to be executed when the worker has terminated."
-              },
-              {
-                "version_added": "10.5.0",
-                "partial_implementation": true,
-                "notes": "Also takes an optional callback to be executed when the worker has terminated.",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--experimental-worker"
-                  }
-                ]
               }
             ],
             "oculus": "mirror",


### PR DESCRIPTION
This PR removes irrelevant flag data for the `--experimental-worker` flag of NodeJS as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-flag-data). This PR was created from results of the `remove-redundant-flags` script.
