### PR TITLE
Remove irrelevant `--experimental-*` flag in NodeJS

### DIFF
--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -894,26 +894,6 @@
                   "version_removed": "16.15.0",
                   "partial_implementation": true,
                   "notes": "The second parameter no longer throws a parser error, but the <code>--experimental-json-modules</code> flag is still needed to load JSON modules."
-                },
-                {
-                  "version_added": "17.0.0",
-                  "version_removed": "17.5.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--experimental-json-modules"
-                    }
-                  ]
-                },
-                {
-                  "version_added": "16.0.0",
-                  "version_removed": "16.14.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony-import-assertions"
-                    }
-                  ]
                 }
               ],
               "oculus": "mirror",

--- a/javascript/operators/await.json
+++ b/javascript/operators/await.json
@@ -74,22 +74,10 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "14.8.0",
-                  "notes": "Not supported in CommonJS modules."
-                },
-                {
-                  "version_added": "14.3.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--experimental-top-level-await"
-                    }
-                  ],
-                  "notes": "Not supported in CommonJS modules."
-                }
-              ],
+              "nodejs": {
+                "version_added": "14.8.0",
+                "notes": "Not supported in CommonJS modules."
+              },
               "oculus": "mirror",
               "opera": [
                 {

--- a/javascript/operators/import.json
+++ b/javascript/operators/import.json
@@ -22,22 +22,10 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "13.2.0",
-                "notes": "Dynamic <code>import</code> can be used in either CommonJS or ES module files, to import either CommonJS or ES module files. See Node's <a href='https://nodejs.org/api/esm.html#esm_import_expressions'>ECMAScript Modules documentation</a> for more details."
-              },
-              {
-                "version_added": "12.0.0",
-                "flags": [
-                  {
-                    "name": "--experimental-modules",
-                    "type": "runtime_flag"
-                  }
-                ],
-                "notes": "Dynamic <code>import</code> can be used in either CommonJS or ES module files, to import either CommonJS or ES module files. See Node's <a href='https://nodejs.org/api/esm.html#esm_import_expressions'>ECMAScript Modules documentation</a> for more details."
-              }
-            ],
+            "nodejs": {
+              "version_added": "13.2.0",
+              "notes": "Dynamic <code>import</code> can be used in either CommonJS or ES module files, to import either CommonJS or ES module files. See Node's <a href='https://nodejs.org/api/esm.html#esm_import_expressions'>ECMAScript Modules documentation</a> for more details."
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -126,26 +114,6 @@
                   "version_removed": "16.15.0",
                   "partial_implementation": true,
                   "notes": "The second parameter no longer throws a parser error, but the <code>--experimental-json-modules</code> flag is still needed to load JSON modules."
-                },
-                {
-                  "version_added": "17.0.0",
-                  "version_removed": "17.5.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--experimental-json-modules"
-                    }
-                  ]
-                },
-                {
-                  "version_added": "16.0.0",
-                  "version_removed": "16.14.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony-import-assertions"
-                    }
-                  ]
                 }
               ],
               "oculus": "mirror",

--- a/javascript/operators/import_meta.json
+++ b/javascript/operators/import_meta.json
@@ -67,33 +67,10 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "20.6.0",
-                  "notes": "Returns a URL object instead of a string."
-                },
-                {
-                  "version_added": "20.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--experimental-import-meta-resolve"
-                    }
-                  ],
-                  "notes": "Returns a URL object instead of a string."
-                },
-                {
-                  "version_added": "12.6.0",
-                  "partial_implementation": true,
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--experimental-import-meta-resolve"
-                    }
-                  ],
-                  "notes": "Returns a Promise resolving to a URL object, instead of a string."
-                }
-              ],
+              "nodejs": {
+                "version_added": "20.6.0",
+                "notes": "Returns a URL object instead of a string."
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -506,32 +506,10 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "13.2.0",
-                "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
-              },
-              {
-                "version_added": "12.0.0",
-                "flags": [
-                  {
-                    "name": "--experimental-modules",
-                    "type": "runtime_flag"
-                  }
-                ],
-                "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/docs/latest-v12.x/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
-              },
-              {
-                "version_added": "8.5.0",
-                "flags": [
-                  {
-                    "name": "--experimental-modules",
-                    "type": "runtime_flag"
-                  }
-                ],
-                "notes": "Module filenames must end with <code>.mjs</code>, not <code>.js</code>. See Node's <a href='https://nodejs.org/docs/latest-v8.x/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
-              }
-            ],
+            "nodejs": {
+              "version_added": "13.2.0",
+              "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -571,32 +549,10 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "13.2.0",
-                  "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
-                },
-                {
-                  "version_added": "12.0.0",
-                  "flags": [
-                    {
-                      "name": "--experimental-modules",
-                      "type": "runtime_flag"
-                    }
-                  ],
-                  "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/docs/latest-v12.x/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
-                },
-                {
-                  "version_added": "8.5.0",
-                  "flags": [
-                    {
-                      "name": "--experimental-modules",
-                      "type": "runtime_flag"
-                    }
-                  ],
-                  "notes": "Module filenames must end with <code>.mjs</code>, not <code>.js</code>. See Node's <a href='https://nodejs.org/docs/latest-v8.x/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
-                }
-              ],
+              "nodejs": {
+                "version_added": "13.2.0",
+                "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -637,22 +593,10 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "13.2.0",
-                  "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
-                },
-                {
-                  "version_added": "12.0.0",
-                  "flags": [
-                    {
-                      "name": "--experimental-modules",
-                      "type": "runtime_flag"
-                    }
-                  ],
-                  "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/docs/latest-v12.x/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
-                }
-              ],
+              "nodejs": {
+                "version_added": "13.2.0",
+                "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -1279,34 +1223,10 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "13.2.0",
-                "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
-              },
-              {
-                "version_added": "12.0.0",
-                "version_removed": "13.2.0",
-                "flags": [
-                  {
-                    "name": "--experimental-modules",
-                    "type": "runtime_flag"
-                  }
-                ],
-                "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/docs/latest-v12.x/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
-              },
-              {
-                "version_added": "8.5.0",
-                "version_removed": "12.0.0",
-                "flags": [
-                  {
-                    "name": "--experimental-modules",
-                    "type": "runtime_flag"
-                  }
-                ],
-                "notes": "Module filenames must end with <code>.mjs</code>, not <code>.js</code>. See Node's <a href='https://nodejs.org/docs/latest-v8.x/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
-              }
-            ],
+            "nodejs": {
+              "version_added": "13.2.0",
+              "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -1444,26 +1364,6 @@
                   {
                     "version_added": "16.15.0",
                     "version_removed": "17.0.0"
-                  },
-                  {
-                    "version_added": "17.0.0",
-                    "version_removed": "17.5.0",
-                    "flags": [
-                      {
-                        "type": "runtime_flag",
-                        "name": "--experimental-json-modules"
-                      }
-                    ]
-                  },
-                  {
-                    "version_added": "16.14.0",
-                    "version_removed": "16.15.0",
-                    "flags": [
-                      {
-                        "type": "runtime_flag",
-                        "name": "--experimental-json-modules"
-                      }
-                    ]
                   }
                 ],
                 "oculus": "mirror",


### PR DESCRIPTION
This PR removes irrelevant flag data for the `--experimental-*` flags of NodeJS as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-flag-data). This PR was created from results of the `remove-redundant-flags` script.
