### PR TITLE
Remove irrelevant `--harmony` flag in NodeJS

### DIFF
--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -339,20 +339,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "4.0.0"
-                },
-                {
-                  "version_added": "0.12.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "4.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -444,20 +433,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "4.0.0"
-                },
-                {
-                  "version_added": "0.12.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "4.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -499,20 +477,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "4.0.0"
-                },
-                {
-                  "version_added": "0.12.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "4.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -844,20 +811,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "6.0.0"
-                },
-                {
-                  "version_added": "5.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "6.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -2150,16 +2106,6 @@
                   "version_added": "10.9.0"
                 },
                 {
-                  "version_added": "6.5.0",
-                  "notes": "The <code>--harmony-array-prototype-values</code> flag is required; the <code>--harmony</code> flag is not sufficient in this case.",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony-array-prototype-values"
-                    }
-                  ]
-                },
-                {
                   "version_added": "0.12.0",
                   "version_removed": "4.0.0"
                 }
@@ -2297,20 +2243,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "6.5.0"
-                },
-                {
-                  "version_added": "6.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "6.5.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -608,20 +608,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "6.5.0"
-                },
-                {
-                  "version_added": "6.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "6.5.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/builtins/AsyncFunction.json
+++ b/javascript/builtins/AsyncFunction.json
@@ -23,20 +23,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "7.6.0"
-              },
-              {
-                "version_added": "7.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "7.6.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -76,20 +65,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "7.6.0"
-                },
-                {
-                  "version_added": "7.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "7.6.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/builtins/AsyncGenerator.json
+++ b/javascript/builtins/AsyncGenerator.json
@@ -21,20 +21,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "10.0.0"
-              },
-              {
-                "version_added": "8.10.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "10.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -71,20 +60,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "10.0.0"
-                },
-                {
-                  "version_added": "8.10.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "10.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -122,20 +100,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "10.0.0"
-                },
-                {
-                  "version_added": "8.10.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "10.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -173,20 +140,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "10.0.0"
-                },
-                {
-                  "version_added": "8.10.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "10.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/builtins/AsyncGeneratorFunction.json
+++ b/javascript/builtins/AsyncGeneratorFunction.json
@@ -21,20 +21,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "10.0.0"
-              },
-              {
-                "version_added": "8.10.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "10.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -72,20 +61,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "10.0.0"
-                },
-                {
-                  "version_added": "8.10.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "10.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/builtins/FinalizationRegistry.json
+++ b/javascript/builtins/FinalizationRegistry.json
@@ -21,20 +21,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "14.6.0"
-              },
-              {
-                "version_added": "13.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony-weak-refs"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "14.6.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -72,20 +61,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "14.6.0"
-                },
-                {
-                  "version_added": "13.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony-weak-refs"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "14.6.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -123,20 +101,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "14.6.0"
-                },
-                {
-                  "version_added": "13.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony-weak-refs"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "14.6.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -213,20 +180,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "14.6.0"
-                },
-                {
-                  "version_added": "13.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony-weak-refs"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "14.6.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -618,20 +618,9 @@
                 "ie": {
                   "version_added": false
                 },
-                "nodejs": [
-                  {
-                    "version_added": "6.5.0"
-                  },
-                  {
-                    "version_added": "6.0.0",
-                    "flags": [
-                      {
-                        "type": "runtime_flag",
-                        "name": "--harmony"
-                      }
-                    ]
-                  }
-                ],
+                "nodejs": {
+                  "version_added": "6.5.0"
+                },
                 "oculus": "mirror",
                 "opera": "mirror",
                 "opera_android": "mirror",
@@ -757,20 +746,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "6.5.0"
-                },
-                {
-                  "version_added": "6.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "6.5.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/builtins/Generator.json
+++ b/javascript/builtins/Generator.json
@@ -23,20 +23,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "4.0.0"
-              },
-              {
-                "version_added": "0.12.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "4.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -75,20 +64,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "4.0.0"
-                },
-                {
-                  "version_added": "0.12.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "4.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -170,20 +148,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "4.0.0"
-                },
-                {
-                  "version_added": "0.12.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "4.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/builtins/GeneratorFunction.json
+++ b/javascript/builtins/GeneratorFunction.json
@@ -23,20 +23,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "4.0.0"
-              },
-              {
-                "version_added": "0.12.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "4.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -76,20 +65,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "4.0.0"
-                },
-                {
-                  "version_added": "0.12.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "4.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -23,20 +23,9 @@
             "ie": {
               "version_added": "11"
             },
-            "nodejs": [
-              {
-                "version_added": "0.12.0"
-              },
-              {
-                "version_added": "0.10.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "0.12.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -76,20 +65,9 @@
               "ie": {
                 "version_added": "11"
               },
-              "nodejs": [
-                {
-                  "version_added": "0.12.0"
-                },
-                {
-                  "version_added": "0.10.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "0.12.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -209,20 +187,9 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "nodejs": [
-                  {
-                    "version_added": "0.12.0"
-                  },
-                  {
-                    "version_added": "0.10.0",
-                    "flags": [
-                      {
-                        "type": "runtime_flag",
-                        "name": "--harmony"
-                      }
-                    ]
-                  }
-                ],
+                "nodejs": {
+                  "version_added": "0.12.0"
+                },
                 "oculus": "mirror",
                 "opera": "mirror",
                 "opera_android": "mirror",
@@ -305,20 +272,9 @@
               "ie": {
                 "version_added": "11"
               },
-              "nodejs": [
-                {
-                  "version_added": "0.12.0"
-                },
-                {
-                  "version_added": "0.10.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "0.12.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -442,20 +398,9 @@
               "ie": {
                 "version_added": "11"
               },
-              "nodejs": [
-                {
-                  "version_added": "0.12.0"
-                },
-                {
-                  "version_added": "0.10.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "0.12.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -549,20 +494,9 @@
               "ie": {
                 "version_added": "11"
               },
-              "nodejs": [
-                {
-                  "version_added": "0.12.0"
-                },
-                {
-                  "version_added": "0.10.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "0.12.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -687,20 +621,9 @@
                 "partial_implementation": true,
                 "notes": "Returns 'undefined' instead of the 'Map' object."
               },
-              "nodejs": [
-                {
-                  "version_added": "0.12.0"
-                },
-                {
-                  "version_added": "0.10.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "0.12.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -881,20 +804,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "6.5.0"
-                },
-                {
-                  "version_added": "6.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "6.5.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -460,20 +460,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "7.0.0"
-                },
-                {
-                  "version_added": "6.5.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "7.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -654,20 +643,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "7.0.0"
-                },
-                {
-                  "version_added": "6.5.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "7.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -1772,20 +1750,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "7.0.0"
-                },
-                {
-                  "version_added": "6.5.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "7.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -531,20 +531,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "6.5.0"
-                },
-                {
-                  "version_added": "6.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "6.5.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -159,20 +159,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "8.10.0"
-                },
-                {
-                  "version_added": "8.3.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "8.10.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -1615,20 +1604,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "6.5.0"
-                },
-                {
-                  "version_added": "6.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "6.5.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -23,20 +23,9 @@
             "ie": {
               "version_added": "11"
             },
-            "nodejs": [
-              {
-                "version_added": "0.12.0"
-              },
-              {
-                "version_added": "0.10.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "0.12.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -76,20 +65,9 @@
               "ie": {
                 "version_added": "11"
               },
-              "nodejs": [
-                {
-                  "version_added": "0.12.0"
-                },
-                {
-                  "version_added": "0.10.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "0.12.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -209,20 +187,9 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "nodejs": [
-                  {
-                    "version_added": "0.12.0"
-                  },
-                  {
-                    "version_added": "0.10.0",
-                    "flags": [
-                      {
-                        "type": "runtime_flag",
-                        "name": "--harmony"
-                      }
-                    ]
-                  }
-                ],
+                "nodejs": {
+                  "version_added": "0.12.0"
+                },
                 "oculus": "mirror",
                 "opera": "mirror",
                 "opera_android": "mirror",
@@ -265,20 +232,9 @@
                 "partial_implementation": true,
                 "notes": "Returns 'undefined' instead of the 'Set' object."
               },
-              "nodejs": [
-                {
-                  "version_added": "0.12.0"
-                },
-                {
-                  "version_added": "0.10.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "0.12.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -360,20 +316,9 @@
               "ie": {
                 "version_added": "11"
               },
-              "nodejs": [
-                {
-                  "version_added": "0.12.0"
-                },
-                {
-                  "version_added": "0.10.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "0.12.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -545,20 +490,9 @@
               "ie": {
                 "version_added": "11"
               },
-              "nodejs": [
-                {
-                  "version_added": "0.12.0"
-                },
-                {
-                  "version_added": "0.10.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "0.12.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -1104,20 +1038,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "6.5.0"
-                },
-                {
-                  "version_added": "6.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "6.5.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -434,20 +434,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "4.0.0"
-                },
-                {
-                  "version_added": "0.12.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "4.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -535,20 +524,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "4.0.0"
-                },
-                {
-                  "version_added": "0.12.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "4.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -772,20 +750,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "4.0.0"
-                },
-                {
-                  "version_added": "0.12.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "4.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -1434,20 +1401,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "8.0.0"
-                },
-                {
-                  "version_added": "7.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "8.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -1487,20 +1443,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "8.0.0"
-                },
-                {
-                  "version_added": "7.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "8.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -1584,20 +1529,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "4.0.0"
-                },
-                {
-                  "version_added": "0.12.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "4.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": {
@@ -1960,20 +1894,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "4.0.0"
-                },
-                {
-                  "version_added": "0.12.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "4.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -237,20 +237,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "6.5.0"
-                },
-                {
-                  "version_added": "6.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "6.5.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -576,20 +565,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "6.5.0"
-                },
-                {
-                  "version_added": "6.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "6.5.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -753,20 +731,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "6.0.0"
-                },
-                {
-                  "version_added": "4.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "6.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -817,20 +817,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "6.0.0"
-                },
-                {
-                  "version_added": "5.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "6.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -2077,20 +2066,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "6.5.0"
-                },
-                {
-                  "version_added": "6.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "6.5.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -23,20 +23,9 @@
             "ie": {
               "version_added": "11"
             },
-            "nodejs": [
-              {
-                "version_added": "0.12.0"
-              },
-              {
-                "version_added": "0.10.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "0.12.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -76,20 +65,9 @@
               "ie": {
                 "version_added": "11"
               },
-              "nodejs": [
-                {
-                  "version_added": "0.12.0"
-                },
-                {
-                  "version_added": "0.10.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "0.12.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -209,20 +187,9 @@
                 "ie": {
                   "version_added": "11"
                 },
-                "nodejs": [
-                  {
-                    "version_added": "0.12.0"
-                  },
-                  {
-                    "version_added": "0.10.0",
-                    "flags": [
-                      {
-                        "type": "runtime_flag",
-                        "name": "--harmony"
-                      }
-                    ]
-                  }
-                ],
+                "nodejs": {
+                  "version_added": "0.12.0"
+                },
                 "oculus": "mirror",
                 "opera": "mirror",
                 "opera_android": "mirror",
@@ -264,20 +231,9 @@
               "ie": {
                 "version_added": "11"
               },
-              "nodejs": [
-                {
-                  "version_added": "0.12.0"
-                },
-                {
-                  "version_added": "0.10.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "0.12.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -318,20 +274,9 @@
               "ie": {
                 "version_added": "11"
               },
-              "nodejs": [
-                {
-                  "version_added": "0.12.0"
-                },
-                {
-                  "version_added": "0.10.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "0.12.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -372,20 +317,9 @@
               "ie": {
                 "version_added": "11"
               },
-              "nodejs": [
-                {
-                  "version_added": "0.12.0"
-                },
-                {
-                  "version_added": "0.10.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "0.12.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -428,20 +362,9 @@
                 "partial_implementation": true,
                 "notes": "Returns 'undefined' instead of the 'Map' object."
               },
-              "nodejs": [
-                {
-                  "version_added": "0.12.0"
-                },
-                {
-                  "version_added": "0.10.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "0.12.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/builtins/WeakRef.json
+++ b/javascript/builtins/WeakRef.json
@@ -21,20 +21,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "14.6.0"
-              },
-              {
-                "version_added": "13.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony-weak-refs"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "14.6.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -72,20 +61,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "14.6.0"
-                },
-                {
-                  "version_added": "13.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony-weak-refs"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "14.6.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -123,20 +101,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "14.6.0"
-                },
-                {
-                  "version_added": "13.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony-weak-refs"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "14.6.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -29,29 +29,9 @@
           "ie": {
             "version_added": false
           },
-          "nodejs": [
-            {
-              "version_added": "6.0.0"
-            },
-            {
-              "version_added": "5.0.0",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--harmony"
-                }
-              ]
-            },
-            {
-              "version_added": "4.0.0",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--use_strict"
-                }
-              ]
-            }
-          ],
+          "nodejs": {
+            "version_added": "6.0.0"
+          },
           "oculus": "mirror",
           "opera": "mirror",
           "opera_android": "mirror",
@@ -97,29 +77,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "6.0.0"
-              },
-              {
-                "version_added": "5.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              },
-              {
-                "version_added": "4.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--use_strict"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "6.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -166,29 +126,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "6.0.0"
-              },
-              {
-                "version_added": "5.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              },
-              {
-                "version_added": "4.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--use_strict"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "6.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -407,29 +347,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "6.0.0"
-              },
-              {
-                "version_added": "5.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              },
-              {
-                "version_added": "4.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--use_strict"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "6.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -255,22 +255,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "4.0.0"
-              },
-              {
-                "version_added": "0.12.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ],
-                "partial_implementation": true,
-                "notes": "The arrow function syntax is supported, but not the correct lexical binding of the <code>this</code> value."
-              }
-            ],
+            "nodejs": {
+              "version_added": "4.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -350,20 +337,9 @@
             "ie": {
               "version_added": "11"
             },
-            "nodejs": [
-              {
-                "version_added": "4.0.0"
-              },
-              {
-                "version_added": "0.10.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "4.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -656,20 +632,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "10.0.0"
-                },
-                {
-                  "version_added": "8.10.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "10.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -708,20 +673,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "7.6.0"
-                },
-                {
-                  "version_added": "7.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "7.6.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -804,20 +758,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "6.0.0"
-              },
-              {
-                "version_added": "4.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "6.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -71,20 +71,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "4.0.0"
-              },
-              {
-                "version_added": "0.12.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "4.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -399,20 +388,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "12.5.0"
-              },
-              {
-                "version_added": "10.4.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "12.5.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": {
@@ -455,20 +433,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "4.0.0"
-              },
-              {
-                "version_added": "0.12.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "4.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -772,20 +739,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "8.10.0"
-                },
-                {
-                  "version_added": "8.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "8.10.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/operators/async_function.json
+++ b/javascript/operators/async_function.json
@@ -24,20 +24,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "7.6.0"
-              },
-              {
-                "version_added": "7.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "7.6.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/javascript/operators/async_generator_function.json
+++ b/javascript/operators/async_generator_function.json
@@ -22,20 +22,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "10.0.0"
-              },
-              {
-                "version_added": "8.10.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "10.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/javascript/operators/await.json
+++ b/javascript/operators/await.json
@@ -23,20 +23,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "7.6.0"
-              },
-              {
-                "version_added": "7.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "7.6.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/javascript/operators/class.json
+++ b/javascript/operators/class.json
@@ -23,20 +23,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "6.0.0"
-              },
-              {
-                "version_added": "5.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "6.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/javascript/operators/exponentiation.json
+++ b/javascript/operators/exponentiation.json
@@ -24,20 +24,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "7.0.0"
-              },
-              {
-                "version_added": "6.5.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "7.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/javascript/operators/exponentiation_assignment.json
+++ b/javascript/operators/exponentiation_assignment.json
@@ -24,20 +24,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "7.0.0"
-              },
-              {
-                "version_added": "6.5.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "7.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -28,20 +28,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "5.0.0"
-              },
-              {
-                "version_added": "4.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "5.0.0"
+            },
             "oculus": "mirror",
             "opera": {
               "version_added": "37"
@@ -85,20 +74,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "5.0.0"
-                },
-                {
-                  "version_added": "4.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "5.0.0"
+              },
               "oculus": "mirror",
               "opera": {
                 "version_added": "37"
@@ -140,20 +118,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "5.0.0"
-                },
-                {
-                  "version_added": "4.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "5.0.0"
+              },
               "oculus": "mirror",
               "opera": {
                 "version_added": "37"
@@ -193,20 +160,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "8.3.0"
-                },
-                {
-                  "version_added": "8.0.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "8.3.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/operators/yield.json
+++ b/javascript/operators/yield.json
@@ -27,20 +27,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "4.0.0"
-              },
-              {
-                "version_added": "0.12.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "4.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/javascript/operators/yield_star.json
+++ b/javascript/operators/yield_star.json
@@ -25,20 +25,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "4.0.0"
-              },
-              {
-                "version_added": "0.12.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "4.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/javascript/regular_expressions.json
+++ b/javascript/regular_expressions.json
@@ -527,20 +527,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "10.0.0"
-              },
-              {
-                "version_added": "8.3.0",
-                "flags": [
-                  {
-                    "name": "--harmony",
-                    "type": "runtime_flag"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "10.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -579,20 +568,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "10.0.0"
-              },
-              {
-                "version_added": "8.3.0",
-                "flags": [
-                  {
-                    "name": "--harmony",
-                    "type": "runtime_flag"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "10.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -766,20 +744,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "10.0.0"
-              },
-              {
-                "version_added": "8.3.0",
-                "flags": [
-                  {
-                    "name": "--harmony",
-                    "type": "runtime_flag"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "10.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -24,20 +24,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "7.6.0"
-              },
-              {
-                "version_added": "7.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "7.6.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -76,20 +65,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "10.0.0"
-              },
-              {
-                "version_added": "8.10.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "10.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -740,21 +718,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "10.0.0"
-              },
-              {
-                "version_added": "8.10.0",
-                "version_removed": "10.0.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony-async-iteration"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "10.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -1056,20 +1022,9 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": [
-              {
-                "version_added": "4.0.0"
-              },
-              {
-                "version_added": "0.12.0",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--harmony"
-                  }
-                ]
-              }
-            ],
+            "nodejs": {
+              "version_added": "4.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -1382,21 +1337,9 @@
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "16.14.0"
-                },
-                {
-                  "version_added": "16.0.0",
-                  "version_removed": "16.14.0",
-                  "flags": [
-                    {
-                      "type": "runtime_flag",
-                      "name": "--harmony-import-assertions"
-                    }
-                  ]
-                }
-              ],
+              "nodejs": {
+                "version_added": "16.14.0"
+              },
               "oculus": "mirror",
               "opera": {
                 "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for the `--harmony` flag of NodeJS as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-flag-data). This PR was created from results of the `remove-redundant-flags` script.
