### PR TITLE
Remove irrelevant `--unstable` flag in Deno

### DIFF
--- a/api/URLPattern.json
+++ b/api/URLPattern.json
@@ -9,21 +9,9 @@
             "version_added": "95"
           },
           "chrome_android": "mirror",
-          "deno": [
-            {
-              "version_added": "1.15"
-            },
-            {
-              "version_added": "1.14",
-              "version_removed": "1.15",
-              "flags": [
-                {
-                  "type": "runtime_flag",
-                  "name": "--unstable"
-                }
-              ]
-            }
-          ],
+          "deno": {
+            "version_added": "1.15"
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -58,21 +46,9 @@
               "version_added": "95"
             },
             "chrome_android": "mirror",
-            "deno": [
-              {
-                "version_added": "1.15"
-              },
-              {
-                "version_added": "1.14",
-                "version_removed": "1.15",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--unstable"
-                  }
-                ]
-              }
-            ],
+            "deno": {
+              "version_added": "1.15"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -144,21 +120,9 @@
               "version_added": "95"
             },
             "chrome_android": "mirror",
-            "deno": [
-              {
-                "version_added": "1.15"
-              },
-              {
-                "version_added": "1.14",
-                "version_removed": "1.15",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--unstable"
-                  }
-                ]
-              }
-            ],
+            "deno": {
+              "version_added": "1.15"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -193,21 +157,9 @@
               "version_added": "95"
             },
             "chrome_android": "mirror",
-            "deno": [
-              {
-                "version_added": "1.15"
-              },
-              {
-                "version_added": "1.14",
-                "version_removed": "1.15",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--unstable"
-                  }
-                ]
-              }
-            ],
+            "deno": {
+              "version_added": "1.15"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -242,21 +194,9 @@
               "version_added": "95"
             },
             "chrome_android": "mirror",
-            "deno": [
-              {
-                "version_added": "1.15"
-              },
-              {
-                "version_added": "1.14",
-                "version_removed": "1.15",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--unstable"
-                  }
-                ]
-              }
-            ],
+            "deno": {
+              "version_added": "1.15"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -291,21 +231,9 @@
               "version_added": "95"
             },
             "chrome_android": "mirror",
-            "deno": [
-              {
-                "version_added": "1.15"
-              },
-              {
-                "version_added": "1.14",
-                "version_removed": "1.15",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--unstable"
-                  }
-                ]
-              }
-            ],
+            "deno": {
+              "version_added": "1.15"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -340,21 +268,9 @@
               "version_added": "95"
             },
             "chrome_android": "mirror",
-            "deno": [
-              {
-                "version_added": "1.15"
-              },
-              {
-                "version_added": "1.14",
-                "version_removed": "1.15",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--unstable"
-                  }
-                ]
-              }
-            ],
+            "deno": {
+              "version_added": "1.15"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -389,21 +305,9 @@
               "version_added": "95"
             },
             "chrome_android": "mirror",
-            "deno": [
-              {
-                "version_added": "1.15"
-              },
-              {
-                "version_added": "1.14",
-                "version_removed": "1.15",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--unstable"
-                  }
-                ]
-              }
-            ],
+            "deno": {
+              "version_added": "1.15"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -438,21 +342,9 @@
               "version_added": "95"
             },
             "chrome_android": "mirror",
-            "deno": [
-              {
-                "version_added": "1.15"
-              },
-              {
-                "version_added": "1.14",
-                "version_removed": "1.15",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--unstable"
-                  }
-                ]
-              }
-            ],
+            "deno": {
+              "version_added": "1.15"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -487,21 +379,9 @@
               "version_added": "95"
             },
             "chrome_android": "mirror",
-            "deno": [
-              {
-                "version_added": "1.15"
-              },
-              {
-                "version_added": "1.14",
-                "version_removed": "1.15",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--unstable"
-                  }
-                ]
-              }
-            ],
+            "deno": {
+              "version_added": "1.15"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -536,21 +416,9 @@
               "version_added": "95"
             },
             "chrome_android": "mirror",
-            "deno": [
-              {
-                "version_added": "1.15"
-              },
-              {
-                "version_added": "1.14",
-                "version_removed": "1.15",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--unstable"
-                  }
-                ]
-              }
-            ],
+            "deno": {
+              "version_added": "1.15"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -585,21 +453,9 @@
               "version_added": "95"
             },
             "chrome_android": "mirror",
-            "deno": [
-              {
-                "version_added": "1.15"
-              },
-              {
-                "version_added": "1.14",
-                "version_removed": "1.15",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--unstable"
-                  }
-                ]
-              }
-            ],
+            "deno": {
+              "version_added": "1.15"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for the `--unstable` flag of Deno as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-flag-data). This PR was created from results of the `remove-redundant-flags` script.
