### PR TITLE
Remove irrelevant Deno flag data for api.Window.localStorage

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -2459,23 +2459,10 @@
               "version_added": "4"
             },
             "chrome_android": "mirror",
-            "deno": [
-              {
-                "version_added": "1.16",
-                "notes": "The key used for the Web Storage bucket is based on various factors. See <a href='https://deno.land/manual/runtime/web_storage_api'>the Deno manual</a>."
-              },
-              {
-                "version_added": "1.10",
-                "version_removed": "1.16",
-                "flags": [
-                  {
-                    "type": "runtime_flag",
-                    "name": "--location",
-                    "value_to_set": "<desired origin>"
-                  }
-                ]
-              }
-            ],
+            "deno": {
+              "version_added": "1.16",
+              "notes": "The key used for the Web Storage bucket is based on various factors. See <a href='https://deno.land/manual/runtime/web_storage_api'>the Deno manual</a>."
+            },
             "edge": {
               "version_added": "12"
             },


### PR DESCRIPTION
This PR removes irrelevant flag data for Deno for the `localStorage` member of the `Window` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-flag-data). This PR was created from results of the `remove-redundant-flags` script.
