### PR TITLE
Remove irrelevant Safari flag data for css.types.color.color-mix

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -146,20 +146,9 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": [
-                {
-                  "version_added": "16.2"
-                },
-                {
-                  "version_added": "15",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "CSS color-mix()"
-                    }
-                  ]
-                }
-              ],
+              "safari": {
+                "version_added": "16.2"
+              },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"


### PR DESCRIPTION
This PR removes irrelevant flag data for Safari (Desktop and iOS/iPadOS) for the `color-mix` member of the `color` CSS value type as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-flag-data). This PR was created from results of the `remove-redundant-flags` script.
