### PR TITLE
Remove irrelevant Opera flag data for javascript.operators.await.top_level

### DIFF
--- a/javascript/operators/await.json
+++ b/javascript/operators/await.json
@@ -91,21 +91,7 @@
                 }
               ],
               "oculus": "mirror",
-              "opera": [
-                {
-                  "version_added": "75"
-                },
-                {
-                  "version_added": "73",
-                  "version_removed": "75",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-javascript-harmony"
-                    }
-                  ]
-                }
-              ],
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": "15"


### PR DESCRIPTION
This PR removes irrelevant flag data for Opera and Opera Android for the `top_level` member of the `await` JavaScript operator as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-flag-data). This PR was created from results of the `remove-redundant-flags` script.
