### PR TITLE
Remove irrelevant Firefox flag data for api.HTMLMediaElement.preservesPitch

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2279,17 +2279,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "101"
-              },
-              {
-                "prefix": "moz",
-                "version_added": "20",
-                "version_removed": "115",
-                "notes": "Disabled by default in version 115 (behind preference <code>dom.media.mozPreservesPitch.enabled</code>). Removed in version 117 (see <a href='https://bugzil.la/1765201'>bug 1765201</a>)."
-              }
-            ],
+            "firefox": {
+              "version_added": "101"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR removes irrelevant flag data for Firefox and Firefox Android for the `preservesPitch` member of the `HTMLMediaElement` API as per the corresponding [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-flag-data). This PR was created from results of the `remove-redundant-flags` script.

Additional Notes: This fixes #20766 in the meantime.
