### PR TITLE
chore(`:blank`): added chromium implementation url

### DIFF
--- a/css/selectors/blank.json
+++ b/css/selectors/blank.json
@@ -9,7 +9,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": "See <a href='https://crbug.com/447880'>bug 447880</a>."
+              "impl_url": "https://crbug.com/447880"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/selectors/blank.json
+++ b/css/selectors/blank.json
@@ -8,7 +8,8 @@
           "spec_url": "https://drafts.csswg.org/selectors/#blank-pseudo",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": "See <a href='https://crbug.com/447880'>bug 447880</a>."
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Added Chromium issue track implementation URL for `:blank` CSS selector feature.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
