### PR TITLE
Browsers: update Safari 17

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -265,12 +265,14 @@
         "16.6": {
           "release_date": "2023-07-24",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_6-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "615.3.12"
         },
         "17": {
-          "status": "beta",
+          "release_date": "2023-09-26",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes",
+          "status": "current",
           "engine": "WebKit",
           "engine_version": "616"
         }


### PR DESCRIPTION
#### Summary

Safari 17 will be released on September 26.

* https://webkit.org/blog/14445/webkit-features-in-safari-17-0/
* https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes
