### PR TITLE
Add Safari 17 support for `popover`, `popovertarget` and `popovertargetaction` attributes

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1215,7 +1215,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "17"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1256,7 +1256,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "17"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1297,7 +1297,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "17"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1222,7 +1222,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -1263,7 +1263,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -1304,7 +1304,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
#### Summary

Safari 17.0 adds support for the `popover`, `popovertarget` and `popovertargetaction` global attributes.

Ref: https://webkit.org/blog/14445/webkit-features-in-safari-17-0/

Update: With the release of Safari 17 on September 26, these 3 global attributes will longer be experimental features.