### PR TITLE
Update CSS `hyphens` full support in Safari 17

### DIFF
--- a/css/properties/hyphenate-character.json
+++ b/css/properties/hyphenate-character.json
@@ -27,10 +27,15 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "5.1"
-            },
+            "safari": [
+              {
+                "version_added": "17"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "5.1"
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -51,14 +51,24 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "prefix": "-webkit-",
-              "version_added": "5.1"
-            },
-            "safari_ios": {
-              "prefix": "-webkit-",
-              "version_added": "4.2"
-            },
+            "safari": [
+              {
+                "version_added": "17"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "5.1"
+              }
+            ],
+            "safari_ios": [
+              {
+                "version_added": "17"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4.2"
+              }
+            ],
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
#### Summary

> Supported in Safari with `-webkit-` prefixes since 2011, the `hyphens` and `hyphenate-character` properties are now supported in their unprefixed form.

Ref: https://webkit.org/blog/14445/webkit-features-in-safari-17-0/