### PR TITLE
Add Safari support for CSS `overflow-block` property

### DIFF
--- a/css/properties/overflow-block.json
+++ b/css/properties/overflow-block.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Safari 17 added support for the CSS `overflow-block` property.

Ref: https://webkit.org/blog/14445/webkit-features-in-safari-17-0/
