### PR TITLE
css.at-rules.counter-style.suffix supported in S17

### DIFF
--- a/css/at-rules/counter-style.json
+++ b/css/at-rules/counter-style.json
@@ -302,7 +302,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add support of S17 for css.at-rules.counter-style.suffix

#### Test results and supporting details

![Capture d’écran 2023-09-25 à 13 11 59](https://github.com/mdn/browser-compat-data/assets/1466293/1bf33062-8ae8-4ae4-8bda-d3e7b5d9e94b)

#### Related issues
Fixes #20754 
