### PR TITLE
Remove confusing browser name

### DIFF
--- a/.github/ISSUE_TEMPLATE/data-problem.yml
+++ b/.github/ISSUE_TEMPLATE/data-problem.yml
@@ -32,7 +32,7 @@ body:
     attributes:
       label: What type of issue is this?
       options:
-        - 'Incorrect support data (example: Chrome says "86" but support was added in "40")'
+        - 'Incorrect support data (example: BrowserX says "86" but support was added in "40")'
         - Browser bug (a bug with a feature that may impact site compatibility)
         - Missing compatibility data
         - Missing specification link (no spec_url property)


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The sentence "(example: Chrome says "46"…) was confusing.

Glancing at the PR, I believed it was actual info. Speaking with Florian, he told me he got tricked too in the past.

So, I propose to change Chrome to BrowserX; I think it is clear enough and no more confusing.
