### PR TITLE
Mark the `gecko_android` webextensions property as android-specific

### DIFF
--- a/webextensions/manifest/browser_specific_settings.json
+++ b/webextensions/manifest/browser_specific_settings.json
@@ -54,10 +54,12 @@
               },
               "edge": "mirror",
               "firefox": {
+                "version_added": false
+              },
+              "firefox_android": {
                 "notes": "Supports <code>strict_min_version</code> and <code>strict_max_version</code>.",
                 "version_added": "113"
               },
-              "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
                 "version_added": false


### PR DESCRIPTION
`gecko_android` is only really used by Firefox for Android. It doesn't makes sense to consider it available on Firefox, it confuses addons-linter, which incorrectly warns about it depending on the Firefox version the extension is compatible with instead of just looking at Firefox for Android compatibility.