### PR TITLE
Firefox 118 release

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -844,28 +844,28 @@
         "117": {
           "release_date": "2023-08-29",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/117",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "117"
         },
         "118": {
           "release_date": "2023-09-26",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/118",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "118"
         },
         "119": {
           "release_date": "2023-10-24",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/119",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "119"
         },
         "120": {
           "release_date": "2023-11-21",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/120",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "120"
         },

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -711,28 +711,28 @@
         "117": {
           "release_date": "2023-08-29",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/117",
-          "status": "current",
+          "status": "retired",
           "engine": "Gecko",
           "engine_version": "117"
         },
         "118": {
           "release_date": "2023-09-26",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/118",
-          "status": "beta",
+          "status": "current",
           "engine": "Gecko",
           "engine_version": "118"
         },
         "119": {
           "release_date": "2023-10-24",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/119",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Gecko",
           "engine_version": "119"
         },
         "120": {
           "release_date": "2023-11-21",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/120",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Gecko",
           "engine_version": "120"
         },


### PR DESCRIPTION
#### Summary

Update Firefox version numbers since 118 was released