### PR TITLE
FF116 HTMLVideoElement.disablePictureInPicture supported

### DIFF
--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -89,7 +89,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "116"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
Fixes #20837 which was added as supported in https://bugzilla.mozilla.org/show_bug.cgi?id=1832154

Note that there is no bcd collector test and this fails the wpt test for me https://wpt.live/picture-in-picture/disable-picture-in-picture.html

But I assume I'm doing something wrong.

