### PR TITLE
FF119 Object.groupBy and Map.groupBy

### DIFF
--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -432,14 +432,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.array_grouping",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "119"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -466,7 +459,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -815,14 +815,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.array_grouping",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "119"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -849,7 +842,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
FF119 supports Object.groupBy and Map.groupBy in https://bugzilla.mozilla.org/show_bug.cgi?id=1792650

This removes the preference and updates to not being experimental.

Related docs work can be tracked in https://github.com/mdn/content/issues/29303