### PR TITLE
FF119 createBidirectionalStream sendOrder option

### DIFF
--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -371,6 +371,40 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "options_sendOrder_parameter": {
+          "__compat": {
+            "description": "<code>options.sendOrder</code> parameter",
+            "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportsendstreamoptions-sendorder",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "119"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "createUnidirectionalStream": {

--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -418,7 +418,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "114"
+              "version_added": "114",
+              "partial_implementation": true,
+              "notes": "Returns a <code>WritableStream</code> instead of a <code>WebTransportSendStream</code>."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -472,6 +472,40 @@
               "deprecated": false
             }
           }
+        },
+        "options_sendOrder_parameter": {
+          "__compat": {
+            "description": "<code>options.sendOrder</code> parameter",
+            "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportsendstreamoptions-sendorder",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "119"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "datagrams": {


### PR DESCRIPTION
FF119 supports `options.sendOrder` as an option to the [`WebTransport.createBidirectionalStream()`](https://developer.mozilla.org/en-US/docs/Web/API/WebTransport/createBidirectionalStream) in 
https://bugzilla.mozilla.org/show_bug.cgi?id=1816925

Note that FF implements the returned stream as a `WritableStream` rather than `WebTransportReceiveStream` (as per spec) so there is no way to get the sendOrder out again. I'd document `WebTransportReceiveStream` except that no one has implemented it yet.

Related docs work can be tracked in https://github.com/mdn/content/issues/29300