### PR TITLE
Add css.at-rules.scope

### DIFF
--- a/css/at-rules/scope.json
+++ b/css/at-rules/scope.json
@@ -1,0 +1,40 @@
+{
+  "css": {
+    "at-rules": {
+      "scope": {
+        "__compat": {
+          "description": "<code>@scope</code>",
+          "spec_url": "https://drafts.csswg.org/css-cascade-6/#scoped-styles",
+          "support": {
+            "chrome": {
+              "version_added": "118"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
_👋 Hi, Chrome DevRel here!_

Chrome 118 will soon ship with support for `@scope`.

- Spec: https://drafts.csswg.org/css-cascade-6/#scoped-styles
- ChromeStatus: https://chromestatus.com/feature/5100672734199808

This PR adds this new at-rule.