### PR TITLE
Update Firefox data for HTMLCanvasElement API

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -826,7 +826,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "117"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -872,7 +872,7 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": "117"
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `HTMLCanvasElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/HTMLCanvasElement
