### PR TITLE
Update Edge data for api.TaskSignal.any_static

### DIFF
--- a/api/TaskSignal.json
+++ b/api/TaskSignal.json
@@ -48,9 +48,7 @@
               "version_added": "116"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `any_static` member of the `TaskSignal` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/TaskSignal/any_static
