### PR TITLE
fix(css): rename 'Adjacent sibling' combinator to 'Next-sibling' combinator

### DIFF
--- a/css/selectors/next-sibling.json
+++ b/css/selectors/next-sibling.json
@@ -1,10 +1,10 @@
 {
   "css": {
     "selectors": {
-      "adjacent_sibling": {
+      "next-sibling": {
         "__compat": {
-          "description": "Adjacent sibling combinator (<code>A + B</code>)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Adjacent_sibling_combinator",
+          "description": "Next-sibling combinator (<code>A + B</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Next-sibling_combinator",
           "spec_url": "https://drafts.csswg.org/selectors/#adjacent-sibling-combinators",
           "support": {
             "chrome": {


### PR DESCRIPTION
- related to content PR https://github.com/mdn/content/pull/29392

Reference https://drafts.csswg.org/selectors/#adjacent-sibling-combinators