### PR TITLE
FF119 HTTP COEP header: credentialless supported on desktop

### DIFF
--- a/http/headers/Cross-Origin-Embedder-Policy.json
+++ b/http/headers/Cross-Origin-Embedder-Policy.json
@@ -46,9 +46,11 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
+                "version_added": "119"
+              },
+              "firefox_android": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -65,7 +67,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
FF119 supports the HTTP [Cross-Origin-Embedder-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy) header directive `credentialless` in https://bugzilla.mozilla.org/show_bug.cgi?id=1851467 on desktop.
It supports the option on android on nightly, but not allowed to set that option, so have set to `false`.

This is part of https://github.com/mdn/content/issues/29413