### PR TITLE
FF119 Window.sidebar (external) not supported

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1408,7 +1408,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "2",
+              "version_added": "1",
               "version_removed": "102",
               "alternative_name": "sidebar",
               "notes": "From Firefox 78 <code>AddSearchProvider()</code> does nothing, as the specification requires."

--- a/api/Window.json
+++ b/api/Window.json
@@ -1407,28 +1407,12 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": [
-              {
-                "version_added": "2",
-                "notes": "From Firefox 78 <code>AddSearchProvider()</code> does nothing, as the specification requires."
-              },
-              {
-                "version_added": "102",
-                "alternative_name": "sidebar",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.window.sidebar.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
-              },
-              {
-                "version_added": "1",
-                "version_removed": "102",
-                "alternative_name": "sidebar"
-              }
-            ],
+            "firefox": {
+              "version_added": "2",
+              "version_removed": "102",
+              "alternative_name": "sidebar",
+              "notes": "From Firefox 78 <code>AddSearchProvider()</code> does nothing, as the specification requires."
+            },
             "firefox_android": [
               {
                 "version_added": "4",

--- a/api/Window.json
+++ b/api/Window.json
@@ -1413,17 +1413,12 @@
               "alternative_name": "sidebar",
               "notes": "From Firefox 78 <code>AddSearchProvider()</code> does nothing, as the specification requires."
             },
-            "firefox_android": [
-              {
-                "version_added": "4",
-                "notes": "From Firefox for Android 79 <code>AddSearchProvider()</code> does nothing, as the specification requires."
-              },
-              {
-                "version_added": "4",
-                "version_removed": "102",
-                "alternative_name": "sidebar"
-              }
-            ],
+            "firefox_android": {
+              "version_added": "4",
+              "version_removed": "102",
+              "alternative_name": "sidebar",
+              "notes": "From Firefox for Android 79 <code>AddSearchProvider()</code> does nothing, as the specification requires."
+            },
             "ie": {
               "version_added": "4"
             },


### PR DESCRIPTION
FF119 removes support for [`Window.sidebar`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sidebar), which is a Mozilla-specific version of `Windows.external` in https://bugzilla.mozilla.org/show_bug.cgi?id=1768486

Support was actually removed in 102, behind a pref. I've reduced this to one entry for each of desktop and android with 102 being the final entry.

Related docs work can be tracked in https://github.com/mdn/content/issues/29306