### PR TITLE
FF119 JS String isWellFormed()/to WellFormed() methods

### DIFF
--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -879,7 +879,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "119"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -2506,7 +2506,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "119"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
FF119 Supports [`String.prototype.isWellFormed()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/isWellFormed) and [`String.prototype.toWellFormed()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toWellFormed) in https://bugzilla.mozilla.org/show_bug.cgi?id=1850755

This updates the versions.

Related docs work can be tracked in https://github.com/mdn/content/issues/29301