### PR TITLE
FF119 SubtleCrypto.deriveKey() supports HKDF as a derivedKeyAlgorith option

### DIFF
--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -314,6 +314,51 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "derivedKeyAlgorithm_option_hkdf": {
+          "__compat": {
+            "description": "<code>HKDF</code> as <code>derivedKeyAlgorithm</code> option value",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveKey",
+            "spec_url": "https://w3c.github.io/webcrypto/#SubtleCrypto-method-deriveKey",
+            "support": {
+              "chrome": {
+                "version_added": "41"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.15"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "119"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "15.0.0",
+                "notes": [
+                  "Supports: NODE-DH",
+                  "Supports: NODE-SCRYPT"
+                ]
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "11"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "digest": {

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -315,6 +315,47 @@
             "deprecated": false
           }
         },
+        "derivedKeyAlgorithm_option_aes": {
+          "__compat": {
+            "description": "<code>AES</code> as <code>derivedKeyAlgorithm</code> option value",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveKey",
+            "spec_url": "https://w3c.github.io/webcrypto/#SubtleCrypto-method-deriveKey",
+            "support": {
+              "chrome": {
+                "version_added": "41"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.15"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "34"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "15.0.0"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "derivedKeyAlgorithm_option_hkdf": {
           "__compat": {
             "description": "<code>HKDF</code> as <code>derivedKeyAlgorithm</code> option value",
@@ -337,17 +378,96 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "15.0.0",
-                "notes": [
-                  "Supports: NODE-DH",
-                  "Supports: NODE-SCRYPT"
-                ]
+                "version_added": false
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "11"
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "derivedKeyAlgorithm_option_hmac": {
+          "__compat": {
+            "description": "<code>HMAC</code> as <code>derivedKeyAlgorithm</code> option value",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveKey",
+            "spec_url": "https://w3c.github.io/webcrypto/#SubtleCrypto-method-deriveKey",
+            "support": {
+              "chrome": {
+                "version_added": "41"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.15"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "34"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "15.0.0"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "derivedKeyAlgorithm_option_pbkdf2": {
+          "__compat": {
+            "description": "<code>PBKDF2</code> as <code>derivedKeyAlgorithm</code> option value",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/deriveKey",
+            "spec_url": "https://w3c.github.io/webcrypto/#SubtleCrypto-method-deriveKey",
+            "support": {
+              "chrome": {
+                "version_added": "41"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.15"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "notes": "See <a href='https://bugzil.la/1856679'>bug 1856679</a>"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
FF119 allows [`SubtleCrypto.deriveKey()`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/deriveKey) to support  HKDF as a `derivedKeyAlgorithm` in https://bugzilla.mozilla.org/show_bug.cgi?id=1851928

I have not fully tested all the support options, as even the engineer I asked wasn't sure what tests map to what features in http://wpt.live/WebCryptoAPI/derive_bits_keys/. However it was stated that this is supported in Chrome. What I have done is mapped the version here to the same as the parent for other browsers. Then checked where possible - e.g. I can find that in deno this is supported in that first version https://deno.land/api@v1.37.1?s=SubtleCrypto#method_deriveKey_13.

EDIT
There are at least 4 possible algorithms to `derivedKeyAlgorithm`: HMAC, PBKDF2, HKDF, and AES. There are also a bunch of values that can be passed as the main algorithm, and also hash algorithms that can be used by some of these. So it is a big complicated mess, little of which is capture currently.

What I have done is added `derivedKeyAlgorithm` subfeatures for: HMAC, PBKDF2, HKDF, and AES. 
- I [know nodejs](https://nodejs.org/docs/latest-v15.x/api/webcrypto.html#webcrypto_subtle_derivekey_algorithm_basekey_derivedkeyalgorithm_extractable_keyusages) supports AES and HMAC from first version 20ish
- I know [Deno supports all options from 1.15](https://deno.land/api@v1.15.0?s=SubtleCrypto)
- I know FF supports HKDF from 119, and probably HMAC and AES since first version.
  There is a bug for supporting PBKDF2 which I have linked.
- Chrome **seems** to have supported all algorithms from first version. 
- Safari has no information. I have put `false` because if it is wrong people are more likely to complain and fix it.
- I think we should expand this approach for all the algorithms on all the methods in this API. However I don't have time to do this, and we'd want to have test code to do it properly in the collector @queengooborg 

Hope this is good enough, even though we know it might not be "100%"

Related docs work can be tracked in https://github.com/mdn/content/issues/29411.

