### PR TITLE
Update Firefox data for col HTML element

### DIFF
--- a/html/elements/col.json
+++ b/html/elements/col.json
@@ -47,7 +47,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": false,
+                "version_added": "1",
                 "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",
@@ -220,7 +220,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": false,
+                "version_added": "1",
                 "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",

--- a/html/elements/col.json
+++ b/html/elements/col.json
@@ -47,7 +47,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "1",
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -219,7 +219,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "1",
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/elements/col.json
+++ b/html/elements/col.json
@@ -48,7 +48,6 @@
               },
               "firefox": {
                 "version_added": "1",
-                "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/elements/col.json
+++ b/html/elements/col.json
@@ -220,7 +220,6 @@
               },
               "firefox": {
                 "version_added": "1",
-                "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `col` HTML element. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.5).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/col
