### PR TITLE
Window.external - fix up FF version

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1407,18 +1407,28 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "version_added": "1",
-              "version_removed": "102",
-              "alternative_name": "sidebar",
-              "notes": "From Firefox 78 <code>AddSearchProvider()</code> does nothing, as the specification requires."
-            },
-            "firefox_android": {
-              "version_added": "4",
-              "version_removed": "102",
-              "alternative_name": "sidebar",
-              "notes": "From Firefox for Android 79 <code>AddSearchProvider()</code> does nothing, as the specification requires."
-            },
+            "firefox": [
+              {
+                "version_added": "2",
+                "notes": "From Firefox 78 <code>AddSearchProvider()</code> does nothing, as the specification requires."
+              },
+              {
+                "version_added": "1",
+                "version_removed": "102",
+                "alternative_name": "sidebar"
+              }
+            ],
+            "firefox_android": [
+              {
+                "version_added": "4",
+                "notes": "From Firefox for Android 79 <code>AddSearchProvider()</code> does nothing, as the specification requires."
+              },
+              {
+                "version_added": "4",
+                "version_removed": "102",
+                "alternative_name": "sidebar"
+              }
+            ],
             "ie": {
               "version_added": "4"
             },


### PR DESCRIPTION
FF has supported `window.external` since version 2 - adds back information that was stripped out in #20856 

Note, in FF102 only the alternative name has been removed.