### PR TITLE
FF119 AuthenticatorAttestationResponse.getPublicKey/KeyAlgorithm/Auth…

### DIFF
--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -107,6 +107,7 @@
       },
       "getAuthenticatorData": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse/getAuthenticatorData",
           "spec_url": "https://w3c.github.io/webauthn/#dom-authenticatorattestationresponse-getauthenticatordata",
           "support": {
             "chrome": {
@@ -115,7 +116,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "119"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -142,6 +143,7 @@
       },
       "getPublicKey": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse/getPublicKey",
           "spec_url": "https://w3c.github.io/webauthn/#dom-authenticatorattestationresponse-getpublickey",
           "support": {
             "chrome": {
@@ -150,7 +152,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "119"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -177,6 +179,7 @@
       },
       "getPublicKeyAlgorithm": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/AuthenticatorAttestationResponse/getPublicKeyAlgorithm",
           "spec_url": "https://w3c.github.io/webauthn/#dom-authenticatorattestationresponse-getpublickeyalgorithm",
           "support": {
             "chrome": {
@@ -185,7 +188,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "119"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF119 supports [`AuthenticatorAttestationResponse.getAuthenticatorData()`](https://developer.mozilla.org/en-US/docs/Web/API/AuthenticatorAttestationResponse/getAuthenticatorData) in https://bugzilla.mozilla.org/show_bug.cgi?id=1816519 , and [`AuthenticatorAttestationResponse.getPublicKeyAlgorithm()`](https://developer.mozilla.org/en-US/docs/Web/API/AuthenticatorAttestationResponse/getPublicKeyAlgorithm) and [`AuthenticatorAttestationResponse.getPublicKey()`](https://developer.mozilla.org/en-US/docs/Web/API/AuthenticatorAttestationResponse/getPublicKey) in https://bugzilla.mozilla.org/show_bug.cgi?id=1816520

This adds the version and MDN links

Related docs work can be tracked in https://github.com/mdn/content/issues/29299