### PR TITLE
FF119 CredentialsContainer.credProps supported

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -201,7 +201,7 @@
                   },
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": false
+                    "version_added": "119"
                   },
                   "firefox_android": "mirror",
                   "ie": {
@@ -220,7 +220,7 @@
                   }
                 },
                 "status": {
-                  "experimental": true,
+                  "experimental": false,
                   "standard_track": true,
                   "deprecated": false
                 }


### PR DESCRIPTION
FF119 supports [`credProp` WebAuthn extension](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#credprops) in https://bugzilla.mozilla.org/show_bug.cgi?id=1844437

This adds the version and MDN link to `CredentialsContainer`. 

Related docs work can be tracked in https://github.com/mdn/content/issues/29307
