### PR TITLE
FF119 PublicKeyCredential.parseCreationOptionsFromJSON and parseReque…

### DIFF
--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -139,6 +139,7 @@
       "isConditionalMediationAvailable_static": {
         "__compat": {
           "description": "<code>isConditionalMediationAvailable()</code> static method",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/isConditionalMediationAvailable",
           "spec_url": "https://w3c.github.io/webauthn/#dom-publickeycredential-isconditionalmediationavailable",
           "support": {
             "chrome": {
@@ -221,6 +222,76 @@
           },
           "status": {
             "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "parseCreationOptionsFromJSON_static": {
+        "__compat": {
+          "description": "<code>parseCreationOptionsFromJSON()</code> static method",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/parseCreationOptionsFromJSON_static",
+          "spec_url": "https://w3c.github.io/webauthn/#dom-publickeycredential-parsecreationoptionsfromjson",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "119"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "parseRequestOptionsFromJSON_static": {
+        "__compat": {
+          "description": "<code>parseRequestOptionsFromJSON()</code> static method",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/parseRequestOptionsFromJSON_static",
+          "spec_url": "https://w3c.github.io/webauthn/#dom-publickeycredential-parserequestoptionsfromjson",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "119"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -398,6 +398,40 @@
             "deprecated": false
           }
         }
+      },
+      "toJSON": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/toJSON",
+          "spec_url": "https://w3c.github.io/webauthn/#dom-publickeycredential-tojson",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "119"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
FF119 supports static methods `PublicKeyCredential.parseCreationOptionsFromJSON()` and `PublicKeyCredential.parseResponseOptionsFromJSON()`, and instance method `PublicKeyCredential.toJSON()` in https://bugzilla.mozilla.org/show_bug.cgi?id=1823782

This adds the versions, which are experimental.

Related docs work can be tracked in https://github.com/mdn/content/issues/29302