### PR TITLE
Update Safari data for html.elements.head.profile

### DIFF
--- a/html/elements/head.json
+++ b/html/elements/head.json
@@ -57,7 +57,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤4"
+                "version_added": "≤4",
+                "version_removed": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/html/elements/head.json
+++ b/html/elements/head.json
@@ -57,7 +57,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤4",
+                "version_added": "1",
                 "version_removed": "16.4"
               },
               "safari_ios": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `profile` member of the `head` HTML element. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.5).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/head/profile
