### PR TITLE
Update Safari data for html.elements.pre.wrap

### DIFF
--- a/html/elements/pre.json
+++ b/html/elements/pre.json
@@ -127,7 +127,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "6"
+                "version_added": "6",
+                "version_removed": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `wrap` member of the `pre` HTML element. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.5).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/pre/wrap
