### PR TITLE
Update Chromium data for html.elements.link.fetchpriority

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -192,7 +192,7 @@
             "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#attr-link-fetchpriority",
             "support": {
               "chrome": {
-                "version_added": "101"
+                "version_added": "102"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `fetchpriority` member of the `link` HTML element. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.5).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/link/fetchpriority
