### PR TITLE
Update Firefox data for colgroup HTML element

### DIFF
--- a/html/elements/colgroup.json
+++ b/html/elements/colgroup.json
@@ -47,7 +47,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": false,
+                "version_added": "1",
                 "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",
@@ -220,7 +220,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": false,
+                "version_added": "1",
                 "impl_url": "https://bugzil.la/915"
               },
               "firefox_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `colgroup` HTML element. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.5).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/colgroup
