### PR TITLE
Update all browsers data for html.elements.link.sizes

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -994,12 +994,12 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "≤80"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "≤72",
                 "impl_url": "https://bugzil.la/441770"
               },
               "firefox_android": "mirror",
@@ -1017,7 +1017,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `sizes` member of the `link` HTML element. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.5).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/link/sizes
