### PR TITLE
Update Chrome/Safari data for rtc HTML element

### DIFF
--- a/html/elements/rtc.json
+++ b/html/elements/rtc.json
@@ -7,7 +7,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#rtc",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `rtc` HTML element. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.5).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/rtc
