### PR TITLE
Update Safari data for html.elements.script.referrerpolicy

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -359,7 +359,7 @@
                 "version_added": null
               },
               "safari": {
-                "version_added": "13.1"
+                "version_added": "14"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `referrerpolicy` member of the `script` HTML element. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.5).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/script/referrerpolicy
