### PR TITLE
Update Edge data for html.elements.source.height

### DIFF
--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -44,9 +44,7 @@
                 "version_added": "90"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "108"
               },
@@ -262,9 +260,7 @@
                 "version_added": "90"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "108"
               },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `height` member of the `source` HTML element. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.5).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/source/height
