### PR TITLE
Updated Node support for EventTarget

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -422,7 +422,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "15.4.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

The compatability data says Node doesn't support the `signal` property of `EventTarget.addEventListener`. However, this support was added in node v15.4.0.

#### Test results and supporting details

[Node Changelog](https://nodejs.org/en/blog/release/v15.4.0)
[Node PR merge comment](https://github.com/nodejs/node/pull/36258#issuecomment-737280775)

#### Related issues

Fixes #18883

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
