### PR TITLE
Browsers: Add Safari 17.1 beta release

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -279,7 +279,7 @@
         "17.1": {
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17_1-release-notes",
           "status": "beta",
-          "engine": "WebKit",
+          "engine": "WebKit"
         }
       }
     }

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -275,6 +275,11 @@
           "status": "current",
           "engine": "WebKit",
           "engine_version": "616"
+        },
+        "17.1": {
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17_1-release-notes",
+          "status": "beta",
+          "engine": "WebKit",
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -251,7 +251,7 @@
         "17.1": {
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17_1-release-notes",
           "status": "beta",
-          "engine": "WebKit",
+          "engine": "WebKit"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -247,6 +247,11 @@
           "status": "current",
           "engine": "WebKit",
           "engine_version": "616"
+        },
+        "17.1": {
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17_1-release-notes",
+          "status": "beta",
+          "engine": "WebKit",
         }
       }
     }


### PR DESCRIPTION
#### Summary

Safari 17.1 is available https://developer.apple.com/documentation/safari-release-notes/safari-17_1-release-notes

Related: #20788