### PR TITLE
Browsers: update chrome

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -809,26 +809,33 @@
         "116": {
           "release_date": "2023-08-15",
           "release_notes": "https://chromereleases.googleblog.com/2023/08/stable-channel-update-for-desktop_15.html",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "116"
         },
         "117": {
           "release_date": "2023-09-12",
-          "status": "beta",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "117"
         },
         "118": {
           "release_date": "2023-10-10",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "118"
         },
         "119": {
-          "status": "planned",
+          "release_date": "2023-10-31",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "119"
+        },
+        "120": {
+          "release_date": "2023-12-05",
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "120"
         }
       }
     }

--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -841,7 +841,7 @@
           "release_date": "2024-01-23",
           "status": "planned",
           "engine": "Blink",
-          "engine_version": "120"
+          "engine_version": "121"
         }
       }
     }

--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -836,7 +836,7 @@
           "status": "nightly",
           "engine": "Blink",
           "engine_version": "120"
-        }
+        },
         "121": {
           "release_date": "2024-01-23",
           "status": "planned",

--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -815,24 +815,30 @@
         },
         "117": {
           "release_date": "2023-09-12",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "117"
         },
         "118": {
           "release_date": "2023-10-10",
-          "status": "beta",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "118"
         },
         "119": {
           "release_date": "2023-10-31",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "119"
         },
         "120": {
           "release_date": "2023-12-05",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "120"
+        }
+        "121": {
+          "release_date": "2024-01-23",
           "status": "planned",
           "engine": "Blink",
           "engine_version": "120"


### PR DESCRIPTION
#### Summary

Chrome 117 (not 116) is the latest stable chrome release.

- https://chromestatus.com/roadmap
- https://chromiumdash.appspot.com/schedule