### PR TITLE
`permissions.request()` is not yet available on Firefox for Android

### DIFF
--- a/webextensions/api/permissions.json
+++ b/webextensions/api/permissions.json
@@ -175,7 +175,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": "102"
+                "version_added": false
               },
               "opera": "mirror",
               "safari": {


### PR DESCRIPTION
GeckoView is ready but not Fenix so we cannot mark this API as compatible with Firefox for Android yet. The UI (and therefore the API) will be implemented soon, see: https://bugzilla.mozilla.org/show_bug.cgi?id=1810047