### PR TITLE
chore(text_fragments): add impl_url for Firefox

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -658,7 +658,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1753933"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds the Firefox implementation url for Text Fragments.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

See: https://bugzilla.mozilla.org/show_bug.cgi?id=1753933