### PR TITLE
Add note to IE support for `font-variant` CSS property

### DIFF
--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -18,7 +18,8 @@
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "Only supports the <code>small-caps</code> and <code>normal</code> keywords."
             },
             "oculus": "mirror",
             "opera": {


### PR DESCRIPTION
#### Summary

All versions of Internet Explorer only support the pre-CSS Fonts Module Level 3 syntax, meaning that it only recognises the `small-caps` and `normal` keywords. 

This is a stark difference compared to the other browsers listed, and non-obvious unless you know to cross-reference with the `font-variant` shorthand compat data and what the functional differences are between `font-variant` and `font-variant` (but shorthand). 

Although IE compat data is no longer actively maintained, flagging this difference (in an albeit high-level, not particularly nuanced way) could help avoid misunderstandings about IE's support for this property.

#### Test results and supporting details

* IE 11 devtools only lists `small-caps` and `normal` keywords for autocompletion for `font-variant`. 
* No other `font-variant` values work in IE 11 or IE 10. (I could not easily test earlier versions). 
