### PR TITLE
Window.json - setImmediate/clearImmediate deprecated

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -770,7 +770,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -5610,7 +5610,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/Window.json
+++ b/api/Window.json
@@ -735,7 +735,6 @@
       "clearImmediate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/clearImmediate",
-          "spec_url": "https://w3c.github.io/setImmediate/#si-clearImmediate",
           "support": {
             "chrome": {
               "version_added": false
@@ -5575,7 +5574,6 @@
       "setImmediate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/setImmediate",
-          "spec_url": "https://w3c.github.io/setImmediate/#si-setImmediate",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/Window.json
+++ b/api/Window.json
@@ -769,7 +769,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -5609,7 +5609,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }


### PR DESCRIPTION
This sets [`Window.setImmediate`](https://developer.mozilla.org/en-US/docs/Web/API/Window/setImmediate) and `clearImmediate` to deprecated.

The discussion in  #20917 suggests this should be non-standard and deprecated. The standard exists but is marked as no longer being worked on. Given it is a draft I think non-standard then makes sense. It never got adopted (other than by node) and never will be, so to me deprecated also makes sense.

Fixes #20917