### PR TITLE
Add `mozactionhint` to BCD under `<input>` as added, removed, and deprecated in FF

### DIFF
--- a/html/elements/input.json
+++ b/html/elements/input.json
@@ -779,7 +779,7 @@
         },
         "mozactionhint": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#non-standard_attributes",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/input#non-standard_attributes",
             "support": {
               "chrome": {
                 "version_added": false

--- a/html/elements/input.json
+++ b/html/elements/input.json
@@ -777,6 +777,40 @@
             }
           }
         },
+        "mozactionhint": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#non-standard_attributes",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "4",
+                "version_removed": "119"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
+        },
         "multiple": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/multiple",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Show `<input>`'s `mozactionhint` property as unsupported in all browsers, added to Firefox in v4, removed from Firefox in v119, deprecated, and never on the standards track.

#### Related issues

Related to https://github.com/mdn/content/issues/29312
Specifically, this PR exists because of @hamishwillee's comment here: https://github.com/mdn/content/issues/29312#issuecomment-1749796455
