### PR TITLE
Remove exception for setImmediate/clearImmediate spec

### DIFF
--- a/test/linter/test-spec-urls.ts
+++ b/test/linter/test-spec-urls.ts
@@ -16,9 +16,6 @@ const specsExceptions = [
   // Remove once https://github.com/whatwg/html/pull/6715 is resolved
   'https://wicg.github.io/controls-list/',
 
-  // Remove once Window.{clearImmediate,setImmediate} are irrelevant and removed
-  'https://w3c.github.io/setImmediate/',
-
   // Exception for April Fools' joke for "418 I'm a teapot"
   'https://www.rfc-editor.org/rfc/rfc2324',
 


### PR DESCRIPTION
This is a follow-up to #20919 which removes the exception for the unlinked spec from BCD.
