### PR TITLE
Update Firefox data for CSSStyleRule API

### DIFF
--- a/api/CSSStyleRule.json
+++ b/api/CSSStyleRule.json
@@ -50,7 +50,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "118"
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -84,7 +84,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "118"
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -118,7 +118,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "118"
+              "version_added": "117"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `CSSStyleRule` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.8).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CSSStyleRule
