### PR TITLE
Update Safari data for DeviceMotionEvent API

### DIFF
--- a/api/DeviceMotionEvent.json
+++ b/api/DeviceMotionEvent.json
@@ -23,7 +23,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "17"
           },
           "safari_ios": {
             "version_added": "4.2"
@@ -97,7 +97,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17"
             },
             "safari_ios": {
               "version_added": "4.2"
@@ -135,7 +135,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17"
             },
             "safari_ios": {
               "version_added": "4.2"
@@ -173,7 +173,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17"
             },
             "safari_ios": {
               "version_added": "4.2"
@@ -247,7 +247,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17"
             },
             "safari_ios": {
               "version_added": "4.2"


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `DeviceMotionEvent` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.8).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/DeviceMotionEvent
