### PR TITLE
Update Safari data for DeviceOrientationEvent API

### DIFF
--- a/api/DeviceOrientationEvent.json
+++ b/api/DeviceOrientationEvent.json
@@ -29,7 +29,7 @@
             "version_added": "14"
           },
           "safari": {
-            "version_added": false
+            "version_added": "17"
           },
           "safari_ios": {
             "version_added": "4.2"
@@ -109,7 +109,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -145,7 +145,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17"
             },
             "safari_ios": {
               "version_added": "4.2"
@@ -185,7 +185,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17"
             },
             "safari_ios": {
               "version_added": "4.2"
@@ -225,7 +225,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17"
             },
             "safari_ios": {
               "version_added": "4.2"


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `DeviceOrientationEvent` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.8).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/DeviceOrientationEvent
