### PR TITLE
Update Chromium data for font-variant-position CSS property

### DIFF
--- a/css/properties/font-variant-position.json
+++ b/css/properties/font-variant-position.json
@@ -7,8 +7,7 @@
           "spec_url": "https://drafts.csswg.org/css-fonts/#font-variant-position-prop",
           "support": {
             "chrome": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/1212668"
+              "version_added": "117"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `font-variant-position` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.8).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/font-variant-position
