### PR TITLE
Add light-dark()

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -513,7 +513,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/262914"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -497,7 +497,8 @@
             "spec_url": "https://drafts.csswg.org/css-color-5/#light-dark",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/1490618"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -491,6 +491,40 @@
             }
           }
         },
+        "light-dark": {
+          "__compat": {
+            "description": "<code>light-dark()</code>",
+            "spec_url": "https://drafts.csswg.org/css-color-5/#light-dark",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "120"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "named-color": {
           "__compat": {
             "description": "Named colors",


### PR DESCRIPTION
_👋 Hi, Chrome DevRel here_

Firefox 120 will ship with `light-dark()` support. This PR adds it.

Relevant links:

- Spec: https://drafts.csswg.org/css-color-5/#light-dark
- Chromium/Blink: https://bugs.chromium.org/p/chromium/issues/detail?id=1490618
- Firefox/Gecko: https://bugzilla.mozilla.org/show_bug.cgi?id=1856999
- Safari/WebKit: https://bugs.webkit.org/show_bug.cgi?id=262914
- Blog article with more info: https://www.bram.us/2023/10/09/the-future-of-css-easy-light-dark-mode-color-switching-with-light-dark/