### PR TITLE
Update Chrome support data for scripting media query

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1483,7 +1483,7 @@
             "spec_url": "https://drafts.csswg.org/mediaqueries-5/#scripting",
             "support": {
               "chrome": {
-                "version_added": "118"
+                "version_added": "120"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

There was a bug in Chrome's scripting implementation that meant it wasn't actually enabled in 118. It's now been fixed so will actually ship in 120.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

https://chromium-review.googlesource.com/c/chromium/src/+/4926489 - My Change to fix the issue.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
