### PR TITLE
103 Early Hints available from Safari 17 and so no longer experimental

### DIFF
--- a/http/status.json
+++ b/http/status.json
@@ -73,12 +73,12 @@
             "oculus": "mirror",
             "opera": "mirror",
             "safari": {
-              "version_added": "preview",
+              "version_added": "17",
               "notes": "Supported in HTTP/2 and later for preconnect."
             }
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

103 Early Hints for preconnect is now enabled by default in Safari 17:

With Safari as the second major browser engine now supporting this by default, the experimental flag can be dropped (also included in this PR).

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<img width="852" alt="image" src="https://github.com/mdn/browser-compat-data/assets/10931297/c62ce96d-cd26-4c5f-afe5-b0ce059cc869">

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes#New-Features

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
