### PR TITLE
 Add Safari 17 "auto none" support in contain-intrinisic-size

### DIFF
--- a/css/properties/contain-intrinsic-size.json
+++ b/css/properties/contain-intrinsic-size.json
@@ -54,7 +54,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
 Add Safari 17 "auto none" support in contain-intrinisic-size

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
See release notes: https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes#CSS
and PR where it was added: https://github.com/WebKit/WebKit/pull/15369,
and where it was fixed: https://github.com/WebKit/WebKit/pull/15812

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
