### PR TITLE
Fix discrepancy between `background-position-y` and `background-position-x`

### DIFF
--- a/css/properties/background-position-x.json
+++ b/css/properties/background-position-x.json
@@ -22,9 +22,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": "18"
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "1"
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

I noticed that there are some difference between to properties which I suspect should have a complete parallel :
- `background-position-y`
- `background-position-x`

- https://github.com/mdn/browser-compat-data/blob/main/css/properties/background-position-y.json
- https://github.com/mdn/browser-compat-data/blob/main/css/properties/background-position-x.json

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

This should an obvious bugfix, if I am mistaken about this, then the PR should be closed and I will open an issue instead.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

N/A
