### PR TITLE
Add spec URL for partitioned cookies

### DIFF
--- a/http/headers/Set-Cookie.json
+++ b/http/headers/Set-Cookie.json
@@ -119,6 +119,8 @@
         "Partitioned": {
           "__compat": {
             "description": "<code>Partitioned</code>",
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#partitioned",
+            "spec_url": "https://datatracker.ietf.org/doc/html/draft-cutler-httpbis-partitioned-cookies",
             "support": {
               "chrome": {
                 "version_added": "114"


### PR DESCRIPTION
#### Summary

This adds the missing spec URL for Partitioned cookies to remove the red block on https://developer.mozilla.org/en-US/docs/Web/Privacy/Partitioned_cookies#specifications

I also added the mdn_url pointing to the Set-Cookies documentation for the attribute

#### Test results and supporting details

I took the spec URL from https://github.com/w3c/browser-specs/pull/823

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
