### PR TITLE
Update Opera data for Cross-Origin-Resource-Policy HTTP header

### DIFF
--- a/http/headers/Cross-Origin-Resource-Policy.json
+++ b/http/headers/Cross-Origin-Resource-Policy.json
@@ -27,12 +27,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "12"
             },


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `Cross-Origin-Resource-Policy` HTTP header. This simply sets Opera to mirror.  This supersedes and closes #20643.
