### PR TITLE
Convert basic bug links in notes to impl_url

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -509,7 +509,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "Firefox doesn't implement this yet. See <a href='https://bugzil.la/847377'>bug 847377</a>."
+              "impl_url": "https://bugzil.la/847377"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -1536,7 +1536,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "notes": "Firefox doesn't implement this yet. See <a href='https://bugzil.la/847377'>bug 847377</a>."
+              "impl_url": "https://bugzil.la/847377"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/http/headers/Cache-Control.json
+++ b/http/headers/Cache-Control.json
@@ -45,7 +45,7 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See Chromium <a href='https://crbug.com/611416'>bug 611416</a>."
+                "impl_url": "https://crbug.com/611416"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -84,13 +84,13 @@
             "support": {
               "chrome": {
                 "version_added": false,
-                "notes": "See Chromium <a href='https://crbug.com/348877'>bug 348877</a>."
+                "impl_url": "https://crbug.com/348877"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "See Bugzilla <a href='https://bugzil.la/995651'>bug 995651</a> comment 7."
+                "impl_url": "https://bugzil.la/995651#c7"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR converts a few notes that only have a bug URL into the `impl_url` property.
