### PR TITLE
Update Safari data for font-synthesis-small-caps CSS property

### DIFF
--- a/css/properties/font-synthesis-small-caps.json
+++ b/css/properties/font-synthesis-small-caps.json
@@ -22,8 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16.4",
-              "notes": "<a href='https://webkit.org/b/232009'>bug 232009</a>."
+              "version_added": "16.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `font-synthesis-small-caps` CSS property. This removes a "resolved fixed" bug link in notes for the feature.

Additional Notes: 
