### PR TITLE
re-add Chrome beforeunload changes

### DIFF
--- a/api/BeforeUnloadEvent.json
+++ b/api/BeforeUnloadEvent.json
@@ -44,9 +44,17 @@
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/browsing-the-web.html#dom-beforeunloadevent-returnvalue",
           "support": {
-            "chrome": {
-              "version_added": "30"
-            },
+            "chrome": [
+              {
+                "version_added": "119"
+              },
+              {
+                "version_added": "30",
+                "version_removed": "119",
+                "partial_implementation": true,
+                "notes": "Before Chrome 119, an empty string incorrectly activated the confirmation dialog."
+              }
+            ],
             "chrome_android": "mirror",
             "deno": {
               "version_added": false
@@ -76,7 +84,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/api/Window.json
+++ b/api/Window.json
@@ -356,18 +356,24 @@
         },
         "event_returnvalue_activation": {
           "__compat": {
-            "description": "Activation using <code>event.returnValue = \"string\";</code>",
+            "description": "Activation by setting <code>event.returnValue</code> to any truthy value",
             "support": {
-              "chrome": {
-                "version_added": "30"
-              },
+              "chrome": [
+                {
+                  "version_added": "119"
+                },
+                {
+                  "version_added": "30",
+                  "version_removed": "118",
+                  "partial_implementation": true,
+                  "notes": "Incorrectly activated the dialog with an empty string value."
+                }
+              ],
               "chrome_android": "mirror",
               "deno": {
                 "version_added": false
               },
-              "edge": {
-                "version_added": "12"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "6"
               },
@@ -434,16 +440,21 @@
             "description": "Activation using <code>event.preventDefault()</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "119"
               },
               "chrome_android": "mirror",
               "deno": {
                 "version_added": false
               },
-              "edge": {
-                "version_added": "12",
-                "version_removed": "79"
-              },
+              "edge": [
+                {
+                  "version_added": "119"
+                },
+                {
+                  "version_added": "12",
+                  "version_removed": "79"
+                }
+              ],
               "firefox": {
                 "version_added": "6"
               },
@@ -472,7 +483,7 @@
         },
         "return_string_activation": {
           "__compat": {
-            "description": "Activation using <code>return \"string\";</code>",
+            "description": "Activation by returning any truthy value",
             "support": {
               "chrome": {
                 "version_added": "1"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

https://github.com/mdn/browser-compat-data/pull/20942 added Chrome data changes for the [`beforeunload` event](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event) (see https://chromestatus.com/feature/4968823574233088).

However, the aforementioned PR had to be reverted because the data included some HTML syntax characters in the note strings that would have caused rendering issues.

This PR resubmits the same changes but with the above issue fixed.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
