### PR TITLE
Window Management API features not supported in Chrome Mobile

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -7172,7 +7172,9 @@
               "chrome": {
                 "version_added": "100"
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": false

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -726,7 +726,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -743,9 +745,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,

--- a/api/ScreenDetailed.json
+++ b/api/ScreenDetailed.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "100"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -41,7 +43,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -75,7 +79,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -109,7 +115,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -143,7 +151,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -177,7 +187,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -211,7 +223,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -245,7 +259,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -279,7 +295,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/ScreenDetails.json
+++ b/api/ScreenDetails.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "100"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -41,7 +43,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -79,7 +83,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -113,7 +119,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -151,7 +159,9 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

PR https://github.com/mdn/browser-compat-data/pull/20600 added support data for [Window Management API](https://w3c.github.io/window-management/) support in Chrome (see [ChromeStatus entry](https://chromestatus.com/feature/5252960583942144)). However, @michaelwasserman informs me that this API is not supported in Chrome Mobile.

This PR aims to rectify this mistake.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
