### PR TITLE
Add missing and new chrome properties to runtime.MessageSender

### DIFF
--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -111,25 +111,6 @@
               }
             }
           },
-          "nativeApplication": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "74"
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "opera": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror"
-              }
-            }
-          },
           "origin": {
             "__compat": {
               "support": {

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -180,11 +180,9 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "45"
+                  "version_added": false
                 },
-                "firefox_android": {
-                  "version_added": "48"
-                },
+                "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
                   "version_added": false

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -27,11 +27,133 @@
               }
             }
           },
+          "documentId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "106"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "documentLifecycle": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "106"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "frameId": {
             "__compat": {
               "support": {
                 "chrome": {
                   "version_added": "41"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            }
+          },
+          "id": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "26"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            }
+          },
+          "nativeApplication": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "74"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "origin": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "80"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "tab": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "26"
                 },
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION
#### Summary

Fixes https://github.com/mdn/content/issues/12041 by adding documentation for `origin` and `nativeApplication` properties and also capturing the more recently added `documentId` and `documentLifecycle`. Also completes the set of documented properties by adding `id` and `tab`.

Complementary content update in https://github.com/mdn/content/pull/29672.
