### PR TITLE
Remove unneeded `createProperties` object to display compat data

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1486,274 +1486,272 @@
               }
             }
           },
-          "createProperties": {
-            "active": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": "5"
-                  },
-                  "edge": {
-                    "version_added": "14"
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": "mirror",
-                  "safari": {
-                    "version_added": "14"
-                  },
-                  "safari_ios": {
-                    "version_added": "15"
-                  }
+          "active": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "5"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
-            },
-            "cookieStoreId": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": "mirror",
-                  "firefox": {
-                    "version_added": "52"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": "mirror",
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": "mirror"
+            }
+          },
+          "cookieStoreId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "discarded": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "63"
+                },
+                "firefox_android": {
+                  "version_added": "63",
+                  "version_removed": "79"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "index": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "5"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
-            },
-            "discarded": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": "mirror",
-                  "firefox": {
-                    "version_added": "63"
-                  },
-                  "firefox_android": {
-                    "version_added": "63",
-                    "version_removed": "79"
-                  },
-                  "opera": "mirror",
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": "mirror"
+            }
+          },
+          "muted": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "100"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "openerTabId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "18"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "57"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
-            },
-            "index": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": "5"
-                  },
-                  "edge": {
-                    "version_added": "14"
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": "mirror",
-                  "safari": {
-                    "version_added": "14"
-                  },
-                  "safari_ios": {
-                    "version_added": "15"
-                  }
+            }
+          },
+          "openInReaderMode": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "58"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "pinned": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "9"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": false
                 }
               }
-            },
-            "muted": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": "mirror",
-                  "firefox": {
-                    "version_added": "100"
-                  },
-                  "firefox_android": "mirror",
-                  "opera": "mirror",
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": "mirror"
+            }
+          },
+          "selected": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "5"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "title": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "63"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "url": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "5"
+                },
+                "edge": {
+                  "notes": "If the <code>url</code> has the 'ms-browser-extension://' protocol it is mistakenly considered a relative URL and the prefix is added redundantly, causing tab to fail loading.",
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "notes": "Before version 57, extensions were not allowed to open 'view-source:' pages.",
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "notes": "Before version 57, extensions were not allowed to open 'view-source:' pages.",
+                  "version_added": "54"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
-            },
-            "openInReaderMode": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": "mirror",
-                  "firefox": {
-                    "version_added": "58"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": "mirror",
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": "mirror"
-                }
-              }
-            },
-            "openerTabId": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": "18"
-                  },
-                  "edge": "mirror",
-                  "firefox": {
-                    "version_added": "57"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": "mirror",
-                  "safari": {
-                    "version_added": "14"
-                  },
-                  "safari_ios": {
-                    "version_added": "15"
-                  }
-                }
-              }
-            },
-            "pinned": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": "9"
-                  },
-                  "edge": "mirror",
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": "mirror",
-                  "safari": {
-                    "version_added": "14"
-                  },
-                  "safari_ios": {
-                    "version_added": false
-                  }
-                }
-              }
-            },
-            "selected": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": "5"
-                  },
-                  "edge": "mirror",
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": "mirror",
-                  "opera": "mirror",
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": "mirror"
-                }
-              }
-            },
-            "title": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": "mirror",
-                  "firefox": {
-                    "version_added": "63"
-                  },
-                  "firefox_android": "mirror",
-                  "opera": "mirror",
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": "mirror"
-                }
-              }
-            },
-            "url": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": "5"
-                  },
-                  "edge": {
-                    "notes": "If the <code>url</code> has the 'ms-browser-extension://' protocol it is mistakenly considered a relative URL and the prefix is added redundantly, causing tab to fail loading.",
-                    "version_added": "14"
-                  },
-                  "firefox": {
-                    "notes": "Before version 57, extensions were not allowed to open 'view-source:' pages.",
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "notes": "Before version 57, extensions were not allowed to open 'view-source:' pages.",
-                    "version_added": "54"
-                  },
-                  "opera": "mirror",
-                  "safari": {
-                    "version_added": "14"
-                  },
-                  "safari_ios": {
-                    "version_added": "15"
-                  }
-                }
-              }
-            },
-            "windowId": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": "5"
-                  },
-                  "edge": {
-                    "version_added": "14"
-                  },
-                  "firefox": {
-                    "version_added": "45"
-                  },
-                  "firefox_android": {
-                    "version_added": "54"
-                  },
-                  "opera": "mirror",
-                  "safari": {
-                    "version_added": "14"
-                  },
-                  "safari_ios": {
-                    "version_added": "15"
-                  }
+            }
+          },
+          "windowId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "5"
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
                 }
               }
             }

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1492,9 +1492,7 @@
                 "chrome": {
                   "version_added": "5"
                 },
-                "edge": {
-                  "version_added": "14"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "45"
                 },
@@ -1560,9 +1558,7 @@
                 "chrome": {
                   "version_added": "5"
                 },
-                "edge": {
-                  "version_added": "14"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "45"
                 },
@@ -1709,10 +1705,7 @@
                 "chrome": {
                   "version_added": "5"
                 },
-                "edge": {
-                  "notes": "If the <code>url</code> has the 'ms-browser-extension://' protocol it is mistakenly considered a relative URL and the prefix is added redundantly, causing tab to fail loading.",
-                  "version_added": "14"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "notes": "Before version 57, extensions were not allowed to open 'view-source:' pages.",
                   "version_added": "45"
@@ -1737,9 +1730,7 @@
                 "chrome": {
                   "version_added": "5"
                 },
-                "edge": {
-                  "version_added": "14"
-                },
+                "edge": "mirror",
                 "firefox": {
                   "version_added": "45"
                 },


### PR DESCRIPTION
#### Summary

This removes the nesting of `createProperties` object parameters to display the compatibility data documentation in the `tabs.create` API.

Fixes #20969 
