### PR TITLE
Correct data for Window.beforeunload_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -364,9 +364,9 @@
                 },
                 {
                   "version_added": "30",
-                  "version_removed": "118",
+                  "version_removed": "119",
                   "partial_implementation": true,
-                  "notes": "Incorrectly activated the dialog with an empty string value."
+                  "notes": "Before Chrome 119, an empty string incorrectly activated the confirmation dialog."
                 }
               ],
               "chrome_android": "mirror",
@@ -483,7 +483,7 @@
         },
         "return_string_activation": {
           "__compat": {
-            "description": "Activation by returning any truthy value",
+            "description": "Activation by returning a string",
             "support": {
               "chrome": {
                 "version_added": "1"


### PR DESCRIPTION
This PR corrects the changes made to the `beforeunload` event of the Window API, following #20964.

CC @chrisdavidmills
