### PR TITLE
Features for resizablearraybuffer are merged into main ECMA spec

### DIFF
--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -103,7 +103,7 @@
           "maxByteLength_option": {
             "__compat": {
               "description": "<code>maxByteLength</code> option",
-              "spec_url": "https://tc39.es/proposal-resizablearraybuffer/#sec-arraybuffer-constructor",
+              "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-arraybuffer-constructor",
               "support": {
                 "chrome": {
                   "version_added": "111"
@@ -326,7 +326,7 @@
         "maxByteLength": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/maxByteLength",
-            "spec_url": "https://tc39.es/proposal-resizablearraybuffer/#sec-get-arraybuffer.prototype.maxbytelength",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-arraybuffer.prototype.maxbytelength",
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -366,7 +366,7 @@
         "resizable": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/resizable",
-            "spec_url": "https://tc39.es/proposal-resizablearraybuffer/#sec-get-arraybuffer.prototype.resizable",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-arraybuffer.prototype.resizable",
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -406,7 +406,7 @@
         "resize": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/resize",
-            "spec_url": "https://tc39.es/proposal-resizablearraybuffer/#sec-arraybuffer.prototype.resize",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-arraybuffer.prototype.resize",
             "support": {
               "chrome": {
                 "version_added": "111"

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -91,7 +91,7 @@
           "maxByteLength_option": {
             "__compat": {
               "description": "<code>maxByteLength</code> option",
-              "spec_url": "https://tc39.es/proposal-resizablearraybuffer/#sec-sharedarraybuffer-constructor",
+              "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-sharedarraybuffer-constructor",
               "support": {
                 "chrome": {
                   "version_added": "111"
@@ -178,7 +178,7 @@
         "grow": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/grow",
-            "spec_url": "https://tc39.es/proposal-resizablearraybuffer/#sec-sharedarraybuffer.prototype.grow",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-sharedarraybuffer.prototype.grow",
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -220,7 +220,7 @@
         "growable": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/growable",
-            "spec_url": "https://tc39.es/proposal-resizablearraybuffer/#sec-get-sharedarraybuffer.prototype.growable",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-sharedarraybuffer.prototype.growable",
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -262,7 +262,7 @@
         "maxByteLength": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/maxByteLength",
-            "spec_url": "https://tc39.es/proposal-resizablearraybuffer/#sec-get-sharedarraybuffer.prototype.maxbytelength",
+            "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-sharedarraybuffer.prototype.maxbytelength",
             "support": {
               "chrome": {
                 "version_added": "111"


### PR DESCRIPTION
Will unblock https://github.com/mdn/browser-compat-data/pull/20459