### PR TITLE
GPC is still a pending spec

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1365,7 +1365,6 @@
       "globalPrivacyControl": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/globalPrivacyControl",
-          "spec_url": "https://privacycg.github.io/gpc-spec/#dom-globalprivacycontrol",
           "support": {
             "chrome": {
               "version_added": false
@@ -1392,7 +1391,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -250,7 +250,6 @@
       "globalPrivacyControl": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerNavigator/globalPrivacyControl",
-          "spec_url": "https://privacycg.github.io/gpc-spec/#dom-globalprivacycontrol",
           "support": {
             "chrome": {
               "version_added": false
@@ -277,7 +276,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }

--- a/http/headers/Sec-GPC.json
+++ b/http/headers/Sec-GPC.json
@@ -4,7 +4,6 @@
       "Sec-GPC": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Sec-GPC",
-          "spec_url": "https://privacycg.github.io/gpc-spec/#the-sec-gpc-header-field-for-http-requests",
           "support": {
             "chrome": {
               "version_added": false
@@ -38,7 +37,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": false
           }
         }


### PR DESCRIPTION
@hamishwillee was right all along in https://github.com/mdn/browser-compat-data/pull/20730. The GPC spec is still a pending spec.

BCD doesn't test for a 'good' spec standing yet, but it will do so once https://github.com/mdn/browser-compat-data/pull/20459 is merged. This PR blocks https://github.com/mdn/browser-compat-data/pull/20459 from passing.