### PR TITLE
Add missing features for CSS API

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -105,6 +105,42 @@
           }
         }
       },
+      "cap_static": {
+        "__compat": {
+          "description": "<code>cap()</code> static method",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-cap",
+          "support": {
+            "chrome": {
+              "version_added": "118"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "ch_static": {
         "__compat": {
           "description": "<code>ch()</code> static method",
@@ -945,6 +981,42 @@
           }
         }
       },
+      "ic_static": {
+        "__compat": {
+          "description": "<code>ic()</code> static method",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-ic",
+          "support": {
+            "chrome": {
+              "version_added": "118"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "in_static": {
         "__compat": {
           "description": "<code>in()</code> static method",
@@ -991,6 +1063,42 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "lh_static": {
+        "__compat": {
+          "description": "<code>lh()</code> static method",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-lh",
+          "support": {
+            "chrome": {
+              "version_added": "118"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -1540,6 +1648,78 @@
           }
         }
       },
+      "rcap_static": {
+        "__compat": {
+          "description": "<code>rcap()</code> static method",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-rcap",
+          "support": {
+            "chrome": {
+              "version_added": "118"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "rch_static": {
+        "__compat": {
+          "description": "<code>rch()</code> static method",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-rch",
+          "support": {
+            "chrome": {
+              "version_added": "118"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "registerProperty_static": {
         "__compat": {
           "description": "<code>registerProperty()</code> static method",
@@ -1586,6 +1766,114 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "rex_static": {
+        "__compat": {
+          "description": "<code>rex()</code> static method",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-rex",
+          "support": {
+            "chrome": {
+              "version_added": "118"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ric_static": {
+        "__compat": {
+          "description": "<code>ric()</code> static method",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-ric",
+          "support": {
+            "chrome": {
+              "version_added": "118"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "rlh_static": {
+        "__compat": {
+          "description": "<code>rlh()</code> static method",
+          "spec_url": "https://drafts.css-houdini.org/css-typed-om/#dom-css-rlh",
+          "support": {
+            "chrome": {
+              "version_added": "118"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing features of the `CSS` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.9).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CSS
