### PR TITLE
Add missing features for api.Document.hasRedemptionRecord

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4325,6 +4325,39 @@
           }
         }
       },
+      "hasRedemptionRecord": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/trust-token-api/#dom-document-hasredemptionrecord",
+          "support": {
+            "chrome": {
+              "version_added": "117"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "hasStorageAccess": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/hasStorageAccess",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing `hasRedemptionRecord` member of the `Document` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.9).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Document/hasRedemptionRecord
