### PR TITLE
Update Chromium data for api.SVGImageElement.crossOrigin

### DIFF
--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -49,7 +49,7 @@
           "spec_url": "https://svgwg.org/svg2-draft/embedded.html#__svg__SVGImageElement__crossOrigin",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "118"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `crossOrigin` member of the `SVGImageElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.9).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/SVGImageElement/crossOrigin
