### PR TITLE
Update Chromium data for TextMetrics API

### DIFF
--- a/api/TextMetrics.json
+++ b/api/TextMetrics.json
@@ -185,7 +185,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-alphabeticbaseline-dev",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "118"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -367,7 +367,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-hangingbaseline-dev",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "118"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -401,7 +401,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/canvas.html#dom-textmetrics-ideographicbaseline-dev",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "118"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `TextMetrics` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.9).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/TextMetrics
