### PR TITLE
Update Safari data for createImageBitmap API

### DIFF
--- a/api/_globals/createImageBitmap.json
+++ b/api/_globals/createImageBitmap.json
@@ -96,7 +96,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -132,7 +132,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -168,7 +168,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -204,7 +204,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -240,7 +240,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -276,7 +276,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `createImageBitmap` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.9).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/createImageBitmap

Additional Notes: Safari 15 was guesstimated as I do not have access to Safari 15.0, only 14.1 and 15.1.
