### PR TITLE
Update Safari data for javascript.builtins.Intl.Locale

### DIFF
--- a/javascript/builtins/Intl/Locale.json
+++ b/javascript/builtins/Intl/Locale.json
@@ -274,7 +274,7 @@
                 "opera_android": "mirror",
                 "safari": [
                   {
-                    "version_added": "preview"
+                    "version_added": "17"
                   },
                   {
                     "version_added": "15.4",
@@ -326,7 +326,7 @@
                 "opera_android": "mirror",
                 "safari": [
                   {
-                    "version_added": "preview"
+                    "version_added": "17"
                   },
                   {
                     "version_added": "15.4",
@@ -378,7 +378,7 @@
                 "opera_android": "mirror",
                 "safari": [
                   {
-                    "version_added": "preview"
+                    "version_added": "17"
                   },
                   {
                     "version_added": "15.4",
@@ -430,7 +430,7 @@
                 "opera_android": "mirror",
                 "safari": [
                   {
-                    "version_added": "preview"
+                    "version_added": "17"
                   },
                   {
                     "version_added": "15.4",
@@ -482,7 +482,7 @@
                 "opera_android": "mirror",
                 "safari": [
                   {
-                    "version_added": "preview"
+                    "version_added": "17"
                   },
                   {
                     "version_added": "15.4",
@@ -534,7 +534,7 @@
                 "opera_android": "mirror",
                 "safari": [
                   {
-                    "version_added": "preview"
+                    "version_added": "17"
                   },
                   {
                     "version_added": "15.4",
@@ -586,7 +586,7 @@
                 "opera_android": "mirror",
                 "safari": [
                   {
-                    "version_added": "preview"
+                    "version_added": "17"
                   },
                   {
                     "version_added": "15.4",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `Locale` member of the `Intl` JavaScript builtin. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.9).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/javascript/builtins/Intl/Locale
