### PR TITLE
Add script to update Firefox release info

### DIFF
--- a/scripts/update-browser-releases/firefox.ts
+++ b/scripts/update-browser-releases/firefox.ts
@@ -1,0 +1,153 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import * as fs from 'node:fs';
+
+import { updateBrowserEntry, newBrowserEntry } from './utils.js';
+
+/**
+ * getFirefoxReleaseNotesURL - Guess the URL of the release notes
+ *
+ * @param {string} version release version
+ * @returns {string} The URL of the release notes or the empty string if not found
+ */
+const getFirefoxReleaseNotesURL = async (version) => {
+  if (version === '1') {
+    return 'https://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/firefox/releases/1.0.html';
+  }
+  return `https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/${version}`;
+};
+
+/**
+ * updateFirefoxFile - Update the json file listing the browser version of a chromium entry
+ *
+ * @param {object} options The list of options for this type of chromiums.
+ */
+export const updateFirefoxReleases = async (options) => {
+  /*
+  //
+  // Extract the current planned version and its release date
+  //
+  const planned = (Number(nightlyTrain.version) + 1).toString();
+  const plannedTrainInfo = await fetch(
+    `${options.firefoxSpecificScheduleURL}${planned}`,
+  );
+  const plannedTrain = await plannedTrainInfo.json();
+  const plannedReleaseDate = plannedTrain.release.substring(0, 10); // Remove the time part
+*/
+  //
+  // Get the firefox.json from the local BCD
+  //
+  const file = fs.readFileSync(`${options.bcdFile}`);
+  const firefoxBCD = JSON.parse(file.toString());
+
+  //
+  // Update the three channels
+  //
+  const channels = new Map([
+    ['current', options.releaseBranch],
+    ['beta', options.betaBranch],
+    ['nightly', options.nightlyBranch],
+  ]);
+  const data = {};
+
+  let stableRelease = 1; // We will need this info afterwards; it will be calculated in the loop.
+
+  for (const [key, value] of channels) {
+    let releaseNotesURL;
+    // Extract version and release date
+    if (key !== 'current') {
+      // Get the JSON for the given train
+      const trainInfo = await fetch(`${options.firefoxScheduleURL}${value}`);
+      const train = await trainInfo.json();
+
+      releaseNotesURL = await getFirefoxReleaseNotesURL(
+        parseFloat(train.version).toString(),
+      );
+
+      data[value] = {};
+      data[value].version = parseFloat(train.version).toString();
+      data[value].releaseDate = train.release.substring(0, 10); // Remove the time part
+    } else {
+      // Get the JSON with all released versions and their dates
+      const firefoxVersions = await fetch(options.firefoxReleaseDateURL);
+      const releasedFirefoxVersions = await firefoxVersions.json();
+
+      // Extract the current stable version and its release date
+
+      Object.entries(releasedFirefoxVersions).forEach(([key]) => {
+        if (parseFloat(key) > stableRelease) {
+          stableRelease = parseFloat(key);
+        }
+      });
+      releaseNotesURL = await getFirefoxReleaseNotesURL(stableRelease);
+
+      data[value] = {};
+      data[value].version = stableRelease;
+      data[value].releaseDate = releasedFirefoxVersions[stableRelease + '.0'];
+    }
+
+    if (firefoxBCD.browsers[options.bcdBrowserName].releases[key]) {
+      updateBrowserEntry(
+        firefoxBCD.browsers[options.bcdBrowserName].releases[key],
+        data[value].releaseDate,
+        key,
+        releaseNotesURL,
+      );
+    } else {
+      // New entry
+      newBrowserEntry(
+        firefoxBCD,
+        options.bcdBrowserName,
+        data[value].version,
+        key,
+        'Gecko',
+        data[value].releaseDate,
+        releaseNotesURL,
+      );
+    }
+  }
+
+  //
+  // Set all older releases are 'retired'
+  //
+  Object.entries(firefoxBCD.browsers[options.bcdBrowserName].releases).forEach(
+    ([key, entry]) => {
+      if (parseFloat(key) < stableRelease) {
+        entry.status = 'retired';
+      }
+    },
+  );
+
+  //
+  // Add a planned version entry
+  //
+  const planned = stableRelease + 3;
+  // Get the JSON for the planned version train
+  const trainInfo = await fetch(`${options.firefoxScheduleURL}${planned}`);
+  const train = await trainInfo.json();
+
+  if (firefoxBCD.browsers[options.bcdBrowserName].releases[planned]) {
+    firefoxBCD.browsers[options.bcdBrowserName].releases[planned].release_date =
+      train.release.substring(0, 10); // Remove the time part
+    firefoxBCD.browsers[options.bcdBrowserName].releases[planned].status =
+      'planned';
+  } else {
+    // New entry
+    newBrowserEntry(
+      firefoxBCD,
+      options.bcdBrowserName,
+      planned,
+      'planned',
+      'Gecko',
+      train.release.substring(0, 10), // Remove the time part
+      await getFirefoxReleaseNotesURL(planned),
+    );
+  }
+
+  //
+  // Write the JSON back into chrome.json
+  //
+  fs.writeFileSync(`./${options.bcdFile}`, JSON.stringify(firefoxBCD, null, 2));
+  console.log(`File generated succesfully: ${options.bcdFile}`);
+};

--- a/scripts/update-browser-releases/firefox.ts
+++ b/scripts/update-browser-releases/firefox.ts
@@ -24,17 +24,6 @@ const getFirefoxReleaseNotesURL = async (version) => {
  * @param {object} options The list of options for this type of chromiums.
  */
 export const updateFirefoxReleases = async (options) => {
-  /*
-  //
-  // Extract the current planned version and its release date
-  //
-  const planned = (Number(nightlyTrain.version) + 1).toString();
-  const plannedTrainInfo = await fetch(
-    `${options.firefoxSpecificScheduleURL}${planned}`,
-  );
-  const plannedTrain = await plannedTrainInfo.json();
-  const plannedReleaseDate = plannedTrain.release.substring(0, 10); // Remove the time part
-*/
   //
   // Get the firefox.json from the local BCD
   //

--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -18,7 +18,7 @@ const argv = yargs(process.argv.slice(2))
     group: 'Engine selection:',
   })
   .option('firefox', {
-    describe: 'Update Google Webview',
+    describe: 'Update Mozilla Firefox',
     type: 'boolean',
     group: 'Engine selection:',
   })
@@ -104,6 +104,17 @@ const options = {
     firefoxScheduleURL:
       'https://whattrainisitnow.com/api/release/schedule/?version=',
   },
+  firefox_android: {
+    bcdFile: './browsers/firefox_android.json',
+    bcdBrowserName: 'firefox_android',
+    betaBranch: 'beta',
+    nightlyBranch: 'nightly',
+    firstRelease: 4,
+    skippedReleases: [11, 12, 13, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78],
+    firefoxReleaseDateURL: 'https://whattrainisitnow.com/api/firefox/releases/',
+    firefoxScheduleURL:
+      'https://whattrainisitnow.com/api/release/schedule/?version=',
+  },
 };
 
 if (updateChrome && updateDesktop) {
@@ -124,4 +135,9 @@ if (updateWebview && updateMobile) {
 if (updateFirefox && updateDesktop) {
   console.log('Check Firefox for Desktop.');
   await updateFirefoxReleases(options.firefox_desktop);
+}
+
+if (updateFirefox && updateMobile) {
+  console.log('Check Firefox for Android.');
+  await updateFirefoxReleases(options.firefox_android);
 }

--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -3,6 +3,7 @@
 import yargs from 'yargs';
 
 import { updateChromiumReleases } from './chrome.js';
+import { updateFirefoxReleases } from './firefox.js';
 
 const argv = yargs(process.argv.slice(2))
   .usage('Usage: npm run update-browser-releases -- (flags)')
@@ -12,6 +13,11 @@ const argv = yargs(process.argv.slice(2))
     group: 'Engine selection:',
   })
   .option('webview', {
+    describe: 'Update Google Webview',
+    type: 'boolean',
+    group: 'Engine selection:',
+  })
+  .option('firefox', {
     describe: 'Update Google Webview',
     type: 'boolean',
     group: 'Engine selection:',
@@ -40,16 +46,18 @@ const argv = yargs(process.argv.slice(2))
   .parse();
 
 // Read arguments
-const updateAllBrowsers = argv['all'] || !(argv['chrome'] || argv['webview']);
+const updateAllBrowsers =
+  argv['all'] || !(argv['chrome'] || argv['webview'] || argv['firefox']);
 const updateChrome = argv['chrome'] || updateAllBrowsers;
 const updateWebview = argv['webview'] || updateAllBrowsers;
+const updateFirefox = argv['firefox'] || updateAllBrowsers;
 const updateAllDevices =
   argv['alldevices'] || !(argv['mobile'] || argv['desktop']);
 const updateMobile = argv['mobile'] || updateAllDevices;
 const updateDesktop = argv['desktop'] || updateAllDevices;
 
 const options = {
-  desktop: {
+  chrome_desktop: {
     bcdFile: './browsers/chrome.json',
     bcdBrowserName: 'chrome',
     browserEngine: 'Blink',
@@ -61,7 +69,7 @@ const options = {
     skippedReleases: [82], // 82 was skipped during COVID
     chromestatusURL: 'https://chromestatus.com/api/v0/channels',
   },
-  android: {
+  chrome_android: {
     bcdFile: './browsers/chrome_android.json',
     bcdBrowserName: 'chrome_android',
     browserEngine: 'Blink',
@@ -85,19 +93,35 @@ const options = {
     skippedReleases: [82], // 82 was skipped during COVID
     chromestatusURL: 'https://chromestatus.com/api/v0/channels',
   },
+  firefox_desktop: {
+    bcdFile: './browsers/firefox.json',
+    bcdBrowserName: 'firefox',
+    betaBranch: 'beta',
+    nightlyBranch: 'nightly',
+    firstRelease: 1,
+    skippedReleases: [],
+    firefoxReleaseDateURL: 'https://whattrainisitnow.com/api/firefox/releases/',
+    firefoxScheduleURL:
+      'https://whattrainisitnow.com/api/release/schedule/?version=',
+  },
 };
 
 if (updateChrome && updateDesktop) {
   console.log('Check Chrome for Desktop.');
-  await updateChromiumReleases(options.desktop);
+  await updateChromiumReleases(options.chrome_desktop);
 }
 
 if (updateChrome && updateMobile) {
   console.log('Check Chrome for Android.');
-  await updateChromiumReleases(options.android);
+  await updateChromiumReleases(options.chrome_android);
 }
 
 if (updateWebview && updateMobile) {
   console.log('Check Webview for Android.');
   await updateChromiumReleases(options.webview_android);
+}
+
+if (updateFirefox && updateDesktop) {
+  console.log('Check Firefox for Desktop.');
+  await updateFirefoxReleases(options.firefox_desktop);
 }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR extends the `update-browser-releases` script to support Firefox browser.

#### Test results and supporting details
Manually tested.

It added the following entries.
![Capture d’écran 2023-10-19 à 15 57 36](https://github.com/mdn/browser-compat-data/assets/1466293/723b27e4-d136-455b-b9b1-ce26c722c145)

Note that it does support Firefox for Android too (on the same schedule than Firefox for Desktop)
![Capture d’écran 2023-10-19 à 17 04 44](https://github.com/mdn/browser-compat-data/assets/1466293/92ac0009-547f-4c3a-8dc0-023ae538a80c)


#### Related issues

