### PR TITLE
Add missing features for text-underline-position CSS property

### DIFF
--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -79,41 +79,6 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤80"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤80"
-              },
-              "firefox": {
-                "version_added": "74"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "left_right": {
-          "__compat": {
-            "description": "<code>left</code> and <code>right</code>",
-            "support": {
-              "chrome": {
                 "version_added": "71"
               },
               "chrome_android": "mirror",
@@ -146,12 +111,10 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "71"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤80"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "74"
               },

--- a/css/properties/text-underline-position.json
+++ b/css/properties/text-underline-position.json
@@ -75,6 +75,40 @@
             }
           }
         },
+        "left": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "≤80"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "≤80"
+              },
+              "firefox": {
+                "version_added": "74"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "left_right": {
           "__compat": {
             "description": "<code>left</code> and <code>right</code>",
@@ -84,6 +118,40 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
+              "firefox": {
+                "version_added": "74"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "right": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "≤80"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "≤80"
+              },
               "firefox": {
                 "version_added": "74"
               },


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing features of the `text-underline-position` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.9).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/text-underline-position
