### PR TITLE
Add missing webassemblyrelaxed-SIMD feature feature

### DIFF
--- a/test/linter/test-spec-urls.ts
+++ b/test/linter/test-spec-urls.ts
@@ -38,6 +38,7 @@ const specsExceptions = [
   'https://github.com/WebAssembly/extended-const/blob/main/proposals',
   'https://github.com/WebAssembly/tail-call/blob/main/proposals',
   'https://github.com/WebAssembly/threads/blob/main/proposal',
+  'https://github.com/WebAssembly/relaxed-simd/blob/main/proposals',
 ];
 
 const allowedSpecURLs = [

--- a/webassembly/relaxed-SIMD.json
+++ b/webassembly/relaxed-SIMD.json
@@ -10,7 +10,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "ie": {

--- a/webassembly/relaxed-SIMD.json
+++ b/webassembly/relaxed-SIMD.json
@@ -1,0 +1,37 @@
+{
+  "webassembly": {
+    "relaxed-SIMD": {
+      "__compat": {
+        "spec_url": "https://github.com/WebAssembly/relaxed-simd/blob/main/proposals/relaxed-simd/Overview.md",
+        "support": {
+          "chrome": {
+            "version_added": "114"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing `webassemblyrelaxed-SIMD` feature. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.9).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/webassembly/relaxed-SIMD
