### PR TITLE
Update Firefox data for CanvasCaptureMediaStreamTrack API

### DIFF
--- a/api/CanvasCaptureMediaStreamTrack.json
+++ b/api/CanvasCaptureMediaStreamTrack.json
@@ -11,7 +11,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "43"
+            "version_added": false
           },
           "firefox_android": "mirror",
           "ie": {
@@ -44,7 +44,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "43"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
@@ -78,7 +78,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "43"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `CanvasCaptureMediaStreamTrack` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CanvasCaptureMediaStreamTrack

Additional Notes: Until the most recent collector release, the test didn't check if the result was a CanvasCaptureMediaStreamTrack or a regular MediaStreamTrack.  CanvasCaptureMediaStreamTrack is not defined in Firefox IDL.  This fixes #20784.