### PR TITLE
Update Firefox data for api.HTMLVideoElement.disablePictureInPicture

### DIFF
--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -89,7 +89,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "116"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `disablePictureInPicture` member of the `HTMLVideoElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/HTMLVideoElement/disablePictureInPicture

Additional Notes: This effectively reverts #20839.  While the flag mentioned in that PR is indeed enabled by default, the property is not (properly) defined in the WebIDL.
