### PR TITLE
Fix TypeScript issue in Firefox browser update script

### DIFF
--- a/scripts/update-browser-releases/firefox.ts
+++ b/scripts/update-browser-releases/firefox.ts
@@ -5,6 +5,8 @@ import * as fs from 'node:fs';
 
 import { updateBrowserEntry, newBrowserEntry } from './utils.js';
 
+import type { ReleaseStatement } from '../../types/types.js';
+
 /**
  * getFirefoxReleaseNotesURL - Guess the URL of the release notes
  *
@@ -100,13 +102,15 @@ export const updateFirefoxReleases = async (options) => {
   //
   // Set all older releases are 'retired'
   //
-  Object.entries(firefoxBCD.browsers[options.bcdBrowserName].releases).forEach(
-    ([key, entry]) => {
-      if (parseFloat(key) < stableRelease) {
-        entry.status = 'retired';
-      }
+  Object.entries(
+    firefoxBCD.browsers[options.bcdBrowserName].releases as {
+      [version: string]: ReleaseStatement;
     },
-  );
+  ).forEach(([key, entry]) => {
+    if (parseFloat(key) < stableRelease) {
+      entry.status = 'retired';
+    }
+  });
 
   //
   // Add a planned version entry


### PR DESCRIPTION
This PR fixes a TypeScript typedef issue in the Firefox browser update script, which is causing an issue with the mdn-bcd-collector (see https://github.com/openwebdocs/mdn-bcd-collector/actions/runs/6586954756/job/17896302875).

This will be self-merged as it is a critical bug fix.
