### PR TITLE
Add missing WebGLTimerQueryEXT API feature

### DIFF
--- a/api/WebGLTimerQueryEXT.json
+++ b/api/WebGLTimerQueryEXT.json
@@ -1,0 +1,54 @@
+{
+  "api": {
+    "WebGLTimerQueryEXT": {
+      "__compat": {
+        "spec_url": "https://registry.khronos.org/webgl/extensions/EXT_disjoint_timer_query/",
+        "support": {
+          "chrome": [
+            {
+              "version_added": "70",
+              "partial_implementation": true,
+              "notes": "Only supported on macOS."
+            },
+            {
+              "version_added": "47",
+              "version_removed": "65",
+              "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+            }
+          ],
+          "chrome_android": {
+            "version_added": "47",
+            "version_removed": "65",
+            "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+          },
+          "edge": "mirror",
+          "firefox": {
+            "version_added": "51",
+            "version_removed": "59",
+            "notes": "Removed due to the <a href='https://www.vusec.net/projects/glitch/'>GLitch exploit</a>."
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": false,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing `WebGLTimerQueryEXT` API. Support was confirmed with the mdn-bcd-collector projcet (v10.2.10) and was copied from api.EXT_disjoint_timer_query.createQueryEXT.
