### PR TITLE
Add missing clip-rule CSS property feature

### DIFF
--- a/css/properties/clip-rule.json
+++ b/css/properties/clip-rule.json
@@ -3,7 +3,7 @@
     "properties": {
       "clip-rule": {
         "__compat": {
-          "spec_url": "https://drafts.fxtf.org/css-masking-1/#the-clip-path",
+          "spec_url": "https://drafts.fxtf.org/css-masking-1/#the-clip-rule",
           "support": {
             "chrome": {
               "version_added": "≤80"

--- a/css/properties/clip-rule.json
+++ b/css/properties/clip-rule.json
@@ -1,0 +1,41 @@
+{
+  "css": {
+    "properties": {
+      "clip-rule": {
+        "__compat": {
+          "spec_url": "https://drafts.fxtf.org/css-masking-1/#the-clip-path",
+          "support": {
+            "chrome": {
+              "version_added": "≤80"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "≤80"
+            },
+            "firefox": {
+              "version_added": "≤72"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "≤13.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing `clip-rule` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/clip-rule
