### PR TITLE
Add missing flood-color CSS property feature

### DIFF
--- a/css/properties/flood-color.json
+++ b/css/properties/flood-color.json
@@ -6,24 +6,24 @@
           "spec_url": "https://drafts.fxtf.org/filter-effects-1/#FloodColorProperty",
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "5"
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "≤80"
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "≤72"
+              "version_added": "3"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": false
+              "version_added": true
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "6"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/flood-color.json
+++ b/css/properties/flood-color.json
@@ -1,0 +1,41 @@
+{
+  "css": {
+    "properties": {
+      "flood-color": {
+        "__compat": {
+          "spec_url": "https://drafts.fxtf.org/filter-effects-1/#FloodColorProperty",
+          "support": {
+            "chrome": {
+              "version_added": "≤80"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "≤80"
+            },
+            "firefox": {
+              "version_added": "≤72"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "≤13.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing `flood-color` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/flood-color
