### PR TITLE
Add missing glyph-orientation-vertical CSS property feature

### DIFF
--- a/css/properties/glyph-orientation-vertical.json
+++ b/css/properties/glyph-orientation-vertical.json
@@ -30,7 +30,7 @@
           "status": {
             "experimental": true,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }

--- a/css/properties/glyph-orientation-vertical.json
+++ b/css/properties/glyph-orientation-vertical.json
@@ -28,7 +28,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": true
           }

--- a/css/properties/glyph-orientation-vertical.json
+++ b/css/properties/glyph-orientation-vertical.json
@@ -1,0 +1,39 @@
+{
+  "css": {
+    "properties": {
+      "glyph-orientation-vertical": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-writing-modes-4/#glyph-orientation",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "≤13.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing `glyph-orientation-vertical` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/glyph-orientation-vertical
