### PR TITLE
Add missing speak CSS property feature

### DIFF
--- a/css/properties/speak.json
+++ b/css/properties/speak.json
@@ -6,14 +6,17 @@
           "spec_url": "https://drafts.csswg.org/css-speech-1/#speaking-props-speak",
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "≤80",
+              "partial_implemenation": true,
+              "notes": "The implementation is not compliant with the specification, see <a href='https://crbug.com/1283584'> bug 1283584</a>."
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "≤80"
             },
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1748064"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/speak.json
+++ b/css/properties/speak.json
@@ -7,8 +7,8 @@
           "support": {
             "chrome": {
               "version_added": "≤80",
-              "partial_implemenation": true,
-              "notes": "The implementation is not compliant with the specification, see <a href='https://crbug.com/1283584'> bug 1283584</a>."
+              "partial_implementation": true,
+              "notes": "The implementation is not compliant with the specification, see <a href='https://crbug.com/1283584'>bug 1283584</a>."
             },
             "chrome_android": "mirror",
             "edge": {

--- a/css/properties/speak.json
+++ b/css/properties/speak.json
@@ -1,0 +1,41 @@
+{
+  "css": {
+    "properties": {
+      "speak": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-speech-1/#speaking-props-speak",
+          "support": {
+            "chrome": {
+              "version_added": "≤80"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "≤80"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing `speak` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/speak
