### PR TITLE
FontFace loading events are not implemented in Safari

### DIFF
--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -427,7 +427,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -462,7 +462,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -497,7 +497,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
Safari does not emit FontFace loading events as of 2023-10-20 (Safari 16.6)

* Incorrect resource: https://caniuse.com/mdn-api_fontfaceset_loadingdone_event
* WebKit Issue: https://bugs.webkit.org/show_bug.cgi?id=154626
* Repro: https://codepen.io/alexkrolick/pen/QWYLRYE?editors=1001

```js
  document.fonts.addEventListener("loading", (event) => {
    console.log('loading', event) // never logged in Safari
  });
```
