### PR TITLE
Update Safari data for javascript.builtins.WebAssembly.Exception.stack

### DIFF
--- a/javascript/builtins/WebAssembly/Exception.json
+++ b/javascript/builtins/WebAssembly/Exception.json
@@ -229,7 +229,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "15.2"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `Exception.stack` member of the `WebAssembly` JavaScript builtin. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/javascript/builtins/WebAssembly/Exception/stack

Additional Notes: This was set to Safari 15.2 in #15954, but I have not been able to confirm support.
