### PR TITLE
Update all browsers data for html.elements.form.autocapitalize

### DIFF
--- a/html/elements/form.json
+++ b/html/elements/form.json
@@ -142,7 +142,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "43"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/html/elements/form.json
+++ b/html/elements/form.json
@@ -142,12 +142,12 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "≤80"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "111"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `autocapitalize` member of the `form` HTML element. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.2.10).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/form/autocapitalize
