### PR TITLE
Add support for 'esr' in update script for firefox[_android].json

### DIFF
--- a/scripts/update-browser-releases/chrome.ts
+++ b/scripts/update-browser-releases/chrome.ts
@@ -171,6 +171,9 @@ export const updateChromiumReleases = async (options) => {
   //
   // Write the update browser's json to file
   //
-  fs.writeFileSync(`./${options.bcdFile}`, JSON.stringify(chromeBCD, null, 2));
+  fs.writeFileSync(
+    `./${options.bcdFile}`,
+    JSON.stringify(chromeBCD, null, 2) + '\n',
+  );
   console.log(chalk`{bold File generated successfully: ${options.bcdFile}}`);
 };

--- a/scripts/update-browser-releases/firefox.ts
+++ b/scripts/update-browser-releases/firefox.ts
@@ -160,6 +160,9 @@ export const updateFirefoxReleases = async (options) => {
   //
   // Write the JSON back into chrome.json
   //
-  fs.writeFileSync(`./${options.bcdFile}`, JSON.stringify(firefoxBCD, null, 2));
+  fs.writeFileSync(
+    `./${options.bcdFile}`,
+    JSON.stringify(firefoxBCD, null, 2) + '\n',
+  );
   console.log(`File generated succesfully: ${options.bcdFile}`);
 };

--- a/scripts/update-browser-releases/firefox.ts
+++ b/scripts/update-browser-releases/firefox.ts
@@ -100,14 +100,33 @@ export const updateFirefoxReleases = async (options) => {
   }
 
   //
-  // Set all older releases are 'retired'
+  // Set all older releases are 'retired' (and the current ESR to 'esr')
   //
+
+  // Find latest ESR
+
+  // Get the JSON with all released versions and their dates
+  const firefoxESRVersions = await fetch(options.firefoxESRDateURL);
+  const esrFirefoxVersions = await firefoxESRVersions.json();
+
+  // Extract the current esr version
+  let esrRelease = 1;
+
+  Object.entries(esrFirefoxVersions).forEach(([key]) => {
+    if (parseInt(key) > esrRelease) {
+      esrRelease = parseInt(key);
+    }
+  });
+
+  // Replace all old entries with 'retired' or 'esr'
   Object.entries(
     firefoxBCD.browsers[options.bcdBrowserName].releases as {
       [version: string]: ReleaseStatement;
     },
   ).forEach(([key, entry]) => {
-    if (parseFloat(key) < stableRelease) {
+    if (key === String(esrRelease)) {
+      entry.status = 'esr';
+    } else if (parseFloat(key) < stableRelease) {
       entry.status = 'retired';
     }
   });

--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -101,6 +101,7 @@ const options = {
     firstRelease: 1,
     skippedReleases: [],
     firefoxReleaseDateURL: 'https://whattrainisitnow.com/api/firefox/releases/',
+    firefoxESRDateURL: 'https://whattrainisitnow.com/api/esr/releases/',
     firefoxScheduleURL:
       'https://whattrainisitnow.com/api/release/schedule/?version=',
   },
@@ -112,6 +113,7 @@ const options = {
     firstRelease: 4,
     skippedReleases: [11, 12, 13, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78],
     firefoxReleaseDateURL: 'https://whattrainisitnow.com/api/firefox/releases/',
+    firefoxESRDateURL: 'https://whattrainisitnow.com/api/esr/releases/',
     firefoxScheduleURL:
       'https://whattrainisitnow.com/api/release/schedule/?version=',
   },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

There is a specificity in firefox.json. The latest ESR version is not tagged 'retired' but 'esr'. This fixes this problem. Note that if the current version is the ESR version, no entry is tagged 'esr'.

This PR also add a final CR at the end of the firefox.json and chrome.json files (also for android and webview), so that the files get closer to the manually edited ones in the past.

#### Notes

The only difference between files generated by the update script and manually edited ones is the ordering of the versions (lexicographic order vs "mathematical" order).

This will be fixed in a follow-up PR once the decision on the order has been taken.


#### Test results and supporting details

Manually tested.
![Capture d’écran 2023-10-23 à 07 17 30](https://github.com/mdn/browser-compat-data/assets/1466293/d3818307-66fa-4f35-a6ad-812896d476ec)
![Capture d’écran 2023-10-23 à 07 18 51](https://github.com/mdn/browser-compat-data/assets/1466293/c1c5e1be-7416-4736-89a7-39a5008f76b8)

