### PR TITLE
Advance Microsoft Edge 118 to stable

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -319,25 +319,26 @@
         "117": {
           "release_date": "2023-09-15",
           "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1170204531-september-15-2023",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "117"
         },
         "118": {
-          "release_date": "2023-10-12",
-          "status": "beta",
+          "release_date": "2023-10-13",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1180208846-october-13-2023",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "118"
         },
         "119": {
           "release_date": "2023-11-02",
-          "status": "nightly",
+          "status": "beta",
           "engine": "Blink",
           "engine_version": "119"
         },
         "120": {
           "release_date": "2023-12-07",
-          "status": "planned",
+          "status": "nightly",
           "engine": "Blink",
           "engine_version": "120"
         },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Change the status of Edge 118 to show that it's the current release.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

See: [Version 118.0.2088.46: October 13, 2023](https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1180208846-october-13-2023)
