### PR TITLE
content_security_policy: support firefox_android

### DIFF
--- a/webextensions/manifest/content_security_policy.json
+++ b/webextensions/manifest/content_security_policy.json
@@ -17,9 +17,7 @@
                 "Until Firefox 105, the <code>object-src</code> directive was required with a secure source. From Firefox 106, the <code>object-src</code> directive is optional."
               ]
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "opera": "mirror",
             "safari": {
               "version_added": "14",
@@ -47,9 +45,7 @@
                 "version_added": "72",
                 "notes": "Until Firefox 105, the <code>object-src</code> directive was required with a secure source. From Firefox 106, the <code>object-src</code> directive is optional."
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
                 "version_added": "15.4",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Support for the `content_security_policy` manifest key is platform-independent, and support should be mirrored (i.e. supported) instead of marked as unsupported.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Some relevant Firefox-side unit tests (note that these tests are not skipped on Android): https://searchfox.org/mozilla-central/rev/10d0e01455559a433670bd718a3ecc0ece5d2cb9/toolkit/components/extensions/test/xpcshell/test_ext_content_security_policy.js and https://searchfox.org/mozilla-central/rev/10d0e01455559a433670bd718a3ecc0ece5d2cb9/toolkit/components/extensions/test/xpcshell/test_ext_wasm.js

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

The mistake was introduced in https://github.com/mdn/browser-compat-data/pull/5325/commits/2fd95ae8e7e5820aec7602a1b8d9f61f4f4007a1.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
