### PR TITLE
docs(opera): updated current browsers release

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -777,14 +777,21 @@
         "103": {
           "release_date": "2023-10-03",
           "release_notes": "https://blogs.opera.com/desktop/2023/10/introducing-opera-103/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "117"
         },
         "104": {
-          "status": "beta",
+          "release_date": "2023-10-23",
+          "release_notes": "https://blogs.opera.com/desktop/2023/10/opera-104-stable/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "118"
+        },
+        "105": {
+          "status": "beta",
+          "engine": "Blink",
+          "engine_version": "119"
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Updated current Operas browser data, as version 104 has been release on 3rd of October:

https://blogs.opera.com/desktop/2023/10/opera-104-stable/

And Opera Beta currently already provides the upcoming version 105 with Chromium-Version 119

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
