### PR TITLE
(Experiment) Add tags to the schema & export a webfeatures tree

### DIFF
--- a/api/AbortController.json
+++ b/api/AbortController.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortController",
         "spec_url": "https://dom.spec.whatwg.org/#interface-abortcontroller",
+        "groups": [
+          "interfaces"
+        ],
         "support": {
           "chrome": {
             "version_added": "66"
@@ -53,6 +56,9 @@
           "description": "<code>AbortController()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortController/AbortController",
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-abortcontroller-abortcontroller①",
+          "groups": [
+            "constructors"
+          ],
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/AbortController.json
+++ b/api/AbortController.json
@@ -4,8 +4,8 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortController",
         "spec_url": "https://dom.spec.whatwg.org/#interface-abortcontroller",
-        "groups": [
-          "interfaces"
+        "tags": [
+          "type:interface"
         ],
         "support": {
           "chrome": {
@@ -56,9 +56,6 @@
           "description": "<code>AbortController()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortController/AbortController",
           "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-abortcontroller-abortcontroller①",
-          "groups": [
-            "constructors"
-          ],
           "support": {
             "chrome": {
               "version_added": "66"

--- a/api/IdleDetector.json
+++ b/api/IdleDetector.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector",
         "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector",
+        "groups": [
+          "idle-detection"
+        ],
         "support": {
           "chrome": {
             "version_added": "94"
@@ -46,6 +49,9 @@
           "description": "<code>IdleDetector()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/IdleDetector",
           "spec_url": "https://wicg.github.io/idle-detection/#dom-idledetector-idledetector",
+          "groups": [
+            "idle-detection"
+          ],
           "support": {
             "chrome": {
               "version_added": "94"
@@ -89,6 +95,9 @@
           "description": "<code>change</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/change_event",
           "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector-onchange",
+          "groups": [
+            "idle-detection"
+          ],
           "support": {
             "chrome": {
               "version_added": "94"
@@ -132,6 +141,9 @@
           "description": "<code>requestPermission()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/requestPermission_static",
           "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector-requestpermission",
+          "groups": [
+            "idle-detection"
+          ],
           "support": {
             "chrome": {
               "version_added": "94"
@@ -174,6 +186,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/screenState",
           "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector-screenstate",
+          "groups": [
+            "idle-detection"
+          ],
           "support": {
             "chrome": {
               "version_added": "94"
@@ -216,6 +231,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/start",
           "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector-start",
+          "groups": [
+            "idle-detection"
+          ],
           "support": {
             "chrome": {
               "version_added": "94"
@@ -258,6 +276,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/userState",
           "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector-userstate",
+          "groups": [
+            "idle-detection"
+          ],
           "support": {
             "chrome": {
               "version_added": "94"

--- a/api/IdleDetector.json
+++ b/api/IdleDetector.json
@@ -5,7 +5,8 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector",
         "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector",
         "groups": [
-          "idle-detection"
+          "idle-detection",
+          "interfaces"
         ],
         "support": {
           "chrome": {
@@ -50,7 +51,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/IdleDetector",
           "spec_url": "https://wicg.github.io/idle-detection/#dom-idledetector-idledetector",
           "groups": [
-            "idle-detection"
+            "idle-detection",
+            "constructors"
           ],
           "support": {
             "chrome": {

--- a/api/IdleDetector.json
+++ b/api/IdleDetector.json
@@ -4,9 +4,8 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector",
         "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector",
-        "groups": [
-          "idle-detection",
-          "interfaces"
+        "tags": [
+          "webfeatures:idle-detection"
         ],
         "support": {
           "chrome": {
@@ -50,9 +49,8 @@
           "description": "<code>IdleDetector()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/IdleDetector",
           "spec_url": "https://wicg.github.io/idle-detection/#dom-idledetector-idledetector",
-          "groups": [
-            "idle-detection",
-            "constructors"
+          "tags": [
+            "webfeatures:idle-detection"
           ],
           "support": {
             "chrome": {
@@ -97,8 +95,8 @@
           "description": "<code>change</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/change_event",
           "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector-onchange",
-          "groups": [
-            "idle-detection"
+          "tags": [
+            "webfeatures:idle-detection"
           ],
           "support": {
             "chrome": {
@@ -143,8 +141,8 @@
           "description": "<code>requestPermission()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/requestPermission_static",
           "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector-requestpermission",
-          "groups": [
-            "idle-detection"
+          "tags": [
+            "webfeatures:idle-detection"
           ],
           "support": {
             "chrome": {
@@ -188,8 +186,8 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/screenState",
           "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector-screenstate",
-          "groups": [
-            "idle-detection"
+          "tags": [
+            "webfeatures:idle-detection"
           ],
           "support": {
             "chrome": {
@@ -233,8 +231,8 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/start",
           "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector-start",
-          "groups": [
-            "idle-detection"
+          "tags": [
+            "webfeatures:idle-detection"
           ],
           "support": {
             "chrome": {
@@ -278,8 +276,8 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/userState",
           "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector-userstate",
-          "groups": [
-            "idle-detection"
+          "tags": [
+            "webfeatures:idle-detection"
           ],
           "support": {
             "chrome": {

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -764,6 +764,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/idle-detection",
             "spec_url": "https://wicg.github.io/idle-detection/#api-permissions-policy",
+            "groups": [
+              "idle-detection"
+            ],
             "support": {
               "chrome": {
                 "version_added": "94"

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -764,8 +764,8 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/idle-detection",
             "spec_url": "https://wicg.github.io/idle-detection/#api-permissions-policy",
-            "groups": [
-              "idle-detection"
+            "tags": [
+              "webfeatures:idle-detection"
             ],
             "support": {
               "chrome": {

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -203,8 +203,8 @@
           "type": "string",
           "description": "A string containing a human-readable description of the feature."
         },
-        "groups": {
-          "description": "An optional array of strings indicating the groups this feature belongs to.",
+        "tags": {
+          "description": "An optional array of strings allowing to assign tags to the feature.",
           "type": "array",
           "minItems": 1,
           "tsType": "string[]"

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -203,6 +203,12 @@
           "type": "string",
           "description": "A string containing a human-readable description of the feature."
         },
+        "groups": {
+          "description": "An optional array of strings indicating the groups this feature belongs to.",
+          "type": "array",
+          "minItems": 1,
+          "tsType": "string[]"
+        },
         "mdn_url": {
           "type": "string",
           "format": "uri",

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -30,7 +30,8 @@ const compatDataTypes = {
   css: 'Contains data for [CSS](https://developer.mozilla.org/docs/Web/CSS) properties, selectors, and at-rules.',
   html: 'Contains data for [HTML](https://developer.mozilla.org/docs/Web/HTML) elements, attributes, and global attributes.',
   http: 'Contains data for [HTTP](https://developer.mozilla.org/docs/Web/HTTP) headers, statuses, and methods.',
-  groups: 'Contains group data',
+  webfeatures:
+    'Contains grouped compatibility data tagged with "webfeatures:GROUPNAME',
   javascript:
     'Contains data for [JavaScript](https://developer.mozilla.org/docs/Web/JavaScript) built-in Objects, statement, operators, and other ECMAScript language features.',
   mathml:
@@ -88,8 +89,8 @@ const generateCompatDataTypes = (): string => {
           ? 'MetaBlock'
           : t[0] === 'browsers'
           ? 'Browsers'
-          : t[0] === 'groups'
-          ? 'Group[]'
+          : t[0] === 'webfeatures'
+          ? 'WebFeature[]'
           : 'Identifier'
       };`,
   );
@@ -97,10 +98,10 @@ const generateCompatDataTypes = (): string => {
   const metaType =
     'export interface MetaBlock {\n  version: string;\n  timestamp: string;\n}';
 
-  const groupType =
-    'export interface Group {\n  id: string;\n  features: string[];\n}';
+  const webFeatureType =
+    'export interface WebFeature {\n  id: string;\n  features: string[];\n compat: CompatStatement\n}';
 
-  return `${metaType}\n\n${groupType}\n\nexport interface CompatData {\n${props.join(
+  return `${metaType}\n\n${webFeatureType}\n\nexport interface CompatData {\n${props.join(
     '\n\n',
   )}\n}\n`;
 };

--- a/scripts/generate-types.ts
+++ b/scripts/generate-types.ts
@@ -30,6 +30,7 @@ const compatDataTypes = {
   css: 'Contains data for [CSS](https://developer.mozilla.org/docs/Web/CSS) properties, selectors, and at-rules.',
   html: 'Contains data for [HTML](https://developer.mozilla.org/docs/Web/HTML) elements, attributes, and global attributes.',
   http: 'Contains data for [HTTP](https://developer.mozilla.org/docs/Web/HTTP) headers, statuses, and methods.',
+  groups: 'Contains group data',
   javascript:
     'Contains data for [JavaScript](https://developer.mozilla.org/docs/Web/JavaScript) built-in Objects, statement, operators, and other ECMAScript language features.',
   mathml:
@@ -87,6 +88,8 @@ const generateCompatDataTypes = (): string => {
           ? 'MetaBlock'
           : t[0] === 'browsers'
           ? 'Browsers'
+          : t[0] === 'groups'
+          ? 'Group[]'
           : 'Identifier'
       };`,
   );
@@ -94,7 +97,10 @@ const generateCompatDataTypes = (): string => {
   const metaType =
     'export interface MetaBlock {\n  version: string;\n  timestamp: string;\n}';
 
-  return `${metaType}\n\nexport interface CompatData {\n${props.join(
+  const groupType =
+    'export interface Group {\n  id: string;\n  features: string[];\n}';
+
+  return `${metaType}\n\n${groupType}\n\nexport interface CompatData {\n${props.join(
     '\n\n',
   )}\n}\n`;
 };

--- a/scripts/lib/stringify-and-order-properties.ts
+++ b/scripts/lib/stringify-and-order-properties.ts
@@ -36,7 +36,7 @@ const propOrder = {
       'description',
       'mdn_url',
       'spec_url',
-      'matches',
+      'groups',
       'support',
       'status',
     ],

--- a/scripts/lib/stringify-and-order-properties.ts
+++ b/scripts/lib/stringify-and-order-properties.ts
@@ -36,7 +36,7 @@ const propOrder = {
       'description',
       'mdn_url',
       'spec_url',
-      'groups',
+      'tags',
       'support',
       'status',
     ],

--- a/scripts/traverse.ts
+++ b/scripts/traverse.ts
@@ -14,7 +14,7 @@ import bcd from '../index.js';
  * @param {BrowserName[]} browsers The browsers to test for
  * @param {string[]} values The values to test for
  * @param {number} depth The depth to traverse
- * @param {string} group The group to filter results with
+ * @param {string} tag The tag to filter results with
  * @param {string} identifier The identifier of the current object
  * @yields {string} The feature identifier
  */
@@ -23,7 +23,7 @@ function* iterateFeatures(
   browsers: BrowserName[],
   values: string[],
   depth: number,
-  group: string,
+  tag: string,
   identifier: string,
 ): IterableIterator<string> {
   depth--;
@@ -31,9 +31,9 @@ function* iterateFeatures(
     for (const i in obj) {
       if (!!obj[i] && typeof obj[i] == 'object' && i !== '__compat') {
         if (obj[i].__compat) {
-          if (group) {
-            const groups = obj[i].__compat.groups;
-            if (groups && groups.includes(group)) {
+          if (tag) {
+            const tags = obj[i].__compat.tags;
+            if (tags && tags.includes(tag)) {
               yield `${identifier}${i}`;
             }
           } else {
@@ -86,7 +86,7 @@ function* iterateFeatures(
           browsers,
           values,
           depth,
-          group,
+          tag,
           identifier + i + '.',
         );
       }
@@ -100,7 +100,7 @@ function* iterateFeatures(
  * @param {string[]} browsers The browsers to traverse for
  * @param {string[]} values The version values to traverse for
  * @param {number} depth The depth to traverse
- * @param {string} group The group to filter results with
+ * @param {string} tag The tag to filter results with
  * @param {string} identifier The identifier of the current object
  * @returns {string[]} An array of the features
  */
@@ -109,11 +109,11 @@ const traverseFeatures = (
   browsers: BrowserName[],
   values: string[],
   depth: number,
-  group: string,
+  tag: string,
   identifier: string,
 ): string[] => {
   const features = Array.from(
-    iterateFeatures(obj, browsers, values, depth, group, identifier),
+    iterateFeatures(obj, browsers, values, depth, tag, identifier),
   );
 
   return features.filter((item, pos) => features.indexOf(item) == pos);
@@ -125,7 +125,7 @@ const traverseFeatures = (
  * @param {BrowserName[]} browsers The browsers to traverse for
  * @param {string[]} values The version values to traverse for
  * @param {number} depth The depth to traverse
- * @param {string} group The group to filter results with
+ * @param {string} tag The tag to filter results with
  * @returns {string[]} The list of features
  */
 const main = (
@@ -143,7 +143,7 @@ const main = (
   browsers: BrowserName[] = Object.keys(bcd.browsers) as BrowserName[],
   values = ['null', 'true'],
   depth = 100,
-  group = '',
+  tag = '',
 ): string[] => {
   const features: string[] = [];
 
@@ -154,7 +154,7 @@ const main = (
         browsers,
         values,
         depth,
-        group,
+        tag,
         folders[folder] + '.',
       ),
     );
@@ -191,9 +191,9 @@ if (esMain(import.meta)) {
           nargs: 1,
           default: [],
         })
-        .option('group', {
-          alias: 'g',
-          describe: 'Filter by group value.',
+        .option('tag', {
+          alias: 't',
+          describe: 'Filter by tag value.',
           type: 'string',
           nargs: 1,
           default: '',
@@ -230,8 +230,8 @@ if (esMain(import.meta)) {
           'Find all features in Samsung Internet that mirror data from Chrome Android',
         )
         .example(
-          'npm run traverse -- -g idle-detection',
-          'Find all features that belong to the idle-detection group',
+          'npm run traverse -- -t webfeatures:idle-detection',
+          'Find all features tagged with webfeatures:idle-detection.',
         );
     },
   );
@@ -243,7 +243,7 @@ if (esMain(import.meta)) {
     argv.browser,
     filter,
     argv.depth,
-    argv.group,
+    argv.tag,
   );
   console.log(features.join('\n'));
   console.log(features.length);

--- a/scripts/traverse.ts
+++ b/scripts/traverse.ts
@@ -14,6 +14,7 @@ import bcd from '../index.js';
  * @param {BrowserName[]} browsers The browsers to test for
  * @param {string[]} values The values to test for
  * @param {number} depth The depth to traverse
+ * @param {string} group The group to filter results with
  * @param {string} identifier The identifier of the current object
  * @yields {string} The feature identifier
  */
@@ -22,6 +23,7 @@ function* iterateFeatures(
   browsers: BrowserName[],
   values: string[],
   depth: number,
+  group: string,
   identifier: string,
 ): IterableIterator<string> {
   depth--;
@@ -29,45 +31,52 @@ function* iterateFeatures(
     for (const i in obj) {
       if (!!obj[i] && typeof obj[i] == 'object' && i !== '__compat') {
         if (obj[i].__compat) {
-          const comp = obj[i].__compat.support;
-          for (const browser of browsers) {
-            let browserData = comp[browser];
-
-            if (!browserData) {
-              if (values.length == 0 || values.includes('null')) {
-                yield `${identifier}${i}`;
-              }
-              continue;
+          if (group) {
+            const groups = obj[i].__compat.groups;
+            if (groups && groups.includes(group)) {
+              yield `${identifier}${i}`;
             }
-            if (!Array.isArray(browserData)) {
-              browserData = [browserData];
-            }
+          } else {
+            const comp = obj[i].__compat.support;
+            for (const browser of browsers) {
+              let browserData = comp[browser];
 
-            for (const range in browserData) {
-              if (browserData[range] === 'mirror') {
-                if (values.includes('mirror')) {
-                  yield `${identifier}${i}`;
-                }
-              } else if (values.includes('nonmirror')) {
-                // If checking for non-mirrored data and it's not mirrored
-                yield `${identifier}${i}`;
-              } else if (browserData[range] === undefined) {
+              if (!browserData) {
                 if (values.length == 0 || values.includes('null')) {
                   yield `${identifier}${i}`;
                 }
-              } else if (
-                values.length == 0 ||
-                values.includes(String(browserData[range].version_added)) ||
-                values.includes(String(browserData[range].version_removed))
-              ) {
-                let f = `${identifier}${i}`;
-                if (browserData[range].prefix) {
-                  f += ` (${browserData[range].prefix} prefix)`;
+                continue;
+              }
+              if (!Array.isArray(browserData)) {
+                browserData = [browserData];
+              }
+
+              for (const range in browserData) {
+                if (browserData[range] === 'mirror') {
+                  if (values.includes('mirror')) {
+                    yield `${identifier}${i}`;
+                  }
+                } else if (values.includes('nonmirror')) {
+                  // If checking for non-mirrored data and it's not mirrored
+                  yield `${identifier}${i}`;
+                } else if (browserData[range] === undefined) {
+                  if (values.length == 0 || values.includes('null')) {
+                    yield `${identifier}${i}`;
+                  }
+                } else if (
+                  values.length == 0 ||
+                  values.includes(String(browserData[range].version_added)) ||
+                  values.includes(String(browserData[range].version_removed))
+                ) {
+                  let f = `${identifier}${i}`;
+                  if (browserData[range].prefix) {
+                    f += ` (${browserData[range].prefix} prefix)`;
+                  }
+                  if (browserData[range].alternative_name) {
+                    f += ` (as ${browserData[range].alternative_name})`;
+                  }
+                  yield f;
                 }
-                if (browserData[range].alternative_name) {
-                  f += ` (as ${browserData[range].alternative_name})`;
-                }
-                yield f;
               }
             }
           }
@@ -77,6 +86,7 @@ function* iterateFeatures(
           browsers,
           values,
           depth,
+          group,
           identifier + i + '.',
         );
       }
@@ -90,6 +100,7 @@ function* iterateFeatures(
  * @param {string[]} browsers The browsers to traverse for
  * @param {string[]} values The version values to traverse for
  * @param {number} depth The depth to traverse
+ * @param {string} group The group to filter results with
  * @param {string} identifier The identifier of the current object
  * @returns {string[]} An array of the features
  */
@@ -98,10 +109,11 @@ const traverseFeatures = (
   browsers: BrowserName[],
   values: string[],
   depth: number,
+  group: string,
   identifier: string,
 ): string[] => {
   const features = Array.from(
-    iterateFeatures(obj, browsers, values, depth, identifier),
+    iterateFeatures(obj, browsers, values, depth, group, identifier),
   );
 
   return features.filter((item, pos) => features.indexOf(item) == pos);
@@ -113,6 +125,7 @@ const traverseFeatures = (
  * @param {BrowserName[]} browsers The browsers to traverse for
  * @param {string[]} values The version values to traverse for
  * @param {number} depth The depth to traverse
+ * @param {string} group The group to filter results with
  * @returns {string[]} The list of features
  */
 const main = (
@@ -130,6 +143,7 @@ const main = (
   browsers: BrowserName[] = Object.keys(bcd.browsers) as BrowserName[],
   values = ['null', 'true'],
   depth = 100,
+  group = '',
 ): string[] => {
   const features: string[] = [];
 
@@ -140,6 +154,7 @@ const main = (
         browsers,
         values,
         depth,
+        group,
         folders[folder] + '.',
       ),
     );
@@ -176,6 +191,13 @@ if (esMain(import.meta)) {
           nargs: 1,
           default: [],
         })
+        .option('group', {
+          alias: 'g',
+          describe: 'Filter by group value.',
+          type: 'string',
+          nargs: 1,
+          default: '',
+        })
         .option('non-real', {
           alias: 'n',
           describe:
@@ -206,13 +228,23 @@ if (esMain(import.meta)) {
         .example(
           'npm run traverse -- -b samsunginternet_android -f mirror',
           'Find all features in Samsung Internet that mirror data from Chrome Android',
+        )
+        .example(
+          'npm run traverse -- -g idle-detection',
+          'Find all features that belong to the idle-detection group',
         );
     },
   );
 
   const filter = [...argv.filter, ...(argv.nonReal ? ['true', 'null'] : [])];
 
-  const features = main(argv.folder, argv.browser, filter, argv.depth);
+  const features = main(
+    argv.folder,
+    argv.browser,
+    filter,
+    argv.depth,
+    argv.group,
+  );
   console.log(features.join('\n'));
   console.log(features.length);
 }


### PR DESCRIPTION
This draft PR is playing with the idea that compat features have tags. I'm experimenting with a few things here:

## `tags` added to `__compat`

Adding a new optional property at the feature level called "tags". It's always an array. It should always be namespaced for validation purposes. The namespace "type:" is just for illustration of future extensions. The only allowed tag namespace this experiment introduces for now is "webfeatures:".
```json
 "tags": [
   "webfeatures:idle-detection",
   "type:interface"
],
```

## Exporting a new `webfeatures` tree

Adding a new "webfeatures" export structure to the BCD build. It is an array of objects collected from BCD features that are tagged with the "webfeatures:GROUPNAME" tag. The object is a WebFeature object with three properties: id (name of the group), features (array of BCD paths), and compat (a computed compat statement from all of the BCD paths):
```json
"webfeatures": [
  {
   "id": "idle-detection" 
   "features": [
      "api.IdleDetector",
      "api.IdleDetector.IdleDetector",
      "api.IdleDetector.change_event",
      "api.IdleDetector.requestPermission_static",
      "api.IdleDetector.screenState",
      "api.IdleDetector.start",
      "api.IdleDetector.userState",
      "http.headers.Permissions-Policy.idle-detection"
    ],
   "compat": { }
  }
],
```

## Contribution tools

### View all features tagged at contribution time
To view which features are part of which tags at contribution time, run the traverse script with a new `tag`/`t` argument: `npm run traverse -- -t webfeatures:idle-detection`. This spits out:
```
api.IdleDetector
api.IdleDetector.IdleDetector
api.IdleDetector.change_event
api.IdleDetector.requestPermission_static
api.IdleDetector.screenState
api.IdleDetector.start
api.IdleDetector.userState
http.headers.Permissions-Policy.idle-detection
8
```

### Applying tags to many features at once

Still to be done. Envision a command line tool here.

`npm run tag apply FEATUREPATH`
`npm run tag remove FEATUREPATH` etc.

## Tag validation

Still to be done. Allow-list? Via web-features? Via a file in BCD?