### PR TITLE
Collector results for Firefox 119

### DIFF
--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -224,7 +224,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "119"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -7606,7 +7606,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "119"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -148,7 +148,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "119"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
I've run the collector for the Firefox 119 release.

This PR sets the following features as shipping in 119:
- api.AuthenticatorAttestationResponse.getTransports (confirmed by https://bugzilla.mozilla.org/show_bug.cgi?id=1536155)
- api.ElementInternals.role (oversight in https://github.com/mdn/browser-compat-data/pull/20911?)
- api.PublicKeyCredential.isConditionalMediationAvailable_static (confirmed by https://bugzilla.mozilla.org/show_bug.cgi?id=1813778)

The following features are already marked as shipping in Firefox 119 in BCD:

- api.AuthenticatorAttestationResponse.getAuthenticatorData
- api.AuthenticatorAttestationResponse.getPublicKey
- api.AuthenticatorAttestationResponse.getPublicKeyAlgorithm
- api.CredentialsContainer.create.publicKey_option.extensions.credProps
- api.Element.ariaAtomic
- api.Element.ariaAutoComplete
- api.Element.ariaBusy
- api.Element.ariaChecked
- api.Element.ariaColCount
- api.Element.ariaColIndex
- api.Element.ariaColSpan
- api.Element.ariaCurrent
- api.Element.ariaDescription
- api.Element.ariaDisabled
- api.Element.ariaExpanded
- api.Element.ariaHasPopup
- api.Element.ariaHidden
- api.Element.ariaInvalid
- api.Element.ariaKeyShortcuts
- api.Element.ariaLabel
- api.Element.ariaLevel
- api.Element.ariaLive
- api.Element.ariaModal
- api.Element.ariaMultiLine
- api.Element.ariaMultiSelectable
- api.Element.ariaOrientation
- api.Element.ariaPlaceholder
- api.Element.ariaPosInSet
- api.Element.ariaPressed
- api.Element.ariaReadOnly
- api.Element.ariaRelevant
- api.Element.ariaRequired
- api.Element.ariaRoleDescription
- api.Element.ariaRowCount
- api.Element.ariaRowIndex
- api.Element.ariaRowSpan
- api.Element.ariaSelected
- api.Element.ariaSetSize
- api.Element.ariaSort
- api.Element.ariaValueMax
- api.Element.ariaValueMin
- api.Element.ariaValueNow
- api.Element.ariaValueText
- api.Element.role
- api.ElementInternals.ariaAtomic
- api.ElementInternals.ariaAutoComplete
- api.ElementInternals.ariaBusy
- api.ElementInternals.ariaChecked
- api.ElementInternals.ariaColCount
- api.ElementInternals.ariaColIndex
- api.ElementInternals.ariaColSpan
- api.ElementInternals.ariaCurrent
- api.ElementInternals.ariaDescription
- api.ElementInternals.ariaDisabled
- api.ElementInternals.ariaExpanded
- api.ElementInternals.ariaHasPopup
- api.ElementInternals.ariaHidden
- api.ElementInternals.ariaInvalid
- api.ElementInternals.ariaKeyShortcuts
- api.ElementInternals.ariaLabel
- api.ElementInternals.ariaLevel
- api.ElementInternals.ariaLive
- api.ElementInternals.ariaModal
- api.ElementInternals.ariaMultiLine
- api.ElementInternals.ariaMultiSelectable
- api.ElementInternals.ariaOrientation
- api.ElementInternals.ariaPlaceholder
- api.ElementInternals.ariaPosInSet
- api.ElementInternals.ariaPressed
- api.ElementInternals.ariaReadOnly
- api.ElementInternals.ariaRelevant
- api.ElementInternals.ariaRequired
- api.ElementInternals.ariaRoleDescription
- api.ElementInternals.ariaRowCount
- api.ElementInternals.ariaRowIndex
- api.ElementInternals.ariaRowSpan
- api.ElementInternals.ariaSelected
- api.ElementInternals.ariaSetSize
- api.ElementInternals.ariaSort
- api.ElementInternals.ariaValueMax
- api.ElementInternals.ariaValueMin
- api.ElementInternals.ariaValueNow
- api.ElementInternals.ariaValueText
- api.PublicKeyCredential.parseCreationOptionsFromJSON_static
- api.PublicKeyCredential.parseRequestOptionsFromJSON_static
- api.PublicKeyCredential.toJSON
- api.SubtleCrypto.deriveKey.derivedKeyAlgorithm_option_hkdf
- api.WebTransport.createBidirectionalStream.options_sendOrder_parameter
- api.WebTransport.createUnidirectionalStream.options_sendOrder_parameter
- css.types.attr.fallback
- html.elements.input.mozactionhint
- http.headers.Cross-Origin-Embedder-Policy.credentialless
- javascript.builtins.Map.groupBy
- javascript.builtins.Object.groupBy
- javascript.builtins.String.isWellFormed
- javascript.builtins.String.toWellFormed

cc @Rumyra and @bsmth maybe you want to double check this against the Firefox 119 releases notes.