### PR TITLE
Add speculation rules prerender key

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -785,6 +785,41 @@
                 }
               }
             },
+            "prerender": {
+              "__compat": {
+                "description": "<code>prerender</code> key",
+                "support": {
+                  "chrome": {
+                    "version_added": "105"
+                  },
+                  "chrome_android": {
+                    "version_added": "103"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
             "referrer_policy": {
               "__compat": {
                 "description": "<code>referrer_policy</code> key",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

The speculation rules data was added by @chrisdavidmills in https://github.com/mdn/browser-compat-data/pull/20742 with a specific note that prefetch was added later. That's fine and correct but given we have a separate `prefetch` key we should also have a `prerender` key with the earlier versions to make this super clear.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://chromestatus.com/feature/5355965538893824
https://chromestatus.com/feature/4899735257743360

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

https://github.com/mdn/browser-compat-data/pull/20742

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
