### PR TITLE
Improve logs for update-browser-versions

### DIFF
--- a/scripts/update-browser-releases/chrome.ts
+++ b/scripts/update-browser-releases/chrome.ts
@@ -41,7 +41,7 @@ const getReleaseNotesURL = async (version, date, core, status) => {
   if (releaseNote.status == 200) {
     return url;
   }
-  console.warn(chalk`{red Release note not found for ${version}}`);
+  console.log(chalk`{red \nRelease note not found for ${version}}`);
   return '';
 };
 
@@ -143,8 +143,8 @@ export const updateChromiumReleases = async (options) => {
       } else {
         // There is a retired version missing. Chromestatus doesn't list them.
         // There is an oddity: the version is not skipped but not in chromestatus
-        console.warn(
-          chalk`{yellow Chrome ${i} not found in Chromestatus! Add it manually or add an exception.}`,
+        console.log(
+          chalk`{yellow \nChrome ${i} not found in Chromestatus! Add it manually or add an exception.}`,
         );
       }
     }
@@ -181,6 +181,4 @@ export const updateChromiumReleases = async (options) => {
   // Write the update browser's json to file
   //
   fs.writeFileSync(`./${options.bcdFile}`, sortStringify(chromeBCD, '') + '\n');
-
-  console.log(chalk`{bold File generated successfully: ${options.bcdFile}}`);
 };

--- a/scripts/update-browser-releases/chrome.ts
+++ b/scripts/update-browser-releases/chrome.ts
@@ -98,9 +98,9 @@ export const updateChromiumReleases = async (options) => {
     ) {
       // The entry already exists
       updateBrowserEntry(
-        chromeBCD.browsers[options.bcdBrowserName].releases[
-          data[value].version
-        ],
+        chromeBCD,
+        options.bcdBrowserName,
+        data[value].version,
         data[value].releaseDate,
         key,
         releaseNotesURL,
@@ -129,9 +129,15 @@ export const updateChromiumReleases = async (options) => {
   ) {
     if (!options.skippedReleases.includes(i)) {
       if (chromeBCD.browsers[options.bcdBrowserName].releases[i.toString()]) {
-        chromeBCD.browsers[options.bcdBrowserName].releases[
-          i.toString()
-        ].status = 'retired';
+        updateBrowserEntry(
+          chromeBCD,
+          options.bcdBrowserName,
+          i.toString(),
+          chromeBCD.browsers[options.bcdBrowserName].releases[i.toString()]
+            .release_date,
+          'retired',
+          '',
+        );
       } else {
         // There is a retired version missing. Chromestatus doesn't list them.
         // There is an oddity: the version is not skipped but not in chromestatus
@@ -145,20 +151,23 @@ export const updateChromiumReleases = async (options) => {
   //
   // Add a planned version entry
   //
-  if (
-    chromeBCD.browsers[options.bcdBrowserName].releases[
-      (data[options.nightlyBranch].version + 1).toString()
-    ]
-  ) {
-    chromeBCD.browsers[options.bcdBrowserName].releases[
-      (data[options.nightlyBranch].version + 1).toString()
-    ].status = 'planned';
+  const plannedVersion = (data[options.nightlyBranch].version + 1).toString();
+  if (chromeBCD.browsers[options.bcdBrowserName].releases[plannedVersion]) {
+    updateBrowserEntry(
+      chromeBCD,
+      options.bcdBrowserName,
+      plannedVersion,
+      chromeBCD.browsers[options.bcdBrowserName].releases[plannedVersion]
+        .release_date,
+      'planned',
+      '',
+    );
   } else {
     // New entry
     newBrowserEntry(
       chromeBCD,
       options.bcdBrowserName,
-      (data[options.nightlyBranch].version + 1).toString(),
+      plannedVersion,
       'planned',
       options.browserEngine,
       '',

--- a/scripts/update-browser-releases/chrome.ts
+++ b/scripts/update-browser-releases/chrome.ts
@@ -9,12 +9,13 @@ import { newBrowserEntry, updateBrowserEntry, sortStringify } from './utils.js';
 
 /**
  * getReleaseNotesURL - Guess the URL of the release notes
+ * @param {string} version Version number
  * @param {string} date Date in the format YYYYMMDD
  * @param {string} core The core of the name of the release note
  * @param {string} status The status of the release
  * @returns {string} The URL of the release notes or the empty string if not found
  */
-const getReleaseNotesURL = async (date, core, status) => {
+const getReleaseNotesURL = async (version, date, core, status) => {
   // If the status isn't stable, do not give back any release notes.
   if (status !== 'stable') {
     return '';
@@ -40,7 +41,7 @@ const getReleaseNotesURL = async (date, core, status) => {
   if (releaseNote.status == 200) {
     return url;
   }
-  console.warn(chalk`{yellow Release note not found}`);
+  console.warn(chalk`{red Release note not found for ${version}}`);
   return '';
 };
 
@@ -88,6 +89,7 @@ export const updateChromiumReleases = async (options) => {
 
     // Update the JSON in memory
     const releaseNotesURL = await getReleaseNotesURL(
+      versionData.version,
       data[value].releaseDate,
       options.releaseNoteCore,
       value,

--- a/scripts/update-browser-releases/edge.ts
+++ b/scripts/update-browser-releases/edge.ts
@@ -5,7 +5,7 @@ import * as fs from 'node:fs';
 
 import chalk from 'chalk-template';
 
-import { newBrowserEntry, updateBrowserEntry } from './utils.js';
+import { newBrowserEntry, updateBrowserEntry, sortStringify } from './utils.js';
 
 /**
  * getFutureReleaseDate - Read the future release date
@@ -212,7 +212,9 @@ export const updateEdgeReleases = async (options) => {
     ) {
       // The entry already exists
       updateBrowserEntry(
-        edgeBCD.browsers[options.bcdBrowserName].releases[data[value].version],
+        edgeBCD,
+        options.bcdBrowserName,
+        data[value].version,
         data[value]?.versionDate,
         key,
         releaseNotesURL,
@@ -264,7 +266,9 @@ export const updateEdgeReleases = async (options) => {
 
   if (edgeBCD.browsers[options.bcdBrowserName].releases[planned]) {
     updateBrowserEntry(
-      edgeBCD.browsers[options.bcdBrowserName].releases[planned],
+      edgeBCD,
+      options.bcdBrowserName,
+      planned,
       releaseDate,
       'planned',
       '',
@@ -289,7 +293,7 @@ export const updateEdgeReleases = async (options) => {
   //
   fs.writeFileSync(
     `./${options.bcdFile}`,
-    JSON.stringify(edgeBCD, null, 2) + '\n',
+    sortStringify(edgeBCD, '') + '\n',
   );
   console.log(chalk`{bold File generated successfully: ${options.bcdFile}}`);
 };

--- a/scripts/update-browser-releases/edge.ts
+++ b/scripts/update-browser-releases/edge.ts
@@ -291,8 +291,5 @@ export const updateEdgeReleases = async (options) => {
   //
   // Write the update browser's json to file
   //
-  fs.writeFileSync(
-    `./${options.bcdFile}`,
-    sortStringify(edgeBCD, '') + '\n',
-  );
+  fs.writeFileSync(`./${options.bcdFile}`, sortStringify(edgeBCD, '') + '\n');
 };

--- a/scripts/update-browser-releases/edge.ts
+++ b/scripts/update-browser-releases/edge.ts
@@ -18,7 +18,7 @@ const getFutureReleaseDate = async (release, releaseScheduleURL) => {
   const scheduleMD = await fetch(releaseScheduleURL);
   const text = await scheduleMD.text();
   if (!text) {
-    console.error(chalk`{red Release file not found.}`);
+    console.log(chalk`{red \nRelease file not found.}`);
     return '';
   }
   // Find the line
@@ -29,7 +29,7 @@ const getFutureReleaseDate = async (release, releaseScheduleURL) => {
   );
   const result = text.match(regexp);
   if (!result) {
-    console.log(chalk`{yellow Release date not found for Edge ${release}.}`);
+    console.log(chalk`{yellow \nRelease date not found for Edge ${release}.}`);
     return '';
   }
   const releaseDateText = result[1];
@@ -99,8 +99,8 @@ const getReleaseNotesURL = async (status, fullRelease, date) => {
   const releaseNote = await fetch(URL);
   if (releaseNote.status != 200) {
     // File not found -> log a warning
-    console.warn(
-      chalk`{red Release note files not found for Edge ${fullRelease}}`,
+    console.log(
+      chalk`{red \nRelease note files not found for Edge ${fullRelease}}`,
     );
     return '';
   }
@@ -109,8 +109,8 @@ const getReleaseNotesURL = async (status, fullRelease, date) => {
   const releaseNoteText = await releaseNote.text();
   if (releaseNoteText.indexOf(`<h2 id="${id}">`) == -1) {
     // Section not found -> log a warning
-    console.warn(
-      chalk`{red Section not found in official release notes for Edge ${fullRelease}}`,
+    console.log(
+      chalk`{red \nSection not found in official release notes for Edge ${fullRelease}}`,
     );
   }
 
@@ -248,8 +248,8 @@ export const updateEdgeReleases = async (options) => {
       } else {
         // There is a retired version missing. Edgeupdates doesn't list them.
         // There is an oddity: the version is not skipped but not in edgeupdates
-        console.warn(
-          chalk`{yellow Edge ${i} not found in Edgeupdates! Add it manually or add an exception.}`,
+        console.log(
+          chalk`{yellow \nEdge ${i} not found in Edgeupdates! Add it manually or add an exception.}`,
         );
       }
     }
@@ -295,5 +295,4 @@ export const updateEdgeReleases = async (options) => {
     `./${options.bcdFile}`,
     sortStringify(edgeBCD, '') + '\n',
   );
-  console.log(chalk`{bold File generated successfully: ${options.bcdFile}}`);
 };

--- a/scripts/update-browser-releases/firefox.ts
+++ b/scripts/update-browser-releases/firefox.ts
@@ -184,6 +184,4 @@ export const updateFirefoxReleases = async (options) => {
     `./${options.bcdFile}`,
     sortStringify(firefoxBCD, '') + '\n',
   );
-
-  console.log(`File generated succesfully: ${options.bcdFile}`);
 };

--- a/scripts/update-browser-releases/firefox.ts
+++ b/scripts/update-browser-releases/firefox.ts
@@ -76,9 +76,13 @@ export const updateFirefoxReleases = async (options) => {
       data[value].releaseDate = releasedFirefoxVersions[stableRelease + '.0'];
     }
 
-    if (firefoxBCD.browsers[options.bcdBrowserName].releases[key]) {
+    if (
+      firefoxBCD.browsers[options.bcdBrowserName].releases[data[value].version]
+    ) {
       updateBrowserEntry(
-        firefoxBCD.browsers[options.bcdBrowserName].releases[key],
+        firefoxBCD,
+        options.bcdBrowserName,
+        data[value].version,
         data[value].releaseDate,
         key,
         releaseNotesURL,
@@ -123,9 +127,23 @@ export const updateFirefoxReleases = async (options) => {
     },
   ).forEach(([key, entry]) => {
     if (key === String(esrRelease)) {
-      entry.status = 'esr';
+      updateBrowserEntry(
+        firefoxBCD,
+        options.bcdBrowserName,
+        key,
+        entry.release_date,
+        'esr',
+        '',
+      );
     } else if (parseFloat(key) < stableRelease) {
-      entry.status = 'retired';
+      updateBrowserEntry(
+        firefoxBCD,
+        options.bcdBrowserName,
+        key,
+        entry.release_date,
+        'retired',
+        '',
+      );
     }
   });
 
@@ -138,10 +156,14 @@ export const updateFirefoxReleases = async (options) => {
   const train = await trainInfo.json();
 
   if (firefoxBCD.browsers[options.bcdBrowserName].releases[planned]) {
-    firefoxBCD.browsers[options.bcdBrowserName].releases[planned].release_date =
-      train.release.substring(0, 10); // Remove the time part
-    firefoxBCD.browsers[options.bcdBrowserName].releases[planned].status =
-      'planned';
+    updateBrowserEntry(
+      firefoxBCD,
+      options.bcdBrowserName,
+      planned,
+      train.release.substring(0, 10),
+      'planned',
+      '',
+    );
   } else {
     // New entry
     newBrowserEntry(

--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -146,31 +146,31 @@ const options = {
 };
 
 if (updateChrome && updateDesktop) {
-  console.log('Check Chrome for Desktop.');
+  console.log('### Updates for Chrome for Desktop.');
   await updateChromiumReleases(options.chrome_desktop);
 }
 
 if (updateChrome && updateMobile) {
-  console.log('Check Chrome for Android.');
+  console.log('### Updates for Chrome for Android.');
   await updateChromiumReleases(options.chrome_android);
 }
 
 if (updateWebview && updateMobile) {
-  console.log('Check Webview for Android.');
+  console.log('### Updates for Webview for Android.');
   await updateChromiumReleases(options.webview_android);
 }
 
 if (updateEdge && updateDesktop) {
-  console.log('Check Edge for Desktop.');
+  console.log('### Updates for Edge for Desktop.');
   await updateEdgeReleases(options.edge_desktop);
 }
 
 if (updateFirefox && updateDesktop) {
-  console.log('Check Firefox for Desktop.');
+  console.log('### Updates for Firefox for Desktop.');
   await updateFirefoxReleases(options.firefox_desktop);
 }
 
 if (updateFirefox && updateMobile) {
-  console.log('Check Firefox for Android.');
+  console.log('### Updates for Firefox for Android.');
   await updateFirefoxReleases(options.firefox_android);
 }

--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -151,7 +151,7 @@ if (updateChrome && updateDesktop) {
 }
 
 if (updateChrome && updateMobile) {
-  console.log('### Updates for Chrome for Android.');
+  console.log('### Updates for Chrome for Android');
   await updateChromiumReleases(options.chrome_android);
 }
 

--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -161,7 +161,7 @@ if (updateWebview && updateMobile) {
 }
 
 if (updateEdge && updateDesktop) {
-  console.log('### Updates for Edge for Desktop.');
+  console.log('### Updates for Edge for Desktop');
   await updateEdgeReleases(options.edge_desktop);
 }
 

--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -166,7 +166,7 @@ if (updateEdge && updateDesktop) {
 }
 
 if (updateFirefox && updateDesktop) {
-  console.log('### Updates for Firefox for Desktop.');
+  console.log('### Updates for Firefox for Desktop');
   await updateFirefoxReleases(options.firefox_desktop);
 }
 

--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -171,6 +171,6 @@ if (updateFirefox && updateDesktop) {
 }
 
 if (updateFirefox && updateMobile) {
-  console.log('### Updates for Firefox for Android.');
+  console.log('### Updates for Firefox for Android');
   await updateFirefoxReleases(options.firefox_android);
 }

--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -156,7 +156,7 @@ if (updateChrome && updateMobile) {
 }
 
 if (updateWebview && updateMobile) {
-  console.log('### Updates for Webview for Android.');
+  console.log('### Updates for Webview for Android');
   await updateChromiumReleases(options.webview_android);
 }
 

--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -146,7 +146,7 @@ const options = {
 };
 
 if (updateChrome && updateDesktop) {
-  console.log('### Updates for Chrome for Desktop.');
+  console.log('### Updates for Chrome for Desktop');
   await updateChromiumReleases(options.chrome_desktop);
 }
 

--- a/scripts/update-browser-releases/utils.ts
+++ b/scripts/update-browser-releases/utils.ts
@@ -136,7 +136,7 @@ export const sortStringify = (obj, indent) => {
 
     if (value instanceof Object) {
       // An object: recursively call this method
-      value = `${sortStringify(value, indent + indentStep, orders)}`;
+      value = `${sortStringify(value, indent + indentStep)}`;
     } else {
       // A value or an array: call the regular JSON.stringify function
       value = `${JSON.stringify(value)}`;

--- a/scripts/update-browser-releases/utils.ts
+++ b/scripts/update-browser-releases/utils.ts
@@ -2,6 +2,7 @@
  * See LICENSE file for more information. */
 
 import { compareVersions } from 'compare-versions';
+import chalk from 'chalk-template';
 
 /**
  * newBrowserEntry - Add a new browser entry in the JSON list
@@ -32,24 +33,45 @@ export const newBrowserEntry = (
   release['status'] = status;
   release['engine'] = engine;
   release['engine_version'] = version.toString();
+  console.log(
+    chalk`{yellow New release detected for {bold ${browser}}: Version {bold ${version}} as a {bold ${status}} release. }`,
+  );
 };
 
 /**
  * updateBrowserEntry - Update browser entry in the JSON list
- * @param {object} entry the entry to update
+ * @param {object} json json file to update
+ * @param {object} browser the entry name where to add it in the bcd file
+ * @param {string} version new version to add
  * @param {string} releaseDate new release date
  * @param {string} status new status
  * @param {string} releaseNotesURL url of the release notes
  */
 export const updateBrowserEntry = (
-  entry,
+  json,
+  browser,
+  version,
   releaseDate,
   status,
   releaseNotesURL,
 ) => {
-  entry['status'] = status;
-  entry['release_date'] = releaseDate;
-  if (releaseNotesURL) {
+  const entry = json.browsers[browser].releases[version];
+  if (entry['status'] !== status) {
+    console.log(
+      chalk`{cyan New status for {bold ${browser} ${version}}: {bold ${status}}, previously ${entry['status']}}`,
+    );
+    entry['status'] = status;
+  }
+  if (entry['release_date'] !== releaseDate) {
+    console.log(
+      chalk`{cyan New release date for {bold ${browser} ${version}}: {bold ${releaseDate}}, previously ${entry['release_date']}}`,
+    );
+    entry['release_date'] = releaseDate;
+  }
+  if (releaseNotesURL && entry['release_notes'] !== releaseNotesURL) {
+    console.log(
+      chalk`{cyan New release notes for {bold ${browser} ${version}}: {bold ${releaseNotesURL}}, previously ${entry['release_notes']}}`,
+    );
     entry['release_notes'] = releaseNotesURL;
   }
 };

--- a/scripts/update-browser-releases/utils.ts
+++ b/scripts/update-browser-releases/utils.ts
@@ -34,7 +34,7 @@ export const newBrowserEntry = (
   release['engine'] = engine;
   release['engine_version'] = version.toString();
   console.log(
-    chalk`{yellow New release detected for {bold ${browser}}: Version {bold ${version}} as a {bold ${status}} release. }`,
+    chalk`{yellow - New release detected for {bold ${browser}}: Version {bold ${version}} as a {bold ${status}} release. }`,
   );
 };
 
@@ -58,19 +58,19 @@ export const updateBrowserEntry = (
   const entry = json.browsers[browser].releases[version];
   if (entry['status'] !== status) {
     console.log(
-      chalk`{cyan New status for {bold ${browser} ${version}}: {bold ${status}}, previously ${entry['status']}}`,
+      chalk`{cyan - New status for {bold ${browser} ${version}}: {bold ${status}}, previously ${entry['status']}}`,
     );
     entry['status'] = status;
   }
   if (entry['release_date'] !== releaseDate) {
     console.log(
-      chalk`{cyan New release date for {bold ${browser} ${version}}: {bold ${releaseDate}}, previously ${entry['release_date']}}`,
+      chalk`{cyan - New release date for {bold ${browser} ${version}}: {bold ${releaseDate}}, previously ${entry['release_date']}}`,
     );
     entry['release_date'] = releaseDate;
   }
   if (releaseNotesURL && entry['release_notes'] !== releaseNotesURL) {
     console.log(
-      chalk`{cyan New release notes for {bold ${browser} ${version}}: {bold ${releaseNotesURL}}, previously ${entry['release_notes']}}`,
+      chalk`{cyan - New release notes for {bold ${browser} ${version}}: {bold ${releaseNotesURL}}, previously ${entry['release_notes']}}`,
     );
     entry['release_notes'] = releaseNotesURL;
   }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The logs of `update-browser-versions` now:
- indicates the changes that have been made
- are colorful
- are compatible with MD.

This output will be used in the future PR that will be generated.

It also set up `sortStringify()` for Edge (no effect, but it guarantees the same order in the future.

#### Test results and supporting details
In the shell:
![Capture d’écran 2023-10-25 à 16 36 26](https://github.com/mdn/browser-compat-data/assets/1466293/ed5e7050-9878-4a2d-ac50-3e99d53c7782)

Integrated inside a PR:
![Capture d’écran 2023-10-25 à 16 39 19](https://github.com/mdn/browser-compat-data/assets/1466293/743dc16c-4a5c-480d-ba51-df9661cb3820)

#### Related issues

None
