### PR TITLE
Update Opera data for api.Sanitizer.sanitize

### DIFF
--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -194,16 +194,7 @@
             "oculus": {
               "version_added": false
             },
-            "opera": {
-              "version_added": "79",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `sanitize` member of the `Sanitizer` API. This sets the feature to mirror from Chrome, which unblocks #21080.
