### PR TITLE
Add workflow to run (on demand) the update-browser-releases script

### DIFF
--- a/.github/workflows/update-browser-version.yml
+++ b/.github/workflows/update-browser-version.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   update:
-    name: Update browser-version
+    name: Update browser version files
     runs-on: ubuntu-latest
     env:
       RESULT:
@@ -28,11 +28,10 @@ jobs:
           echo "RESULT<<EOF" >> $GITHUB_ENV
           npm run update-browser-releases -- --all >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
-          echo $GITHUB_ENV
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }} # need the rights to create and edit PRs
           commit-message: Update browser releases json files
           committer: GitHub <noreply@github.com>
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>

--- a/.github/workflows/update-browser-version.yml
+++ b/.github/workflows/update-browser-version.yml
@@ -1,0 +1,46 @@
+name: Update browser versions
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    name: Update browser-version
+    runs-on: ubuntu-latest
+    env:
+      RESULT:
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # get the full repository checkout, not just the inciting commit
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+      - run: npm install -D typescript
+      - run: npm install -D ts-node
+      - name: Run update-browser-version script
+        id: ubr
+        run: |
+          echo "RESULT<<EOF" >> $GITHUB_ENV
+          npm run update-browser-releases -- --all >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+          echo $GITHUB_ENV
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.PAT }}
+          commit-message: Update browser releases json files
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          signoff: false
+          branch: browser-version-json
+          delete-branch: true
+          title: "Update browser version files"
+          body: |
+            The output of the `update-browser_version` script is:
+            ${{ env.RESULT }}
+          draft: false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR adds a workflow to run `update-browser-releases.ts` that updates Chrome, Firefox, and Edge JSON files containing version numbers and release dates.

Note: the workflow will run only on-demand now; we want to gather experience before adding a cron entry.
![Capture d’écran 2023-10-26 à 07 21 05](https://github.com/mdn/browser-compat-data/assets/1466293/2f790674-b0ea-4a76-aca4-22682a002d63)

Note 2: I'm using GITHUB_TOKEN as the secret for the privileges. I have no access to the secrets on bcd, so I couldn't double check if it has the correct privileges (especially creation and modifications of PRs).

If not, the workflow will fail at the PR-creation step (but no havoc will be done). If this is the case, somebody with the proper privileges must add a secret with an adequate access token. Then we can use it (1 line change). There are already such secrets in use on bcd for other workflows.

@ddbeck @queengooborg, @caugner, you may be able to check secrets, and we can double-check this before merging this PR.

Note 3: This workflow creates/updates a PR but does not merge anything automatically.

#### Test results and supporting details

I've created this workflow on a test branch on the repo teoli2003. And it generates such PR: https://github.com/teoli2003/browser-compat-data/pull/25 (Test failures are insignificant: they happen because I manually "trimmed" the browser JSON files to have more output, so some browser releases are no longer listed, making the CI complain about these versions used elsewhere on MDN).

This is the typical run logs of the workflow: https://github.com/teoli2003/browser-compat-data/actions/runs/6649711751/job/18068684301

The only difference on my repo+branch is that I used a PAT token (instead of GITHUB_TOKEN, with the required privileges (my PAT local token will expire in November).

#### Related issues

None
