### PR TITLE
Update close-incomplete-issues.yml to close issues without problem summary

### DIFF
--- a/.github/workflows/close-incomplete-issues.yml
+++ b/.github/workflows/close-incomplete-issues.yml
@@ -16,20 +16,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           labels: "invalid :no_entry_sign:"
           comment: |
-            This issue was automatically closed because it appears to be empty. The issue is not different from the issue template and no actionable information has been provided.
+            This issue was automatically closed because the template has not been properly filled out. A summary has not been added to the title of the issue.
 
-            If this has been closed in error, edit the title and body, and post a follow-up comment.
-          normalize-newlines: true
-          title-contains: "<PUT TITLE HERE>"
-          body-contains: "<!-- Tips: where applicable, specify browser name, browser version, and mobile operating system version -->\n\n#### What information was incorrect, unhelpful, or incomplete?\n\n#### What did you expect to see?\n\n#### Did you test this? If so, how?\n\n"
-      - uses: ddbeck/invalid-issue-closer@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          labels: "invalid :no_entry_sign:"
-          comment: |
-            This issue was automatically closed because it appears to be empty. The issue is not different from the issue template and no actionable information has been provided.
-
-            If this has been closed in error, edit the title and body, and post a follow-up comment.
+            If this has been closed in error, edit the title and/or body, and post a follow-up comment.
           normalize-newlines: true
           title-contains: "<SUMMARIZE THE PROBLEM>"
-          body-contains: "<!-- Tips: where applicable, specify browser name, browser version, and mobile operating system version -->\n\n#### What information was incorrect, unhelpful, or incomplete?\n#### What did you expect to see?\n#### Did you test this? If so, how?\n"


### PR DESCRIPTION
This PR updates the workflow to close issues that don't have a summary of the problem in the title.  Since updating the issue templates, this workflow has practically never triggered.  Most of our [spam issues](https://github.com/mdn/browser-compat-data/issues?q=is%3Aissue+is%3Aclosed+%3CSUMMARIZE+THE+PROBLEM%3E+label%3A%22spam+%3Awastebasket%3A%22) and many [invalid issues](https://github.com/mdn/browser-compat-data/issues?q=is%3Aissue+is%3Aclosed+%3CSUMMARIZE+THE+PROBLEM%3E+-label%3A%22spam+%3Awastebasket%3A%22+label%3A%22invalid+%3Ano_entry_sign%3A%22) include the default title generated from MDN Web Docs, with only a [small handful of legitimate issues](https://github.com/mdn/browser-compat-data/issues?q=is%3Aissue+is%3Aclosed+%3CSUMMARIZE+THE+PROBLEM%3E+-label%3A%22spam+%3Awastebasket%3A%22+-label%3A%22invalid+%3Ano_entry_sign%3A%22+-label%3A%22duplicate+%3Adancing_women%3A%22) containing the template text.