### PR TITLE
Update property order enforcement

### DIFF
--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -64,6 +64,14 @@
           "description": "The upstream browser this browser derives from (e.g. Firefox Android is derived from Firefox, Edge is derived from Chrome).",
           "tsType": "BrowserName"
         },
+        "preview_name": {
+          "type": "string",
+          "description": "The name of the browser's preview channel (e.g. 'Nightly' for Firefox or 'TP' for Safari)."
+        },
+        "pref_url": {
+          "type": "string",
+          "description": "URL of the page where feature flags can be changed (e.g. 'about:config' for Firefox or 'chrome://flags' for Chrome)."
+        },
         "accepts_flags": {
           "type": "boolean",
           "description": "Whether the browser supports user-toggleable flags that enable or disable features."
@@ -71,14 +79,6 @@
         "accepts_webextensions": {
           "type": "boolean",
           "description": "Whether the browser supports extensions."
-        },
-        "pref_url": {
-          "type": "string",
-          "description": "URL of the page where feature flags can be changed (e.g. 'about:config' for Firefox or 'chrome://flags' for Chrome)."
-        },
-        "preview_name": {
-          "type": "string",
-          "description": "The name of the browser's preview channel (e.g. 'Nightly' for Firefox or 'TP' for Safari)."
         },
         "releases": {
           "type": "object",
@@ -111,6 +111,11 @@
           "pattern": "^https://",
           "description": "A link to the release notes or changelog for a given release."
         },
+        "status": {
+          "$ref": "#/definitions/browser_status",
+          "description": "A property indicating where in the lifetime cycle this release is in (e.g. current, retired, beta, nightly).",
+          "tsType": "BrowserStatus"
+        },
         "engine": {
           "$ref": "#/definitions/browser_engine",
           "description": "Name of the browser's underlying engine.",
@@ -119,11 +124,6 @@
         "engine_version": {
           "type": "string",
           "description": "Version of the engine corresponding to the browser version."
-        },
-        "status": {
-          "$ref": "#/definitions/browser_status",
-          "description": "A property indicating where in the lifetime cycle this release is in (e.g. current, retired, beta, nightly).",
-          "tsType": "BrowserStatus"
         }
       },
       "required": ["status"],

--- a/scripts/fix/index.ts
+++ b/scripts/fix/index.ts
@@ -39,14 +39,16 @@ const load = async (...files: string[]): Promise<void> => {
     }
 
     if (fsStats.isFile()) {
-      if (path.extname(file) === '.json') {
-        fixBrowserOrder(file);
-        fixFeatureOrder(file);
+      if (path.extname(file) === '.json' && !file.endsWith('.schema.json')) {
         fixPropertyOrder(file);
-        fixStatementOrder(file);
-        fixLinks(file);
-        fixStatus(file);
-        fixMirror(file);
+        if (!file.includes('/browsers/')) {
+          fixBrowserOrder(file);
+          fixFeatureOrder(file);
+          fixStatementOrder(file);
+          fixLinks(file);
+          fixStatus(file);
+          fixMirror(file);
+        }
       }
     } else {
       const subFiles = (await fs.readdir(file)).map((subfile) =>
@@ -64,6 +66,7 @@ if (esMain(import.meta)) {
   } else {
     await load(
       'api',
+      'browsers',
       'css',
       'html',
       'http',

--- a/scripts/fix/property-order.ts
+++ b/scripts/fix/property-order.ts
@@ -3,64 +3,8 @@
 
 import fs from 'node:fs';
 
-import { Identifier, CompatStatement, StatusBlock } from '../../types/types.js';
 import { IS_WINDOWS } from '../../test/utils.js';
-
-const propOrder = {
-  __compat: [
-    'description',
-    'mdn_url',
-    'spec_url',
-    'matches',
-    'support',
-    'status',
-  ],
-  status: ['experimental', 'standard_track', 'deprecated'],
-};
-
-/**
- * Perform property ordering
- * @param {CompatStatement|StatusBlock} value The object to order properties for
- * @param {string[]} order The order to follow
- * @returns {CompatStatement|StatusBlock} The ordered object
- */
-const doOrder = <T>(value: T, order: string[]): T => {
-  if (value && typeof value === 'object') {
-    return order.reduce((result: { [index: string]: any }, key: string) => {
-      if (key in value) {
-        result[key] = value[key];
-      }
-      return result;
-    }, {}) as T;
-  }
-  return value;
-};
-
-/**
- * Return a new feature object whose first-level properties have been
- * ordered according to doOrder, and so will be stringified in that
- * order as well. This relies on guaranteed "own" property ordering,
- * which is insertion order for non-integer keys (which is our case).
- * @param {string} key The key in the object
- * @param {Identifier} value The value of the key
- * @returns {Identifier} The new value
- */
-export const orderProperties = (key: string, value: Identifier): Identifier => {
-  if (value instanceof Object && '__compat' in value) {
-    value.__compat = doOrder(
-      value.__compat as CompatStatement,
-      propOrder.__compat,
-    );
-
-    if ('status' in value.__compat) {
-      value.__compat.status = doOrder(
-        value.__compat.status as StatusBlock,
-        propOrder.status,
-      );
-    }
-  }
-  return value;
-};
+import stringifyAndOrderProperties from '../lib/stringify-and-order-properties.js';
 
 /**
  * Fix issues with the property order throughout the BCD files
@@ -68,7 +12,7 @@ export const orderProperties = (key: string, value: Identifier): Identifier => {
  */
 const fixPropertyOrder = (filename: string): void => {
   let actual = fs.readFileSync(filename, 'utf-8').trim();
-  let expected = JSON.stringify(JSON.parse(actual, orderProperties), null, 2);
+  let expected = stringifyAndOrderProperties(actual);
 
   if (IS_WINDOWS) {
     // prevent false positives from git.core.autocrlf on Windows

--- a/scripts/lib/stringify-and-order-properties.ts
+++ b/scripts/lib/stringify-and-order-properties.ts
@@ -1,0 +1,197 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import { compareVersions } from 'compare-versions';
+
+import {
+  CompatStatement,
+  SimpleSupportStatement,
+  StatusBlock,
+  BrowserStatement,
+  ReleaseStatement,
+} from '../../types/types.js';
+
+const propOrder = {
+  browsers: {
+    browser: [
+      'name',
+      'type',
+      'upstream',
+      'preview_name',
+      'pref_url',
+      'accepts_flags',
+      'accepts_webextensions',
+      'releases',
+    ],
+    release: [
+      'release_date',
+      'release_notes',
+      'status',
+      'engine',
+      'engine_version',
+    ],
+  },
+  data: {
+    __compat: [
+      'description',
+      'mdn_url',
+      'spec_url',
+      'matches',
+      'support',
+      'status',
+    ],
+    support: [
+      'alternative_name',
+      'prefix',
+      'version_added',
+      'version_removed',
+      'flags',
+      'impl_url',
+      'partial_implementation',
+      'notes',
+    ],
+    status: ['experimental', 'standard_track', 'deprecated'],
+  },
+};
+
+/**
+ * Perform property ordering
+ * @param {any} value The object to order properties for
+ * @param {string[]} order The order to follow
+ * @returns {any} The ordered object
+ */
+const doOrder = <T>(value: T, order: string[]): T => {
+  if (value && typeof value === 'object') {
+    return order.reduce((result: { [index: string]: any }, key: string) => {
+      if (key in value) {
+        result[key] = value[key];
+      }
+      return result;
+    }, {}) as T;
+  }
+  return value;
+};
+
+/**
+ * Return a stringified version of the releases list in a browser file, with a
+ * prefix and suffix added, which will be removed after performing JSON
+ * stringification. This is important because JavaScript wants to move object
+ * entries with a floating point as the key to the very end of the list.
+ * @param {any} releases The release data
+ * @returns {string} The stringified releases
+ */
+export const stringifyReleases = (releases: {
+  [version: string]: ReleaseStatement;
+}): string => {
+  const indentStep = '  '; // Constant with the indent step that sortStringify will use
+
+  const sortedKeys = Object.keys(releases).sort(compareVersions);
+
+  let result = '';
+  for (let i = 0; i < sortedKeys.length; i++) {
+    const k = sortedKeys[i];
+    const v = JSON.stringify(releases[k], null, 2).replace(/\n/g, '\n  ');
+
+    // Add it to the result
+    result += `${indentStep}"${k}": ${v}`;
+
+    // Check if this is the last entry or not: if not, add a comma
+    if (i != sortedKeys.length - 1) {
+      result += ',';
+    }
+
+    // We always need a carriage return
+    result += '\n';
+  }
+  return `*#*#{\n${result}}#*#*`; // Close the brace and return the string
+};
+
+/**
+ * Return a new feature object whose first-level properties have been
+ * ordered according to doOrder, and so will be stringified in that
+ * order as well. This relies on guaranteed "own" property ordering,
+ * which is insertion order for non-integer keys (which is our case).
+ * @param {string} key The key in the object
+ * @param {any} value The value of the key
+ * @returns {any} The new value
+ */
+export const orderProperties = (key: string, value: any): any => {
+  if (value instanceof Object) {
+    // Order properties for data
+    if ('__compat' in value) {
+      value.__compat = doOrder(
+        value.__compat as CompatStatement,
+        propOrder.data.__compat,
+      );
+
+      for (const browser of Object.keys(value.__compat.support)) {
+        const result: SimpleSupportStatement[] = [];
+        let data = value.__compat.support[browser];
+        if (!Array.isArray(data)) {
+          data = [data];
+        }
+
+        for (const statement of data) {
+          result.push(
+            doOrder(
+              statement as SimpleSupportStatement,
+              propOrder.data.support,
+            ),
+          );
+        }
+
+        value.__compat.support[browser] =
+          result.length === 1 ? result[0] : result;
+      }
+
+      if ('status' in value.__compat) {
+        value.__compat.status = doOrder(
+          value.__compat.status as StatusBlock,
+          propOrder.data.status,
+        );
+      }
+    }
+
+    // Order properties for browsers
+    if ('browsers' in value) {
+      const browser = Object.keys(value.browsers)[0];
+
+      value.browsers[browser] = doOrder(
+        value.browsers[browser] as BrowserStatement,
+        propOrder.browsers.browser,
+      );
+
+      for (const r of Object.keys(value.browsers[browser].releases)) {
+        value.browsers[browser].releases[r] = doOrder(
+          value.browsers[browser].releases[r] as ReleaseStatement,
+          propOrder.browsers.release,
+        );
+      }
+
+      value.browsers[browser].releases = stringifyReleases(
+        value.browsers[browser].releases,
+      );
+    }
+  }
+  return value;
+};
+
+const stringifyAndOrderProperties = (rawdata: any): string => {
+  if (rawdata instanceof Object) {
+    rawdata = JSON.stringify(rawdata);
+  }
+  const data = JSON.parse(rawdata, orderProperties);
+
+  if ('browsers' in data) {
+    // Browser data needs to be stringified in a special way due to the release data
+    return JSON.stringify(data, null, 2)
+      .replace('"*#*#', '')
+      .replace('#*#*"', '')
+      .replace(/\\n/g, '\n      ')
+      .replace(/\\"/g, '"');
+  }
+
+  return JSON.stringify(data, null, 2);
+};
+
+export default stringifyAndOrderProperties;

--- a/scripts/update-browser-releases/chrome.ts
+++ b/scripts/update-browser-releases/chrome.ts
@@ -5,7 +5,9 @@ import * as fs from 'node:fs';
 
 import chalk from 'chalk-template';
 
-import { newBrowserEntry, updateBrowserEntry, sortStringify } from './utils.js';
+import stringify from '../lib/stringify-and-order-properties.js';
+
+import { newBrowserEntry, updateBrowserEntry } from './utils.js';
 
 /**
  * getReleaseNotesURL - Guess the URL of the release notes
@@ -180,5 +182,5 @@ export const updateChromiumReleases = async (options) => {
   //
   // Write the update browser's json to file
   //
-  fs.writeFileSync(`./${options.bcdFile}`, sortStringify(chromeBCD, '') + '\n');
+  fs.writeFileSync(`./${options.bcdFile}`, stringify(chromeBCD) + '\n');
 };

--- a/scripts/update-browser-releases/edge.ts
+++ b/scripts/update-browser-releases/edge.ts
@@ -5,7 +5,9 @@ import * as fs from 'node:fs';
 
 import chalk from 'chalk-template';
 
-import { newBrowserEntry, updateBrowserEntry, sortStringify } from './utils.js';
+import stringify from '../lib/stringify-and-order-properties.js';
+
+import { newBrowserEntry, updateBrowserEntry } from './utils.js';
 
 /**
  * getFutureReleaseDate - Read the future release date
@@ -291,5 +293,5 @@ export const updateEdgeReleases = async (options) => {
   //
   // Write the update browser's json to file
   //
-  fs.writeFileSync(`./${options.bcdFile}`, sortStringify(edgeBCD, '') + '\n');
+  fs.writeFileSync(`./${options.bcdFile}`, stringify(edgeBCD) + '\n');
 };

--- a/scripts/update-browser-releases/firefox.ts
+++ b/scripts/update-browser-releases/firefox.ts
@@ -3,7 +3,9 @@
 
 import * as fs from 'node:fs';
 
-import { updateBrowserEntry, newBrowserEntry, sortStringify } from './utils.js';
+import stringify from '../lib/stringify-and-order-properties.js';
+
+import { newBrowserEntry, updateBrowserEntry } from './utils.js';
 
 import type { ReleaseStatement } from '../../types/types.js';
 
@@ -178,10 +180,7 @@ export const updateFirefoxReleases = async (options) => {
   }
 
   //
-  // Write the JSON back into chrome.json
+  // Write the update browser's json to file
   //
-  fs.writeFileSync(
-    `./${options.bcdFile}`,
-    sortStringify(firefoxBCD, '') + '\n',
-  );
+  fs.writeFileSync(`./${options.bcdFile}`, stringify(firefoxBCD) + '\n');
 };

--- a/scripts/update-browser-releases/utils.ts
+++ b/scripts/update-browser-releases/utils.ts
@@ -1,7 +1,6 @@
 /* This file is a part of @mdn/browser-compat-data
  * See LICENSE file for more information. */
 
-import { compareVersions } from 'compare-versions';
 import chalk from 'chalk-template';
 
 /**
@@ -74,84 +73,4 @@ export const updateBrowserEntry = (
     );
     entry['release_notes'] = releaseNotesURL;
   }
-};
-
-/**
- * sortStringify - Stringify an object using a mixed lexicographic-semver order
- * @param {object} obj The object to stringify
- * @param {string} indent The indentation to add, as a string
- * @returns {string} The URL of the release notes or the empty string if not found
- */
-export const sortStringify = (obj, indent) => {
-  // We want the 'release' object to be after 'type' and 'upstream'
-  // The others in lexicographic order.
-  // This is an array of array because there may be different orders
-  // at different ordering
-  // Non-listed entries will be put in the lexcicographical order.
-  const orders = [
-    ['type', 'update', 'releases'],
-    ['release_date', 'status', 'release_notes', 'engine', 'engine_version'],
-  ];
-
-  const indentStep = '  '; // Constant with the indent step that sortStringify will use
-
-  const sortedKeys = Object.keys(obj).sort((a, b) => {
-    // If they both start with a number, convert to float (so that 1.5 < 10)
-    // and apply number comparison
-    if (a[0] >= '0' && a[0] <= '9' && b[0] >= '0' && b[0] <= '9') {
-      return compareVersions(a, b);
-    }
-
-    // Use lexicographic order unless they are in a hardcoded position
-
-    // Order according the hardcoded arrays
-    let hardcoded; // Initially undefined
-    orders.forEach((order) => {
-      if (hardcoded) {
-        return; // Already found
-      }
-
-      // Check if both entry are in the order array
-      if (order.indexOf(a) != -1 && order.indexOf(b) != -1) {
-        hardcoded = order.indexOf(a) - order.indexOf(b);
-      }
-    });
-
-    // Hardcoded order detected: let's use it
-    if (hardcoded) {
-      return hardcoded;
-    }
-
-    // Normal string comparison: lexicographic order
-    if (a === b) {
-      return 0;
-    }
-    return a > b ? 1 : -1;
-  });
-
-  let result = '{\n'; // obj is an object, it must be enclosed in braces
-  for (let i = 0; i < sortedKeys.length; i++) {
-    const key = sortedKeys[i];
-    let value = obj[key];
-
-    if (value instanceof Object) {
-      // An object: recursively call this method
-      value = `${sortStringify(value, indent + indentStep)}`;
-    } else {
-      // A value or an array: call the regular JSON.stringify function
-      value = `${JSON.stringify(value)}`;
-    }
-
-    // Add it to the result
-    result += `${indent}${indentStep}"${key}": ${value}`;
-
-    // Check if this is the last entry or not: if not, add a comma
-    if (i != sortedKeys.length - 1) {
-      result += ',';
-    }
-
-    // We always need a carriage return
-    result += '\n';
-  }
-  return `${result}${indent}}`; // Close the brace and return the string
 };

--- a/test/linter/test-style.ts
+++ b/test/linter/test-style.ts
@@ -14,38 +14,62 @@ import {
 import { orderSupportBlock } from '../../scripts/fix/browser-order.js';
 import { orderFeatures } from '../../scripts/fix/feature-order.js';
 import { orderStatements } from '../../scripts/fix/statement-order.js';
-import { orderProperties } from '../../scripts/fix/property-order.js';
+import stringifyAndOrderProperties from '../../scripts/lib/stringify-and-order-properties.js';
 
 /**
  * Process the data for any styling errors that cannot be caught by Prettier or the schema
  * @param {string} rawData The raw contents of the file to test
  * @param {Logger} logger The logger to output errors to
+ * @param {string} category The category of the file
  */
-const processData = (rawData: string, logger: Logger): void => {
+const processData = (
+  rawData: string,
+  logger: Logger,
+  category: string,
+): void => {
   let actual = rawData;
-  /** @type {import('../../types').CompatData} */
+  let expectedPropertySorting = stringifyAndOrderProperties(rawData);
+
+  // prevent false positives from git.core.autocrlf on Windows
+  if (IS_WINDOWS) {
+    actual = actual.replace(/\r/g, '');
+    expectedPropertySorting = expectedPropertySorting.replace(/\r/g, '');
+  }
+
+  if (actual !== expectedPropertySorting) {
+    logger.error(
+      chalk`Property sorting error on ${jsonDiff(
+        actual,
+        expectedPropertySorting,
+      )}`,
+      { tip: chalk`Run {bold npm run fix} to fix sorting automatically` },
+    );
+  }
+
+  // Skip remaining checks if file is browser file
+  if (category === 'browsers') {
+    return;
+  }
+
   const dataObject = JSON.parse(actual);
   let expected = JSON.stringify(dataObject, null, 2);
   let expectedBrowserSorting = JSON.stringify(dataObject, orderSupportBlock, 2);
   let expectedFeatureSorting = JSON.stringify(dataObject, orderFeatures, 2);
   let expectedStatementSorting = JSON.stringify(dataObject, orderStatements, 2);
-  let expectedPropertySorting = JSON.stringify(dataObject, orderProperties, 2);
 
   // prevent false positives from git.core.autocrlf on Windows
   if (IS_WINDOWS) {
-    actual = actual.replace(/\r/g, '');
     expected = expected.replace(/\r/g, '');
     expectedBrowserSorting = expectedBrowserSorting.replace(/\r/g, '');
     expectedFeatureSorting = expectedFeatureSorting.replace(/\r/g, '');
     expectedStatementSorting = expectedStatementSorting.replace(/\r/g, '');
-    expectedPropertySorting = expectedPropertySorting.replace(/\r/g, '');
   }
 
   if (actual !== expected) {
     logger.error(chalk`{red → Error on ${jsonDiff(actual, expected)}}`);
   }
 
-  if (expected !== expectedBrowserSorting) {
+  if (actual !== expectedBrowserSorting) {
     logger.error(
       chalk`Browser sorting error on ${jsonDiff(
         actual,
@@ -55,7 +79,7 @@ const processData = (rawData: string, logger: Logger): void => {
     );
   }
 
-  if (expected !== expectedFeatureSorting) {
+  if (actual !== expectedFeatureSorting) {
     logger.error(
       chalk`Feature sorting error on ${jsonDiff(
         actual,
@@ -65,23 +89,13 @@ const processData = (rawData: string, logger: Logger): void => {
     );
   }
 
-  if (expected !== expectedStatementSorting) {
+  if (actual !== expectedStatementSorting) {
     logger.error(
       chalk`Statement sorting error on ${jsonDiff(
         actual,
         expectedFeatureSorting,
       )}`,
       { fixable: true },
-    );
-  }
-
-  if (expected !== expectedPropertySorting) {
-    logger.error(
-      chalk`Property sorting error on ${jsonDiff(
-        actual,
-        expectedFeatureSorting,
-      )}`,
-      { tip: chalk`Run {bold npm run fix} to fix sorting automatically` },
     );
   }
 
@@ -106,8 +120,6 @@ export default {
    * @param {LinterData} root The data to test
    */
   check: (logger: Logger, { rawdata, path: { category } }: LinterData) => {
-    if (category !== 'browsers') {
-      processData(rawdata, logger);
-    }
+    processData(rawdata, logger, category);
   },
 } as Linter;

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -283,7 +283,7 @@ export class Linters {
           level: 'error',
           title: linter.name,
           path: data.path.full,
-          message: 'Linter failure! ' + e,
+          message: 'Linter failure! ' + e.stack,
         });
       }
     }


### PR DESCRIPTION
This PR updates the property order enforcement so that it performs the following:

- Enforces property order within browser data
  - The `sortStringify` function from the `update-browser-releases` script was taken and spliced in to enforce proper release sorting
  - In turn, the `update-browser-releases` script were updated to use the new function
- Enforces property order for individual compatibility statements

This enforces the ordering performed in #21094.