### PR TITLE
Fix property order in files throughout BCD

### DIFF
--- a/api/AnimationEffect.json
+++ b/api/AnimationEffect.json
@@ -15,9 +15,9 @@
               "version_added": "63"
             },
             {
+              "alternative_name": "AnimationEffectReadOnly",
               "version_added": "48",
-              "version_removed": "63",
-              "alternative_name": "AnimationEffectReadOnly"
+              "version_removed": "63"
             }
           ],
           "firefox_android": "mirror",

--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -10,9 +10,9 @@
               "version_added": "43"
             },
             {
+              "prefix": "WebKit",
               "version_added": "1",
-              "version_removed": "70",
-              "prefix": "WebKit"
+              "version_removed": "70"
             }
           ],
           "chrome_android": "mirror",
@@ -81,9 +81,9 @@
               "version_added": "43"
             },
             {
+              "prefix": "WebKit",
               "version_added": "≤37",
-              "version_removed": "70",
-              "prefix": "WebKit"
+              "version_removed": "70"
             }
           ]
         },

--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -10,9 +10,9 @@
               "version_added": "35"
             },
             {
+              "prefix": "webkit",
               "version_added": "14",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ],
           "chrome_android": "mirror",
@@ -34,9 +34,9 @@
               "version_added": "14.1"
             },
             {
+              "prefix": "webkit",
               "version_added": "6",
-              "version_removed": "14.1",
-              "prefix": "webkit"
+              "version_removed": "14.1"
             }
           ],
           "safari_ios": "mirror",
@@ -64,9 +64,9 @@
                 ]
               },
               {
+                "prefix": "webkit",
                 "version_added": "14",
-                "version_removed": "57",
-                "prefix": "webkit"
+                "version_removed": "57"
               }
             ],
             "chrome_android": "mirror",
@@ -90,9 +90,9 @@
                 ]
               },
               {
+                "prefix": "webkit",
                 "version_added": "15",
-                "version_removed": "44",
-                "prefix": "webkit"
+                "version_removed": "44"
               }
             ],
             "opera_android": [
@@ -104,9 +104,9 @@
                 ]
               },
               {
+                "prefix": "webkit",
                 "version_added": "14",
-                "version_removed": "43",
-                "prefix": "webkit"
+                "version_removed": "43"
               }
             ],
             "safari": [
@@ -114,8 +114,8 @@
                 "version_added": "14.1"
               },
               {
-                "version_added": "6",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "6"
               }
             ],
             "safari_ios": "mirror",
@@ -128,9 +128,9 @@
                 ]
               },
               {
+                "prefix": "webkit",
                 "version_added": "1.0",
-                "version_removed": "7.0",
-                "prefix": "webkit"
+                "version_removed": "7.0"
               }
             ],
             "webview_android": [
@@ -142,9 +142,9 @@
                 ]
               },
               {
+                "prefix": "webkit",
                 "version_added": "≤37",
-                "version_removed": "57",
-                "prefix": "webkit"
+                "version_removed": "57"
               }
             ]
           },

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -27,9 +27,9 @@
               "version_added": "18.0.0"
             },
             {
+              "alternative_name": "buffer.Blob",
               "version_added": "15.7.0",
               "version_removed": "18.0.0",
-              "alternative_name": "buffer.Blob",
               "notes": [
                 "Experimental implementation.",
                 "Must be imported using <code>require('buffer').Blob</code> or <code>import { Blob } from 'buffer'</code>."
@@ -203,9 +203,9 @@
                 "version_added": "21"
               },
               {
+                "prefix": "webkit",
                 "version_added": "5",
-                "version_removed": "25",
-                "prefix": "webkit"
+                "version_removed": "25"
               }
             ],
             "chrome_android": "mirror",
@@ -221,9 +221,9 @@
                 "notes": "Before Firefox 12, there was a bug that affected the behavior of <code>Blob.slice()</code>; it did not work for <code>start</code> and <code>end</code> positions outside the range of signed 64-bit values; it has now been fixed to support unsigned 64-bit values."
               },
               {
+                "prefix": "moz",
                 "version_added": "5",
-                "version_removed": "13",
-                "prefix": "moz"
+                "version_removed": "13"
               }
             ],
             "firefox_android": "mirror",
@@ -245,9 +245,9 @@
                 "version_added": "7"
               },
               {
+                "prefix": "webkit",
                 "version_added": "6",
-                "version_removed": "7",
-                "prefix": "webkit"
+                "version_removed": "7"
               }
             ],
             "safari_ios": "mirror",

--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -13,14 +13,14 @@
             },
             {
               "version_added": "56",
-              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
                   "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "enabled"
                 }
-              ]
+              ],
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled."
             }
           ],
           "chrome_android": {
@@ -34,14 +34,14 @@
             },
             {
               "version_added": "79",
-              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
                   "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "enabled"
                 }
-              ]
+              ],
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled."
             }
           ],
           "firefox": {

--- a/api/BluetoothCharacteristicProperties.json
+++ b/api/BluetoothCharacteristicProperties.json
@@ -13,14 +13,14 @@
             },
             {
               "version_added": "56",
-              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
                   "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "enabled"
                 }
-              ]
+              ],
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled."
             }
           ],
           "chrome_android": {
@@ -34,14 +34,14 @@
             },
             {
               "version_added": "79",
-              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
                   "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "enabled"
                 }
-              ]
+              ],
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled."
             }
           ],
           "firefox": {

--- a/api/BluetoothDevice.json
+++ b/api/BluetoothDevice.json
@@ -13,14 +13,14 @@
             },
             {
               "version_added": "56",
-              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
                   "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "enabled"
                 }
-              ]
+              ],
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled."
             }
           ],
           "chrome_android": {
@@ -34,14 +34,14 @@
             },
             {
               "version_added": "79",
-              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
                   "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "enabled"
                 }
-              ]
+              ],
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled."
             }
           ],
           "firefox": {

--- a/api/BluetoothRemoteGATTCharacteristic.json
+++ b/api/BluetoothRemoteGATTCharacteristic.json
@@ -13,14 +13,14 @@
             },
             {
               "version_added": "56",
-              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
                   "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "enabled"
                 }
-              ]
+              ],
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled."
             }
           ],
           "chrome_android": {
@@ -34,14 +34,14 @@
             },
             {
               "version_added": "79",
-              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
                   "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "enabled"
                 }
-              ]
+              ],
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled."
             }
           ],
           "firefox": {

--- a/api/BluetoothRemoteGATTDescriptor.json
+++ b/api/BluetoothRemoteGATTDescriptor.json
@@ -13,14 +13,14 @@
             },
             {
               "version_added": "57",
-              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
                   "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "enabled"
                 }
-              ]
+              ],
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled."
             }
           ],
           "chrome_android": {
@@ -34,14 +34,14 @@
             },
             {
               "version_added": "79",
-              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
                   "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "enabled"
                 }
-              ]
+              ],
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled."
             }
           ],
           "firefox": {

--- a/api/BluetoothRemoteGATTServer.json
+++ b/api/BluetoothRemoteGATTServer.json
@@ -13,14 +13,14 @@
             },
             {
               "version_added": "56",
-              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
                   "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "enabled"
                 }
-              ]
+              ],
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled."
             }
           ],
           "chrome_android": {
@@ -34,14 +34,14 @@
             },
             {
               "version_added": "79",
-              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
                   "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "enabled"
                 }
-              ]
+              ],
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled."
             }
           ],
           "firefox": {

--- a/api/BluetoothRemoteGATTService.json
+++ b/api/BluetoothRemoteGATTService.json
@@ -13,14 +13,14 @@
             },
             {
               "version_added": "56",
-              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
                   "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "enabled"
                 }
-              ]
+              ],
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled."
             }
           ],
           "chrome_android": {
@@ -34,14 +34,14 @@
             },
             {
               "version_added": "79",
-              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
                   "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "enabled"
                 }
-              ]
+              ],
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled."
             }
           ],
           "firefox": {

--- a/api/BluetoothUUID.json
+++ b/api/BluetoothUUID.json
@@ -13,14 +13,14 @@
             },
             {
               "version_added": "56",
-              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
                   "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "enabled"
                 }
-              ]
+              ],
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled."
             }
           ],
           "chrome_android": {
@@ -34,14 +34,14 @@
             },
             {
               "version_added": "79",
-              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
               "flags": [
                 {
                   "type": "preference",
                   "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "enabled"
                 }
-              ]
+              ],
+              "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled."
             }
           ],
           "firefox": {

--- a/api/BroadcastChannel.json
+++ b/api/BroadcastChannel.json
@@ -27,8 +27,8 @@
             "version_added": false
           },
           "nodejs": {
-            "version_added": "15.4.0",
             "alternative_name": "worker_threads.BroadcastChannel",
+            "version_added": "15.4.0",
             "notes": [
               "Experimental implementation",
               "Must be imported using either <code>require('worker_threads')</code> or <code>import * from 'worker_threads'</code>."

--- a/api/CSSKeyframeRule.json
+++ b/api/CSSKeyframeRule.json
@@ -10,9 +10,9 @@
               "version_added": "31"
             },
             {
+              "prefix": "WebKit",
               "version_added": "1",
-              "version_removed": "31",
-              "prefix": "WebKit"
+              "version_removed": "31"
             }
           ],
           "chrome_android": "mirror",
@@ -24,9 +24,9 @@
               "version_added": "48"
             },
             {
+              "prefix": "Moz",
               "version_added": "5",
-              "version_removed": "48",
-              "prefix": "Moz"
+              "version_removed": "48"
             }
           ],
           "firefox_android": "mirror",
@@ -43,9 +43,9 @@
               "version_removed": "15"
             },
             {
+              "prefix": "WebKit",
               "version_added": "15",
-              "version_removed": "18",
-              "prefix": "WebKit"
+              "version_removed": "18"
             }
           ],
           "opera_android": [
@@ -57,9 +57,9 @@
               "version_removed": "14"
             },
             {
+              "prefix": "WebKit",
               "version_added": "14",
-              "version_removed": "18",
-              "prefix": "WebKit"
+              "version_removed": "18"
             }
           ],
           "safari": [
@@ -67,9 +67,9 @@
               "version_added": "9"
             },
             {
+              "prefix": "WebKit",
               "version_added": "4",
-              "version_removed": "9",
-              "prefix": "WebKit"
+              "version_removed": "9"
             }
           ],
           "safari_ios": "mirror",
@@ -79,9 +79,9 @@
               "version_added": "4.4.3"
             },
             {
+              "prefix": "WebKit",
               "version_added": "1",
-              "version_removed": "4.4.3",
-              "prefix": "WebKit"
+              "version_removed": "4.4.3"
             }
           ]
         },

--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -10,9 +10,9 @@
               "version_added": "31"
             },
             {
+              "prefix": "WebKit",
               "version_added": "1",
-              "version_removed": "31",
-              "prefix": "WebKit"
+              "version_removed": "31"
             }
           ],
           "chrome_android": "mirror",
@@ -24,9 +24,9 @@
               "version_added": "48"
             },
             {
+              "prefix": "Moz",
               "version_added": "5",
-              "version_removed": "48",
-              "prefix": "Moz"
+              "version_removed": "48"
             }
           ],
           "firefox_android": "mirror",
@@ -43,14 +43,14 @@
               "version_removed": "15"
             },
             {
+              "prefix": "WebKit",
               "version_added": "15",
-              "version_removed": "18",
-              "prefix": "WebKit"
+              "version_removed": "18"
             },
             {
+              "prefix": "O",
               "version_added": "12",
-              "version_removed": "12.1",
-              "prefix": "O"
+              "version_removed": "12.1"
             }
           ],
           "opera_android": [
@@ -62,14 +62,14 @@
               "version_removed": "14"
             },
             {
+              "prefix": "WebKit",
               "version_added": "14",
-              "version_removed": "18",
-              "prefix": "WebKit"
+              "version_removed": "18"
             },
             {
+              "prefix": "O",
               "version_added": "12",
-              "version_removed": "12.1",
-              "prefix": "O"
+              "version_removed": "12.1"
             }
           ],
           "safari": [
@@ -77,9 +77,9 @@
               "version_added": "9.1"
             },
             {
+              "prefix": "WebKit",
               "version_added": "4",
-              "version_removed": "9.1",
-              "prefix": "WebKit"
+              "version_removed": "9.1"
             }
           ],
           "safari_ios": "mirror",
@@ -89,9 +89,9 @@
               "version_added": "4.4.3"
             },
             {
+              "prefix": "WebKit",
               "version_added": "1",
-              "version_removed": "4.4.3",
-              "prefix": "WebKit"
+              "version_removed": "4.4.3"
             }
           ]
         },
@@ -111,9 +111,9 @@
                 "version_added": "41"
               },
               {
+                "alternative_name": "insertRule",
                 "version_added": "1",
-                "version_removed": "45",
-                "alternative_name": "insertRule"
+                "version_removed": "45"
               }
             ],
             "chrome_android": "mirror",
@@ -125,9 +125,9 @@
                 "version_added": "21"
               },
               {
+                "alternative_name": "insertRule",
                 "version_added": "5",
-                "version_removed": "21",
-                "alternative_name": "insertRule"
+                "version_removed": "21"
               }
             ],
             "firefox_android": "mirror",
@@ -144,9 +144,9 @@
                 "version_removed": "15"
               },
               {
+                "alternative_name": "insertRule",
                 "version_added": "15",
-                "version_removed": "31",
-                "alternative_name": "insertRule"
+                "version_removed": "31"
               }
             ],
             "opera_android": [
@@ -158,9 +158,9 @@
                 "version_removed": "14"
               },
               {
+                "alternative_name": "insertRule",
                 "version_added": "14",
-                "version_removed": "32",
-                "alternative_name": "insertRule"
+                "version_removed": "32"
               }
             ],
             "safari": [
@@ -168,8 +168,8 @@
                 "version_added": "9.1"
               },
               {
-                "version_added": "4",
-                "alternative_name": "insertRule"
+                "alternative_name": "insertRule",
+                "version_added": "4"
               }
             ],
             "safari_ios": "mirror",

--- a/api/CanvasRenderingContext2D.json
+++ b/api/CanvasRenderingContext2D.json
@@ -414,8 +414,8 @@
               },
               {
                 "version_added": "90",
-                "notes": "Implements an older version of the specification. The gradient starts from a line going vertically up from the center, like the equivalent CSS function.",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "Implements an older version of the specification. The gradient starts from a line going vertically up from the center, like the equivalent CSS function."
               }
             ],
             "firefox_android": "mirror",
@@ -431,8 +431,8 @@
               },
               {
                 "version_added": "15",
-                "notes": "Implements an older version of the specification. The gradient starts from a line going vertically up from the center, like the equivalent CSS function.",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "Implements an older version of the specification. The gradient starts from a line going vertically up from the center, like the equivalent CSS function."
               }
             ],
             "safari_ios": "mirror",
@@ -659,8 +659,8 @@
                 "version_added": "32"
               },
               {
-                "version_added": "28",
-                "alternative_name": "drawSystemFocusRing"
+                "alternative_name": "drawSystemFocusRing",
+                "version_added": "28"
               }
             ],
             "firefox_android": "mirror",
@@ -1491,8 +1491,8 @@
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "11",
-              "prefix": "ms"
+              "prefix": "ms",
+              "version_added": "11"
             },
             "oculus": "mirror",
             "opera": "mirror",

--- a/api/Clipboard.json
+++ b/api/Clipboard.json
@@ -189,7 +189,6 @@
               },
               {
                 "version_added": "63",
-                "partial_implementation": true,
                 "flags": [
                   {
                     "type": "preference",
@@ -197,6 +196,7 @@
                     "value_to_set": "true"
                   }
                 ],
+                "partial_implementation": true,
                 "notes": [
                   "This method accepts a <code>DataTransfer</code> object instead of an array of <code>ClipboardItem</code> objects.",
                   "Writing to the clipboard is available without permission in secure contexts and browser extensions, but only from user-initiated event callbacks. Browser extensions with the <code>\"clipboardWrite\"</code> permission can write to the clipboard at any time."

--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -36,9 +36,9 @@
               "notes": "<code>Crypto</code> is not a concrete interface, but its methods are available on the global <code>crypto</code> object."
             },
             {
+              "alternative_name": "crypto.webcrypto",
               "version_added": "15.0.0",
               "version_removed": "19.0.0",
-              "alternative_name": "crypto.webcrypto",
               "partial_implementation": true,
               "notes": "<code>Crypto</code> is not a concrete interface, but calling <code>require('crypto').webcrypto</code> returns an instance of the <code>Crypto</code> class."
             }
@@ -191,9 +191,9 @@
                 "version_added": "11"
               },
               {
+                "prefix": "webkit",
                 "version_added": "7",
-                "version_removed": "11.1",
-                "prefix": "webkit"
+                "version_removed": "11.1"
               }
             ],
             "safari_ios": "mirror",

--- a/api/DOMMatrix.json
+++ b/api/DOMMatrix.json
@@ -10,12 +10,12 @@
               "version_added": "61"
             },
             {
-              "version_added": "5",
-              "alternative_name": "SVGMatrix"
+              "alternative_name": "SVGMatrix",
+              "version_added": "5"
             },
             {
-              "version_added": "2",
-              "alternative_name": "WebKitCSSMatrix"
+              "alternative_name": "WebKitCSSMatrix",
+              "version_added": "2"
             }
           ],
           "chrome_android": "mirror",
@@ -24,17 +24,17 @@
               "version_added": "79"
             },
             {
-              "version_added": "12",
-              "alternative_name": "WebKitCSSMatrix"
+              "alternative_name": "WebKitCSSMatrix",
+              "version_added": "12"
             },
             {
-              "version_added": "12",
-              "alternative_name": "SVGMatrix"
+              "alternative_name": "SVGMatrix",
+              "version_added": "12"
             },
             {
+              "alternative_name": "MSCSSMatrix",
               "version_added": "12",
-              "version_removed": "79",
-              "alternative_name": "MSCSSMatrix"
+              "version_removed": "79"
             }
           ],
           "firefox": [
@@ -42,27 +42,27 @@
               "version_added": "33"
             },
             {
-              "version_added": "49",
-              "alternative_name": "WebKitCSSMatrix"
+              "alternative_name": "WebKitCSSMatrix",
+              "version_added": "49"
             },
             {
-              "version_added": "1.5",
-              "alternative_name": "SVGMatrix"
+              "alternative_name": "SVGMatrix",
+              "version_added": "1.5"
             }
           ],
           "firefox_android": "mirror",
           "ie": [
             {
-              "version_added": "11",
-              "alternative_name": "WebKitCSSMatrix"
+              "alternative_name": "WebKitCSSMatrix",
+              "version_added": "11"
             },
             {
-              "version_added": "10",
-              "alternative_name": "MSCSSMatrix"
+              "alternative_name": "MSCSSMatrix",
+              "version_added": "10"
             },
             {
-              "version_added": "9",
-              "alternative_name": "SVGMatrix"
+              "alternative_name": "SVGMatrix",
+              "version_added": "9"
             }
           ],
           "oculus": "mirror",
@@ -71,12 +71,12 @@
               "version_added": "48"
             },
             {
-              "version_added": "15",
-              "alternative_name": "WebKitCSSMatrix"
+              "alternative_name": "WebKitCSSMatrix",
+              "version_added": "15"
             },
             {
-              "version_added": "≤12.1",
-              "alternative_name": "SVGMatrix"
+              "alternative_name": "SVGMatrix",
+              "version_added": "≤12.1"
             }
           ],
           "opera_android": [
@@ -84,12 +84,12 @@
               "version_added": "48"
             },
             {
-              "version_added": "14",
-              "alternative_name": "WebKitCSSMatrix"
+              "alternative_name": "WebKitCSSMatrix",
+              "version_added": "14"
             },
             {
-              "version_added": "≤12.1",
-              "alternative_name": "SVGMatrix"
+              "alternative_name": "SVGMatrix",
+              "version_added": "≤12.1"
             }
           ],
           "safari": [
@@ -97,12 +97,12 @@
               "version_added": "11"
             },
             {
-              "version_added": "5",
-              "alternative_name": "SVGMatrix"
+              "alternative_name": "SVGMatrix",
+              "version_added": "5"
             },
             {
-              "version_added": "4",
-              "alternative_name": "WebKitCSSMatrix"
+              "alternative_name": "WebKitCSSMatrix",
+              "version_added": "4"
             }
           ],
           "safari_ios": [
@@ -110,12 +110,12 @@
               "version_added": "11"
             },
             {
-              "version_added": "4",
-              "alternative_name": "SVGMatrix"
+              "alternative_name": "SVGMatrix",
+              "version_added": "4"
             },
             {
-              "version_added": "3",
-              "alternative_name": "WebKitCSSMatrix"
+              "alternative_name": "WebKitCSSMatrix",
+              "version_added": "3"
             }
           ],
           "samsunginternet_android": "mirror",
@@ -138,12 +138,12 @@
                 "version_added": "61"
               },
               {
-                "version_added": "5",
-                "alternative_name": "SVGMatrix"
+                "alternative_name": "SVGMatrix",
+                "version_added": "5"
               },
               {
-                "version_added": "2",
-                "alternative_name": "WebKitCSSMatrix"
+                "alternative_name": "WebKitCSSMatrix",
+                "version_added": "2"
               }
             ],
             "chrome_android": "mirror",
@@ -152,17 +152,17 @@
                 "version_added": "79"
               },
               {
-                "version_added": "12",
-                "alternative_name": "WebKitCSSMatrix"
+                "alternative_name": "WebKitCSSMatrix",
+                "version_added": "12"
               },
               {
-                "version_added": "12",
-                "alternative_name": "SVGMatrix"
+                "alternative_name": "SVGMatrix",
+                "version_added": "12"
               },
               {
+                "alternative_name": "MSCSSMatrix",
                 "version_added": "12",
-                "version_removed": "79",
-                "alternative_name": "MSCSSMatrix"
+                "version_removed": "79"
               }
             ],
             "firefox": [
@@ -170,27 +170,27 @@
                 "version_added": "33"
               },
               {
-                "version_added": "49",
-                "alternative_name": "WebKitCSSMatrix"
+                "alternative_name": "WebKitCSSMatrix",
+                "version_added": "49"
               },
               {
-                "version_added": "1.5",
-                "alternative_name": "SVGMatrix"
+                "alternative_name": "SVGMatrix",
+                "version_added": "1.5"
               }
             ],
             "firefox_android": "mirror",
             "ie": [
               {
-                "version_added": "11",
-                "alternative_name": "WebKitCSSMatrix"
+                "alternative_name": "WebKitCSSMatrix",
+                "version_added": "11"
               },
               {
-                "version_added": "10",
-                "alternative_name": "MSCSSMatrix"
+                "alternative_name": "MSCSSMatrix",
+                "version_added": "10"
               },
               {
-                "version_added": "9",
-                "alternative_name": "SVGMatrix"
+                "alternative_name": "SVGMatrix",
+                "version_added": "9"
               }
             ],
             "oculus": "mirror",
@@ -199,12 +199,12 @@
                 "version_added": "48"
               },
               {
-                "version_added": "15",
-                "alternative_name": "WebKitCSSMatrix"
+                "alternative_name": "WebKitCSSMatrix",
+                "version_added": "15"
               },
               {
-                "version_added": "≤12.1",
-                "alternative_name": "SVGMatrix"
+                "alternative_name": "SVGMatrix",
+                "version_added": "≤12.1"
               }
             ],
             "opera_android": [
@@ -212,12 +212,12 @@
                 "version_added": "48"
               },
               {
-                "version_added": "14",
-                "alternative_name": "WebKitCSSMatrix"
+                "alternative_name": "WebKitCSSMatrix",
+                "version_added": "14"
               },
               {
-                "version_added": "≤12.1",
-                "alternative_name": "SVGMatrix"
+                "alternative_name": "SVGMatrix",
+                "version_added": "≤12.1"
               }
             ],
             "safari": [
@@ -225,12 +225,12 @@
                 "version_added": "11"
               },
               {
-                "version_added": "5",
-                "alternative_name": "SVGMatrix"
+                "alternative_name": "SVGMatrix",
+                "version_added": "5"
               },
               {
-                "version_added": "4",
-                "alternative_name": "WebKitCSSMatrix"
+                "alternative_name": "WebKitCSSMatrix",
+                "version_added": "4"
               }
             ],
             "safari_ios": [
@@ -238,12 +238,12 @@
                 "version_added": "11"
               },
               {
-                "version_added": "4",
-                "alternative_name": "SVGMatrix"
+                "alternative_name": "SVGMatrix",
+                "version_added": "4"
               },
               {
-                "version_added": "3",
-                "alternative_name": "WebKitCSSMatrix"
+                "alternative_name": "WebKitCSSMatrix",
+                "version_added": "3"
               }
             ],
             "samsunginternet_android": "mirror",

--- a/api/DirectoryEntrySync.json
+++ b/api/DirectoryEntrySync.json
@@ -5,8 +5,8 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DirectoryEntrySync",
         "support": {
           "chrome": {
-            "version_added": "13",
-            "prefix": "webkit"
+            "prefix": "webkit",
+            "version_added": "13"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -30,8 +30,8 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": "37",
-            "prefix": "webkit"
+            "prefix": "webkit",
+            "version_added": "37"
           }
         },
         "status": {

--- a/api/DirectoryReaderSync.json
+++ b/api/DirectoryReaderSync.json
@@ -5,8 +5,8 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/DirectoryReaderSync",
         "support": {
           "chrome": {
-            "version_added": "13",
-            "prefix": "webkit"
+            "prefix": "webkit",
+            "version_added": "13"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -30,8 +30,8 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": "37",
-            "prefix": "webkit"
+            "prefix": "webkit",
+            "version_added": "37"
           }
         },
         "status": {

--- a/api/Document.json
+++ b/api/Document.json
@@ -2617,9 +2617,9 @@
                 "version_added": "79"
               },
               {
+                "prefix": "ms",
                 "version_added": "12",
                 "version_removed": "79",
-                "prefix": "ms",
                 "notes": "Returns a <code>NodeList</code> instead of an array. See <a href='https://msdn.microsoft.com/en-us/library/hh772121(v=vs.85).aspx'>the MSDN documentation</a>. Returns <code>null</code> when the point provided has no elements beneath it (e.g., when given a point outside the document)."
               }
             ],
@@ -2628,8 +2628,8 @@
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "10",
               "prefix": "ms",
+              "version_added": "10",
               "notes": "Returns a <code>NodeList</code> instead of an array. See <a href='https://msdn.microsoft.com/en-us/library/hh772121(v=vs.85).aspx'>the MSDN documentation</a>. Returns <code>null</code> when the point provided has no elements beneath it (e.g., when given a point outside the document)."
             },
             "oculus": "mirror",
@@ -2995,8 +2995,8 @@
                 "version_added": "71"
               },
               {
-                "version_added": "15",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "15"
               }
             ],
             "chrome_android": "mirror",
@@ -3005,8 +3005,8 @@
                 "version_added": "79"
               },
               {
-                "version_added": "12",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "12"
               },
               {
                 "version_added": "12",
@@ -3018,14 +3018,14 @@
                 "version_added": "64"
               },
               {
-                "version_added": "9",
-                "alternative_name": "mozCancelFullScreen"
+                "alternative_name": "mozCancelFullScreen",
+                "version_added": "9"
               }
             ],
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "11",
-              "alternative_name": "msExitFullscreen"
+              "alternative_name": "msExitFullscreen",
+              "version_added": "11"
             },
             "oculus": "mirror",
             "opera": [
@@ -3033,8 +3033,8 @@
                 "version_added": "58"
               },
               {
-                "version_added": "15",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "15"
               },
               {
                 "version_added": "12.1",
@@ -3046,8 +3046,8 @@
                 "version_added": "50"
               },
               {
-                "version_added": "14",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "14"
               },
               {
                 "version_added": "12.1",
@@ -3059,13 +3059,13 @@
                 "version_added": "16.4"
               },
               {
-                "version_added": "5.1",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "5.1"
               }
             ],
             "safari_ios": {
-              "version_added": "12",
               "prefix": "webkit",
+              "version_added": "12",
               "partial_implementation": true,
               "notes": "Only available on iPad, not on iPhone."
             },
@@ -3075,8 +3075,8 @@
                 "version_added": "71"
               },
               {
-                "version_added": "≤37",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "≤37"
               }
             ]
           },
@@ -3168,8 +3168,8 @@
                 "version_added": "37"
               },
               {
-                "version_added": "22",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "22"
               }
             ],
             "chrome_android": "mirror",
@@ -3181,9 +3181,9 @@
                 "version_added": "50"
               },
               {
+                "prefix": "moz",
                 "version_added": "14",
-                "version_removed": "50",
-                "prefix": "moz"
+                "version_removed": "50"
               }
             ],
             "firefox_android": "mirror",
@@ -3508,8 +3508,8 @@
                 "version_added": "71"
               },
               {
-                "version_added": "15",
-                "alternative_name": "webkitIsFullScreen"
+                "alternative_name": "webkitIsFullScreen",
+                "version_added": "15"
               }
             ],
             "chrome_android": "mirror",
@@ -3518,8 +3518,8 @@
                 "version_added": "79"
               },
               {
-                "version_added": "12",
-                "alternative_name": "webkitIsFullScreen"
+                "alternative_name": "webkitIsFullScreen",
+                "version_added": "12"
               }
             ],
             "firefox": [
@@ -3527,8 +3527,8 @@
                 "version_added": "64"
               },
               {
-                "version_added": "9",
-                "alternative_name": "mozFullScreen"
+                "alternative_name": "mozFullScreen",
+                "version_added": "9"
               }
             ],
             "firefox_android": "mirror",
@@ -3543,13 +3543,13 @@
                 "version_added": "16.4"
               },
               {
-                "version_added": "6",
-                "alternative_name": "webkitIsFullScreen"
+                "alternative_name": "webkitIsFullScreen",
+                "version_added": "6"
               }
             ],
             "safari_ios": {
-              "version_added": "12",
               "alternative_name": "webkitIsFullScreen",
+              "version_added": "12",
               "partial_implementation": true,
               "notes": "Only available on iPad, not on iPhone."
             },
@@ -3559,8 +3559,8 @@
                 "version_added": "71"
               },
               {
-                "version_added": "≤37",
-                "alternative_name": "webkitIsFullScreen"
+                "alternative_name": "webkitIsFullScreen",
+                "version_added": "≤37"
               }
             ]
           },
@@ -3582,8 +3582,8 @@
                 "version_added": "71"
               },
               {
-                "version_added": "15",
-                "alternative_name": "webkitfullscreenchange"
+                "alternative_name": "webkitfullscreenchange",
+                "version_added": "15"
               }
             ],
             "chrome_android": "mirror",
@@ -3592,8 +3592,8 @@
                 "version_added": "79"
               },
               {
-                "version_added": "12",
-                "alternative_name": "webkitfullscreenchange"
+                "alternative_name": "webkitfullscreenchange",
+                "version_added": "12"
               },
               {
                 "version_added": "12",
@@ -3605,14 +3605,14 @@
                 "version_added": "64"
               },
               {
-                "version_added": "10",
-                "alternative_name": "mozfullscreenchange"
+                "alternative_name": "mozfullscreenchange",
+                "version_added": "10"
               }
             ],
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "11",
-              "alternative_name": "MSFullscreenChange"
+              "alternative_name": "MSFullscreenChange",
+              "version_added": "11"
             },
             "oculus": "mirror",
             "opera": [
@@ -3620,8 +3620,8 @@
                 "version_added": "58"
               },
               {
-                "version_added": "15",
-                "alternative_name": "webkitfullscreenchange"
+                "alternative_name": "webkitfullscreenchange",
+                "version_added": "15"
               },
               {
                 "version_added": "12.1",
@@ -3633,8 +3633,8 @@
                 "version_added": "50"
               },
               {
-                "version_added": "14",
-                "alternative_name": "webkitfullscreenchange"
+                "alternative_name": "webkitfullscreenchange",
+                "version_added": "14"
               },
               {
                 "version_added": "12.1",
@@ -3646,13 +3646,13 @@
                 "version_added": "16.4"
               },
               {
-                "version_added": "5.1",
-                "alternative_name": "webkitfullscreenchange"
+                "alternative_name": "webkitfullscreenchange",
+                "version_added": "5.1"
               }
             ],
             "safari_ios": {
-              "version_added": "12",
               "alternative_name": "webkitfullscreenchange",
+              "version_added": "12",
               "partial_implementation": true,
               "notes": "Only available on iPad, not on iPhone."
             },
@@ -3662,8 +3662,8 @@
                 "version_added": "71"
               },
               {
-                "version_added": "≤37",
-                "alternative_name": "webkitfullscreenchange"
+                "alternative_name": "webkitfullscreenchange",
+                "version_added": "≤37"
               }
             ]
           },
@@ -3684,8 +3684,8 @@
                 "version_added": "71"
               },
               {
-                "version_added": "20",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "20"
               }
             ],
             "chrome_android": "mirror",
@@ -3694,8 +3694,8 @@
                 "version_added": "79"
               },
               {
-                "version_added": "12",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "12"
               },
               {
                 "version_added": "12",
@@ -3707,14 +3707,14 @@
                 "version_added": "64"
               },
               {
-                "version_added": "9",
-                "alternative_name": "mozFullScreenElement"
+                "alternative_name": "mozFullScreenElement",
+                "version_added": "9"
               }
             ],
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "11",
-              "alternative_name": "msFullscreenElement"
+              "alternative_name": "msFullscreenElement",
+              "version_added": "11"
             },
             "oculus": "mirror",
             "opera": [
@@ -3722,8 +3722,8 @@
                 "version_added": "58"
               },
               {
-                "version_added": "15",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "15"
               },
               {
                 "version_added": "12.1",
@@ -3735,8 +3735,8 @@
                 "version_added": "50"
               },
               {
-                "version_added": "14",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "14"
               },
               {
                 "version_added": "12.1",
@@ -3748,8 +3748,8 @@
                 "version_added": "16.4"
               },
               {
-                "version_added": "6",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "6"
               }
             ],
             "safari_ios": [
@@ -3759,8 +3759,8 @@
                 "notes": "Only available on iPad, not on iPhone."
               },
               {
-                "version_added": "12",
                 "prefix": "webkit",
+                "version_added": "12",
                 "partial_implementation": true,
                 "notes": "Only available on iPad, not on iPhone."
               }
@@ -3785,8 +3785,8 @@
                 "version_added": "71"
               },
               {
-                "version_added": "20",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "20"
               }
             ],
             "chrome_android": "mirror",
@@ -3798,14 +3798,14 @@
                 "version_added": "64"
               },
               {
-                "version_added": "10",
-                "alternative_name": "mozFullScreenEnabled"
+                "alternative_name": "mozFullScreenEnabled",
+                "version_added": "10"
               }
             ],
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "11",
-              "alternative_name": "msFullscreenEnabled"
+              "alternative_name": "msFullscreenEnabled",
+              "version_added": "11"
             },
             "oculus": "mirror",
             "opera": [
@@ -3813,8 +3813,8 @@
                 "version_added": "58"
               },
               {
-                "version_added": "15",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "15"
               },
               {
                 "version_added": "12.1",
@@ -3826,8 +3826,8 @@
                 "version_added": "50"
               },
               {
-                "version_added": "14",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "14"
               },
               {
                 "version_added": "12.1",
@@ -3839,13 +3839,13 @@
                 "version_added": "16.4"
               },
               {
-                "version_added": "6",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "6"
               }
             ],
             "safari_ios": {
-              "version_added": "12",
               "prefix": "webkit",
+              "version_added": "12",
               "partial_implementation": true,
               "notes": "Only available on iPad, not on iPhone."
             },
@@ -3870,8 +3870,8 @@
                 "version_added": "71"
               },
               {
-                "version_added": "18",
-                "alternative_name": "webkitfullscreenerror"
+                "alternative_name": "webkitfullscreenerror",
+                "version_added": "18"
               }
             ],
             "chrome_android": "mirror",
@@ -3880,8 +3880,8 @@
                 "version_added": "79"
               },
               {
-                "version_added": "12",
-                "alternative_name": "webkitfullscreenerror"
+                "alternative_name": "webkitfullscreenerror",
+                "version_added": "12"
               },
               {
                 "version_added": "12",
@@ -3893,14 +3893,14 @@
                 "version_added": "64"
               },
               {
-                "version_added": "10",
-                "alternative_name": "mozfullscreenerror"
+                "alternative_name": "mozfullscreenerror",
+                "version_added": "10"
               }
             ],
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "11",
-              "alternative_name": "MSFullscreenError"
+              "alternative_name": "MSFullscreenError",
+              "version_added": "11"
             },
             "oculus": "mirror",
             "opera": [
@@ -3908,8 +3908,8 @@
                 "version_added": "58"
               },
               {
-                "version_added": "15",
-                "alternative_name": "webkitfullscreenerror"
+                "alternative_name": "webkitfullscreenerror",
+                "version_added": "15"
               },
               {
                 "version_added": "12.1",
@@ -3921,8 +3921,8 @@
                 "version_added": "50"
               },
               {
-                "version_added": "14",
-                "alternative_name": "webkitfullscreenerror"
+                "alternative_name": "webkitfullscreenerror",
+                "version_added": "14"
               },
               {
                 "version_added": "12.1",
@@ -3934,13 +3934,13 @@
                 "version_added": "16.4"
               },
               {
-                "version_added": "6",
-                "alternative_name": "webkitfullscreenerror"
+                "alternative_name": "webkitfullscreenerror",
+                "version_added": "6"
               }
             ],
             "safari_ios": {
-              "version_added": "12",
               "alternative_name": "webkitfullscreenerror",
+              "version_added": "12",
               "partial_implementation": true,
               "notes": "Only available on iPad, not on iPhone."
             },
@@ -3950,8 +3950,8 @@
                 "version_added": "71"
               },
               {
-                "version_added": "≤37",
-                "alternative_name": "webkitfullscreenerror"
+                "alternative_name": "webkitfullscreenerror",
+                "version_added": "≤37"
               }
             ]
           },
@@ -4462,8 +4462,8 @@
                 "version_added": "33"
               },
               {
-                "version_added": "13",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "13"
               }
             ],
             "chrome_android": "mirror",
@@ -4476,9 +4476,9 @@
                 "notes": "Since Firefox 56 it also returns <code>true</code> on macOS when the window is completely hidden by another non-translucent application."
               },
               {
+                "prefix": "moz",
                 "version_added": "10",
-                "version_removed": "52",
-                "prefix": "moz"
+                "version_removed": "52"
               }
             ],
             "firefox_android": "mirror",
@@ -4502,8 +4502,8 @@
                 "version_added": "4.4.3"
               },
               {
-                "version_added": "≤37",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "≤37"
               }
             ]
           },
@@ -5214,9 +5214,9 @@
                 "version_added": "36"
               },
               {
+                "prefix": "webkit",
                 "version_added": "22",
-                "version_removed": "38",
-                "prefix": "webkit"
+                "version_removed": "38"
               }
             ],
             "chrome_android": "mirror",
@@ -5228,9 +5228,9 @@
                 "version_added": "50"
               },
               {
+                "prefix": "moz",
                 "version_added": "14",
-                "version_removed": "50",
-                "prefix": "moz"
+                "version_removed": "50"
               }
             ],
             "firefox_android": "mirror",
@@ -5273,9 +5273,9 @@
                 "version_added": "50"
               },
               {
+                "prefix": "moz",
                 "version_added": "14",
-                "version_removed": "50",
-                "prefix": "moz"
+                "version_removed": "50"
               }
             ],
             "firefox_android": "mirror",
@@ -5315,9 +5315,9 @@
                 "version_added": "36"
               },
               {
+                "prefix": "webkit",
                 "version_added": "22",
-                "version_removed": "38",
-                "prefix": "webkit"
+                "version_removed": "38"
               }
             ],
             "chrome_android": "mirror",
@@ -5329,9 +5329,9 @@
                 "version_added": "50"
               },
               {
+                "prefix": "moz",
                 "version_added": "14",
-                "version_removed": "50",
-                "prefix": "moz"
+                "version_removed": "50"
               }
             ],
             "firefox_android": "mirror",
@@ -6680,8 +6680,8 @@
                 "notes": "The <code>onvisibilitychange</code> event handler property is not supported."
               },
               {
-                "version_added": "13",
                 "prefix": "webkit",
+                "version_added": "13",
                 "partial_implementation": true,
                 "notes": "The <code>onvisibilitychange</code> event handler property is not supported."
               }
@@ -6717,8 +6717,8 @@
                 "notes": "The <code>onvisibilitychange</code> event handler property is not supported."
               },
               {
-                "version_added": "15",
                 "prefix": "webkit",
+                "version_added": "15",
                 "partial_implementation": true,
                 "notes": "The <code>onvisibilitychange</code> event handler property is not supported."
               },
@@ -6739,8 +6739,8 @@
                 "notes": "The <code>onvisibilitychange</code> event handler property is not supported."
               },
               {
-                "version_added": "14",
                 "prefix": "webkit",
+                "version_added": "14",
                 "partial_implementation": true,
                 "notes": "The <code>onvisibilitychange</code> event handler property is not supported."
               },
@@ -6790,8 +6790,8 @@
                 "notes": "The <code>onvisibilitychange</code> event handler property is not supported."
               },
               {
-                "version_added": "≤37",
                 "prefix": "webkit",
+                "version_added": "≤37",
                 "partial_implementation": true,
                 "notes": "The <code>onvisibilitychange</code> event handler property is not supported."
               }
@@ -6814,8 +6814,8 @@
                 "version_added": "33"
               },
               {
-                "version_added": "13",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "13"
               }
             ],
             "chrome_android": "mirror",
@@ -6827,9 +6827,9 @@
                 "version_added": "18"
               },
               {
+                "prefix": "moz",
                 "version_added": "10",
-                "version_removed": "52",
-                "prefix": "moz"
+                "version_removed": "52"
               }
             ],
             "firefox_android": "mirror",
@@ -6842,8 +6842,8 @@
                 "version_added": "20"
               },
               {
-                "version_added": "15",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "15"
               },
               {
                 "version_added": "12.1",
@@ -6855,8 +6855,8 @@
                 "version_added": "20"
               },
               {
-                "version_added": "14",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "14"
               },
               {
                 "version_added": "12.1",
@@ -6873,8 +6873,8 @@
                 "version_added": "4.4.3"
               },
               {
-                "version_added": "≤37",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "≤37"
               }
             ]
           },

--- a/api/EXT_texture_filter_anisotropic.json
+++ b/api/EXT_texture_filter_anisotropic.json
@@ -10,8 +10,8 @@
               "version_added": "34"
             },
             {
-              "version_added": "35",
-              "prefix": "WEBKIT_"
+              "prefix": "WEBKIT_",
+              "version_added": "35"
             }
           ],
           "chrome_android": "mirror",
@@ -20,8 +20,8 @@
               "version_added": "12"
             },
             {
-              "version_added": "79",
-              "prefix": "WEBKIT_"
+              "prefix": "WEBKIT_",
+              "version_added": "79"
             }
           ],
           "firefox": {
@@ -43,8 +43,8 @@
               "version_added": "3.0"
             },
             {
-              "version_added": "4.0",
-              "prefix": "WEBKIT_"
+              "prefix": "WEBKIT_",
+              "version_added": "4.0"
             }
           ],
           "webview_android": "mirror"

--- a/api/Element.json
+++ b/api/Element.json
@@ -591,8 +591,8 @@
                 "version_added": "79"
               },
               {
-                "version_added": "81",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "81"
               },
               {
                 "version_added": "43",
@@ -607,8 +607,8 @@
                 "version_added": "18"
               },
               {
-                "version_added": "81",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "81"
               },
               {
                 "version_added": "12",
@@ -662,8 +662,8 @@
                 "version_added": "79"
               },
               {
-                "version_added": "81",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "81"
               },
               {
                 "version_added": "43",
@@ -678,8 +678,8 @@
                 "version_added": "18"
               },
               {
-                "version_added": "81",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "81"
               },
               {
                 "version_added": "12",
@@ -733,8 +733,8 @@
                 "version_added": "79"
               },
               {
-                "version_added": "81",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "81"
               },
               {
                 "version_added": "43",
@@ -749,8 +749,8 @@
                 "version_added": "18"
               },
               {
-                "version_added": "81",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "81"
               },
               {
                 "version_added": "12",
@@ -2968,8 +2968,8 @@
               {
                 "version_added": "8",
                 "version_removed": "22",
-                "notes": "Not supported for SVG elements.",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "Not supported for SVG elements."
               }
             ],
             "chrome_android": "mirror",
@@ -2980,8 +2980,8 @@
               {
                 "version_added": "12",
                 "version_removed": "16",
-                "notes": "Not supported for SVG elements.",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "Not supported for SVG elements."
               }
             ],
             "firefox": {
@@ -2990,8 +2990,8 @@
             "firefox_android": "mirror",
             "ie": {
               "version_added": "10",
-              "notes": "Not supported for SVG elements.",
-              "partial_implementation": true
+              "partial_implementation": true,
+              "notes": "Not supported for SVG elements."
             },
             "oculus": "mirror",
             "opera": {
@@ -3007,8 +3007,8 @@
               {
                 "version_added": "6",
                 "version_removed": "7",
-                "notes": "Not supported for SVG elements.",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "Not supported for SVG elements."
               }
             ],
             "safari_ios": "mirror",
@@ -3020,8 +3020,8 @@
               {
                 "version_added": "3",
                 "version_removed": "4.4",
-                "notes": "Not supported for SVG elements.",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "Not supported for SVG elements."
               }
             ]
           },
@@ -4027,8 +4027,8 @@
                 "version_added": "71"
               },
               {
-                "version_added": "15",
-                "alternative_name": "webkitfullscreenchange"
+                "alternative_name": "webkitfullscreenchange",
+                "version_added": "15"
               }
             ],
             "chrome_android": "mirror",
@@ -4037,8 +4037,8 @@
                 "version_added": "79"
               },
               {
-                "version_added": "12",
-                "alternative_name": "webkitfullscreenchange"
+                "alternative_name": "webkitfullscreenchange",
+                "version_added": "12"
               },
               {
                 "version_added": "12",
@@ -4050,8 +4050,8 @@
                 "version_added": "64"
               },
               {
-                "version_added": "10",
-                "alternative_name": "mozfullscreenchange"
+                "alternative_name": "mozfullscreenchange",
+                "version_added": "10"
               }
             ],
             "firefox_android": "mirror",
@@ -4064,8 +4064,8 @@
                 "version_added": "58"
               },
               {
-                "version_added": "15",
-                "alternative_name": "webkitfullscreenchange"
+                "alternative_name": "webkitfullscreenchange",
+                "version_added": "15"
               },
               {
                 "version_added": "12.1",
@@ -4077,8 +4077,8 @@
                 "version_added": "50"
               },
               {
-                "version_added": "14",
-                "alternative_name": "webkitfullscreenchange"
+                "alternative_name": "webkitfullscreenchange",
+                "version_added": "14"
               },
               {
                 "version_added": "12.1",
@@ -4090,13 +4090,13 @@
                 "version_added": "16.4"
               },
               {
-                "version_added": "5.1",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "5.1"
               }
             ],
             "safari_ios": {
-              "version_added": "12",
               "prefix": "webkit",
+              "version_added": "12",
               "partial_implementation": true,
               "notes": "Only available on iPad, not on iPhone."
             },
@@ -4106,8 +4106,8 @@
                 "version_added": "71"
               },
               {
-                "version_added": "≤37",
-                "alternative_name": "webkitfullscreenchange"
+                "alternative_name": "webkitfullscreenchange",
+                "version_added": "≤37"
               }
             ]
           },
@@ -4129,8 +4129,8 @@
                 "version_added": "71"
               },
               {
-                "version_added": "18",
-                "alternative_name": "webkitfullscreenerror"
+                "alternative_name": "webkitfullscreenerror",
+                "version_added": "18"
               }
             ],
             "chrome_android": "mirror",
@@ -4139,8 +4139,8 @@
                 "version_added": "79"
               },
               {
-                "version_added": "12",
-                "alternative_name": "webkitfullscreenerror"
+                "alternative_name": "webkitfullscreenerror",
+                "version_added": "12"
               },
               {
                 "version_added": "12",
@@ -4152,8 +4152,8 @@
                 "version_added": "64"
               },
               {
-                "version_added": "10",
-                "alternative_name": "mozfullscreenerror"
+                "alternative_name": "mozfullscreenerror",
+                "version_added": "10"
               }
             ],
             "firefox_android": "mirror",
@@ -4166,8 +4166,8 @@
                 "version_added": "58"
               },
               {
-                "version_added": "15",
-                "alternative_name": "webkitfullscreenerror"
+                "alternative_name": "webkitfullscreenerror",
+                "version_added": "15"
               },
               {
                 "version_added": "12.1",
@@ -4179,8 +4179,8 @@
                 "version_added": "50"
               },
               {
-                "version_added": "14",
-                "alternative_name": "webkitfullscreenerror"
+                "alternative_name": "webkitfullscreenerror",
+                "version_added": "14"
               },
               {
                 "version_added": "12.1",
@@ -4192,13 +4192,13 @@
                 "version_added": "16.4"
               },
               {
-                "version_added": "6",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "6"
               }
             ],
             "safari_ios": {
-              "version_added": "12",
               "prefix": "webkit",
+              "version_added": "12",
               "partial_implementation": true,
               "notes": "Only available on iPad, not on iPhone."
             },
@@ -4208,8 +4208,8 @@
                 "version_added": "71"
               },
               {
-                "version_added": "≤37",
-                "alternative_name": "webkitfullscreenerror"
+                "alternative_name": "webkitfullscreenerror",
+                "version_added": "≤37"
               }
             ]
           },
@@ -5639,8 +5639,8 @@
                 "version_added": "33"
               },
               {
-                "version_added": "4",
-                "alternative_name": "webkitMatchesSelector"
+                "alternative_name": "webkitMatchesSelector",
+                "version_added": "4"
               }
             ],
             "chrome_android": "mirror",
@@ -5649,13 +5649,13 @@
                 "version_added": "15"
               },
               {
-                "version_added": "12",
-                "alternative_name": "webkitMatchesSelector"
+                "alternative_name": "webkitMatchesSelector",
+                "version_added": "12"
               },
               {
+                "alternative_name": "msMatchesSelector",
                 "version_added": "12",
-                "version_removed": "79",
-                "alternative_name": "msMatchesSelector"
+                "version_removed": "79"
               }
             ],
             "firefox": [
@@ -5663,12 +5663,12 @@
                 "version_added": "34"
               },
               {
-                "version_added": "44",
-                "alternative_name": "webkitMatchesSelector"
+                "alternative_name": "webkitMatchesSelector",
+                "version_added": "44"
               },
               {
-                "version_added": "3.6",
                 "alternative_name": "mozMatchesSelector",
+                "version_added": "3.6",
                 "notes": [
                   "Before Firefox 4, invalid selector strings caused false to be returned instead of throwing an exception.",
                   "See <a href='https://bugzil.la/1119718'>bug 1119718</a> for removal."
@@ -5680,18 +5680,18 @@
                 "version_added": "34"
               },
               {
-                "version_added": "44",
-                "alternative_name": "webkitMatchesSelector"
+                "alternative_name": "webkitMatchesSelector",
+                "version_added": "44"
               },
               {
-                "version_added": "4",
                 "alternative_name": "mozMatchesSelector",
+                "version_added": "4",
                 "notes": "See <a href='https://bugzil.la/1119718'>bug 1119718</a> for removal."
               }
             ],
             "ie": {
-              "version_added": "9",
-              "alternative_name": "msMatchesSelector"
+              "alternative_name": "msMatchesSelector",
+              "version_added": "9"
             },
             "oculus": "mirror",
             "opera": [
@@ -5699,13 +5699,13 @@
                 "version_added": "21"
               },
               {
-                "version_added": "15",
-                "alternative_name": "webkitMatchesSelector"
+                "alternative_name": "webkitMatchesSelector",
+                "version_added": "15"
               },
               {
+                "alternative_name": "oMatchesSelector",
                 "version_added": "11.5",
-                "version_removed": "15",
-                "alternative_name": "oMatchesSelector"
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -5713,13 +5713,13 @@
                 "version_added": "21"
               },
               {
-                "version_added": "14",
-                "alternative_name": "webkitMatchesSelector"
+                "alternative_name": "webkitMatchesSelector",
+                "version_added": "14"
               },
               {
+                "alternative_name": "oMatchesSelector",
                 "version_added": "11.5",
-                "version_removed": "14",
-                "alternative_name": "oMatchesSelector"
+                "version_removed": "14"
               }
             ],
             "safari": [
@@ -5727,8 +5727,8 @@
                 "version_added": "8"
               },
               {
-                "version_added": "5",
-                "alternative_name": "webkitMatchesSelector"
+                "alternative_name": "webkitMatchesSelector",
+                "version_added": "5"
               }
             ],
             "safari_ios": "mirror",
@@ -5738,8 +5738,8 @@
                 "version_added": "4.4"
               },
               {
-                "version_added": "≤37",
-                "alternative_name": "webkitMatchesSelector"
+                "alternative_name": "webkitMatchesSelector",
+                "version_added": "≤37"
               }
             ]
           },
@@ -6336,9 +6336,9 @@
                 "version_added": "12"
               },
               {
+                "alternative_name": "mspointercancel",
                 "version_added": "12",
-                "version_removed": "79",
-                "alternative_name": "mspointercancel"
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -6352,8 +6352,8 @@
                 "version_added": "11"
               },
               {
-                "version_added": "10",
-                "alternative_name": "mspointercancel"
+                "alternative_name": "mspointercancel",
+                "version_added": "10"
               }
             ],
             "oculus": "mirror",
@@ -6391,9 +6391,9 @@
                 "version_added": "12"
               },
               {
+                "alternative_name": "mspointerdown",
                 "version_added": "12",
-                "version_removed": "79",
-                "alternative_name": "mspointerdown"
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -6407,8 +6407,8 @@
                 "version_added": "11"
               },
               {
-                "version_added": "10",
-                "alternative_name": "mspointerdown"
+                "alternative_name": "mspointerdown",
+                "version_added": "10"
               }
             ],
             "oculus": "mirror",
@@ -6446,9 +6446,9 @@
                 "version_added": "12"
               },
               {
+                "alternative_name": "mspointerenter",
                 "version_added": "12",
-                "version_removed": "79",
-                "alternative_name": "mspointerenter"
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -6462,8 +6462,8 @@
                 "version_added": "11"
               },
               {
-                "version_added": "10",
-                "alternative_name": "mspointerenter"
+                "alternative_name": "mspointerenter",
+                "version_added": "10"
               }
             ],
             "oculus": "mirror",
@@ -6501,9 +6501,9 @@
                 "version_added": "12"
               },
               {
+                "alternative_name": "mspointerleave",
                 "version_added": "12",
-                "version_removed": "79",
-                "alternative_name": "mspointerleave"
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -6517,8 +6517,8 @@
                 "version_added": "11"
               },
               {
-                "version_added": "10",
-                "alternative_name": "mspointerleave"
+                "alternative_name": "mspointerleave",
+                "version_added": "10"
               }
             ],
             "oculus": "mirror",
@@ -6556,9 +6556,9 @@
                 "version_added": "12"
               },
               {
+                "alternative_name": "mspointermove",
                 "version_added": "12",
-                "version_removed": "79",
-                "alternative_name": "mspointermove"
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -6572,8 +6572,8 @@
                 "version_added": "11"
               },
               {
-                "version_added": "10",
-                "alternative_name": "mspointermove"
+                "alternative_name": "mspointermove",
+                "version_added": "10"
               }
             ],
             "oculus": "mirror",
@@ -6611,9 +6611,9 @@
                 "version_added": "12"
               },
               {
+                "alternative_name": "mspointerout",
                 "version_added": "12",
-                "version_removed": "79",
-                "alternative_name": "mspointerout"
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -6627,8 +6627,8 @@
                 "version_added": "11"
               },
               {
-                "version_added": "10",
-                "alternative_name": "mspointerout"
+                "alternative_name": "mspointerout",
+                "version_added": "10"
               }
             ],
             "oculus": "mirror",
@@ -6666,9 +6666,9 @@
                 "version_added": "12"
               },
               {
+                "alternative_name": "mspointerover",
                 "version_added": "12",
-                "version_removed": "79",
-                "alternative_name": "mspointerover"
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -6682,8 +6682,8 @@
                 "version_added": "11"
               },
               {
-                "version_added": "10",
-                "alternative_name": "mspointerover"
+                "alternative_name": "mspointerover",
+                "version_added": "10"
               }
             ],
             "oculus": "mirror",
@@ -6759,9 +6759,9 @@
                 "version_added": "12"
               },
               {
+                "alternative_name": "mspointerup",
                 "version_added": "12",
-                "version_removed": "79",
-                "alternative_name": "mspointerup"
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -6775,8 +6775,8 @@
                 "version_added": "11"
               },
               {
-                "version_added": "10",
-                "alternative_name": "mspointerup"
+                "alternative_name": "mspointerup",
+                "version_added": "10"
               }
             ],
             "oculus": "mirror",
@@ -7033,8 +7033,8 @@
                 "version_added": "11"
               },
               {
-                "version_added": "10",
-                "prefix": "ms"
+                "prefix": "ms",
+                "version_added": "10"
               }
             ],
             "oculus": "mirror",
@@ -7293,8 +7293,8 @@
                 "version_added": "71"
               },
               {
-                "version_added": "15",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "15"
               }
             ],
             "chrome_android": "mirror",
@@ -7303,8 +7303,8 @@
                 "version_added": "79"
               },
               {
-                "version_added": "12",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "12"
               },
               {
                 "version_added": "12",
@@ -7316,8 +7316,8 @@
                 "version_added": "64"
               },
               {
-                "version_added": "9",
                 "alternative_name": "mozRequestFullScreen",
+                "version_added": "9",
                 "notes": "Before Firefox 44, Firefox incorrectly allowed elements inside a <code>&lt;frame&gt;</code> or <code>&lt;object&gt;</code> element to request, and to be granted, fullscreen. In Firefox 44 and onwards this has been fixed: only elements in the top-level document or in an <code>&lt;iframe&gt;</code> element with the <code>allowfullscreen</code> attribute can be displayed fullscreen."
               }
             ],
@@ -7326,14 +7326,14 @@
                 "version_added": "64"
               },
               {
-                "version_added": "9",
                 "alternative_name": "mozRequestFullScreen",
+                "version_added": "9",
                 "notes": "Before Firefox 44, Firefox incorrectly allowed elements inside a <code>&lt;frame&gt;</code> or an <code>&lt;object&gt;</code> to request, and to be granted, fullscreen. In Firefox 44 and onwards this has been fixed: only elements in the top-level document or in an <code><code>&lt;iframe&gt;</code></code> with the <code>allowfullscreen</code> attribute can be displayed fullscreen."
               }
             ],
             "ie": {
-              "version_added": "11",
-              "alternative_name": "msRequestFullscreen"
+              "alternative_name": "msRequestFullscreen",
+              "version_added": "11"
             },
             "oculus": "mirror",
             "opera": [
@@ -7341,8 +7341,8 @@
                 "version_added": "58"
               },
               {
-                "version_added": "15",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "15"
               },
               {
                 "version_added": "12.1",
@@ -7354,8 +7354,8 @@
                 "version_added": "50"
               },
               {
-                "version_added": "14",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "14"
               },
               {
                 "version_added": "12.1",
@@ -7367,13 +7367,13 @@
                 "version_added": "16.4"
               },
               {
-                "version_added": "5.1",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "5.1"
               }
             ],
             "safari_ios": {
-              "version_added": "12",
               "prefix": "webkit",
+              "version_added": "12",
               "partial_implementation": true,
               "notes": "Only available on iPad, not on iPhone. Shows an overlay button which can not be disabled."
             },
@@ -7383,8 +7383,8 @@
                 "version_added": "71"
               },
               {
-                "version_added": "≤37",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "≤37"
               }
             ]
           },
@@ -7509,9 +7509,9 @@
                 "notes": "From version 92, returns a promise instead of <code>undefined</code>. The behavior reflects <a href='https://github.com/w3c/pointerlock/pull/49'>a proposed specification change</a>."
               },
               {
+                "prefix": "webkit",
                 "version_added": "22",
-                "version_removed": "38",
-                "prefix": "webkit"
+                "version_removed": "38"
               }
             ],
             "chrome_android": "mirror",
@@ -7524,9 +7524,9 @@
                 "version_added": "50"
               },
               {
+                "prefix": "moz",
                 "version_added": "14",
-                "version_removed": "50",
-                "prefix": "moz"
+                "version_removed": "50"
               }
             ],
             "firefox_android": "mirror",
@@ -7548,9 +7548,9 @@
                 "notes": "From version 16, returns a promise instead of <code>undefined</code>. The behavior reflects <a href='https://github.com/w3c/pointerlock/pull/49'>a proposed specification change</a>."
               },
               {
+                "prefix": "webkit",
                 "version_added": "1.5",
-                "version_removed": "3.0",
-                "prefix": "webkit"
+                "version_removed": "3.0"
               }
             ],
             "webview_android": "mirror"
@@ -8813,8 +8813,8 @@
                 "version_added": "11"
               },
               {
-                "version_added": "10",
-                "prefix": "ms"
+                "prefix": "ms",
+                "version_added": "10"
               }
             ],
             "oculus": "mirror",

--- a/api/EntrySync.json
+++ b/api/EntrySync.json
@@ -5,8 +5,8 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/EntrySync",
         "support": {
           "chrome": {
-            "version_added": "13",
-            "prefix": "webkit"
+            "prefix": "webkit",
+            "version_added": "13"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -30,8 +30,8 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": "37",
-            "prefix": "webkit"
+            "prefix": "webkit",
+            "version_added": "37"
           }
         },
         "status": {

--- a/api/Event.json
+++ b/api/Event.json
@@ -220,8 +220,8 @@
                 "version_added": "53"
               },
               {
-                "version_removed": "53",
                 "version_added": "1",
+                "version_removed": "53",
                 "partial_implementation": true,
                 "notes": "Only supported for <a href='https://developer.mozilla.org/docs/Web/API/UIEvent'><code>UIEvent</code></a>, not all <code>Event</code> objects."
               }
@@ -312,9 +312,9 @@
                 "version_added": "53"
               },
               {
+                "alternative_name": "deepPath",
                 "version_added": "50",
-                "version_removed": "53",
-                "alternative_name": "deepPath"
+                "version_removed": "53"
               }
             ],
             "chrome_android": "mirror",

--- a/api/FeaturePolicy.json
+++ b/api/FeaturePolicy.json
@@ -10,8 +10,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "65",
             "alternative_name": "Policy",
+            "version_added": "65",
             "flags": [
               {
                 "type": "preference",

--- a/api/FileEntrySync.json
+++ b/api/FileEntrySync.json
@@ -5,8 +5,8 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/FileEntrySync",
         "support": {
           "chrome": {
-            "version_added": "13",
-            "prefix": "webkit"
+            "prefix": "webkit",
+            "version_added": "13"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -30,8 +30,8 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
-            "version_added": "37",
-            "prefix": "webkit"
+            "prefix": "webkit",
+            "version_added": "37"
           }
         },
         "status": {

--- a/api/GeolocationCoordinates.json
+++ b/api/GeolocationCoordinates.json
@@ -10,9 +10,9 @@
               "version_added": "79"
             },
             {
+              "alternative_name": "Coordinates",
               "version_added": "5",
-              "version_removed": "78",
-              "alternative_name": "Coordinates"
+              "version_removed": "78"
             }
           ],
           "chrome_android": "mirror",
@@ -21,9 +21,9 @@
               "version_added": "79"
             },
             {
+              "alternative_name": "Coordinates",
               "version_added": "12",
-              "version_removed": "79",
-              "alternative_name": "Coordinates"
+              "version_removed": "79"
             }
           ],
           "firefox": [
@@ -31,9 +31,9 @@
               "version_added": "72"
             },
             {
+              "alternative_name": "Coordinates",
               "version_added": "3.5",
-              "version_removed": "71",
-              "alternative_name": "Coordinates"
+              "version_removed": "71"
             }
           ],
           "firefox_android": "mirror",
@@ -90,9 +90,9 @@
               "version_added": "79"
             },
             {
+              "alternative_name": "Coordinates",
               "version_added": "≤37",
-              "version_removed": "78",
-              "alternative_name": "Coordinates"
+              "version_removed": "78"
             }
           ]
         },

--- a/api/GeolocationPosition.json
+++ b/api/GeolocationPosition.json
@@ -10,9 +10,9 @@
               "version_added": "79"
             },
             {
+              "alternative_name": "Position",
               "version_added": "5",
-              "version_removed": "78",
-              "alternative_name": "Position"
+              "version_removed": "78"
             }
           ],
           "chrome_android": "mirror",
@@ -21,9 +21,9 @@
               "version_added": "79"
             },
             {
+              "alternative_name": "Position",
               "version_added": "12",
-              "version_removed": "79",
-              "alternative_name": "Position"
+              "version_removed": "79"
             }
           ],
           "firefox": [
@@ -31,9 +31,9 @@
               "version_added": "72"
             },
             {
+              "alternative_name": "Position",
               "version_added": "3.5",
-              "version_removed": "71",
-              "alternative_name": "Position"
+              "version_removed": "71"
             }
           ],
           "firefox_android": "mirror",
@@ -76,9 +76,9 @@
               "version_added": "79"
             },
             {
+              "alternative_name": "Position",
               "version_added": "≤37",
-              "version_removed": "78",
-              "alternative_name": "Position"
+              "version_removed": "78"
             }
           ]
         },

--- a/api/GeolocationPositionError.json
+++ b/api/GeolocationPositionError.json
@@ -10,9 +10,9 @@
               "version_added": "79"
             },
             {
+              "alternative_name": "PositionError",
               "version_added": "5",
-              "version_removed": "78",
-              "alternative_name": "PositionError"
+              "version_removed": "78"
             }
           ],
           "chrome_android": "mirror",
@@ -21,9 +21,9 @@
               "version_added": "79"
             },
             {
+              "alternative_name": "PositionError",
               "version_added": "12",
-              "version_removed": "79",
-              "alternative_name": "PositionError"
+              "version_removed": "79"
             }
           ],
           "firefox": [
@@ -31,9 +31,9 @@
               "version_added": "72"
             },
             {
+              "alternative_name": "PositionError",
               "version_added": "3.5",
-              "version_removed": "71",
-              "alternative_name": "PositionError"
+              "version_removed": "71"
             }
           ],
           "firefox_android": "mirror",
@@ -66,9 +66,9 @@
               "version_added": "79"
             },
             {
+              "alternative_name": "PositionError",
               "version_added": "≤37",
-              "version_removed": "78",
-              "alternative_name": "PositionError"
+              "version_removed": "78"
             }
           ]
         },

--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -65,9 +65,9 @@
                 "version_added": "15.4"
               },
               {
+                "alternative_name": "attributionsourceid",
                 "version_added": "14.1",
-                "version_removed": "15.4",
-                "alternative_name": "attributionsourceid"
+                "version_removed": "15.4"
               }
             ],
             "safari_ios": "mirror",

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -262,8 +262,8 @@
                   "version_added": "33"
                 },
                 {
-                  "version_added": "9",
-                  "alternative_name": "experimental-webgl"
+                  "alternative_name": "experimental-webgl",
+                  "version_added": "9"
                 }
               ],
               "chrome_android": "mirror",
@@ -272,8 +272,8 @@
                   "version_added": "79"
                 },
                 {
-                  "version_added": "12",
-                  "alternative_name": "experimental-webgl"
+                  "alternative_name": "experimental-webgl",
+                  "version_added": "12"
                 }
               ],
               "firefox": [
@@ -281,14 +281,14 @@
                   "version_added": "24"
                 },
                 {
-                  "version_added": "3.6",
-                  "alternative_name": "experimental-webgl"
+                  "alternative_name": "experimental-webgl",
+                  "version_added": "3.6"
                 }
               ],
               "firefox_android": "mirror",
               "ie": {
-                "version_added": "11",
-                "alternative_name": "experimental-webgl"
+                "alternative_name": "experimental-webgl",
+                "version_added": "11"
               },
               "oculus": "mirror",
               "opera": [
@@ -296,8 +296,8 @@
                   "version_added": "15"
                 },
                 {
-                  "version_added": "9",
-                  "alternative_name": "experimental-webgl"
+                  "alternative_name": "experimental-webgl",
+                  "version_added": "9"
                 }
               ],
               "opera_android": [
@@ -305,8 +305,8 @@
                   "version_added": "14"
                 },
                 {
-                  "version_added": "10.1",
-                  "alternative_name": "experimental-webgl"
+                  "alternative_name": "experimental-webgl",
+                  "version_added": "10.1"
                 }
               ],
               "safari": [
@@ -314,8 +314,8 @@
                   "version_added": "8"
                 },
                 {
-                  "version_added": "5.1",
-                  "alternative_name": "experimental-webgl"
+                  "alternative_name": "experimental-webgl",
+                  "version_added": "5.1"
                 }
               ],
               "safari_ios": [
@@ -323,8 +323,8 @@
                   "version_added": "8"
                 },
                 {
-                  "version_added": "8",
-                  "alternative_name": "experimental-webgl"
+                  "alternative_name": "experimental-webgl",
+                  "version_added": "8"
                 }
               ],
               "samsunginternet_android": "mirror",
@@ -333,8 +333,8 @@
                   "version_added": "37"
                 },
                 {
-                  "version_added": "37",
-                  "alternative_name": "experimental-webgl"
+                  "alternative_name": "experimental-webgl",
+                  "version_added": "37"
                 }
               ]
             },
@@ -521,8 +521,8 @@
                   "version_added": "51"
                 },
                 {
-                  "version_added": "25",
-                  "alternative_name": "experimental-webgl2"
+                  "alternative_name": "experimental-webgl2",
+                  "version_added": "25"
                 }
               ],
               "firefox_android": "mirror",
@@ -1023,9 +1023,9 @@
                 "version_added": "79"
               },
               {
+                "prefix": "ms",
                 "version_added": "12",
-                "version_removed": "79",
-                "prefix": "ms"
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -1033,8 +1033,8 @@
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "10",
-              "prefix": "ms"
+              "prefix": "ms",
+              "version_added": "10"
             },
             "oculus": "mirror",
             "opera": "mirror",

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -438,9 +438,9 @@
                 "version_added": "102"
               },
               {
+                "alternative_name": "fetchpriority",
                 "version_added": "101",
-                "version_removed": "102",
-                "alternative_name": "fetchpriority"
+                "version_removed": "102"
               }
             ],
             "chrome_android": "mirror",

--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -244,9 +244,9 @@
                 "version_added": "102"
               },
               {
+                "alternative_name": "fetchpriority",
                 "version_added": "101",
-                "version_removed": "102",
-                "alternative_name": "fetchpriority"
+                "version_removed": "102"
               }
             ],
             "chrome_android": "mirror",

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -99,8 +99,8 @@
                 "version_added": "23"
               },
               {
-                "version_added": "26",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "26"
               }
             ],
             "chrome_android": "mirror",
@@ -131,8 +131,8 @@
                 "version_added": "4.4"
               },
               {
-                "version_added": "≤37",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "≤37"
               }
             ]
           },
@@ -473,8 +473,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "15",
-              "prefix": "moz"
+              "prefix": "moz",
+              "version_added": "15"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -627,9 +627,9 @@
                 "version_added": "22"
               },
               {
+                "alternative_name": "crossorigin",
                 "version_added": "12",
-                "version_removed": "22",
-                "alternative_name": "crossorigin"
+                "version_removed": "22"
               }
             ],
             "firefox_android": "mirror",
@@ -2893,9 +2893,9 @@
                 "notes": "Only supports <code>MediaStream</code> objects (see <a href='https://bugzil.la/886194'>bug 886194</a>)."
               },
               {
+                "prefix": "moz",
                 "version_added": "18",
-                "version_removed": "58",
-                "prefix": "moz"
+                "version_removed": "58"
               }
             ],
             "firefox_android": "mirror",

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -311,9 +311,9 @@
                 "version_added": "102"
               },
               {
+                "alternative_name": "fetchpriority",
                 "version_added": "101",
-                "version_removed": "102",
-                "alternative_name": "fetchpriority"
+                "version_removed": "102"
               }
             ],
             "chrome_android": "mirror",

--- a/api/IDBCursor.json
+++ b/api/IDBCursor.json
@@ -10,9 +10,9 @@
               "version_added": "24"
             },
             {
+              "prefix": "webkit",
               "version_added": "23",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ],
           "chrome_android": "mirror",
@@ -24,9 +24,9 @@
               "version_added": "16"
             },
             {
+              "prefix": "moz",
               "version_added": "10",
-              "version_removed": "16",
-              "prefix": "moz"
+              "version_removed": "16"
             }
           ],
           "firefox_android": {
@@ -41,9 +41,9 @@
               "version_added": "44"
             },
             {
+              "prefix": "webkit",
               "version_added": "15",
-              "version_removed": "44",
-              "prefix": "webkit"
+              "version_removed": "44"
             }
           ],
           "opera_android": [
@@ -51,9 +51,9 @@
               "version_added": "43"
             },
             {
+              "prefix": "webkit",
               "version_added": "14",
-              "version_removed": "43",
-              "prefix": "webkit"
+              "version_removed": "43"
             }
           ],
           "safari": {
@@ -66,9 +66,9 @@
               "version_added": "4.4"
             },
             {
+              "prefix": "webkit",
               "version_added": "≤37",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ]
         },

--- a/api/IDBCursorWithValue.json
+++ b/api/IDBCursorWithValue.json
@@ -10,9 +10,9 @@
               "version_added": "24"
             },
             {
+              "prefix": "webkit",
               "version_added": "23",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ],
           "chrome_android": "mirror",
@@ -24,9 +24,9 @@
               "version_added": "16"
             },
             {
+              "prefix": "moz",
               "version_added": "10",
-              "version_removed": "16",
-              "prefix": "moz"
+              "version_removed": "16"
             }
           ],
           "firefox_android": {
@@ -52,9 +52,9 @@
               "version_added": "4.4"
             },
             {
+              "prefix": "webkit",
               "version_added": "≤37",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ]
         },

--- a/api/IDBDatabase.json
+++ b/api/IDBDatabase.json
@@ -10,9 +10,9 @@
               "version_added": "24"
             },
             {
+              "prefix": "webkit",
               "version_added": "23",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ],
           "chrome_android": "mirror",
@@ -24,9 +24,9 @@
               "version_added": "16"
             },
             {
+              "prefix": "moz",
               "version_added": "10",
-              "version_removed": "16",
-              "prefix": "moz"
+              "version_removed": "16"
             }
           ],
           "firefox_android": {
@@ -52,9 +52,9 @@
               "version_added": "4.4"
             },
             {
+              "prefix": "webkit",
               "version_added": "≤37",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ]
         },

--- a/api/IDBFactory.json
+++ b/api/IDBFactory.json
@@ -10,9 +10,9 @@
               "version_added": "24"
             },
             {
+              "prefix": "webkit",
               "version_added": "23",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ],
           "chrome_android": "mirror",
@@ -24,9 +24,9 @@
               "version_added": "16"
             },
             {
+              "prefix": "moz",
               "version_added": "10",
-              "version_removed": "16",
-              "prefix": "moz"
+              "version_removed": "16"
             }
           ],
           "firefox_android": {
@@ -52,9 +52,9 @@
               "version_added": "4.4"
             },
             {
+              "prefix": "webkit",
               "version_added": "≤37",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ]
         },

--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -10,9 +10,9 @@
               "version_added": "24"
             },
             {
+              "prefix": "webkit",
               "version_added": "23",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ],
           "chrome_android": "mirror",
@@ -24,9 +24,9 @@
               "version_added": "16"
             },
             {
+              "prefix": "moz",
               "version_added": "10",
-              "version_removed": "16",
-              "prefix": "moz"
+              "version_removed": "16"
             }
           ],
           "firefox_android": {
@@ -52,9 +52,9 @@
               "version_added": "4.4"
             },
             {
+              "prefix": "webkit",
               "version_added": "≤37",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ]
         },

--- a/api/IDBKeyRange.json
+++ b/api/IDBKeyRange.json
@@ -10,9 +10,9 @@
               "version_added": "24"
             },
             {
+              "prefix": "webkit",
               "version_added": "23",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ],
           "chrome_android": "mirror",
@@ -24,9 +24,9 @@
               "version_added": "16"
             },
             {
+              "prefix": "moz",
               "version_added": "10",
-              "version_removed": "16",
-              "prefix": "moz"
+              "version_removed": "16"
             }
           ],
           "firefox_android": {
@@ -42,9 +42,9 @@
               "version_added": "14"
             },
             {
+              "prefix": "webkit",
               "version_added": "14",
-              "version_removed": "44",
-              "prefix": "webkit"
+              "version_removed": "44"
             }
           ],
           "safari": {
@@ -57,9 +57,9 @@
               "version_added": "4.4"
             },
             {
+              "prefix": "webkit",
               "version_added": "≤37",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ]
         },

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -10,9 +10,9 @@
               "version_added": "24"
             },
             {
+              "prefix": "webkit",
               "version_added": "23",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ],
           "chrome_android": "mirror",
@@ -24,9 +24,9 @@
               "version_added": "16"
             },
             {
+              "prefix": "moz",
               "version_added": "10",
-              "version_removed": "16",
-              "prefix": "moz"
+              "version_removed": "16"
             }
           ],
           "firefox_android": {
@@ -52,9 +52,9 @@
               "version_added": "4.4"
             },
             {
+              "prefix": "webkit",
               "version_added": "≤37",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ]
         },

--- a/api/IDBOpenDBRequest.json
+++ b/api/IDBOpenDBRequest.json
@@ -10,9 +10,9 @@
               "version_added": "24"
             },
             {
+              "prefix": "webkit",
               "version_added": "23",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ],
           "chrome_android": "mirror",
@@ -24,9 +24,9 @@
               "version_added": "16"
             },
             {
+              "prefix": "moz",
               "version_added": "10",
-              "version_removed": "16",
-              "prefix": "moz"
+              "version_removed": "16"
             }
           ],
           "firefox_android": {
@@ -52,9 +52,9 @@
               "version_added": "4.4"
             },
             {
+              "prefix": "webkit",
               "version_added": "≤37",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ]
         },

--- a/api/IDBRequest.json
+++ b/api/IDBRequest.json
@@ -10,9 +10,9 @@
               "version_added": "24"
             },
             {
+              "prefix": "webkit",
               "version_added": "2",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ],
           "chrome_android": [
@@ -20,9 +20,9 @@
               "version_added": "25"
             },
             {
+              "prefix": "webkit",
               "version_added": "25",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ],
           "edge": {
@@ -33,9 +33,9 @@
               "version_added": "16"
             },
             {
+              "prefix": "moz",
               "version_added": "10",
-              "version_removed": "16",
-              "prefix": "moz"
+              "version_removed": "16"
             }
           ],
           "firefox_android": {
@@ -61,9 +61,9 @@
               "version_added": "4.4"
             },
             {
+              "prefix": "webkit",
               "version_added": "≤37",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ]
         },

--- a/api/IDBTransaction.json
+++ b/api/IDBTransaction.json
@@ -10,9 +10,9 @@
               "version_added": "24"
             },
             {
+              "prefix": "webkit",
               "version_added": "23",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ],
           "chrome_android": "mirror",
@@ -24,9 +24,9 @@
               "version_added": "16"
             },
             {
+              "prefix": "moz",
               "version_added": "10",
-              "version_removed": "16",
-              "prefix": "moz"
+              "version_removed": "16"
             }
           ],
           "firefox_android": {
@@ -52,9 +52,9 @@
               "version_added": "4.4"
             },
             {
+              "prefix": "webkit",
               "version_added": "≤37",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ]
         },

--- a/api/IDBVersionChangeEvent.json
+++ b/api/IDBVersionChangeEvent.json
@@ -10,8 +10,8 @@
               "version_added": "24"
             },
             {
-              "version_added": "12",
-              "prefix": "webkit"
+              "prefix": "webkit",
+              "version_added": "12"
             }
           ],
           "chrome_android": "mirror",
@@ -23,9 +23,9 @@
               "version_added": "16"
             },
             {
+              "prefix": "moz",
               "version_added": "10",
-              "version_removed": "16",
-              "prefix": "moz"
+              "version_removed": "16"
             }
           ],
           "firefox_android": {
@@ -47,8 +47,8 @@
               "version_added": "4.4"
             },
             {
-              "version_added": "≤37",
-              "prefix": "webkit"
+              "prefix": "webkit",
+              "version_added": "≤37"
             }
           ]
         },

--- a/api/ImageBitmapRenderingContext.json
+++ b/api/ImageBitmapRenderingContext.json
@@ -81,9 +81,9 @@
                 "version_added": "50"
               },
               {
+                "alternative_name": "transferImageBitmap",
                 "version_added": "46",
-                "version_removed": "52",
-                "alternative_name": "transferImageBitmap"
+                "version_removed": "52"
               }
             ],
             "firefox_android": "mirror",

--- a/api/ImageCapture.json
+++ b/api/ImageCapture.json
@@ -199,8 +199,8 @@
               },
               {
                 "version_added": "59",
-                "partial_implementation": true,
                 "version_removed": "60",
+                "partial_implementation": true,
                 "notes": "<code>photoSettings</code> parameter not supported."
               }
             ],
@@ -248,8 +248,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "35",
               "alternative_name": "videoStreamTrack",
+              "version_added": "35",
               "flags": [
                 {
                   "type": "preference",

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -560,9 +560,9 @@
                   "version_added": "79"
                 },
                 {
+                  "alternative_name": "Win",
                   "version_added": "12",
-                  "version_removed": "79",
-                  "alternative_name": "Win"
+                  "version_removed": "79"
                 }
               ],
               "firefox": {
@@ -570,8 +570,8 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": "9",
-                "alternative_name": "Win"
+                "alternative_name": "Win",
+                "version_added": "9"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -603,9 +603,9 @@
                   "version_added": "79"
                 },
                 {
+                  "alternative_name": "Scroll",
                   "version_added": "12",
-                  "version_removed": "79",
-                  "alternative_name": "Scroll"
+                  "version_removed": "79"
                 }
               ],
               "firefox": {
@@ -613,8 +613,8 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": "9",
-                "alternative_name": "Scroll"
+                "alternative_name": "Scroll",
+                "version_added": "9"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/api/MediaSource.json
+++ b/api/MediaSource.json
@@ -10,9 +10,9 @@
               "version_added": "31"
             },
             {
+              "prefix": "WebKit",
               "version_added": "23",
-              "version_removed": "31",
-              "prefix": "WebKit"
+              "version_removed": "31"
             }
           ],
           "chrome_android": "mirror",
@@ -59,9 +59,9 @@
                 "version_added": "31"
               },
               {
+                "prefix": "WebKit",
                 "version_added": "23",
-                "version_removed": "31",
-                "prefix": "WebKit"
+                "version_removed": "31"
               }
             ],
             "chrome_android": {

--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -10,8 +10,8 @@
               "version_added": "55"
             },
             {
-              "version_added": "21",
-              "prefix": "webkit"
+              "prefix": "webkit",
+              "version_added": "21"
             }
           ],
           "chrome_android": "mirror",
@@ -20,8 +20,8 @@
               "version_added": "12"
             },
             {
-              "version_added": "79",
-              "prefix": "webkit"
+              "prefix": "webkit",
+              "version_added": "79"
             }
           ],
           "firefox": {
@@ -58,8 +58,8 @@
                 "version_added": "55"
               },
               {
-                "version_added": "21",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "21"
               }
             ],
             "chrome_android": "mirror",
@@ -68,8 +68,8 @@
                 "version_added": "12"
               },
               {
-                "version_added": "79",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "79"
               }
             ],
             "firefox": {

--- a/api/MediaTrackSettings.json
+++ b/api/MediaTrackSettings.json
@@ -91,9 +91,9 @@
                 "version_added": "55"
               },
               {
+                "prefix": "moz",
                 "version_added": "50",
-                "version_removed": "55",
-                "prefix": "moz"
+                "version_removed": "55"
               }
             ],
             "firefox_android": "mirror",
@@ -532,9 +532,9 @@
                 "version_added": "55"
               },
               {
+                "prefix": "moz",
                 "version_added": "50",
-                "version_removed": "55",
-                "prefix": "moz"
+                "version_removed": "55"
               }
             ],
             "firefox_android": "mirror",

--- a/api/MediaTrackSupportedConstraints.json
+++ b/api/MediaTrackSupportedConstraints.json
@@ -88,9 +88,9 @@
                 "version_added": "55"
               },
               {
+                "prefix": "moz",
                 "version_added": "46",
-                "version_removed": "55",
-                "prefix": "moz"
+                "version_removed": "55"
               }
             ],
             "firefox_android": "mirror",
@@ -489,9 +489,9 @@
                 "version_added": "55"
               },
               {
+                "prefix": "moz",
                 "version_added": "46",
-                "version_removed": "55",
-                "prefix": "moz"
+                "version_removed": "55"
               }
             ],
             "firefox_android": "mirror",

--- a/api/MerchantValidationEvent.json
+++ b/api/MerchantValidationEvent.json
@@ -11,14 +11,14 @@
           "edge": "mirror",
           "firefox": {
             "version_added": "preview",
-            "notes": "Available only in Nightly builds.",
             "flags": [
               {
                 "name": "dom.payments.request.supportedRegions",
                 "type": "preference",
                 "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
               }
-            ]
+            ],
+            "notes": "Available only in Nightly builds."
           },
           "firefox_android": "mirror",
           "ie": {
@@ -52,14 +52,14 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "preview",
-              "notes": "Available only in Nightly builds.",
               "flags": [
                 {
                   "name": "dom.payments.request.supportedRegions",
                   "type": "preference",
                   "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
                 }
-              ]
+              ],
+              "notes": "Available only in Nightly builds."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -94,14 +94,14 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "preview",
-              "notes": "Available only in Nightly builds.",
               "flags": [
                 {
                   "name": "dom.payments.request.supportedRegions",
                   "type": "preference",
                   "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
                 }
-              ]
+              ],
+              "notes": "Available only in Nightly builds."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -135,14 +135,14 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "preview",
-              "notes": "Available only in Nightly builds.",
               "flags": [
                 {
                   "name": "dom.payments.request.supportedRegions",
                   "type": "preference",
                   "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
                 }
-              ]
+              ],
+              "notes": "Available only in Nightly builds."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -176,14 +176,14 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "preview",
-              "notes": "Available only in Nightly builds.",
               "flags": [
                 {
                   "name": "dom.payments.request.supportedRegions",
                   "type": "preference",
                   "value_to_set": "A comma-delineated list of one or more 2-character ISO country codes indicating the countries in which to support payments (for example, <code>US,CA</code>."
                 }
-              ]
+              ],
+              "notes": "Available only in Nightly builds."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -562,9 +562,9 @@
                 "version_added": "37"
               },
               {
+                "prefix": "webkit",
                 "version_added": "22",
-                "version_removed": "37",
-                "prefix": "webkit"
+                "version_removed": "37"
               }
             ],
             "chrome_android": "mirror",
@@ -576,9 +576,9 @@
                 "version_added": "41"
               },
               {
+                "prefix": "moz",
                 "version_added": "1",
-                "version_removed": "41",
-                "prefix": "moz"
+                "version_removed": "41"
               }
             ],
             "firefox_android": "mirror",
@@ -593,9 +593,9 @@
                 "version_added": "9"
               },
               {
+                "prefix": "webkit",
                 "version_added": "6",
-                "version_removed": "8",
-                "prefix": "webkit"
+                "version_removed": "8"
               }
             ],
             "safari_ios": [
@@ -603,9 +603,9 @@
                 "version_added": "8"
               },
               {
+                "prefix": "webkit",
                 "version_added": "6",
-                "version_removed": "8",
-                "prefix": "webkit"
+                "version_removed": "8"
               }
             ],
             "samsunginternet_android": [
@@ -613,9 +613,9 @@
                 "version_added": "3.0"
               },
               {
+                "prefix": "webkit",
                 "version_added": "1.0",
-                "version_removed": "3.0",
-                "prefix": "webkit"
+                "version_removed": "3.0"
               }
             ],
             "webview_android": "mirror"
@@ -637,9 +637,9 @@
                 "version_added": "37"
               },
               {
+                "prefix": "webkit",
                 "version_added": "22",
-                "version_removed": "37",
-                "prefix": "webkit"
+                "version_removed": "37"
               }
             ],
             "chrome_android": "mirror",
@@ -651,9 +651,9 @@
                 "version_added": "41"
               },
               {
+                "prefix": "moz",
                 "version_added": "1",
-                "version_removed": "41",
-                "prefix": "moz"
+                "version_removed": "41"
               }
             ],
             "firefox_android": "mirror",
@@ -668,9 +668,9 @@
                 "version_added": "9"
               },
               {
+                "prefix": "webkit",
                 "version_added": "6",
-                "version_removed": "8",
-                "prefix": "webkit"
+                "version_removed": "8"
               }
             ],
             "safari_ios": [
@@ -678,9 +678,9 @@
                 "version_added": "8"
               },
               {
+                "prefix": "webkit",
                 "version_added": "6",
-                "version_removed": "8",
-                "prefix": "webkit"
+                "version_removed": "8"
               }
             ],
             "samsunginternet_android": [
@@ -688,9 +688,9 @@
                 "version_added": "3.0"
               },
               {
+                "prefix": "webkit",
                 "version_added": "1.0",
-                "version_removed": "3.0",
-                "prefix": "webkit"
+                "version_removed": "3.0"
               }
             ],
             "webview_android": "mirror"

--- a/api/MutationObserver.json
+++ b/api/MutationObserver.json
@@ -10,8 +10,8 @@
               "version_added": "26"
             },
             {
-              "version_added": "18",
-              "prefix": "WebKit"
+              "prefix": "WebKit",
+              "version_added": "18"
             }
           ],
           "chrome_android": "mirror",
@@ -37,8 +37,8 @@
               "version_added": "7"
             },
             {
-              "version_added": "6",
-              "prefix": "WebKit"
+              "prefix": "WebKit",
+              "version_added": "6"
             }
           ],
           "safari_ios": "mirror",
@@ -48,8 +48,8 @@
               "version_added": "4.4"
             },
             {
-              "version_added": "≤37",
-              "prefix": "WebKit"
+              "prefix": "WebKit",
+              "version_added": "≤37"
             }
           ]
         },
@@ -70,8 +70,8 @@
                 "version_added": "26"
               },
               {
-                "version_added": "18",
-                "prefix": "WebKit"
+                "prefix": "WebKit",
+                "version_added": "18"
               }
             ],
             "chrome_android": "mirror",
@@ -97,8 +97,8 @@
                 "version_added": "7"
               },
               {
-                "version_added": "6",
-                "prefix": "WebKit"
+                "prefix": "WebKit",
+                "version_added": "6"
               }
             ],
             "safari_ios": "mirror",
@@ -108,8 +108,8 @@
                 "version_added": "4.4"
               },
               {
-                "version_added": "≤37",
-                "prefix": "WebKit"
+                "prefix": "WebKit",
+                "version_added": "≤37"
               }
             ]
           },

--- a/api/NamedNodeMap.json
+++ b/api/NamedNodeMap.json
@@ -21,9 +21,9 @@
               "version_removed": "22"
             },
             {
+              "alternative_name": "MozNamedAttrMap",
               "version_added": "22",
-              "version_removed": "34",
-              "alternative_name": "MozNamedAttrMap"
+              "version_removed": "34"
             }
           ],
           "firefox_android": "mirror",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -348,14 +348,14 @@
               },
               {
                 "version_added": "56",
-                "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "#enable-experimental-web-platform-features",
                     "value_to_set": "enabled"
                   }
-                ]
+                ],
+                "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled."
               }
             ],
             "chrome_android": {
@@ -369,14 +369,14 @@
               },
               {
                 "version_added": "79",
-                "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled.",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "#enable-experimental-web-platform-features",
                     "value_to_set": "enabled"
                   }
-                ]
+                ],
+                "notes": "In Linux and versions of Windows earlier than 10, this flag must be enabled."
               }
             ],
             "firefox": {
@@ -885,9 +885,9 @@
             },
             "firefox_android": "mirror",
             "ie": {
+              "prefix": "ms",
               "version_added": "9",
               "version_removed": "11",
-              "prefix": "ms",
               "notes": "For IE11 and subsequent versions, use <code>window.doNotTrack</code>"
             },
             "oculus": "mirror",
@@ -1103,8 +1103,8 @@
                 "version_added": "35"
               },
               {
-                "version_added": "21",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "21"
               }
             ],
             "chrome_android": "mirror",
@@ -1133,8 +1133,8 @@
                 "version_added": "37"
               },
               {
-                "version_added": "≤37",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "≤37"
               }
             ]
           },
@@ -1253,8 +1253,8 @@
                 "version_added": "53"
               },
               {
-                "version_added": "21",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "21"
               }
             ],
             "chrome_android": "mirror",
@@ -1263,17 +1263,17 @@
                 "version_added": "12"
               },
               {
-                "version_added": "79",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "79"
               }
             ],
             "firefox": {
-              "version_added": "17",
-              "prefix": "moz"
+              "prefix": "moz",
+              "version_added": "17"
             },
             "firefox_android": {
-              "version_added": "24",
-              "prefix": "moz"
+              "prefix": "moz",
+              "version_added": "24"
             },
             "ie": {
               "version_added": false
@@ -1284,8 +1284,8 @@
                 "version_added": "40"
               },
               {
-                "version_added": "15",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "15"
               },
               {
                 "version_added": "12",
@@ -1297,8 +1297,8 @@
                 "version_added": "41"
               },
               {
-                "version_added": "14",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "14"
               },
               {
                 "version_added": "12",
@@ -1316,8 +1316,8 @@
                 "version_added": "53"
               },
               {
-                "version_added": "40",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "40"
               }
             ]
           },
@@ -1809,8 +1809,8 @@
                 "version_added": "11"
               },
               {
-                "version_added": "10",
-                "prefix": "ms"
+                "prefix": "ms",
+                "version_added": "10"
               }
             ],
             "oculus": "mirror",
@@ -2025,17 +2025,17 @@
             "description": "Returns MIME types from plugins rather than hard-coded PDF values",
             "support": {
               "chrome": {
-                "version_removed": "94",
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "94"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_removed": "94",
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "94"
               },
               "firefox": {
-                "version_removed": "99",
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "99"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -2043,12 +2043,12 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_removed": "80",
-                "version_added": "≤12.1"
+                "version_added": "≤12.1",
+                "version_removed": "80"
               },
               "opera_android": {
-                "version_removed": "66",
-                "version_added": "≤12.1"
+                "version_added": "≤12.1",
+                "version_removed": "66"
               },
               "safari": {
                 "version_added": "1"
@@ -2316,17 +2316,17 @@
             "description": "Returns plugins rather than hard-coded PDF plugin values",
             "support": {
               "chrome": {
-                "version_removed": "94",
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "94"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_removed": "94",
-                "version_added": "12"
+                "version_added": "12",
+                "version_removed": "94"
               },
               "firefox": {
-                "version_removed": "99",
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "99"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -2334,12 +2334,12 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_removed": "80",
-                "version_added": "≤12.1"
+                "version_added": "≤12.1",
+                "version_removed": "80"
               },
               "opera_android": {
-                "version_removed": "66",
-                "version_added": "≤12.1"
+                "version_added": "≤12.1",
+                "version_removed": "66"
               },
               "safari": {
                 "version_added": "1"
@@ -3982,8 +3982,8 @@
               "version_added": "17"
             },
             "firefox": {
-              "notes": "In Firefox private windows, the <code>serviceWorker</code> object is <code>undefined</code>. See <a href='https://bugzil.la/1320796'>bug 1320796</a>.",
-              "version_added": "44"
+              "version_added": "44",
+              "notes": "In Firefox private windows, the <code>serviceWorker</code> object is <code>undefined</code>. See <a href='https://bugzil.la/1320796'>bug 1320796</a>."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4593,9 +4593,9 @@
                 ]
               },
               {
+                "prefix": "moz",
                 "version_added": "11",
-                "version_removed": "16",
-                "prefix": "moz"
+                "version_removed": "16"
               }
             ],
             "firefox_android": [
@@ -4613,9 +4613,9 @@
                 ]
               },
               {
+                "prefix": "moz",
                 "version_added": "14",
-                "version_removed": "16",
-                "prefix": "moz"
+                "version_removed": "16"
               }
             ],
             "ie": {

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -97,8 +97,8 @@
                 "version_added": "22"
               },
               {
-                "version_added": "4",
-                "prefix": "moz"
+                "prefix": "moz",
+                "version_added": "4"
               }
             ],
             "firefox_android": "mirror",

--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -10,9 +10,9 @@
               "version_added": "35"
             },
             {
+              "prefix": "webkit",
               "version_added": "25",
-              "version_removed": "57",
-              "prefix": "webkit"
+              "version_removed": "57"
             }
           ],
           "chrome_android": "mirror",
@@ -34,9 +34,9 @@
               "version_added": "14.1"
             },
             {
+              "prefix": "webkit",
               "version_added": "7",
-              "version_removed": "14.1",
-              "prefix": "webkit"
+              "version_removed": "14.1"
             }
           ],
           "safari_ios": "mirror",
@@ -60,9 +60,9 @@
                 "version_added": "35"
               },
               {
+                "prefix": "webkit",
                 "version_added": "25",
-                "version_removed": "57",
-                "prefix": "webkit"
+                "version_removed": "57"
               }
             ],
             "chrome_android": "mirror",
@@ -84,9 +84,9 @@
                 "version_added": "14.1"
               },
               {
+                "prefix": "webkit",
                 "version_added": "7",
-                "version_removed": "14.1",
-                "prefix": "webkit"
+                "version_removed": "14.1"
               }
             ],
             "safari_ios": "mirror",

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -157,8 +157,8 @@
                 "version_added": "105"
               },
               {
-                "version_added": "105",
-                "alternative_name": "toBlob"
+                "alternative_name": "toBlob",
+                "version_added": "105"
               }
             ],
             "firefox_android": "mirror",

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -29,8 +29,8 @@
           },
           "nodejs": {
             "version_added": "8.5.0",
-            "notes": "Exported from the <code>perf_hooks</code> module",
-            "partial_implementation": true
+            "partial_implementation": true,
+            "notes": "Exported from the <code>perf_hooks</code> module"
           },
           "oculus": "mirror",
           "opera": "mirror",
@@ -62,9 +62,9 @@
                 "version_added": "29"
               },
               {
+                "prefix": "webkit",
                 "version_added": "25",
-                "version_removed": "29",
-                "prefix": "webkit"
+                "version_removed": "29"
               }
             ],
             "chrome_android": "mirror",
@@ -117,9 +117,9 @@
                 "version_added": "29"
               },
               {
+                "prefix": "webkit",
                 "version_added": "25",
-                "version_removed": "29",
-                "prefix": "webkit"
+                "version_removed": "29"
               }
             ],
             "chrome_android": "mirror",
@@ -172,9 +172,9 @@
                 "version_added": "46"
               },
               {
+                "prefix": "webkit",
                 "version_added": "22",
-                "version_removed": "57",
-                "prefix": "webkit"
+                "version_removed": "57"
               }
             ],
             "chrome_android": "mirror",
@@ -874,9 +874,9 @@
                 "version_added": "46"
               },
               {
+                "alternative_name": "webkitresourcetimingbufferfull",
                 "version_added": "22",
-                "version_removed": "57",
-                "alternative_name": "webkitresourcetimingbufferfull"
+                "version_removed": "57"
               }
             ],
             "chrome_android": "mirror",
@@ -923,9 +923,9 @@
                 "version_added": "46"
               },
               {
+                "prefix": "webkit",
                 "version_added": "22",
-                "version_removed": "57",
-                "prefix": "webkit"
+                "version_removed": "57"
               }
             ],
             "chrome_android": "mirror",
@@ -1027,8 +1027,8 @@
               "version_added": "9"
             },
             "nodejs": {
-              "version_added": "8.5.0",
               "alternative_name": "nodeTiming",
+              "version_added": "8.5.0",
               "partial_implementation": true,
               "notes": "Returns node specific timing object"
             },

--- a/api/PerformanceEntry.json
+++ b/api/PerformanceEntry.json
@@ -10,8 +10,8 @@
               "version_added": "46"
             },
             {
-              "version_added": "25",
-              "prefix": "webkit"
+              "prefix": "webkit",
+              "version_added": "25"
             }
           ],
           "chrome_android": "mirror",

--- a/api/PerformanceObserver.json
+++ b/api/PerformanceObserver.json
@@ -19,8 +19,8 @@
           },
           "nodejs": {
             "version_added": "8.5.0",
-            "notes": "Exported from the <code>perf_hooks</code> module",
-            "partial_implementation": true
+            "partial_implementation": true,
+            "notes": "Exported from the <code>perf_hooks</code> module"
           },
           "oculus": "mirror",
           "opera": "mirror",
@@ -168,8 +168,8 @@
             },
             "nodejs": {
               "version_added": "8.5.0",
-              "notes": "Exported from the <code>perf_hooks</code> module",
-              "partial_implementation": true
+              "partial_implementation": true,
+              "notes": "Exported from the <code>perf_hooks</code> module"
             },
             "oculus": "mirror",
             "opera": "mirror",

--- a/api/PictureInPictureEvent.json
+++ b/api/PictureInPictureEvent.json
@@ -10,9 +10,9 @@
               "version_added": "85"
             },
             {
+              "alternative_name": "EnterPictureInPictureEvent",
               "version_added": "69",
-              "version_removed": "85",
-              "alternative_name": "EnterPictureInPictureEvent"
+              "version_removed": "85"
             }
           ],
           "chrome_android": {
@@ -34,8 +34,8 @@
               "version_added": "16"
             },
             {
-              "version_added": "13.1",
-              "alternative_name": "EnterPictureInPictureEvent"
+              "alternative_name": "EnterPictureInPictureEvent",
+              "version_added": "13.1"
             }
           ],
           "safari_ios": "mirror",
@@ -61,9 +61,9 @@
                 "version_added": "85"
               },
               {
+                "alternative_name": "EnterPictureInPictureEvent",
                 "version_added": "69",
-                "version_removed": "85",
-                "alternative_name": "EnterPictureInPictureEvent"
+                "version_removed": "85"
               }
             ],
             "chrome_android": {
@@ -85,8 +85,8 @@
                 "version_added": "16"
               },
               {
-                "version_added": "13.1",
-                "alternative_name": "EnterPictureInPictureEvent"
+                "alternative_name": "EnterPictureInPictureEvent",
+                "version_added": "13.1"
               }
             ],
             "safari_ios": "mirror",

--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -23,8 +23,8 @@
               "version_added": "11"
             },
             {
-              "version_added": "10",
               "prefix": "MS",
+              "version_added": "10",
               "partial_implementation": true,
               "notes": "See <a href='https://msdn.microsoft.com/library/dn304886'>MSDN Pointer events updates</a>."
             }
@@ -69,8 +69,8 @@
                 "version_added": "11"
               },
               {
-                "version_added": "10",
                 "prefix": "MS",
+                "version_added": "10",
                 "partial_implementation": true,
                 "notes": "See <a href='https://msdn.microsoft.com/library/dn304886'>MSDN Pointer events updates</a>."
               }

--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -126,9 +126,9 @@
                 "version_added": "79"
               },
               {
+                "alternative_name": "transport",
                 "version_added": "15",
-                "version_removed": "79",
-                "alternative_name": "transport"
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -209,9 +209,9 @@
                 "version_added": "79"
               },
               {
+                "alternative_name": "dtlsstatechange",
                 "version_added": "12",
-                "version_removed": "79",
-                "alternative_name": "dtlsstatechange"
+                "version_removed": "79"
               }
             ],
             "firefox": {

--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -452,8 +452,8 @@
                   "version_added": "71"
                 },
                 {
-                  "version_added": "58",
-                  "alternative_name": "currentRtt"
+                  "alternative_name": "currentRtt",
+                  "version_added": "58"
                 }
               ],
               "chrome_android": "mirror",
@@ -770,8 +770,8 @@
                   "version_added": "42"
                 },
                 {
-                  "version_added": "29",
-                  "alternative_name": "mozPriority"
+                  "alternative_name": "mozPriority",
+                  "version_added": "29"
                 }
               ],
               "firefox_android": "mirror",
@@ -1043,8 +1043,8 @@
                   "version_added": "71"
                 },
                 {
-                  "version_added": "58",
-                  "alternative_name": "totalRtt"
+                  "alternative_name": "totalRtt",
+                  "version_added": "58"
                 }
               ],
               "chrome_android": "mirror",
@@ -1088,8 +1088,8 @@
                   "version_added": "56"
                 },
                 {
-                  "version_added": "29",
-                  "alternative_name": "componentId"
+                  "alternative_name": "componentId",
+                  "version_added": "29"
                 }
               ],
               "firefox_android": "mirror",
@@ -3411,8 +3411,8 @@
                   "version_added": "65"
                 },
                 {
-                  "version_added": "27",
-                  "alternative_name": "ipAddress"
+                  "alternative_name": "ipAddress",
+                  "version_added": "27"
                 }
               ],
               "firefox_android": "mirror",
@@ -3553,8 +3553,8 @@
                   "version_added": "72"
                 },
                 {
-                  "version_added": "27",
-                  "alternative_name": "portNumber"
+                  "alternative_name": "portNumber",
+                  "version_added": "27"
                 }
               ],
               "firefox_android": "mirror",
@@ -3627,8 +3627,8 @@
                   "version_added": "64"
                 },
                 {
-                  "version_added": "31",
-                  "alternative_name": "mozLocalTransport"
+                  "alternative_name": "mozLocalTransport",
+                  "version_added": "31"
                 }
               ],
               "firefox_android": "mirror",
@@ -3697,8 +3697,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "31",
-                "alternative_name": "transport"
+                "alternative_name": "transport",
+                "version_added": "31"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -5386,8 +5386,8 @@
                   "version_added": "65"
                 },
                 {
-                  "version_added": "27",
-                  "alternative_name": "ipAddress"
+                  "alternative_name": "ipAddress",
+                  "version_added": "27"
                 }
               ],
               "firefox_android": "mirror",
@@ -5528,8 +5528,8 @@
                   "version_added": "72"
                 },
                 {
-                  "version_added": "27",
-                  "alternative_name": "portNumber"
+                  "alternative_name": "portNumber",
+                  "version_added": "27"
                 }
               ],
               "firefox_android": "mirror",
@@ -5602,8 +5602,8 @@
                   "version_added": "64"
                 },
                 {
-                  "version_added": "31",
-                  "alternative_name": "mozLocalTransport"
+                  "alternative_name": "mozLocalTransport",
+                  "version_added": "31"
                 }
               ],
               "firefox_android": "mirror",
@@ -5672,8 +5672,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "31",
-                "alternative_name": "transport"
+                "alternative_name": "transport",
+                "version_added": "31"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -371,8 +371,8 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4",
               "alternative_name": "SVGLoad",
+              "version_added": "4",
               "notes": "See <a href='https://bugzil.la/620002'>bug 620002</a> for implementation status of the standard <code>load</code> event."
             },
             "firefox_android": "mirror",

--- a/api/Screen.json
+++ b/api/Screen.json
@@ -380,18 +380,18 @@
             },
             "chrome_android": "mirror",
             "edge": {
+              "prefix": "ms",
               "version_added": "12",
-              "version_removed": "79",
-              "prefix": "ms"
+              "version_removed": "79"
             },
             "firefox": {
-              "version_added": "14",
-              "prefix": "moz"
+              "prefix": "moz",
+              "version_added": "14"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "11",
-              "prefix": "ms"
+              "prefix": "ms",
+              "version_added": "11"
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -506,8 +506,8 @@
                 "version_added": "79"
               },
               {
-                "version_added": "12",
                 "prefix": "ms",
+                "version_added": "12",
                 "notes": "Edge does not return an <code>Orientation</code> object; instead, it returns the orientation type as a string."
               }
             ],
@@ -516,14 +516,14 @@
                 "version_added": "43"
               },
               {
-                "version_added": "14",
-                "prefix": "moz"
+                "prefix": "moz",
+                "version_added": "14"
               }
             ],
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "11",
               "prefix": "ms",
+              "version_added": "11",
               "notes": "Not supported on Windows 7."
             },
             "oculus": "mirror",
@@ -553,20 +553,20 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12",
               "alternative_name": "msorientationchange",
+              "version_added": "12",
               "version_removed": "79"
             },
             "firefox": {
               "version_added": false
             },
             "firefox_android": {
-              "version_added": "14",
-              "alternative_name": "mozorientationchange"
+              "alternative_name": "mozorientationchange",
+              "version_added": "14"
             },
             "ie": {
-              "version_added": "11",
-              "alternative_name": "msorientationchange"
+              "alternative_name": "msorientationchange",
+              "version_added": "11"
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -671,18 +671,18 @@
             },
             "chrome_android": "mirror",
             "edge": {
+              "prefix": "ms",
               "version_added": "12",
-              "version_removed": "79",
-              "prefix": "ms"
+              "version_removed": "79"
             },
             "firefox": {
-              "version_added": "14",
-              "prefix": "moz"
+              "prefix": "moz",
+              "version_added": "14"
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "11",
-              "prefix": "ms"
+              "prefix": "ms",
+              "version_added": "11"
             },
             "oculus": "mirror",
             "opera": "mirror",

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -231,8 +231,8 @@
                 "version_added": "64"
               },
               {
-                "version_added": "63",
-                "alternative_name": "mozFullScreenElement"
+                "alternative_name": "mozFullScreenElement",
+                "version_added": "63"
               }
             ],
             "firefox_android": "mirror",

--- a/api/SourceBuffer.json
+++ b/api/SourceBuffer.json
@@ -10,9 +10,9 @@
               "version_added": "31"
             },
             {
+              "prefix": "WebKit",
               "version_added": "23",
-              "version_removed": "31",
-              "prefix": "WebKit"
+              "version_removed": "31"
             }
           ],
           "chrome_android": "mirror",

--- a/api/SourceBufferList.json
+++ b/api/SourceBufferList.json
@@ -10,9 +10,9 @@
               "version_added": "31"
             },
             {
+              "prefix": "WebKit",
               "version_added": "23",
-              "version_removed": "31",
-              "prefix": "WebKit"
+              "version_removed": "31"
             }
           ],
           "chrome_android": "mirror",

--- a/api/SpeechGrammar.json
+++ b/api/SpeechGrammar.json
@@ -6,8 +6,8 @@
         "spec_url": "https://wicg.github.io/speech-api/#speechreco-speechgrammar",
         "support": {
           "chrome": {
-            "version_added": "25",
-            "prefix": "webkit"
+            "prefix": "webkit",
+            "version_added": "25"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -54,8 +54,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SpeechGrammar/SpeechGrammar",
           "support": {
             "chrome": {
-              "version_added": "25",
-              "prefix": "webkit"
+              "prefix": "webkit",
+              "version_added": "25"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -33,9 +33,9 @@
               "version_added": "11"
             },
             {
+              "prefix": "WebKit",
               "version_added": "7",
-              "version_removed": "11.1",
-              "prefix": "WebKit"
+              "version_removed": "11.1"
             }
           ],
           "safari_ios": "mirror",
@@ -940,8 +940,8 @@
                 "version_added": "1.14"
               },
               {
-                "version_removed": "1.14",
                 "version_added": "1.12",
+                "version_removed": "1.14",
                 "partial_implementation": true,
                 "notes": "Not supported: ECDSA, HMAC."
               }

--- a/api/TextDecoder.json
+++ b/api/TextDecoder.json
@@ -19,8 +19,8 @@
             },
             {
               "version_added": "18",
-              "notes": "Implemented a slightly different version of the spec.",
-              "partial_implementation": true
+              "partial_implementation": true,
+              "notes": "Implemented a slightly different version of the spec."
             }
           ],
           "firefox_android": "mirror",
@@ -74,8 +74,8 @@
               },
               {
                 "version_added": "18",
-                "notes": "Implemented a slightly different version of the spec.",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "Implemented a slightly different version of the spec."
               }
             ],
             "firefox_android": "mirror",
@@ -169,8 +169,8 @@
               },
               {
                 "version_added": "18",
-                "notes": "Implemented a slightly different version of the spec.",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "Implemented a slightly different version of the spec."
               }
             ],
             "firefox_android": "mirror",
@@ -224,8 +224,8 @@
               },
               {
                 "version_added": "18",
-                "notes": "Implemented a slightly different version of the spec.",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "Implemented a slightly different version of the spec."
               }
             ],
             "firefox_android": "mirror",

--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -10,9 +10,9 @@
               "version_added": "27"
             },
             {
+              "prefix": "WebKit",
               "version_added": "2",
-              "version_removed": "71",
-              "prefix": "WebKit"
+              "version_removed": "71"
             }
           ],
           "chrome_android": "mirror",
@@ -66,9 +66,9 @@
               "version_added": "4.4"
             },
             {
+              "prefix": "WebKit",
               "version_added": "≤37",
-              "version_removed": "71",
-              "prefix": "WebKit"
+              "version_removed": "71"
             }
           ]
         },

--- a/api/URL.json
+++ b/api/URL.json
@@ -10,8 +10,8 @@
               "version_added": "32"
             },
             {
-              "version_added": "19",
-              "prefix": "webkit"
+              "prefix": "webkit",
+              "version_added": "19"
             }
           ],
           "chrome_android": "mirror",
@@ -48,8 +48,8 @@
               "version_added": "7"
             },
             {
-              "version_added": "6",
-              "prefix": "webkit"
+              "prefix": "webkit",
+              "version_added": "6"
             }
           ],
           "safari_ios": "mirror",
@@ -59,8 +59,8 @@
               "version_added": "4.4"
             },
             {
-              "version_added": "4",
-              "prefix": "webkit"
+              "prefix": "webkit",
+              "version_added": "4"
             }
           ]
         },

--- a/api/WEBGL_compressed_texture_s3tc.json
+++ b/api/WEBGL_compressed_texture_s3tc.json
@@ -10,9 +10,9 @@
               "version_added": "26"
             },
             {
+              "prefix": "WEBKIT_",
               "version_added": "26",
-              "version_removed": "56",
-              "prefix": "WEBKIT_"
+              "version_removed": "56"
             }
           ],
           "chrome_android": {

--- a/api/WEBGL_depth_texture.json
+++ b/api/WEBGL_depth_texture.json
@@ -10,8 +10,8 @@
               "version_added": "26"
             },
             {
-              "version_added": "22",
-              "prefix": "WEBKIT_"
+              "prefix": "WEBKIT_",
+              "version_added": "22"
             }
           ],
           "chrome_android": "mirror",

--- a/api/WEBGL_lose_context.json
+++ b/api/WEBGL_lose_context.json
@@ -10,8 +10,8 @@
               "version_added": "26"
             },
             {
-              "version_added": "18",
-              "prefix": "WEBKIT_"
+              "prefix": "WEBKIT_",
+              "version_added": "18"
             }
           ],
           "chrome_android": "mirror",
@@ -45,8 +45,8 @@
               "version_added": "≤37"
             },
             {
-              "version_added": "≤37",
-              "prefix": "WEBKIT_"
+              "prefix": "WEBKIT_",
+              "version_added": "≤37"
             }
           ]
         },

--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -20,9 +20,9 @@
               "version_added": "11"
             },
             {
+              "prefix": "Moz",
               "version_added": "7",
               "version_removed": "11",
-              "prefix": "Moz",
               "notes": "Message size limited to 16 MB (see <a href='https://bugzil.la/711205'>bug 711205</a>)."
             }
           ],
@@ -71,9 +71,9 @@
                 "version_added": "11"
               },
               {
+                "prefix": "Moz",
                 "version_added": "7",
-                "version_removed": "11",
-                "prefix": "Moz"
+                "version_removed": "11"
               }
             ],
             "firefox_android": "mirror",

--- a/api/Window.json
+++ b/api/Window.json
@@ -636,9 +636,9 @@
                 "version_added": "23"
               },
               {
+                "prefix": "moz",
                 "version_added": "11",
-                "version_removed": "23",
-                "prefix": "moz"
+                "version_removed": "23"
               }
             ],
             "firefox_android": "mirror",
@@ -653,9 +653,9 @@
                 "version_added": "7"
               },
               {
+                "prefix": "webkit",
                 "version_added": "6",
-                "version_removed": "7",
-                "prefix": "webkit"
+                "version_removed": "7"
               }
             ],
             "safari_ios": "mirror",
@@ -1082,9 +1082,9 @@
                 "version_added": "6"
               },
               {
+                "alternative_name": "mozOrientation",
                 "version_added": "3.6",
-                "version_removed": "6",
-                "alternative_name": "mozOrientation"
+                "version_removed": "6"
               }
             ],
             "firefox_android": "mirror",
@@ -1423,9 +1423,9 @@
                 "notes": "From Firefox 78 <code>AddSearchProvider()</code> does nothing, as the specification requires."
               },
               {
+                "alternative_name": "sidebar",
                 "version_added": "1",
-                "version_removed": "102",
-                "alternative_name": "sidebar"
+                "version_removed": "102"
               }
             ],
             "firefox_android": [
@@ -1434,9 +1434,9 @@
                 "notes": "From Firefox for Android 79 <code>AddSearchProvider()</code> does nothing, as the specification requires."
               },
               {
+                "alternative_name": "sidebar",
                 "version_added": "4",
-                "version_removed": "102",
-                "alternative_name": "sidebar"
+                "version_removed": "102"
               }
             ],
             "ie": {
@@ -2984,8 +2984,8 @@
                 "version_added": "1"
               },
               {
-                "version_added": "1",
-                "alternative_name": "clientInformation"
+                "alternative_name": "clientInformation",
+                "version_added": "1"
               }
             ],
             "chrome_android": "mirror",
@@ -2997,8 +2997,8 @@
                 "version_added": "12"
               },
               {
-                "version_added": "12",
-                "alternative_name": "clientInformation"
+                "alternative_name": "clientInformation",
+                "version_added": "12"
               }
             ],
             "firefox": [
@@ -3006,8 +3006,8 @@
                 "version_added": "1"
               },
               {
-                "version_added": "91",
-                "alternative_name": "clientInformation"
+                "alternative_name": "clientInformation",
+                "version_added": "91"
               }
             ],
             "firefox_android": "mirror",
@@ -3016,8 +3016,8 @@
                 "version_added": "4"
               },
               {
-                "version_added": "≤6",
-                "alternative_name": "clientInformation"
+                "alternative_name": "clientInformation",
+                "version_added": "≤6"
               }
             ],
             "oculus": "mirror",
@@ -3026,8 +3026,8 @@
                 "version_added": "3"
               },
               {
-                "version_added": "15",
-                "alternative_name": "clientInformation"
+                "alternative_name": "clientInformation",
+                "version_added": "15"
               }
             ],
             "opera_android": [
@@ -3035,8 +3035,8 @@
                 "version_added": "10.1"
               },
               {
-                "version_added": "14",
-                "alternative_name": "clientInformation"
+                "alternative_name": "clientInformation",
+                "version_added": "14"
               }
             ],
             "safari": [
@@ -3044,8 +3044,8 @@
                 "version_added": "1"
               },
               {
-                "version_added": "1",
-                "alternative_name": "clientInformation"
+                "alternative_name": "clientInformation",
+                "version_added": "1"
               }
             ],
             "safari_ios": "mirror",
@@ -4188,8 +4188,8 @@
                 "version_added": "24"
               },
               {
-                "version_added": "10",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "10"
               }
             ],
             "chrome_android": "mirror",
@@ -4203,15 +4203,15 @@
                 "notes": "Callback parameter is a <code>DOMHighResTimestamp</code>. This means ten microsecond precision and zero time as <code>performance.now()</code>."
               },
               {
+                "prefix": "moz",
                 "version_added": "11",
                 "version_removed": "42",
-                "prefix": "moz",
                 "notes": "Callback parameter is a <code>DOMTimestamp</code>. This means millisecond precision and zero time as <code>Date.now()</code>."
               },
               {
+                "prefix": "moz",
                 "version_added": "4",
                 "version_removed": "11",
-                "prefix": "moz",
                 "notes": "Could be called with no input parameters."
               }
             ],
@@ -4220,9 +4220,9 @@
                 "version_added": "23"
               },
               {
+                "prefix": "moz",
                 "version_added": "14",
-                "version_removed": "42",
-                "prefix": "moz"
+                "version_removed": "42"
               }
             ],
             "ie": {
@@ -4237,8 +4237,8 @@
                 "version_added": "7"
               },
               {
-                "version_added": "6",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "6"
               }
             ],
             "safari_ios": "mirror",
@@ -4248,8 +4248,8 @@
                 "version_added": "4.4"
               },
               {
-                "version_added": "≤37",
-                "prefix": "webkit"
+                "prefix": "webkit",
+                "version_added": "≤37"
               }
             ]
           },
@@ -4265,8 +4265,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/requestFileSystem",
           "support": {
             "chrome": {
-              "version_added": "13",
-              "prefix": "webkit"
+              "prefix": "webkit",
+              "version_added": "13"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -4290,8 +4290,8 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": "37",
-              "prefix": "webkit"
+              "prefix": "webkit",
+              "version_added": "37"
             }
           },
           "status": {
@@ -4475,8 +4475,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/resolveLocalFileSystemURL",
           "support": {
             "chrome": {
-              "version_added": "13",
-              "prefix": "webkit"
+              "prefix": "webkit",
+              "version_added": "13"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -5314,8 +5314,8 @@
                 "version_added": "1"
               },
               {
-                "version_added": "1",
-                "alternative_name": "pageXOffset"
+                "alternative_name": "pageXOffset",
+                "version_added": "1"
               }
             ],
             "chrome_android": "mirror",
@@ -5324,8 +5324,8 @@
                 "version_added": "12"
               },
               {
-                "version_added": "12",
-                "alternative_name": "pageXOffset"
+                "alternative_name": "pageXOffset",
+                "version_added": "12"
               }
             ],
             "firefox": [
@@ -5333,14 +5333,14 @@
                 "version_added": "1"
               },
               {
-                "version_added": "1",
-                "alternative_name": "pageXOffset"
+                "alternative_name": "pageXOffset",
+                "version_added": "1"
               }
             ],
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "9",
-              "alternative_name": "pageXOffset"
+              "alternative_name": "pageXOffset",
+              "version_added": "9"
             },
             "oculus": "mirror",
             "opera": [
@@ -5348,8 +5348,8 @@
                 "version_added": "9.6"
               },
               {
-                "version_added": "4",
-                "alternative_name": "pageXOffset"
+                "alternative_name": "pageXOffset",
+                "version_added": "4"
               }
             ],
             "opera_android": [
@@ -5357,8 +5357,8 @@
                 "version_added": "10.1"
               },
               {
-                "version_added": "10.1",
-                "alternative_name": "pageXOffset"
+                "alternative_name": "pageXOffset",
+                "version_added": "10.1"
               }
             ],
             "safari": [
@@ -5366,8 +5366,8 @@
                 "version_added": "1"
               },
               {
-                "version_added": "1",
-                "alternative_name": "pageXOffset"
+                "alternative_name": "pageXOffset",
+                "version_added": "1"
               }
             ],
             "safari_ios": "mirror",
@@ -5426,8 +5426,8 @@
                 "version_added": "1"
               },
               {
-                "version_added": "1",
-                "alternative_name": "pageYOffset"
+                "alternative_name": "pageYOffset",
+                "version_added": "1"
               }
             ],
             "chrome_android": "mirror",
@@ -5436,8 +5436,8 @@
                 "version_added": "12"
               },
               {
-                "version_added": "12",
-                "alternative_name": "pageYOffset"
+                "alternative_name": "pageYOffset",
+                "version_added": "12"
               }
             ],
             "firefox": [
@@ -5445,14 +5445,14 @@
                 "version_added": "1"
               },
               {
-                "version_added": "1",
-                "alternative_name": "pageYOffset"
+                "alternative_name": "pageYOffset",
+                "version_added": "1"
               }
             ],
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "9",
-              "alternative_name": "pageYOffset"
+              "alternative_name": "pageYOffset",
+              "version_added": "9"
             },
             "oculus": "mirror",
             "opera": [
@@ -5460,8 +5460,8 @@
                 "version_added": "9.6"
               },
               {
-                "version_added": "4",
-                "alternative_name": "pageYOffset"
+                "alternative_name": "pageYOffset",
+                "version_added": "4"
               }
             ],
             "opera_android": [
@@ -5469,8 +5469,8 @@
                 "version_added": "10.1"
               },
               {
-                "version_added": "10.1",
-                "alternative_name": "pageYOffset"
+                "alternative_name": "pageYOffset",
+                "version_added": "10.1"
               }
             ],
             "safari": [
@@ -5478,8 +5478,8 @@
                 "version_added": "1"
               },
               {
-                "version_added": "1",
-                "alternative_name": "pageYOffset"
+                "alternative_name": "pageYOffset",
+                "version_added": "1"
               }
             ],
             "safari_ios": "mirror",
@@ -6656,8 +6656,8 @@
               "version_added": false
             },
             "chrome_android": {
-              "version_removed": "80",
               "version_added": "56",
+              "version_removed": "80",
               "notes": [
                 "Chrome for Android 56 supports only Google Daydream View.",
                 "Chrome for Android 57 adds support for Google Cardboard."

--- a/api/Worker.json
+++ b/api/Worker.json
@@ -496,13 +496,13 @@
             "nodejs": [
               {
                 "version_added": "12.17.0",
-                "notes": "Supports <code>transferList</code> argument for transferring <code>ArrayBuffer</code> and <code>MessagePort</code> objects",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "Supports <code>transferList</code> argument for transferring <code>ArrayBuffer</code> and <code>MessagePort</code> objects"
               },
               {
                 "version_added": "11.7.0",
-                "notes": "Supports <code>transferList</code> argument for transferring <code>ArrayBuffer</code> and <code>MessagePort</code> objects",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "Supports <code>transferList</code> argument for transferring <code>ArrayBuffer</code> and <code>MessagePort</code> objects"
               }
             ],
             "oculus": "mirror",

--- a/api/_globals/crypto.json
+++ b/api/_globals/crypto.json
@@ -20,8 +20,8 @@
           },
           "firefox_android": "mirror",
           "ie": {
-            "version_added": "11",
-            "prefix": "ms"
+            "prefix": "ms",
+            "version_added": "11"
           },
           "oculus": "mirror",
           "opera": "mirror",

--- a/api/_globals/indexedDB.json
+++ b/api/_globals/indexedDB.json
@@ -20,8 +20,8 @@
               "version_added": "16"
             },
             {
-              "version_added": "10",
-              "prefix": "moz"
+              "prefix": "moz",
+              "version_added": "10"
             }
           ],
           "firefox_android": {

--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -192,10 +192,10 @@
         },
         "99": {
           "release_date": "2022-03-03",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-990115030-march-3",
           "status": "retired",
           "engine": "Blink",
-          "engine_version": "99",
-          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-990115030-march-3"
+          "engine_version": "99"
         },
         "100": {
           "release_date": "2022-04-01",

--- a/browsers/oculus.json
+++ b/browsers/oculus.json
@@ -9,181 +9,181 @@
       "accepts_webextensions": false,
       "releases": {
         "5.0": {
-          "engine": "Blink",
-          "engine_version": "66",
           "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-50",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "66"
         },
         "5.4": {
-          "engine": "Blink",
-          "engine_version": "66",
           "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-54",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "66"
         },
         "6.0": {
-          "engine": "Blink",
-          "engine_version": "74",
           "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-60",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "74"
         },
         "7.0": {
-          "engine": "Blink",
-          "engine_version": "77",
           "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-70",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "77"
         },
         "7.1": {
-          "engine": "Blink",
-          "engine_version": "77",
           "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-71",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "77"
         },
         "8.0": {
-          "engine": "Blink",
-          "engine_version": "79",
           "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-80",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "79"
         },
         "8.1": {
-          "engine": "Blink",
-          "engine_version": "79",
           "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-81",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "79"
         },
         "9.0": {
-          "engine": "Blink",
-          "engine_version": "81",
           "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-90",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "81"
         },
         "10.0": {
-          "engine": "Blink",
-          "engine_version": "83",
           "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-100",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "83"
         },
         "11.0": {
-          "engine": "Blink",
-          "engine_version": "84",
           "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-110",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "84"
         },
         "12.0": {
-          "engine": "Blink",
-          "engine_version": "86",
           "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-120",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "86"
         },
         "13.0": {
-          "engine": "Blink",
-          "engine_version": "87",
           "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-130",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "87"
         },
         "14.0": {
-          "engine": "Blink",
-          "engine_version": "88",
           "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-140",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "88"
         },
         "15.0": {
-          "engine": "Blink",
-          "engine_version": "89",
           "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-150",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "89"
         },
         "15.1": {
-          "engine": "Blink",
-          "engine_version": "89",
           "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-151",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "89"
         },
         "16.0": {
-          "engine": "Blink",
-          "engine_version": "91",
           "release_date": "2021-06-14",
           "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-160",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "91"
         },
         "16.1": {
-          "engine": "Blink",
-          "engine_version": "91",
           "release_date": "2021-06-22",
           "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes/#oculus-browser-161",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "91"
         },
         "16.2": {
-          "engine": "Blink",
-          "engine_version": "91",
           "release_date": "2021-07-06",
           "release_notes": "https://developer.oculus.com/documentation/web/browser-release-notes#oculus-browser-162",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "91"
         },
         "16.3": {
-          "engine": "Blink",
-          "engine_version": "91",
           "release_date": "2021-07-19",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "91"
         },
         "16.4": {
-          "engine": "Blink",
-          "engine_version": "91",
           "release_date": "2021-08-02",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "91"
         },
         "16.5": {
-          "engine": "Blink",
-          "engine_version": "91",
           "release_date": "2021-08-16",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "91"
         },
         "16.6": {
-          "engine": "Blink",
-          "engine_version": "91",
           "release_date": "2021-08-30",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "91"
         },
         "17.0": {
-          "engine": "Blink",
-          "engine_version": "93",
           "release_date": "2021-09-13",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "93"
         },
         "18.0": {
-          "engine": "Blink",
-          "engine_version": "95",
           "release_date": "2021-11-30",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "95"
         },
         "19.0": {
-          "engine": "Blink",
-          "engine_version": "96",
           "release_date": "2022-01-31",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "96"
         },
         "20.0": {
-          "engine": "Blink",
-          "engine_version": "98",
           "release_date": "2022-03-14",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "98"
         },
         "21.0": {
-          "engine": "Blink",
-          "engine_version": "100",
           "release_date": "2022-04-25",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "100"
         },
         "22.0": {
-          "engine": "Blink",
-          "engine_version": "102",
           "release_date": "2022-06-06",
-          "status": "retired"
+          "status": "retired",
+          "engine": "Blink",
+          "engine_version": "102"
         },
         "23.0": {
-          "engine": "Blink",
-          "engine_version": "104",
           "release_date": "2022-08-15",
-          "status": "current"
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "104"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -8,100 +8,100 @@
       "accepts_webextensions": true,
       "releases": {
         "1": {
+          "release_date": "2007-06-29",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "522.11",
-          "release_date": "2007-06-29"
+          "engine_version": "522.11"
         },
         "2": {
+          "release_date": "2008-07-11",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "525.18",
-          "release_date": "2008-07-11"
+          "engine_version": "525.18"
         },
         "3": {
+          "release_date": "2009-06-17",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "528.18",
-          "release_date": "2009-06-17"
+          "engine_version": "528.18"
         },
         "3.2": {
+          "release_date": "2010-04-03",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "531.21",
-          "release_date": "2010-04-03"
+          "engine_version": "531.21"
         },
         "4": {
+          "release_date": "2010-06-21",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "532.9",
-          "release_date": "2010-06-21"
+          "engine_version": "532.9"
         },
         "4.2": {
+          "release_date": "2010-11-22",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "533.17",
-          "release_date": "2010-11-22"
+          "engine_version": "533.17"
         },
         "5": {
+          "release_date": "2011-10-12",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "534.46",
-          "release_date": "2011-10-12"
+          "engine_version": "534.46"
         },
         "6": {
+          "release_date": "2012-09-10",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "536.26",
-          "release_date": "2012-09-10"
+          "engine_version": "536.26"
         },
         "7": {
+          "release_date": "2013-09-18",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "537.51",
-          "release_date": "2013-09-18"
+          "engine_version": "537.51"
         },
         "8": {
+          "release_date": "2014-09-17",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "600.1.4",
-          "release_date": "2014-09-17"
+          "engine_version": "600.1.4"
         },
         "9": {
+          "release_date": "2015-09-16",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "601.1.56",
-          "release_date": "2015-09-16"
+          "engine_version": "601.1.56"
         },
         "9.3": {
+          "release_date": "2016-03-21",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "601.5.17",
-          "release_date": "2016-03-21"
+          "engine_version": "601.5.17"
         },
         "10": {
+          "release_date": "2016-09-13",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "602.1.50",
-          "release_date": "2016-09-13"
+          "engine_version": "602.1.50"
         },
         "10.3": {
+          "release_date": "2017-03-27",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "603.2.1",
-          "release_date": "2017-03-27"
+          "engine_version": "603.2.1"
         },
         "11": {
+          "release_date": "2017-09-19",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "604.2.4",
-          "release_date": "2017-09-19"
+          "engine_version": "604.2.4"
         },
         "11.3": {
+          "release_date": "2018-03-29",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "605.1.33",
-          "release_date": "2018-03-29"
+          "engine_version": "605.1.33"
         },
         "12": {
           "release_date": "2018-09-17",

--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -25,8 +25,8 @@
                 "version_added": "16"
               },
               {
-                "version_added": "49",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "49"
               },
               {
                 "prefix": "-moz-",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -1256,14 +1256,14 @@
             "support": {
               "chrome": {
                 "version_added": "85",
-                "impl_url": "https://crbug.com/1051189",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "#enable-experimental-web-platform-features",
                     "value_to_set": "Enabled"
                   }
-                ]
+                ],
+                "impl_url": "https://crbug.com/1051189"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1390,8 +1390,8 @@
                   "version_added": "102"
                 },
                 {
-                  "partial_implementation": true,
                   "version_added": "63",
+                  "partial_implementation": true,
                   "notes": "Only supports range notations where the feature name comes before any value <code>(width &#62; 500px)</code>"
                 }
               ],
@@ -1434,8 +1434,8 @@
                   "version_added": "8"
                 },
                 {
-                  "partial_implementation": true,
                   "version_added": "3.5",
+                  "partial_implementation": true,
                   "notes": "Supports <a href='https://developer.mozilla.org/docs/Web/CSS/integer'><code>&lt;integer&gt;</code></a> values only."
                 }
               ],

--- a/css/properties/animation-delay.json
+++ b/css/properties/animation-delay.json
@@ -31,8 +31,8 @@
                 "notes": "Before Firefox 57, Firefox does not repaint elements outside the viewport that are animated into the viewport with a delay. This bug affects only some platforms, such as Windows."
               },
               {
-                "version_added": "49",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "49"
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/animation-direction.json
+++ b/css/properties/animation-direction.json
@@ -30,8 +30,8 @@
                 "version_added": "16"
               },
               {
-                "version_added": "49",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "49"
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/animation-duration.json
+++ b/css/properties/animation-duration.json
@@ -30,8 +30,8 @@
                 "version_added": "16"
               },
               {
-                "version_added": "49",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "49"
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/animation-fill-mode.json
+++ b/css/properties/animation-fill-mode.json
@@ -30,8 +30,8 @@
                 "version_added": "16"
               },
               {
-                "version_added": "49",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "49"
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/animation-iteration-count.json
+++ b/css/properties/animation-iteration-count.json
@@ -30,8 +30,8 @@
                 "version_added": "16"
               },
               {
-                "version_added": "49",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "49"
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/animation-timeline.json
+++ b/css/properties/animation-timeline.json
@@ -54,16 +54,16 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "110",
-                "notes": [
-                  "Zero scroll range is treated as 100% but should be 0% (see <a href='https://bugzil.la/1780865'>bug 1780865</a>).",
-                  "Supports the deprecated <code>horizontal</code> and <code>vertical</code> axis values, and not the <code>x</code> and <code>y</code> values."
-                ],
                 "flags": [
                   {
                     "type": "preference",
                     "name": "layout.css.scroll-driven-animations.enabled",
                     "value_to_set": "true"
                   }
+                ],
+                "notes": [
+                  "Zero scroll range is treated as 100% but should be 0% (see <a href='https://bugzil.la/1780865'>bug 1780865</a>).",
+                  "Supports the deprecated <code>horizontal</code> and <code>vertical</code> axis values, and not the <code>x</code> and <code>y</code> values."
                 ]
               },
               "firefox_android": "mirror",

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -11,8 +11,8 @@
                 "version_added": "84"
               },
               {
-                "version_added": "1",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "1"
               }
             ],
             "chrome_android": "mirror",
@@ -21,8 +21,8 @@
                 "version_added": "84"
               },
               {
-                "version_added": "12",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "12"
               }
             ],
             "firefox": [
@@ -30,12 +30,12 @@
                 "version_added": "80"
               },
               {
-                "version_added": "64",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "64"
               },
               {
-                "version_added": "1",
-                "prefix": "-moz-"
+                "prefix": "-moz-",
+                "version_added": "1"
               }
             ],
             "firefox_android": "mirror",
@@ -50,8 +50,8 @@
                 "version_added": "15.4"
               },
               {
-                "version_added": "3",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "3"
               }
             ],
             "safari_ios": [
@@ -59,8 +59,8 @@
                 "version_added": "15.4"
               },
               {
-                "version_added": "1",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "1"
               }
             ],
             "samsunginternet_android": "mirror",

--- a/css/properties/backface-visibility.json
+++ b/css/properties/backface-visibility.json
@@ -30,8 +30,8 @@
                 "version_added": "16"
               },
               {
-                "version_added": "49",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "49"
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -11,8 +11,8 @@
                 "version_added": "1"
               },
               {
-                "version_added": "1",
                 "prefix": "-webkit-",
+                "version_added": "1",
                 "notes": "Chrome accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
@@ -32,14 +32,14 @@
                 "version_added": "4"
               },
               {
-                "version_added": "49",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "49"
               },
               {
+                "prefix": "-moz-",
                 "version_added": "1",
                 "version_removed": "4",
                 "partial_implementation": true,
-                "prefix": "-moz-",
                 "notes": "Used the <code>-moz-background-clip: padding | border</code> syntax."
               }
             ],
@@ -48,8 +48,8 @@
                 "version_added": "14"
               },
               {
-                "version_added": "49",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "49"
               }
             ],
             "ie": {
@@ -62,8 +62,8 @@
                 "version_added": "10.5"
               },
               {
-                "version_added": "15",
                 "prefix": "-webkit-",
+                "version_added": "15",
                 "notes": "Opera accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
@@ -72,8 +72,8 @@
                 "version_added": "11"
               },
               {
-                "version_added": "14",
                 "prefix": "-webkit-",
+                "version_added": "14",
                 "notes": "Opera accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
@@ -82,8 +82,8 @@
                 "version_added": "5"
               },
               {
-                "version_added": "3",
                 "prefix": "-webkit-",
+                "version_added": "3",
                 "notes": "Safari accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
@@ -92,8 +92,8 @@
                 "version_added": "5"
               },
               {
-                "version_added": "1",
                 "prefix": "-webkit-",
+                "version_added": "1",
                 "notes": "Safari accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
@@ -103,8 +103,8 @@
                 "version_added": "4"
               },
               {
-                "version_added": "≤37",
                 "prefix": "-webkit-",
+                "version_added": "≤37",
                 "notes": "WebView accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ]

--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -53,8 +53,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "4",
-                "prefix": "-moz-"
+                "prefix": "-moz-",
+                "version_added": "4"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -11,8 +11,8 @@
                 "version_added": "1"
               },
               {
-                "version_added": "1",
                 "prefix": "-webkit-",
+                "version_added": "1",
                 "notes": "Chrome accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
@@ -32,14 +32,14 @@
                 "version_added": "4"
               },
               {
-                "version_added": "49",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "49"
               },
               {
+                "prefix": "-moz-",
                 "version_added": "1",
                 "version_removed": "4",
                 "partial_implementation": true,
-                "prefix": "-moz-",
                 "notes": "Used the <code>-moz-background-clip: padding | border</code> syntax."
               }
             ],
@@ -48,8 +48,8 @@
                 "version_added": "14"
               },
               {
-                "version_added": "49",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "49"
               }
             ],
             "ie": {
@@ -62,8 +62,8 @@
                 "version_added": "10.5"
               },
               {
-                "version_added": "15",
                 "prefix": "-webkit-",
+                "version_added": "15",
                 "notes": "Opera accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
@@ -72,8 +72,8 @@
                 "version_added": "11"
               },
               {
-                "version_added": "14",
                 "prefix": "-webkit-",
+                "version_added": "14",
                 "notes": "Opera accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
@@ -82,8 +82,8 @@
                 "version_added": "3"
               },
               {
-                "version_added": "3",
                 "prefix": "-webkit-",
+                "version_added": "3",
                 "notes": "Webkit accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
@@ -92,8 +92,8 @@
                 "version_added": "1"
               },
               {
-                "version_added": "1",
                 "prefix": "-webkit-",
+                "version_added": "1",
                 "notes": "Webkit accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ],
@@ -103,8 +103,8 @@
                 "version_added": "4"
               },
               {
-                "version_added": "4",
                 "prefix": "-webkit-",
+                "version_added": "4",
                 "notes": "WebView accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
               }
             ]

--- a/css/properties/background-size.json
+++ b/css/properties/background-size.json
@@ -11,8 +11,8 @@
                 "version_added": "3"
               },
               {
-                "version_added": "1",
                 "prefix": "-webkit-",
+                "version_added": "1",
                 "notes": "WebKit-based browsers originally implemented an older draft of CSS3 <code>background-size</code> in which an omitted second value is treated as duplicating the first value; this draft does not include the <code>contain</code> or <code>cover</code> keywords."
               }
             ],
@@ -31,8 +31,8 @@
                 "version_added": "4"
               },
               {
-                "version_added": "49",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "49"
               },
               {
                 "prefix": "-moz-",
@@ -50,14 +50,14 @@
                 "version_added": "10"
               },
               {
-                "version_added": "15",
                 "prefix": "-webkit-",
+                "version_added": "15",
                 "notes": "WebKit-based browsers originally implemented an older draft of CSS3 <code>background-size</code> in which an omitted second value is treated as duplicating the first value; this draft does not include the <code>contain</code> or <code>cover</code> keywords."
               },
               {
+                "prefix": "-o-",
                 "version_added": "9.5",
                 "version_removed": "15",
-                "prefix": "-o-",
                 "notes": "Opera 9.5's computation of the background positioning area is incorrect for fixed backgrounds. Opera 9.5 also interprets the two-value form as a horizontal scaling factor and, from appearances, a vertical clipping dimension. This has been fixed in Opera 10."
               }
             ],
@@ -66,14 +66,14 @@
                 "version_added": "10.1"
               },
               {
-                "version_added": "14",
                 "prefix": "-webkit-",
+                "version_added": "14",
                 "notes": "WebKit-based browsers originally implemented an older draft of CSS3 <code>background-size</code> in which an omitted second value is treated as duplicating the first value; this draft does not include the <code>contain</code> or <code>cover</code> keywords."
               },
               {
+                "prefix": "-o-",
                 "version_added": "10.1",
                 "version_removed": "14",
-                "prefix": "-o-",
                 "notes": "Opera 9.5's computation of the background positioning area is incorrect for fixed backgrounds. Opera 9.5 also interprets the two-value form as a horizontal scaling factor and, from appearances, a vertical clipping dimension. This has been fixed in Opera 10."
               }
             ],
@@ -103,8 +103,8 @@
                 "version_added": "2.2"
               },
               {
-                "version_added": "≤37",
                 "prefix": "-webkit-",
+                "version_added": "≤37",
                 "notes": "WebKit-based browsers originally implemented an older draft of CSS3 <code>background-size</code> in which an omitted second value is treated as duplicating the first value; this draft does not include the <code>contain</code> or <code>cover</code> keywords."
               }
             ]

--- a/css/properties/block-size.json
+++ b/css/properties/block-size.json
@@ -128,8 +128,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "41",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "41"
                 }
               ],
               "firefox_android": "mirror",
@@ -169,8 +169,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "41",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "41"
                 }
               ],
               "firefox_android": "mirror",

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -38,8 +38,8 @@
                 ]
               },
               {
-                "version_added": "3.5",
                 "prefix": "-moz-",
+                "version_added": "3.5",
                 "notes": "Before Firefox 15, an earlier version of the specification was implemented, prefixed."
               }
             ],
@@ -54,9 +54,9 @@
                 "notes": "Before Opera 98, a border image's absolute or percentage length width may not take precedence over a narrower <code>border-width</code> (<a href='https://crbug.com/767352'>bug 767352</a>)."
               },
               {
+                "prefix": "-o-",
                 "version_added": "10.5",
-                "version_removed": "15",
-                "prefix": "-o-"
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -65,9 +65,9 @@
                 "notes": "A border image's absolute or percentage length width may not take precedence over a narrower <code>border-width</code> (<a href='https://crbug.com/767352'>bug 767352</a>)."
               },
               {
+                "prefix": "-o-",
                 "version_added": "11",
-                "version_removed": "14",
-                "prefix": "-o-"
+                "version_removed": "14"
               }
             ],
             "safari": [

--- a/css/properties/border-inline-end-color.json
+++ b/css/properties/border-inline-end-color.json
@@ -16,8 +16,8 @@
                 "version_added": "41"
               },
               {
-                "version_added": "3",
-                "alternative_name": "-moz-border-end-color"
+                "alternative_name": "-moz-border-end-color",
+                "version_added": "3"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/border-inline-end-style.json
+++ b/css/properties/border-inline-end-style.json
@@ -16,8 +16,8 @@
                 "version_added": "41"
               },
               {
-                "version_added": "3",
-                "alternative_name": "-moz-border-end-style"
+                "alternative_name": "-moz-border-end-style",
+                "version_added": "3"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/border-inline-end-width.json
+++ b/css/properties/border-inline-end-width.json
@@ -16,8 +16,8 @@
                 "version_added": "41"
               },
               {
-                "version_added": "3",
-                "alternative_name": "-moz-border-end-width"
+                "alternative_name": "-moz-border-end-width",
+                "version_added": "3"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/border-inline-start-color.json
+++ b/css/properties/border-inline-start-color.json
@@ -16,8 +16,8 @@
                 "version_added": "41"
               },
               {
-                "version_added": "3",
-                "alternative_name": "-moz-border-start-color"
+                "alternative_name": "-moz-border-start-color",
+                "version_added": "3"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/border-inline-start-style.json
+++ b/css/properties/border-inline-start-style.json
@@ -16,8 +16,8 @@
                 "version_added": "41"
               },
               {
-                "version_added": "3",
-                "alternative_name": "-moz-border-start-style"
+                "alternative_name": "-moz-border-start-style",
+                "version_added": "3"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -90,8 +90,8 @@
                 "version_added": "≤37"
               },
               {
-                "version_added": "2",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "2"
               }
             ]
           },

--- a/css/properties/box-align.json
+++ b/css/properties/box-align.json
@@ -6,22 +6,22 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-align",
           "support": {
             "chrome": {
-              "version_added": "1",
-              "prefix": "-webkit-"
+              "prefix": "-webkit-",
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12",
-              "prefix": "-webkit-"
+              "prefix": "-webkit-",
+              "version_added": "12"
             },
             "firefox": [
               {
-                "version_added": "49",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "49"
               },
               {
-                "version_added": "1",
-                "prefix": "-moz-"
+                "prefix": "-moz-",
+                "version_added": "1"
               }
             ],
             "firefox_android": "mirror",
@@ -33,23 +33,23 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "3",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "3"
               },
               {
+                "prefix": "-khtml-",
                 "version_added": "1.1",
-                "version_removed": "3",
-                "prefix": "-khtml-"
+                "version_removed": "3"
               }
             ],
             "safari_ios": {
-              "version_added": "1",
-              "prefix": "-webkit-"
+              "prefix": "-webkit-",
+              "version_added": "1"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": "≤37",
-              "prefix": "-webkit-"
+              "prefix": "-webkit-",
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -53,8 +53,8 @@
               }
             ],
             "safari": {
-              "version_added": "7",
               "prefix": "-webkit-",
+              "version_added": "7",
               "notes": "This property is only supported for inline elements."
             },
             "safari_ios": "mirror",

--- a/css/properties/box-flex-group.json
+++ b/css/properties/box-flex-group.json
@@ -6,9 +6,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-flex-group",
           "support": {
             "chrome": {
+              "prefix": "-webkit-",
               "version_added": "1",
-              "version_removed": "67",
-              "prefix": "-webkit-"
+              "version_removed": "67"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -24,24 +24,24 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "3",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "3"
               },
               {
+                "prefix": "-khtml-",
                 "version_added": "1.1",
-                "version_removed": "3",
-                "prefix": "-khtml-"
+                "version_removed": "3"
               }
             ],
             "safari_ios": {
-              "version_added": "1",
-              "prefix": "-webkit-"
+              "prefix": "-webkit-",
+              "version_added": "1"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
+              "prefix": "-webkit-",
               "version_added": "≤37",
-              "version_removed": "67",
-              "prefix": "-webkit-"
+              "version_removed": "67"
             }
           },
           "status": {

--- a/css/properties/box-lines.json
+++ b/css/properties/box-lines.json
@@ -6,9 +6,9 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-lines",
           "support": {
             "chrome": {
+              "prefix": "-webkit-",
               "version_added": "1",
-              "version_removed": "67",
-              "prefix": "-webkit-"
+              "version_removed": "67"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -24,24 +24,24 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "3",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "3"
               },
               {
+                "prefix": "-khtml-",
                 "version_added": "1.1",
-                "version_removed": "3",
-                "prefix": "-khtml-"
+                "version_removed": "3"
               }
             ],
             "safari_ios": {
-              "version_added": "1",
-              "prefix": "-webkit-"
+              "prefix": "-webkit-",
+              "version_added": "1"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
+              "prefix": "-webkit-",
               "version_added": "≤37",
-              "version_removed": "67",
-              "prefix": "-webkit-"
+              "version_removed": "67"
             }
           },
           "status": {

--- a/css/properties/box-ordinal-group.json
+++ b/css/properties/box-ordinal-group.json
@@ -6,13 +6,13 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/box-ordinal-group",
           "support": {
             "chrome": {
-              "version_added": "1",
-              "prefix": "-webkit-"
+              "prefix": "-webkit-",
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12",
-              "prefix": "-webkit-"
+              "prefix": "-webkit-",
+              "version_added": "12"
             },
             "firefox": [
               {
@@ -33,23 +33,23 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "3",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "3"
               },
               {
+                "prefix": "-khtml-",
                 "version_added": "1.1",
-                "version_removed": "3",
-                "prefix": "-khtml-"
+                "version_removed": "3"
               }
             ],
             "safari_ios": {
-              "version_added": "1",
-              "prefix": "-webkit-"
+              "prefix": "-webkit-",
+              "version_added": "1"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": "≤37",
-              "prefix": "-webkit-"
+              "prefix": "-webkit-",
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -96,8 +96,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "57",
-                  "alternative_name": "grid-column-gap"
+                  "alternative_name": "grid-column-gap",
+                  "version_added": "57"
                 }
               ],
               "chrome_android": "mirror",
@@ -106,8 +106,8 @@
                   "version_added": "16"
                 },
                 {
-                  "version_added": "16",
-                  "alternative_name": "grid-column-gap"
+                  "alternative_name": "grid-column-gap",
+                  "version_added": "16"
                 }
               ],
               "firefox": [
@@ -115,8 +115,8 @@
                   "version_added": "61"
                 },
                 {
-                  "version_added": "52",
-                  "alternative_name": "grid-column-gap"
+                  "alternative_name": "grid-column-gap",
+                  "version_added": "52"
                 }
               ],
               "firefox_android": "mirror",
@@ -131,8 +131,8 @@
                   "version_added": "12"
                 },
                 {
-                  "version_added": "10.1",
-                  "alternative_name": "grid-column-gap"
+                  "alternative_name": "grid-column-gap",
+                  "version_added": "10.1"
                 }
               ],
               "safari_ios": "mirror",

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -125,8 +125,8 @@
               },
               "firefox": {
                 "version_added": "113",
-                "notes": "<code>content: &lt;gradient&gt;</code>` doesn't paint on ::before/::after pseudo elements. See <a href='https://bugzil.la/1832901'>bug 1832901</a>.",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "<code>content: &lt;gradient&gt;</code>` doesn't paint on ::before/::after pseudo elements. See <a href='https://bugzil.la/1832901'>bug 1832901</a>."
               },
               "firefox_android": "mirror",
               "ie": {
@@ -162,8 +162,8 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "113",
-                "notes": "<code>content: image-set(…);</code>` doesn't paint on ::before/::after pseudo elements. See <a href='https://bugzil.la/1832901'>bug 1832901</a>.",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "<code>content: image-set(…);</code>` doesn't paint on ::before/::after pseudo elements. See <a href='https://bugzil.la/1832901'>bug 1832901</a>."
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/custom-property.json
+++ b/css/properties/custom-property.json
@@ -63,9 +63,9 @@
                   "version_added": "11.1"
                 },
                 {
+                  "alternative_name": "constant",
                   "version_added": "11",
-                  "version_removed": "11.1",
-                  "alternative_name": "constant"
+                  "version_removed": "11.1"
                 }
               ],
               "safari_ios": "mirror",

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -303,8 +303,8 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": {
-                "notes": "Samsung Internet added this earlier than the corresponding Chrome version would indicate.",
-                "version_added": "6.0"
+                "version_added": "6.0",
+                "notes": "Samsung Internet added this earlier than the corresponding Chrome version would indicate."
               },
               "webview_android": "mirror"
             },
@@ -455,8 +455,8 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": {
-                "notes": "Samsung Internet added this earlier than the corresponding Chrome version would indicate.",
-                "version_added": "6.0"
+                "version_added": "6.0",
+                "notes": "Samsung Internet added this earlier than the corresponding Chrome version would indicate."
               },
               "webview_android": "mirror"
             },

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -186,8 +186,8 @@
                   "version_added": "94"
                 },
                 {
-                  "version_added": "22",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "22"
                 }
               ],
               "firefox_android": "mirror",
@@ -224,8 +224,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "22",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "22"
                 }
               ],
               "firefox_android": "mirror",
@@ -262,8 +262,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "22",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "22"
                 }
               ],
               "firefox_android": "mirror",

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -35,8 +35,8 @@
                 "version_added": "11"
               },
               {
-                "version_added": "10",
-                "alternative_name": "-ms-flex-positive"
+                "alternative_name": "-ms-flex-positive",
+                "version_added": "10"
               }
             ],
             "oculus": "mirror",

--- a/css/properties/font-kerning.json
+++ b/css/properties/font-kerning.json
@@ -33,8 +33,8 @@
                 "version_added": "9"
               },
               {
-                "version_added": "6",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "6"
               }
             ],
             "safari_ios": "mirror",

--- a/css/properties/font-smooth.json
+++ b/css/properties/font-smooth.json
@@ -6,14 +6,14 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-smooth",
           "support": {
             "chrome": {
-              "version_added": "5",
-              "alternative_name": "-webkit-font-smoothing"
+              "alternative_name": "-webkit-font-smoothing",
+              "version_added": "5"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "25",
               "alternative_name": "-moz-osx-font-smoothing",
+              "version_added": "25",
               "notes": "Only works on macOS."
             },
             "firefox_android": {
@@ -26,14 +26,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "4",
-              "alternative_name": "-webkit-font-smoothing"
+              "alternative_name": "-webkit-font-smoothing",
+              "version_added": "4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": "≤37",
-              "alternative_name": "-webkit-font-smoothing"
+              "alternative_name": "-webkit-font-smoothing",
+              "version_added": "≤37"
             }
           },
           "status": {

--- a/css/properties/forced-color-adjust.json
+++ b/css/properties/forced-color-adjust.json
@@ -15,8 +15,8 @@
                 "version_added": "79"
               },
               {
-                "version_added": "12",
-                "alternative_name": "-ms-high-contrast-adjust"
+                "alternative_name": "-ms-high-contrast-adjust",
+                "version_added": "12"
               }
             ],
             "firefox": {
@@ -24,8 +24,8 @@
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "10",
-              "alternative_name": "-ms-high-contrast-adjust"
+              "alternative_name": "-ms-high-contrast-adjust",
+              "version_added": "10"
             },
             "oculus": "mirror",
             "opera": "mirror",

--- a/css/properties/gap.json
+++ b/css/properties/gap.json
@@ -80,8 +80,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "57",
-                  "alternative_name": "grid-gap"
+                  "alternative_name": "grid-gap",
+                  "version_added": "57"
                 }
               ],
               "chrome_android": "mirror",
@@ -90,8 +90,8 @@
                   "version_added": "16"
                 },
                 {
-                  "version_added": "16",
-                  "alternative_name": "grid-gap"
+                  "alternative_name": "grid-gap",
+                  "version_added": "16"
                 }
               ],
               "firefox": [
@@ -99,8 +99,8 @@
                   "version_added": "61"
                 },
                 {
-                  "version_added": "52",
-                  "alternative_name": "grid-gap"
+                  "alternative_name": "grid-gap",
+                  "version_added": "52"
                 }
               ],
               "firefox_android": "mirror",
@@ -115,8 +115,8 @@
                   "version_added": "12"
                 },
                 {
-                  "version_added": "10.1",
-                  "alternative_name": "grid-gap"
+                  "alternative_name": "grid-gap",
+                  "version_added": "10.1"
                 }
               ],
               "safari_ios": "mirror",

--- a/css/properties/grid-auto-columns.json
+++ b/css/properties/grid-auto-columns.json
@@ -15,9 +15,9 @@
                 "version_added": "16"
               },
               {
+                "alternative_name": "-ms-grid-columns",
                 "version_added": "12",
-                "version_removed": "79",
-                "alternative_name": "-ms-grid-columns"
+                "version_removed": "79"
               }
             ],
             "firefox": [
@@ -33,8 +33,8 @@
             ],
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "10",
-              "alternative_name": "-ms-grid-columns"
+              "alternative_name": "-ms-grid-columns",
+              "version_added": "10"
             },
             "oculus": "mirror",
             "opera": "mirror",

--- a/css/properties/grid-auto-rows.json
+++ b/css/properties/grid-auto-rows.json
@@ -15,9 +15,9 @@
                 "version_added": "16"
               },
               {
+                "alternative_name": "-ms-grid-rows",
                 "version_added": "12",
-                "version_removed": "79",
-                "alternative_name": "-ms-grid-rows"
+                "version_removed": "79"
               }
             ],
             "firefox": [
@@ -33,8 +33,8 @@
             ],
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "10",
-              "alternative_name": "-ms-grid-rows"
+              "alternative_name": "-ms-grid-rows",
+              "version_added": "10"
             },
             "oculus": "mirror",
             "opera": "mirror",

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -29,8 +29,8 @@
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "10",
-              "alternative_name": "-ms-grid-columns"
+              "alternative_name": "-ms-grid-columns",
+              "version_added": "10"
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -222,14 +222,14 @@
                 {
                   "version_added": "57",
                   "version_removed": "76",
-                  "notes": "<code>repeat(auto-fill, ...)</code> and <code>repeat(auto-fit, ...)</code> only support one repeated column (see <a href='https://bugzil.la/1341507'>bug 1341507</a>).",
-                  "partial_implementation": true
+                  "partial_implementation": true,
+                  "notes": "<code>repeat(auto-fill, ...)</code> and <code>repeat(auto-fit, ...)</code> only support one repeated column (see <a href='https://bugzil.la/1341507'>bug 1341507</a>)."
                 },
                 {
                   "version_added": "52",
                   "version_removed": "57",
-                  "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>).",
-                  "partial_implementation": true
+                  "partial_implementation": true,
+                  "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>)."
                 }
               ],
               "firefox_android": "mirror",

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -29,8 +29,8 @@
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "10",
-              "alternative_name": "-ms-grid-rows"
+              "alternative_name": "-ms-grid-rows",
+              "version_added": "10"
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -223,14 +223,14 @@
                 {
                   "version_added": "57",
                   "version_removed": "76",
-                  "notes": "<code>repeat(auto-fill, ...)</code> and <code>repeat(auto-fit, ...)</code> only support one repeated column (see <a href='https://bugzil.la/1341507'>bug 1341507</a>).",
-                  "partial_implementation": true
+                  "partial_implementation": true,
+                  "notes": "<code>repeat(auto-fill, ...)</code> and <code>repeat(auto-fit, ...)</code> only support one repeated column (see <a href='https://bugzil.la/1341507'>bug 1341507</a>)."
                 },
                 {
                   "version_added": "52",
                   "version_removed": "57",
-                  "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>).",
-                  "partial_implementation": true
+                  "partial_implementation": true,
+                  "notes": "<a href='https://developer.mozilla.org/docs/Web/CSS/calc'><code>calc()</code></a> doesn't work in <code>repeat()</code> (see <a href='https://bugzil.la/1350069'>bug 1350069</a>)."
                 }
               ],
               "firefox_android": "mirror",

--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -64,8 +64,8 @@
                   "version_added": "11"
                 },
                 {
-                  "version_added": "9",
-                  "prefix": "-webkit-"
+                  "prefix": "-webkit-",
+                  "version_added": "9"
                 }
               ],
               "safari_ios": "mirror",
@@ -132,8 +132,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "3",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "3"
                 }
               ],
               "firefox_android": "mirror",
@@ -175,8 +175,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "3",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "3"
                 }
               ],
               "firefox_android": "mirror",
@@ -230,8 +230,8 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": {
-                "version_added": "5.0",
-                "alternative_name": "-webkit-fill-available"
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "5.0"
               },
               "webview_android": "mirror"
             },

--- a/css/properties/inline-size.json
+++ b/css/properties/inline-size.json
@@ -131,8 +131,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "41",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "41"
                 }
               ],
               "firefox_android": "mirror",
@@ -172,8 +172,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "41",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "41"
                 }
               ],
               "firefox_android": "mirror",

--- a/css/properties/line-break.json
+++ b/css/properties/line-break.json
@@ -40,13 +40,13 @@
                 "version_added": "11"
               },
               {
-                "version_added": "3",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "3"
               },
               {
+                "prefix": "-khtml-",
                 "version_added": "2",
-                "version_removed": "3",
-                "prefix": "-khtml-"
+                "version_removed": "3"
               }
             ],
             "safari_ios": [
@@ -54,8 +54,8 @@
                 "version_added": "11"
               },
               {
-                "version_added": "1",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "1"
               }
             ],
             "samsunginternet_android": "mirror",

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -1084,8 +1084,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "1",
-                "prefix": "-moz-"
+                "prefix": "-moz-",
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1202,8 +1202,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "1",
-                "prefix": "-moz-"
+                "prefix": "-moz-",
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1446,8 +1446,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "1",
-                "prefix": "-moz-"
+                "prefix": "-moz-",
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1482,8 +1482,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "1",
-                "prefix": "-moz-"
+                "prefix": "-moz-",
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1756,8 +1756,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "1",
-                "prefix": "-moz-"
+                "prefix": "-moz-",
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1790,8 +1790,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "1",
-                "prefix": "-moz-"
+                "prefix": "-moz-",
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/margin-inline-end.json
+++ b/css/properties/margin-inline-end.json
@@ -11,8 +11,8 @@
                 "version_added": "69"
               },
               {
-                "version_added": "2",
-                "alternative_name": "-webkit-margin-end"
+                "alternative_name": "-webkit-margin-end",
+                "version_added": "2"
               }
             ],
             "chrome_android": "mirror",
@@ -22,8 +22,8 @@
                 "version_added": "41"
               },
               {
-                "version_added": "3",
-                "alternative_name": "-moz-margin-end"
+                "alternative_name": "-moz-margin-end",
+                "version_added": "3"
               }
             ],
             "firefox_android": "mirror",
@@ -38,8 +38,8 @@
                 "version_added": "12.1"
               },
               {
-                "version_added": "3",
-                "alternative_name": "-webkit-margin-end"
+                "alternative_name": "-webkit-margin-end",
+                "version_added": "3"
               }
             ],
             "safari_ios": [
@@ -47,8 +47,8 @@
                 "version_added": "12.2"
               },
               {
-                "version_added": "3",
-                "alternative_name": "-webkit-margin-end"
+                "alternative_name": "-webkit-margin-end",
+                "version_added": "3"
               }
             ],
             "samsunginternet_android": "mirror",
@@ -57,8 +57,8 @@
                 "version_added": "87"
               },
               {
-                "version_added": "2",
-                "alternative_name": "-webkit-margin-end"
+                "alternative_name": "-webkit-margin-end",
+                "version_added": "2"
               }
             ]
           },

--- a/css/properties/margin-inline-start.json
+++ b/css/properties/margin-inline-start.json
@@ -11,8 +11,8 @@
                 "version_added": "69"
               },
               {
-                "version_added": "2",
-                "alternative_name": "-webkit-margin-start"
+                "alternative_name": "-webkit-margin-start",
+                "version_added": "2"
               }
             ],
             "chrome_android": "mirror",
@@ -22,8 +22,8 @@
                 "version_added": "41"
               },
               {
-                "version_added": "3",
-                "alternative_name": "-moz-margin-start"
+                "alternative_name": "-moz-margin-start",
+                "version_added": "3"
               }
             ],
             "firefox_android": "mirror",
@@ -38,8 +38,8 @@
                 "version_added": "12.1"
               },
               {
-                "version_added": "3",
-                "alternative_name": "-webkit-margin-start"
+                "alternative_name": "-webkit-margin-start",
+                "version_added": "3"
               }
             ],
             "safari_ios": [
@@ -47,8 +47,8 @@
                 "version_added": "12.2"
               },
               {
-                "version_added": "3",
-                "alternative_name": "-webkit-margin-start"
+                "alternative_name": "-webkit-margin-start",
+                "version_added": "3"
               }
             ],
             "samsunginternet_android": "mirror",
@@ -57,8 +57,8 @@
                 "version_added": "87"
               },
               {
-                "version_added": "2",
-                "alternative_name": "-webkit-margin-start"
+                "alternative_name": "-webkit-margin-start",
+                "version_added": "2"
               }
             ]
           },

--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -50,8 +50,8 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "1.0",
-              "prefix": "-webkit-"
+              "prefix": "-webkit-",
+              "version_added": "1.0"
             },
             "webview_android": {
               "prefix": "-webkit-",

--- a/css/properties/max-block-size.json
+++ b/css/properties/max-block-size.json
@@ -125,8 +125,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "41",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "41"
                 }
               ],
               "firefox_android": "mirror",
@@ -166,8 +166,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "41",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "41"
                 }
               ],
               "firefox_android": "mirror",

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -64,9 +64,9 @@
                   "version_added": "94"
                 },
                 {
-                  "partial_implementation": true,
                   "prefix": "-moz-",
                   "version_added": "3",
+                  "partial_implementation": true,
                   "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
                 }
               ],
@@ -158,8 +158,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "3",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "3"
                 }
               ],
               "firefox_android": "mirror",
@@ -178,8 +178,8 @@
                   "version_added": "11"
                 },
                 {
-                  "version_added": "9",
-                  "prefix": "-webkit-"
+                  "prefix": "-webkit-",
+                  "version_added": "9"
                 }
               ],
               "safari_ios": "mirror",
@@ -207,8 +207,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "3",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "3"
                 }
               ],
               "firefox_android": "mirror",
@@ -227,8 +227,8 @@
                   "version_added": "11"
                 },
                 {
-                  "version_added": "9",
-                  "prefix": "-webkit-"
+                  "prefix": "-webkit-",
+                  "version_added": "9"
                 }
               ],
               "safari_ios": "mirror",

--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -135,8 +135,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "41",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "41"
                 }
               ],
               "firefox_android": "mirror",
@@ -174,8 +174,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "41",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "41"
                 }
               ],
               "firefox_android": "mirror",

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -62,9 +62,9 @@
                   "version_added": "94"
                 },
                 {
-                  "partial_implementation": true,
                   "prefix": "-moz-",
                   "version_added": "3",
+                  "partial_implementation": true,
                   "notes": "Firefox implements the definitions given in CSS3 Basic Box. This defines <code>available</code> and not <code>fit-available</code>. Also, the definition of <code>fit-content</code> is simpler than in CSS3 Sizing."
                 }
               ],
@@ -172,8 +172,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "3",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "3"
                 }
               ],
               "firefox_android": "mirror",
@@ -241,8 +241,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "3",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "3"
                 }
               ],
               "firefox_android": "mirror",

--- a/css/properties/min-block-size.json
+++ b/css/properties/min-block-size.json
@@ -123,8 +123,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "41",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "41"
                 }
               ],
               "firefox_android": "mirror",
@@ -162,8 +162,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "41",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "41"
                 }
               ],
               "firefox_android": "mirror",

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -203,8 +203,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "3",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "3"
                 }
               ],
               "firefox_android": "mirror",
@@ -223,8 +223,8 @@
                   "version_added": "11"
                 },
                 {
-                  "version_added": "9",
-                  "prefix": "-webkit-"
+                  "prefix": "-webkit-",
+                  "version_added": "9"
                 }
               ],
               "safari_ios": "mirror",
@@ -252,8 +252,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "3",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "3"
                 }
               ],
               "firefox_android": "mirror",
@@ -272,8 +272,8 @@
                   "version_added": "11"
                 },
                 {
-                  "version_added": "9",
-                  "prefix": "-webkit-"
+                  "prefix": "-webkit-",
+                  "version_added": "9"
                 }
               ],
               "safari_ios": "mirror",

--- a/css/properties/min-inline-size.json
+++ b/css/properties/min-inline-size.json
@@ -129,8 +129,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "41",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "41"
                 }
               ],
               "firefox_android": "mirror",
@@ -168,8 +168,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "41",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "41"
                 }
               ],
               "firefox_android": "mirror",

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -218,8 +218,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "3",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "3"
                 }
               ],
               "firefox_android": "mirror",
@@ -282,8 +282,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "3",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "3"
                 }
               ],
               "firefox_android": "mirror",

--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -190,14 +190,14 @@
               "firefox": [
                 {
                   "version_added": "112",
-                  "notes": "<code>&lt;size&gt;</code> is optional with the default value <code>closest-side</code>.",
                   "flags": [
                     {
                       "type": "preference",
                       "name": "layout.css.motion-path-ray.enabled",
                       "value_to_set": "true"
                     }
-                  ]
+                  ],
+                  "notes": "<code>&lt;size&gt;</code> is optional with the default value <code>closest-side</code>."
                 },
                 {
                   "version_added": "72",

--- a/css/properties/opacity.json
+++ b/css/properties/opacity.json
@@ -39,9 +39,9 @@
                 "version_added": "2"
               },
               {
+                "prefix": "-khtml-",
                 "version_added": "1.1",
-                "version_removed": "2",
-                "prefix": "-khtml-"
+                "version_removed": "2"
               }
             ],
             "safari_ios": "mirror",

--- a/css/properties/outline-color.json
+++ b/css/properties/outline-color.json
@@ -60,8 +60,8 @@
                 "version_removed": "79"
               },
               "firefox": {
-                "version_removed": "3",
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "3"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/outline.json
+++ b/css/properties/outline.json
@@ -110,8 +110,8 @@
                 "version_removed": "79"
               },
               "firefox": {
-                "version_removed": "3",
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "3"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/padding-inline-end.json
+++ b/css/properties/padding-inline-end.json
@@ -11,8 +11,8 @@
                 "version_added": "69"
               },
               {
-                "version_added": "2",
-                "alternative_name": "-webkit-padding-end"
+                "alternative_name": "-webkit-padding-end",
+                "version_added": "2"
               }
             ],
             "chrome_android": "mirror",
@@ -22,8 +22,8 @@
                 "version_added": "41"
               },
               {
-                "version_added": "3",
-                "alternative_name": "-moz-padding-end"
+                "alternative_name": "-moz-padding-end",
+                "version_added": "3"
               }
             ],
             "firefox_android": "mirror",
@@ -38,8 +38,8 @@
                 "version_added": "12.1"
               },
               {
-                "version_added": "3",
-                "alternative_name": "-webkit-padding-end"
+                "alternative_name": "-webkit-padding-end",
+                "version_added": "3"
               }
             ],
             "safari_ios": [
@@ -47,8 +47,8 @@
                 "version_added": "12.2"
               },
               {
-                "version_added": "3",
-                "alternative_name": "-webkit-padding-end"
+                "alternative_name": "-webkit-padding-end",
+                "version_added": "3"
               }
             ],
             "samsunginternet_android": "mirror",
@@ -57,8 +57,8 @@
                 "version_added": "87"
               },
               {
-                "version_added": "2",
-                "alternative_name": "-webkit-padding-end"
+                "alternative_name": "-webkit-padding-end",
+                "version_added": "2"
               }
             ]
           },

--- a/css/properties/padding-inline-start.json
+++ b/css/properties/padding-inline-start.json
@@ -11,8 +11,8 @@
                 "version_added": "69"
               },
               {
-                "version_added": "2",
-                "alternative_name": "-webkit-padding-start"
+                "alternative_name": "-webkit-padding-start",
+                "version_added": "2"
               }
             ],
             "chrome_android": "mirror",
@@ -22,8 +22,8 @@
                 "version_added": "41"
               },
               {
-                "version_added": "3",
-                "alternative_name": "-moz-padding-start"
+                "alternative_name": "-moz-padding-start",
+                "version_added": "3"
               }
             ],
             "firefox_android": "mirror",
@@ -38,8 +38,8 @@
                 "version_added": "12.1"
               },
               {
-                "version_added": "3",
-                "alternative_name": "-webkit-padding-start"
+                "alternative_name": "-webkit-padding-start",
+                "version_added": "3"
               }
             ],
             "safari_ios": [
@@ -47,8 +47,8 @@
                 "version_added": "12.2"
               },
               {
-                "version_added": "3",
-                "alternative_name": "-webkit-padding-start"
+                "alternative_name": "-webkit-padding-start",
+                "version_added": "3"
               }
             ],
             "samsunginternet_android": "mirror",
@@ -57,8 +57,8 @@
                 "version_added": "87"
               },
               {
-                "version_added": "2",
-                "alternative_name": "-webkit-padding-start"
+                "alternative_name": "-webkit-padding-start",
+                "version_added": "2"
               }
             ]
           },

--- a/css/properties/perspective-origin.json
+++ b/css/properties/perspective-origin.json
@@ -30,8 +30,8 @@
                 "version_added": "16"
               },
               {
-                "version_added": "49",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "49"
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/perspective.json
+++ b/css/properties/perspective.json
@@ -30,8 +30,8 @@
                 "version_added": "16"
               },
               {
-                "version_added": "49",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "49"
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/print-color-adjust.json
+++ b/css/properties/print-color-adjust.json
@@ -7,8 +7,8 @@
           "spec_url": "https://drafts.csswg.org/css-color-adjust/#propdef-print-color-adjust",
           "support": {
             "chrome": {
-              "version_added": "17",
               "prefix": "-webkit-",
+              "version_added": "17",
               "notes": [
                 "Chrome does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants.",
                 "Before version 26, if background images are clipped (for example, when using <code>background-image</code> sprites) and <code>-webkit-print-color-adjust</code> is set to <code>exact</code>, then backgrounds will appear distorted when printed. Solid backgrounds and background images that are not clipped (i.e., backgrounds that have narrower and shorter than the element to which they are applied) are printed correctly. See <a href='https://crbug.com/131054'>Chromium bug 131054</a>."
@@ -16,8 +16,8 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "79",
               "prefix": "-webkit-",
+              "version_added": "79",
               "notes": "Edge does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants."
             },
             "firefox": [
@@ -25,8 +25,8 @@
                 "version_added": "97"
               },
               {
-                "version_added": "48",
-                "alternative_name": "color-adjust"
+                "alternative_name": "color-adjust",
+                "version_added": "48"
               }
             ],
             "firefox_android": "mirror",
@@ -35,13 +35,13 @@
             },
             "oculus": "mirror",
             "opera": {
-              "version_added": "15",
               "prefix": "-webkit-",
+              "version_added": "15",
               "notes": "Opera does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants."
             },
             "opera_android": {
-              "version_added": "15",
               "prefix": "-webkit-",
+              "version_added": "15",
               "notes": "Opera does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants."
             },
             "safari": [
@@ -49,23 +49,23 @@
                 "version_added": "15.4"
               },
               {
-                "version_added": "6",
                 "prefix": "-webkit-",
+                "version_added": "6",
                 "notes": "Safari does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants."
               }
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": "1.0",
               "prefix": "-webkit-",
+              "version_added": "1.0",
               "notes": [
                 "Samsung Internet does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants.",
                 "In version 1, if background images are clipped (for example, when using <code>background-image</code> sprites) and <code>-webkit-print-color-adjust</code> is set to <code>exact</code>, then backgrounds will appear distorted when printed. Solid backgrounds and background images that are not clipped (i.e., backgrounds that have narrower and shorter than the element to which they are applied) are printed correctly. See <a href='https://crbug.com/131054'>Chromium bug 131054</a>."
               ]
             },
             "webview_android": {
-              "version_added": "4.4",
               "prefix": "-webkit-",
+              "version_added": "4.4",
               "notes": "WebView does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants."
             }
           },

--- a/css/properties/row-gap.json
+++ b/css/properties/row-gap.json
@@ -80,8 +80,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "57",
-                  "alternative_name": "grid-row-gap"
+                  "alternative_name": "grid-row-gap",
+                  "version_added": "57"
                 }
               ],
               "chrome_android": "mirror",
@@ -90,8 +90,8 @@
                   "version_added": "16"
                 },
                 {
-                  "version_added": "16",
-                  "alternative_name": "grid-row-gap"
+                  "alternative_name": "grid-row-gap",
+                  "version_added": "16"
                 }
               ],
               "firefox": [
@@ -99,8 +99,8 @@
                   "version_added": "61"
                 },
                 {
-                  "version_added": "52",
-                  "alternative_name": "grid-row-gap"
+                  "alternative_name": "grid-row-gap",
+                  "version_added": "52"
                 }
               ],
               "firefox_android": "mirror",
@@ -115,8 +115,8 @@
                   "version_added": "12"
                 },
                 {
-                  "version_added": "10.1",
-                  "alternative_name": "grid-row-gap"
+                  "alternative_name": "grid-row-gap",
+                  "version_added": "10.1"
                 }
               ],
               "safari_ios": "mirror",

--- a/css/properties/ruby-position.json
+++ b/css/properties/ruby-position.json
@@ -11,8 +11,8 @@
                 "version_added": "84"
               },
               {
-                "version_added": "1",
                 "prefix": "-webkit-",
+                "version_added": "1",
                 "notes": "Implemented as a non-standard, prefixed, version of <code>ruby-position</code>, <code>-webkit-ruby-position</code>: it has two properties: <code>before</code> and <code>after</code> (both equivalent, for ltr and rtl scripts to the standard <code>over</code> value used with <code>ruby-align: start</code>)."
               }
             ],
@@ -22,8 +22,8 @@
                 "version_added": "84"
               },
               {
-                "version_added": "79",
                 "prefix": "-webkit-",
+                "version_added": "79",
                 "notes": "Implemented as a non-standard, prefixed, version of <code>ruby-position</code>, <code>-webkit-ruby-position</code>: it has two properties: <code>before</code> and <code>after</code> (both equivalent, for ltr and rtl scripts to the standard <code>over</code> value used with <code>ruby-align: start</code>)."
               },
               {
@@ -43,8 +43,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7",
               "prefix": "-webkit-",
+              "version_added": "7",
               "notes": "Implemented as a non-standard, prefixed, version of <code>ruby-position</code>, <code>-webkit-ruby-position</code>: it has two properties: <code>before</code> and <code>after</code> (both equivalent, for ltr and rtl scripts to the standard <code>over</code> value used with <code>ruby-align: start</code>)."
             },
             "safari_ios": "mirror",

--- a/css/properties/scroll-margin-bottom.json
+++ b/css/properties/scroll-margin-bottom.json
@@ -26,8 +26,8 @@
                 "version_added": "14.1"
               },
               {
-                "version_added": "11",
                 "alternative_name": "scroll-snap-margin-bottom",
+                "version_added": "11",
                 "partial_implementation": true,
                 "notes": "Before version 14.1, scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
               }
@@ -37,8 +37,8 @@
                 "version_added": "14.5"
               },
               {
-                "version_added": "11",
                 "alternative_name": "scroll-snap-margin-bottom",
+                "version_added": "11",
                 "partial_implementation": true,
                 "notes": "Before version 14.5, scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
               }

--- a/css/properties/scroll-margin-left.json
+++ b/css/properties/scroll-margin-left.json
@@ -26,8 +26,8 @@
                 "version_added": "14.1"
               },
               {
-                "version_added": "11",
                 "alternative_name": "scroll-snap-margin-left",
+                "version_added": "11",
                 "partial_implementation": true,
                 "notes": "Before version 14.1, scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
               }
@@ -37,8 +37,8 @@
                 "version_added": "14.5"
               },
               {
-                "version_added": "11",
                 "alternative_name": "scroll-snap-margin-left",
+                "version_added": "11",
                 "partial_implementation": true,
                 "notes": "Before version 14.5, scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
               }

--- a/css/properties/scroll-margin-right.json
+++ b/css/properties/scroll-margin-right.json
@@ -26,8 +26,8 @@
                 "version_added": "14.1"
               },
               {
-                "version_added": "11",
                 "alternative_name": "scroll-snap-margin-right",
+                "version_added": "11",
                 "partial_implementation": true,
                 "notes": "Before version 14.1, scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
               }
@@ -37,8 +37,8 @@
                 "version_added": "14.5"
               },
               {
-                "version_added": "11",
                 "alternative_name": "scroll-snap-margin-right",
+                "version_added": "11",
                 "partial_implementation": true,
                 "notes": "Before version 14.5, scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
               }

--- a/css/properties/scroll-margin-top.json
+++ b/css/properties/scroll-margin-top.json
@@ -26,8 +26,8 @@
                 "version_added": "14.1"
               },
               {
-                "version_added": "11",
                 "alternative_name": "scroll-snap-margin-top",
+                "version_added": "11",
                 "partial_implementation": true,
                 "notes": "Before version 14.1, scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
               }
@@ -37,8 +37,8 @@
                 "version_added": "14.5"
               },
               {
-                "version_added": "11",
                 "alternative_name": "scroll-snap-margin-top",
+                "version_added": "11",
                 "partial_implementation": true,
                 "notes": "Before version 14.5, scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
               }

--- a/css/properties/scroll-margin.json
+++ b/css/properties/scroll-margin.json
@@ -34,8 +34,8 @@
                 "version_added": "14.1"
               },
               {
-                "version_added": "11",
                 "alternative_name": "scroll-snap-margin",
+                "version_added": "11",
                 "partial_implementation": true,
                 "notes": "Before version 14.1, scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
               }
@@ -45,8 +45,8 @@
                 "version_added": "14.5"
               },
               {
-                "version_added": "11",
                 "alternative_name": "scroll-snap-margin",
+                "version_added": "11",
                 "partial_implementation": true,
                 "notes": "Before version 14.5, scroll margin is not applied for scrolls to fragment target or <code>scrollIntoView()</code>, see <a href='https://webkit.org/b/189265'>bug 189265</a>."
               }

--- a/css/properties/scroll-snap-type.json
+++ b/css/properties/scroll-snap-type.json
@@ -15,9 +15,9 @@
                 "version_added": "79"
               },
               {
+                "prefix": "-ms-",
                 "version_added": "12",
                 "version_removed": "79",
-                "prefix": "-ms-",
                 "notes": "Edge supports an earlier draft of CSS Scroll Snap without axis values."
               }
             ],
@@ -48,8 +48,8 @@
               }
             ],
             "ie": {
-              "version_added": "10",
               "prefix": "-ms-",
+              "version_added": "10",
               "notes": "Internet Explorer supports an earlier draft of CSS Scroll Snap without axis values."
             },
             "oculus": "mirror",
@@ -60,8 +60,8 @@
                 "version_added": "11"
               },
               {
-                "version_added": "9",
                 "prefix": "-webkit-",
+                "version_added": "9",
                 "notes": "Older Safari versions support an earlier draft of CSS Scroll Snap without axis values."
               }
             ],

--- a/css/properties/scroll-timeline-axis.json
+++ b/css/properties/scroll-timeline-axis.json
@@ -13,17 +13,17 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "111",
-              "notes": [
-                "The syntax of the shorthand property uses the fixed order of name and then the axis.",
-                "Supports the deprecated <code>horizontal</code> and <code>vertical</code> values, and not the <code>x</code> and <code>y</code> values.",
-                "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`."
-              ],
               "flags": [
                 {
                   "type": "preference",
                   "name": "layout.css.scroll-driven-animations.enabled",
                   "value_to_set": "true"
                 }
+              ],
+              "notes": [
+                "The syntax of the shorthand property uses the fixed order of name and then the axis.",
+                "Supports the deprecated <code>horizontal</code> and <code>vertical</code> values, and not the <code>x</code> and <code>y</code> values.",
+                "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`."
               ]
             },
             "firefox_android": "mirror",

--- a/css/properties/scroll-timeline-name.json
+++ b/css/properties/scroll-timeline-name.json
@@ -13,16 +13,16 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "111",
-              "notes": [
-                "The syntax of the shorthand property uses the fixed order of name and then the axis.",
-                "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`."
-              ],
               "flags": [
                 {
                   "type": "preference",
                   "name": "layout.css.scroll-driven-animations.enabled",
                   "value_to_set": "true"
                 }
+              ],
+              "notes": [
+                "The syntax of the shorthand property uses the fixed order of name and then the axis.",
+                "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`."
               ]
             },
             "firefox_android": "mirror",

--- a/css/properties/scroll-timeline.json
+++ b/css/properties/scroll-timeline.json
@@ -15,17 +15,17 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "111",
-              "notes": [
-                "The syntax of the shorthand property uses the fixed order of name and then the axis.",
-                "Supports the deprecated <code>horizontal</code> and <code>vertical</code> axis values, and not the <code>x</code> and <code>y</code> values.",
-                "The <code>@scroll-timeline</code> at-rule is replaced with the longhand properties <code>scroll-timeline-name</code> and <code>scroll-timeline-axis</code> and the shorthand property <code>scroll-timeline</code>."
-              ],
               "flags": [
                 {
                   "type": "preference",
                   "name": "layout.css.scroll-driven-animations.enabled",
                   "value_to_set": "true"
                 }
+              ],
+              "notes": [
+                "The syntax of the shorthand property uses the fixed order of name and then the axis.",
+                "Supports the deprecated <code>horizontal</code> and <code>vertical</code> axis values, and not the <code>x</code> and <code>y</code> values.",
+                "The <code>@scroll-timeline</code> at-rule is replaced with the longhand properties <code>scroll-timeline-name</code> and <code>scroll-timeline-axis</code> and the shorthand property <code>scroll-timeline</code>."
               ]
             },
             "firefox_android": "mirror",

--- a/css/properties/scrollbar-3dlight-color.json
+++ b/css/properties/scrollbar-3dlight-color.json
@@ -19,8 +19,8 @@
                 "version_added": "5"
               },
               {
-                "version_added": "8",
-                "prefix": "-ms-"
+                "prefix": "-ms-",
+                "version_added": "8"
               }
             ],
             "oculus": "mirror",

--- a/css/properties/scrollbar-arrow-color.json
+++ b/css/properties/scrollbar-arrow-color.json
@@ -19,8 +19,8 @@
                 "version_added": "5"
               },
               {
-                "version_added": "8",
-                "prefix": "-ms-"
+                "prefix": "-ms-",
+                "version_added": "8"
               }
             ],
             "oculus": "mirror",

--- a/css/properties/scrollbar-base-color.json
+++ b/css/properties/scrollbar-base-color.json
@@ -19,8 +19,8 @@
                 "version_added": "5"
               },
               {
-                "version_added": "8",
-                "prefix": "-ms-"
+                "prefix": "-ms-",
+                "version_added": "8"
               }
             ],
             "oculus": "mirror",

--- a/css/properties/scrollbar-darkshadow-color.json
+++ b/css/properties/scrollbar-darkshadow-color.json
@@ -19,8 +19,8 @@
                 "version_added": "5"
               },
               {
-                "version_added": "8",
-                "prefix": "-ms-"
+                "prefix": "-ms-",
+                "version_added": "8"
               }
             ],
             "oculus": "mirror",

--- a/css/properties/scrollbar-face-color.json
+++ b/css/properties/scrollbar-face-color.json
@@ -19,8 +19,8 @@
                 "version_added": "5"
               },
               {
-                "version_added": "8",
-                "prefix": "-ms-"
+                "prefix": "-ms-",
+                "version_added": "8"
               }
             ],
             "oculus": "mirror",

--- a/css/properties/scrollbar-highlight-color.json
+++ b/css/properties/scrollbar-highlight-color.json
@@ -19,8 +19,8 @@
                 "version_added": "5"
               },
               {
-                "version_added": "8",
-                "prefix": "-ms-"
+                "prefix": "-ms-",
+                "version_added": "8"
               }
             ],
             "oculus": "mirror",

--- a/css/properties/scrollbar-shadow-color.json
+++ b/css/properties/scrollbar-shadow-color.json
@@ -19,8 +19,8 @@
                 "version_added": "5"
               },
               {
-                "version_added": "8",
-                "prefix": "-ms-"
+                "prefix": "-ms-",
+                "version_added": "8"
               }
             ],
             "oculus": "mirror",

--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -143,8 +143,8 @@
             "description": "<code>match-parent</code>",
             "support": {
               "chrome": {
-                "version_added": "16",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "16"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -11,9 +11,9 @@
                 "version_added": "48"
               },
               {
-                "partial_implementation": true,
                 "alternative_name": "-webkit-text-combine",
                 "version_added": "9",
+                "partial_implementation": true,
                 "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='https://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without <code>digits</code>."
               }
             ],
@@ -23,9 +23,9 @@
                 "version_added": "79"
               },
               {
+                "alternative_name": "-ms-text-combine-horizontal",
                 "version_added": "12",
-                "version_removed": "79",
-                "alternative_name": "-ms-text-combine-horizontal"
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -34,8 +34,8 @@
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "11",
-              "alternative_name": "-ms-text-combine-horizontal"
+              "alternative_name": "-ms-text-combine-horizontal",
+              "version_added": "11"
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -45,9 +45,9 @@
                 "version_added": "15.4"
               },
               {
-                "partial_implementation": true,
                 "alternative_name": "-webkit-text-combine",
                 "version_added": "5.1",
+                "partial_implementation": true,
                 "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='https://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without <code>digits</code>."
               }
             ],
@@ -58,9 +58,9 @@
                 "version_added": "48"
               },
               {
-                "partial_implementation": true,
                 "alternative_name": "-webkit-text-combine",
                 "version_added": "≤37",
+                "partial_implementation": true,
                 "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='https://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without <code>digits</code>."
               }
             ]
@@ -85,8 +85,8 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": "11",
-                "alternative_name": "-ms-text-combine-horizontal"
+                "alternative_name": "-ms-text-combine-horizontal",
+                "version_added": "11"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/css/properties/text-decoration-skip.json
+++ b/css/properties/text-decoration-skip.json
@@ -37,8 +37,8 @@
                 "notes": "Supports only <code>none</code>, <code>auto</code>, and <code>objects</code> values."
               },
               {
-                "version_added": "7",
                 "prefix": "-webkit-",
+                "version_added": "7",
                 "notes": "Supports only <code>none</code>, <code>auto</code>, and <code>objects</code> values."
               }
             ],

--- a/css/properties/touch-action.json
+++ b/css/properties/touch-action.json
@@ -28,8 +28,8 @@
                 "version_added": "11"
               },
               {
-                "version_added": "10",
-                "prefix": "-ms-"
+                "prefix": "-ms-",
+                "version_added": "10"
               }
             ],
             "oculus": "mirror",
@@ -73,8 +73,8 @@
                   "version_added": "11"
                 },
                 {
-                  "version_added": "10",
-                  "prefix": "-ms-"
+                  "prefix": "-ms-",
+                  "version_added": "10"
                 }
               ],
               "oculus": "mirror",
@@ -114,8 +114,8 @@
                   "version_added": "11"
                 },
                 {
-                  "version_added": "10",
-                  "prefix": "-ms-"
+                  "prefix": "-ms-",
+                  "version_added": "10"
                 }
               ],
               "oculus": "mirror",
@@ -157,8 +157,8 @@
                   "version_added": "11"
                 },
                 {
-                  "version_added": "10",
-                  "prefix": "-ms-"
+                  "prefix": "-ms-",
+                  "version_added": "10"
                 }
               ],
               "oculus": "mirror",
@@ -202,8 +202,8 @@
                   "version_added": "11"
                 },
                 {
-                  "version_added": "10",
-                  "prefix": "-ms-"
+                  "prefix": "-ms-",
+                  "version_added": "10"
                 }
               ],
               "oculus": "mirror",
@@ -243,8 +243,8 @@
                   "version_added": "11"
                 },
                 {
-                  "version_added": "10",
-                  "prefix": "-ms-"
+                  "prefix": "-ms-",
+                  "version_added": "10"
                 }
               ],
               "oculus": "mirror",

--- a/css/properties/transition-delay.json
+++ b/css/properties/transition-delay.json
@@ -30,8 +30,8 @@
                 "version_added": "16"
               },
               {
-                "version_added": "49",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "49"
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/transition-duration.json
+++ b/css/properties/transition-duration.json
@@ -30,8 +30,8 @@
                 "version_added": "16"
               },
               {
-                "version_added": "49",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "49"
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -30,8 +30,8 @@
                 "version_added": "16"
               },
               {
-                "version_added": "49",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "49"
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -30,8 +30,8 @@
                 "version_added": "16"
               },
               {
-                "version_added": "49",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "49"
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -35,8 +35,8 @@
                 ]
               },
               {
-                "version_added": "49",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "49"
               },
               {
                 "prefix": "-moz-",

--- a/css/properties/user-modify.json
+++ b/css/properties/user-modify.json
@@ -32,18 +32,18 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "3",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "3"
               },
               {
+                "prefix": "-khtml-",
                 "version_added": "2",
-                "version_removed": "3",
-                "prefix": "-khtml-"
+                "version_removed": "3"
               }
             ],
             "safari_ios": {
-              "version_added": "5",
-              "prefix": "-webkit-"
+              "prefix": "-webkit-",
+              "version_added": "5"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {

--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -53,13 +53,13 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "3",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "3"
               },
               {
+                "prefix": "-khtml-",
                 "version_added": "2",
-                "version_removed": "3",
-                "prefix": "-khtml-"
+                "version_removed": "3"
               }
             ],
             "safari_ios": {
@@ -205,9 +205,9 @@
                   "version_added": "21"
                 },
                 {
+                  "prefix": "-moz-",
                   "version_added": "1",
-                  "version_removed": "65",
-                  "prefix": "-moz-"
+                  "version_removed": "65"
                 }
               ],
               "firefox_android": "mirror",

--- a/css/properties/view-timeline-axis.json
+++ b/css/properties/view-timeline-axis.json
@@ -13,14 +13,14 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "114",
-              "notes": "Now supports the <code>x</code> and <code>y</code> values, and also the deprecated <code>horizontal</code> and <code>vertical</code> values.",
               "flags": [
                 {
                   "type": "preference",
                   "name": "layout.css.scroll-driven-animations.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "notes": "Now supports the <code>x</code> and <code>y</code> values, and also the deprecated <code>horizontal</code> and <code>vertical</code> values."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/view-timeline.json
+++ b/css/properties/view-timeline.json
@@ -15,14 +15,14 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "114",
-              "notes": "Now supports the <code>x</code> and <code>y</code> values, and also the deprecated <code>horizontal</code> and <code>vertical</code> values.",
               "flags": [
                 {
                   "type": "preference",
                   "name": "layout.css.scroll-driven-animations.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "notes": "Now supports the <code>x</code> and <code>y</code> values, and also the deprecated <code>horizontal</code> and <code>vertical</code> values."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -198,8 +198,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "3",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "3"
                 }
               ],
               "firefox_android": "mirror",
@@ -255,8 +255,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "3",
-                  "prefix": "-moz-"
+                  "prefix": "-moz-",
+                  "version_added": "3"
                 }
               ],
               "firefox_android": "mirror",
@@ -313,8 +313,8 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": {
-                "version_added": "5.0",
-                "alternative_name": "-webkit-fill-available"
+                "alternative_name": "-webkit-fill-available",
+                "version_added": "5.0"
               },
               "webview_android": "mirror"
             },

--- a/css/selectors/-moz-submit-invalid.json
+++ b/css/selectors/-moz-submit-invalid.json
@@ -14,14 +14,14 @@
             "firefox": [
               {
                 "version_added": "88",
-                "notes": "From Firefox 88 the feature has been placed behind a flag. See <a href='https://bugzil.la/1694129'>bug 1694129</a>.",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "layout.css.moz-submit-invalid.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "notes": "From Firefox 88 the feature has been placed behind a flag. See <a href='https://bugzil.la/1694129'>bug 1694129</a>."
               },
               {
                 "version_added": "4",

--- a/css/selectors/any-link.json
+++ b/css/selectors/any-link.json
@@ -23,9 +23,9 @@
                 "version_added": "50"
               },
               {
+                "prefix": "-moz-",
                 "version_added": "1",
-                "version_removed": "50",
-                "prefix": "-moz-"
+                "version_removed": "50"
               }
             ],
             "firefox_android": "mirror",
@@ -40,13 +40,13 @@
                 "version_added": "9"
               },
               {
-                "version_added": "3",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "3"
               },
               {
+                "prefix": "-khtml-",
                 "version_added": "1.2",
-                "version_removed": "3",
-                "prefix": "-khtml-"
+                "version_removed": "3"
               }
             ],
             "safari_ios": [

--- a/css/selectors/autofill.json
+++ b/css/selectors/autofill.json
@@ -8,8 +8,8 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-autofill",
           "support": {
             "chrome": {
-              "version_added": "1",
-              "prefix": "-webkit-"
+              "prefix": "-webkit-",
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -34,8 +34,8 @@
                 "version_added": "15"
               },
               {
-                "version_added": "3",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "3"
               }
             ],
             "safari_ios": [
@@ -43,8 +43,8 @@
                 "version_added": "15"
               },
               {
-                "version_added": "1",
-                "prefix": "-webkit-"
+                "prefix": "-webkit-",
+                "version_added": "1"
               }
             ],
             "samsunginternet_android": "mirror",

--- a/css/selectors/file-selector-button.json
+++ b/css/selectors/file-selector-button.json
@@ -12,8 +12,8 @@
                 "version_added": "89"
               },
               {
-                "version_added": "1",
-                "alternative_name": "::-webkit-file-upload-button"
+                "alternative_name": "::-webkit-file-upload-button",
+                "version_added": "1"
               }
             ],
             "chrome_android": "mirror",
@@ -22,13 +22,13 @@
                 "version_added": "89"
               },
               {
-                "version_added": "79",
-                "alternative_name": "::-webkit-file-upload-button"
+                "alternative_name": "::-webkit-file-upload-button",
+                "version_added": "79"
               },
               {
+                "alternative_name": "::-ms-browse",
                 "version_added": "12",
-                "version_removed": "79",
-                "alternative_name": "::-ms-browse"
+                "version_removed": "79"
               }
             ],
             "firefox": {
@@ -36,8 +36,8 @@
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "10",
-              "alternative_name": "::-ms-browse"
+              "alternative_name": "::-ms-browse",
+              "version_added": "10"
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -47,8 +47,8 @@
                 "version_added": "14.1"
               },
               {
-                "version_added": "3",
-                "alternative_name": "::-webkit-file-upload-button"
+                "alternative_name": "::-webkit-file-upload-button",
+                "version_added": "3"
               }
             ],
             "safari_ios": [
@@ -56,8 +56,8 @@
                 "version_added": "14.5"
               },
               {
-                "version_added": "1",
-                "alternative_name": "::-webkit-file-upload-button"
+                "alternative_name": "::-webkit-file-upload-button",
+                "version_added": "1"
               }
             ],
             "samsunginternet_android": "mirror",

--- a/css/selectors/focus-visible.json
+++ b/css/selectors/focus-visible.json
@@ -17,8 +17,8 @@
                 "version_added": "85"
               },
               {
-                "version_added": "4",
-                "alternative_name": ":-moz-focusring"
+                "alternative_name": ":-moz-focusring",
+                "version_added": "4"
               }
             ],
             "firefox_android": "mirror",

--- a/css/selectors/fullscreen.json
+++ b/css/selectors/fullscreen.json
@@ -25,8 +25,8 @@
                 "version_added": "64"
               },
               {
-                "version_added": "9",
-                "alternative_name": ":-moz-full-screen"
+                "alternative_name": ":-moz-full-screen",
+                "version_added": "9"
               }
             ],
             "firefox_android": "mirror",

--- a/css/selectors/is.json
+++ b/css/selectors/is.json
@@ -12,8 +12,8 @@
                 "version_added": "88"
               },
               {
-                "version_added": "12",
                 "alternative_name": ":-webkit-any()",
+                "version_added": "12",
                 "notes": "Doesn't support combinators."
               }
             ],
@@ -24,8 +24,8 @@
                 "version_added": "78"
               },
               {
-                "version_added": "4",
                 "alternative_name": ":-moz-any()",
+                "version_added": "4",
                 "notes": [
                   "Doesn't support combinators.",
                   "See <a href='https://bugzil.la/906353'>bug 906353</a>."
@@ -44,12 +44,12 @@
                 "version_added": "14"
               },
               {
-                "version_added": "9",
-                "alternative_name": ":matches()"
+                "alternative_name": ":matches()",
+                "version_added": "9"
               },
               {
-                "version_added": "5",
                 "alternative_name": ":-webkit-any()",
+                "version_added": "5",
                 "notes": "Doesn't support combinators."
               }
             ],
@@ -58,12 +58,12 @@
                 "version_added": "14"
               },
               {
-                "version_added": "9",
-                "alternative_name": ":matches()"
+                "alternative_name": ":matches()",
+                "version_added": "9"
               },
               {
-                "version_added": "5",
                 "alternative_name": ":-webkit-any()",
+                "version_added": "5",
                 "notes": "Doesn't support combinators."
               }
             ],
@@ -86,8 +86,8 @@
                 "version_added": "88"
               },
               {
-                "version_added": "≤37",
                 "alternative_name": ":-webkit-any()",
+                "version_added": "≤37",
                 "notes": "Doesn't support combinators."
               }
             ]

--- a/css/selectors/placeholder-shown.json
+++ b/css/selectors/placeholder-shown.json
@@ -24,8 +24,8 @@
             ],
             "firefox_android": "mirror",
             "ie": {
-              "version_added": "10",
-              "alternative_name": ":-ms-input-placeholder"
+              "alternative_name": ":-ms-input-placeholder",
+              "version_added": "10"
             },
             "oculus": "mirror",
             "opera": "mirror",

--- a/css/selectors/selection.json
+++ b/css/selectors/selection.json
@@ -19,8 +19,8 @@
                 "version_added": "62"
               },
               {
-                "version_added": "1",
-                "prefix": "-moz-"
+                "prefix": "-moz-",
+                "version_added": "1"
               }
             ],
             "firefox_android": "mirror",

--- a/css/selectors/user-invalid.json
+++ b/css/selectors/user-invalid.json
@@ -18,8 +18,8 @@
                 "version_added": "88"
               },
               {
-                "version_added": "4",
-                "alternative_name": ":-moz-ui-invalid"
+                "alternative_name": ":-moz-ui-invalid",
+                "version_added": "4"
               }
             ],
             "firefox_android": "mirror",

--- a/css/selectors/user-valid.json
+++ b/css/selectors/user-valid.json
@@ -18,8 +18,8 @@
                 "version_added": "88"
               },
               {
-                "version_added": "4",
-                "alternative_name": ":-moz-ui-valid"
+                "alternative_name": ":-moz-ui-valid",
+                "version_added": "4"
               }
             ],
             "firefox_android": "mirror",

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -118,16 +118,16 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "partial_implementation": true,
                   "version_added": "29",
                   "version_removed": "57",
+                  "partial_implementation": true,
                   "notes": "<code>-moz-element()</code> is limited to <a href='https://developer.mozilla.org/docs/Web/CSS/background-image'><code>background-image</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/background'><code>background</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/border-image'><code>border-image</code></a> and <a href='https://developer.mozilla.org/docs/Web/CSS/border-image-source'><code>border-image-source</code></a>."
                 },
                 {
                   "prefix": "-moz-",
-                  "partial_implementation": true,
                   "version_added": "4",
                   "version_removed": "29",
+                  "partial_implementation": true,
                   "notes": "<code>-moz-element()</code> is limited to <a href='https://developer.mozilla.org/docs/Web/CSS/background-image'><code>background-image</code></a> and <a href='https://developer.mozilla.org/docs/Web/CSS/background'><code>background</code></a>."
                 }
               ],
@@ -138,16 +138,16 @@
                 },
                 {
                   "prefix": "-moz-",
-                  "partial_implementation": true,
                   "version_added": "29",
                   "version_removed": "60",
+                  "partial_implementation": true,
                   "notes": "<code>-moz-element()</code> is limited to <a href='https://developer.mozilla.org/docs/Web/CSS/background-image'><code>background-image</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/background'><code>background</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/border-image'><code>border-image</code></a> and <a href='https://developer.mozilla.org/docs/Web/CSS/border-image-source'><code>border-image-source</code></a>."
                 },
                 {
                   "prefix": "-moz-",
-                  "partial_implementation": true,
                   "version_added": "4",
                   "version_removed": "29",
+                  "partial_implementation": true,
                   "notes": "<code>-moz-element()</code> is limited to <a href='https://developer.mozilla.org/docs/Web/CSS/background-image'><code>background-image</code></a> and <a href='https://developer.mozilla.org/docs/Web/CSS/background'><code>background</code></a>."
                 }
               ],

--- a/css/types/ray.json
+++ b/css/types/ray.json
@@ -53,14 +53,14 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "116",
-                "notes": "<code>&lt;at-position&gt;</code> is optional. If omitted, the <code>offset-position</code> of the element is used.",
                 "flags": [
                   {
                     "type": "preference",
                     "name": "layout.css.motion-path-ray.enabled",
                     "value_to_set": "true"
                   }
-                ]
+                ],
+                "notes": "<code>&lt;at-position&gt;</code> is optional. If omitted, the <code>offset-position</code> of the element is used."
               },
               "firefox_android": "mirror",
               "ie": {
@@ -95,25 +95,25 @@
               "firefox": [
                 {
                   "version_added": "112",
-                  "notes": "<code>&lt;size&gt;</code> is optional. If omitted, the value <code>closest-side</code> is used.",
                   "flags": [
                     {
                       "type": "preference",
                       "name": "layout.css.motion-path-ray.enabled",
                       "value_to_set": "true"
                     }
-                  ]
+                  ],
+                  "notes": "<code>&lt;size&gt;</code> is optional. If omitted, the value <code>closest-side</code> is used."
                 },
                 {
                   "version_added": "72",
-                  "notes": "<code>&lt;size&gt;</code> is required.",
                   "flags": [
                     {
                       "type": "preference",
                       "name": "layout.css.motion-path-ray.enabled",
                       "value_to_set": "true"
                     }
-                  ]
+                  ],
+                  "notes": "<code>&lt;size&gt;</code> is required."
                 }
               ],
               "firefox_android": "mirror",

--- a/css/types/resolution.json
+++ b/css/types/resolution.json
@@ -19,8 +19,8 @@
                 "version_added": "8"
               },
               {
-                "partial_implementation": true,
                 "version_added": "3.5",
+                "partial_implementation": true,
                 "notes": "Supports <a href='https://developer.mozilla.org/docs/Web/CSS/integer'><code>&lt;integer&gt;</code></a> values only."
               }
             ],

--- a/html/elements/fieldset.json
+++ b/html/elements/fieldset.json
@@ -52,8 +52,8 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "partial_implementation": true,
                 "version_added": "12",
+                "partial_implementation": true,
                 "notes": "Does not work with nested fieldsets. For example: <code>&lt;fieldset disabled&gt;&lt;fieldset&gt;&lt;!--Still enabled--&gt;&lt;/fieldset&gt;&lt;/fieldset&gt;</code>"
               },
               "firefox": {

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -986,9 +986,9 @@
                     "version_added": "85"
                   },
                   {
-                    "partial_implementation": true,
                     "version_added": "56",
                     "version_removed": "57",
+                    "partial_implementation": true,
                     "notes": "Disabled due to various web compatibility issues (e.g. <a href='https://bugzil.la/1405761'>bug 1405761</a>)."
                   }
                 ],

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -293,8 +293,8 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_removed": "65",
-                  "version_added": true
+                  "version_added": true,
+                  "version_removed": "65"
                 },
                 "chrome_android": "mirror",
                 "edge": {

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -46,9 +46,9 @@
                   "version_added": "111"
                 },
                 {
+                  "alternative_name": "shadowroot",
                   "version_added": "90",
-                  "version_removed": "111",
-                  "alternative_name": "shadowroot"
+                  "version_removed": "111"
                 }
               ],
               "chrome_android": "mirror",

--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -11,8 +11,8 @@
                 "version_added": "25"
               },
               {
-                "version_added": "14",
-                "alternative_name": "X-Webkit-CSP"
+                "alternative_name": "X-Webkit-CSP",
+                "version_added": "14"
               }
             ],
             "chrome_android": {
@@ -26,17 +26,17 @@
                 "version_added": "23"
               },
               {
-                "version_added": "4",
-                "alternative_name": "X-Content-Security-Policy"
+                "alternative_name": "X-Content-Security-Policy",
+                "version_added": "4"
               }
             ],
             "firefox_android": {
               "version_added": "23"
             },
             "ie": {
+              "alternative_name": "X-Content-Security-Policy",
               "version_added": "10",
-              "notes": "Only supporting 'sandbox' directive.",
-              "alternative_name": "X-Content-Security-Policy"
+              "notes": "Only supporting 'sandbox' directive."
             },
             "oculus": "mirror",
             "opera": {
@@ -48,8 +48,8 @@
                 "version_added": "7"
               },
               {
-                "version_added": "6",
-                "alternative_name": "X-Webkit-CSP"
+                "alternative_name": "X-Webkit-CSP",
+                "version_added": "6"
               }
             ],
             "safari_ios": "mirror",

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -11,15 +11,15 @@
                 "version_added": "88"
               },
               {
-                "version_added": "60",
-                "alternative_name": "Feature-Policy"
+                "alternative_name": "Feature-Policy",
+                "version_added": "60"
               }
             ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "74",
               "alternative_name": "Feature-Policy",
+              "version_added": "74",
               "partial_implementation": true,
               "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
             },
@@ -31,8 +31,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1",
               "alternative_name": "Feature-Policy",
+              "version_added": "11.1",
               "partial_implementation": true,
               "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
             },
@@ -56,8 +56,8 @@
                   "version_added": "88"
                 },
                 {
-                  "version_added": "66",
-                  "alternative_name": "Feature-Policy"
+                  "alternative_name": "Feature-Policy",
+                  "version_added": "66"
                 }
               ],
               "chrome_android": "mirror",
@@ -96,8 +96,8 @@
                   "version_added": "88"
                 },
                 {
-                  "version_added": "66",
-                  "alternative_name": "Feature-Policy"
+                  "alternative_name": "Feature-Policy",
+                  "version_added": "66"
                 }
               ],
               "chrome_android": "mirror",
@@ -170,15 +170,15 @@
                   "version_added": "88"
                 },
                 {
-                  "version_added": "64",
-                  "alternative_name": "Feature-Policy"
+                  "alternative_name": "Feature-Policy",
+                  "version_added": "64"
                 }
               ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "74",
                 "alternative_name": "Feature-Policy: autoplay",
+                "version_added": "74",
                 "partial_implementation": true,
                 "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
               },
@@ -247,15 +247,15 @@
                   "version_added": "88"
                 },
                 {
-                  "version_added": "64",
-                  "alternative_name": "Feature-Policy"
+                  "alternative_name": "Feature-Policy",
+                  "version_added": "64"
                 }
               ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "74",
                 "alternative_name": "Feature-Policy: camera",
+                "version_added": "74",
                 "partial_implementation": true,
                 "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
               },
@@ -271,8 +271,8 @@
                 "version_added": "45"
               },
               "safari": {
-                "version_added": "11.1",
-                "alternative_name": "Feature-Policy: camera"
+                "alternative_name": "Feature-Policy: camera",
+                "version_added": "11.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -296,8 +296,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "74",
                 "alternative_name": "Feature-Policy: display-capture",
+                "version_added": "74",
                 "partial_implementation": true,
                 "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
               },
@@ -311,8 +311,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "13",
                 "alternative_name": "Feature-Policy: display-capture",
+                "version_added": "13",
                 "partial_implementation": true,
                 "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
               },
@@ -345,8 +345,8 @@
                   ]
                 },
                 {
-                  "version_added": "64",
                   "alternative_name": "Feature-Policy",
+                  "version_added": "64",
                   "flags": [
                     {
                       "type": "runtime_flag",
@@ -360,8 +360,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "74",
                 "alternative_name": "Feature-Policy: document-domain",
+                "version_added": "74",
                 "flags": [
                   {
                     "type": "preference",
@@ -401,15 +401,15 @@
                   "version_added": "88"
                 },
                 {
-                  "version_added": "64",
-                  "alternative_name": "Feature-Policy"
+                  "alternative_name": "Feature-Policy",
+                  "version_added": "64"
                 }
               ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "74",
                 "alternative_name": "Feature-Policy: encrypted-media",
+                "version_added": "74",
                 "flags": [
                   {
                     "type": "preference",
@@ -533,15 +533,15 @@
                   "version_added": "88"
                 },
                 {
-                  "version_added": "62",
-                  "alternative_name": "Feature-Policy"
+                  "alternative_name": "Feature-Policy",
+                  "version_added": "62"
                 }
               ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "74",
                 "alternative_name": "Feature-Policy: fullscreen",
+                "version_added": "74",
                 "partial_implementation": true,
                 "notes": [
                   "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>).",
@@ -580,8 +580,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "91",
                 "alternative_name": "Feature-Policy: gamepad",
+                "version_added": "91",
                 "partial_implementation": true,
                 "notes": [
                   "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>).",
@@ -619,15 +619,15 @@
                   "version_added": "88"
                 },
                 {
-                  "version_added": "64",
-                  "alternative_name": "Feature-Policy"
+                  "alternative_name": "Feature-Policy",
+                  "version_added": "64"
                 }
               ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "74",
                 "alternative_name": "Feature-Policy: geolocation",
+                "version_added": "74",
                 "partial_implementation": true,
                 "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)."
               },
@@ -662,8 +662,8 @@
                   "version_added": "88"
                 },
                 {
-                  "version_added": "66",
-                  "alternative_name": "Feature-Policy"
+                  "alternative_name": "Feature-Policy",
+                  "version_added": "66"
                 }
               ],
               "chrome_android": "mirror",
@@ -842,8 +842,8 @@
                   "version_added": "88"
                 },
                 {
-                  "version_added": "66",
-                  "alternative_name": "Feature-Policy"
+                  "alternative_name": "Feature-Policy",
+                  "version_added": "66"
                 }
               ],
               "chrome_android": "mirror",
@@ -884,15 +884,15 @@
                   "version_added": "88"
                 },
                 {
-                  "version_added": "64",
-                  "alternative_name": "Feature-Policy"
+                  "alternative_name": "Feature-Policy",
+                  "version_added": "64"
                 }
               ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "74",
                 "alternative_name": "Feature-Policy: microphone",
+                "version_added": "74",
                 "partial_implementation": true,
                 "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
               },
@@ -908,8 +908,8 @@
                 "version_added": "45"
               },
               "safari": {
-                "version_added": "11.1",
-                "alternative_name": "Feature-Policy: microphone"
+                "alternative_name": "Feature-Policy: microphone",
+                "version_added": "11.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -932,15 +932,15 @@
                   "version_added": "88"
                 },
                 {
-                  "version_added": "64",
-                  "alternative_name": "Feature-Policy"
+                  "alternative_name": "Feature-Policy",
+                  "version_added": "64"
                 }
               ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "74",
                 "alternative_name": "Feature-Policy: midi",
+                "version_added": "74",
                 "flags": [
                   {
                     "type": "preference",
@@ -1018,15 +1018,15 @@
                   "version_added": "88"
                 },
                 {
-                  "version_added": "60",
-                  "alternative_name": "Feature-Policy"
+                  "alternative_name": "Feature-Policy",
+                  "version_added": "60"
                 }
               ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "74",
                 "alternative_name": "Feature-Policy: payment",
+                "version_added": "74",
                 "flags": [
                   {
                     "type": "preference",
@@ -1066,8 +1066,8 @@
                   "version_added": "88"
                 },
                 {
-                  "version_added": "71",
-                  "alternative_name": "Feature-Policy"
+                  "alternative_name": "Feature-Policy",
+                  "version_added": "71"
                 }
               ],
               "chrome_android": {
@@ -1112,8 +1112,8 @@
                   "version_added": "88"
                 },
                 {
-                  "version_added": "84",
-                  "alternative_name": "Feature-Policy"
+                  "alternative_name": "Feature-Policy",
+                  "version_added": "84"
                 }
               ],
               "chrome_android": "mirror",
@@ -1156,15 +1156,15 @@
                   "version_added": "88"
                 },
                 {
-                  "version_added": "84",
-                  "alternative_name": "Feature-Policy"
+                  "alternative_name": "Feature-Policy",
+                  "version_added": "84"
                 }
               ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "118",
                 "alternative_name": "Feature-Policy: publickey-credentials-get",
+                "version_added": "118",
                 "partial_implementation": true,
                 "notes": "Only supported through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements."
               },
@@ -1203,8 +1203,8 @@
                   "version_added": "88"
                 },
                 {
-                  "version_added": "84",
-                  "alternative_name": "Feature-Policy"
+                  "alternative_name": "Feature-Policy",
+                  "version_added": "84"
                 }
               ],
               "chrome_android": "mirror",
@@ -1278,8 +1278,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "116",
                 "alternative_name": "Feature-Policy: speaker-selection",
+                "version_added": "116",
                 "partial_implementation": true,
                 "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)"
               },
@@ -1351,8 +1351,8 @@
                   "version_added": "88"
                 },
                 {
-                  "version_added": "60",
-                  "alternative_name": "Feature-Policy"
+                  "alternative_name": "Feature-Policy",
+                  "version_added": "60"
                 }
               ],
               "chrome_android": "mirror",
@@ -1393,15 +1393,15 @@
                   "version_added": "88"
                 },
                 {
-                  "version_added": "86",
-                  "alternative_name": "Feature-Policy"
+                  "alternative_name": "Feature-Policy",
+                  "version_added": "86"
                 }
               ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "81",
                 "alternative_name": "Feature-Policy: web-share",
+                "version_added": "81",
                 "partial_implementation": true,
                 "notes": [
                   "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>).",
@@ -1512,8 +1512,8 @@
                   "version_added": "88"
                 },
                 {
-                  "version_added": "79",
-                  "alternative_name": "Feature-Policy"
+                  "alternative_name": "Feature-Policy",
+                  "version_added": "79"
                 }
               ],
               "chrome_android": "mirror",

--- a/http/headers/Sec-GPC.json
+++ b/http/headers/Sec-GPC.json
@@ -12,14 +12,14 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "preview",
-              "notes": "Opt-in to GPC by setting the preference <code>privacy.globalprivacycontrol.enabled</code> to <code>true</code>.",
               "flags": [
                 {
                   "type": "preference",
                   "name": "privacy.globalprivacycontrol.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "notes": "Opt-in to GPC by setting the preference <code>privacy.globalprivacycontrol.enabled</code> to <code>true</code>."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/http/headers/X-Content-Type-Options.json
+++ b/http/headers/X-Content-Type-Options.json
@@ -12,8 +12,8 @@
               },
               {
                 "version_added": "1",
-                "notes": "Not supported for stylesheets.",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "Not supported for stylesheets."
               }
             ],
             "chrome_android": [
@@ -22,8 +22,8 @@
               },
               {
                 "version_added": true,
-                "notes": "Not supported for stylesheets.",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "Not supported for stylesheets."
               }
             ],
             "edge": {

--- a/http/status.json
+++ b/http/status.json
@@ -53,7 +53,6 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "102",
-              "notes": "Supported in HTTP1.0 and later for preconnect.",
               "flags": [
                 {
                   "type": "preference",
@@ -65,7 +64,8 @@
                   "name": "network.early-hints.preconnect.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "notes": "Supported in HTTP1.0 and later for preconnect."
             },
             "ie": {
               "version_added": false

--- a/javascript/builtins/Intl/Locale.json
+++ b/javascript/builtins/Intl/Locale.json
@@ -248,8 +248,8 @@
               "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getCalendars",
               "support": {
                 "chrome": {
-                  "version_added": "99",
                   "alternative_name": "calendars",
+                  "version_added": "99",
                   "notes": "Implemented as an accessor property."
                 },
                 "chrome_android": "mirror",
@@ -265,8 +265,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "18.0.0",
                   "alternative_name": "calendars",
+                  "version_added": "18.0.0",
                   "notes": "Implemented as an accessor property."
                 },
                 "oculus": "mirror",
@@ -277,9 +277,9 @@
                     "version_added": "17"
                   },
                   {
+                    "alternative_name": "calendars",
                     "version_added": "15.4",
                     "version_removed": "preview",
-                    "alternative_name": "calendars",
                     "notes": "Implemented as an accessor property."
                   }
                 ],
@@ -300,8 +300,8 @@
               "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getCollations",
               "support": {
                 "chrome": {
-                  "version_added": "99",
                   "alternative_name": "collations",
+                  "version_added": "99",
                   "notes": "Implemented as an accessor property."
                 },
                 "chrome_android": "mirror",
@@ -317,8 +317,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "18.0.0",
                   "alternative_name": "collations",
+                  "version_added": "18.0.0",
                   "notes": "Implemented as an accessor property."
                 },
                 "oculus": "mirror",
@@ -329,9 +329,9 @@
                     "version_added": "17"
                   },
                   {
+                    "alternative_name": "collations",
                     "version_added": "15.4",
                     "version_removed": "preview",
-                    "alternative_name": "collations",
                     "notes": "Implemented as an accessor property."
                   }
                 ],
@@ -352,8 +352,8 @@
               "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getHourCycles",
               "support": {
                 "chrome": {
-                  "version_added": "99",
                   "alternative_name": "hourCycles",
+                  "version_added": "99",
                   "notes": "Implemented as an accessor property."
                 },
                 "chrome_android": "mirror",
@@ -369,8 +369,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "18.0.0",
                   "alternative_name": "hourCycles",
+                  "version_added": "18.0.0",
                   "notes": "Implemented as an accessor property."
                 },
                 "oculus": "mirror",
@@ -381,9 +381,9 @@
                     "version_added": "17"
                   },
                   {
+                    "alternative_name": "hourCycles",
                     "version_added": "15.4",
                     "version_removed": "preview",
-                    "alternative_name": "hourCycles",
                     "notes": "Implemented as an accessor property."
                   }
                 ],
@@ -404,8 +404,8 @@
               "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getNumberingSystems",
               "support": {
                 "chrome": {
-                  "version_added": "99",
                   "alternative_name": "numberingSystems",
+                  "version_added": "99",
                   "notes": "Implemented as an accessor property."
                 },
                 "chrome_android": "mirror",
@@ -421,8 +421,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "18.0.0",
                   "alternative_name": "numberingSystems",
+                  "version_added": "18.0.0",
                   "notes": "Implemented as an accessor property."
                 },
                 "oculus": "mirror",
@@ -433,9 +433,9 @@
                     "version_added": "17"
                   },
                   {
+                    "alternative_name": "numberingSystems",
                     "version_added": "15.4",
                     "version_removed": "preview",
-                    "alternative_name": "numberingSystems",
                     "notes": "Implemented as an accessor property."
                   }
                 ],
@@ -456,8 +456,8 @@
               "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getTextInfo",
               "support": {
                 "chrome": {
-                  "version_added": "99",
                   "alternative_name": "textInfo",
+                  "version_added": "99",
                   "notes": "Implemented as an accessor property."
                 },
                 "chrome_android": "mirror",
@@ -473,8 +473,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "18.0.0",
                   "alternative_name": "textInfo",
+                  "version_added": "18.0.0",
                   "notes": "Implemented as an accessor property."
                 },
                 "oculus": "mirror",
@@ -485,9 +485,9 @@
                     "version_added": "17"
                   },
                   {
+                    "alternative_name": "textInfo",
                     "version_added": "15.4",
                     "version_removed": "preview",
-                    "alternative_name": "textInfo",
                     "notes": "Implemented as an accessor property."
                   }
                 ],
@@ -508,8 +508,8 @@
               "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getTimeZones",
               "support": {
                 "chrome": {
-                  "version_added": "99",
                   "alternative_name": "timeZones",
+                  "version_added": "99",
                   "notes": "Implemented as an accessor property."
                 },
                 "chrome_android": "mirror",
@@ -525,8 +525,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "18.0.0",
                   "alternative_name": "timeZones",
+                  "version_added": "18.0.0",
                   "notes": "Implemented as an accessor property."
                 },
                 "oculus": "mirror",
@@ -537,9 +537,9 @@
                     "version_added": "17"
                   },
                   {
+                    "alternative_name": "timeZones",
                     "version_added": "15.4",
                     "version_removed": "preview",
-                    "alternative_name": "timeZones",
                     "notes": "Implemented as an accessor property."
                   }
                 ],
@@ -560,8 +560,8 @@
               "spec_url": "https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.getWeekInfo",
               "support": {
                 "chrome": {
-                  "version_added": "99",
                   "alternative_name": "weekInfo",
+                  "version_added": "99",
                   "notes": "Implemented as an accessor property."
                 },
                 "chrome_android": "mirror",
@@ -577,8 +577,8 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "18.0.0",
                   "alternative_name": "weekInfo",
+                  "version_added": "18.0.0",
                   "notes": "Implemented as an accessor property."
                 },
                 "oculus": "mirror",
@@ -589,9 +589,9 @@
                     "version_added": "17"
                   },
                   {
+                    "alternative_name": "weekInfo",
                     "version_added": "15.4",
                     "version_removed": "preview",
-                    "alternative_name": "weekInfo",
                     "notes": "Implemented as an accessor property."
                   }
                 ],

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -449,9 +449,9 @@
                   "version_added": "preview"
                 },
                 {
+                  "alternative_name": "Array.prototype.groupToMap",
                   "version_added": "16.4",
-                  "version_removed": "preview",
-                  "alternative_name": "Array.prototype.groupToMap"
+                  "version_removed": "preview"
                 }
               ],
               "safari_ios": "mirror",

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -832,9 +832,9 @@
                   "version_added": "preview"
                 },
                 {
+                  "alternative_name": "Array.prototype.groupToMap",
                   "version_added": "16.4",
-                  "version_removed": "preview",
-                  "alternative_name": "Array.prototype.groupToMap"
+                  "version_removed": "preview"
                 }
               ],
               "safari_ios": "mirror",

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -2592,8 +2592,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "4",
-                  "alternative_name": "trimRight"
+                  "alternative_name": "trimRight",
+                  "version_added": "4"
                 }
               ],
               "chrome_android": "mirror",
@@ -2602,8 +2602,8 @@
                   "version_added": "1.0"
                 },
                 {
-                  "version_added": "1.0",
-                  "alternative_name": "trimRight"
+                  "alternative_name": "trimRight",
+                  "version_added": "1.0"
                 }
               ],
               "edge": [
@@ -2611,8 +2611,8 @@
                   "version_added": "79"
                 },
                 {
-                  "version_added": "12",
-                  "alternative_name": "trimRight"
+                  "alternative_name": "trimRight",
+                  "version_added": "12"
                 }
               ],
               "firefox": [
@@ -2620,8 +2620,8 @@
                   "version_added": "61"
                 },
                 {
-                  "version_added": "3.5",
-                  "alternative_name": "trimRight"
+                  "alternative_name": "trimRight",
+                  "version_added": "3.5"
                 }
               ],
               "firefox_android": "mirror",
@@ -2633,8 +2633,8 @@
                   "version_added": "10.0.0"
                 },
                 {
-                  "version_added": "0.12.0",
-                  "alternative_name": "trimRight"
+                  "alternative_name": "trimRight",
+                  "version_added": "0.12.0"
                 }
               ],
               "oculus": "mirror",
@@ -2650,8 +2650,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "≤37",
-                  "alternative_name": "trimRight"
+                  "alternative_name": "trimRight",
+                  "version_added": "≤37"
                 }
               ]
             },
@@ -2672,8 +2672,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "4",
-                  "alternative_name": "trimLeft"
+                  "alternative_name": "trimLeft",
+                  "version_added": "4"
                 }
               ],
               "chrome_android": "mirror",
@@ -2682,8 +2682,8 @@
                   "version_added": "1.0"
                 },
                 {
-                  "version_added": "1.0",
-                  "alternative_name": "trimLeft"
+                  "alternative_name": "trimLeft",
+                  "version_added": "1.0"
                 }
               ],
               "edge": [
@@ -2691,8 +2691,8 @@
                   "version_added": "79"
                 },
                 {
-                  "version_added": "12",
-                  "alternative_name": "trimLeft"
+                  "alternative_name": "trimLeft",
+                  "version_added": "12"
                 }
               ],
               "firefox": [
@@ -2700,8 +2700,8 @@
                   "version_added": "61"
                 },
                 {
-                  "version_added": "3.5",
-                  "alternative_name": "trimLeft"
+                  "alternative_name": "trimLeft",
+                  "version_added": "3.5"
                 }
               ],
               "firefox_android": "mirror",
@@ -2713,8 +2713,8 @@
                   "version_added": "10.0.0"
                 },
                 {
-                  "version_added": "0.12.0",
-                  "alternative_name": "trimLeft"
+                  "alternative_name": "trimLeft",
+                  "version_added": "0.12.0"
                 }
               ],
               "oculus": "mirror",
@@ -2730,8 +2730,8 @@
                   "version_added": "66"
                 },
                 {
-                  "version_added": "≤37",
-                  "alternative_name": "trimLeft"
+                  "alternative_name": "trimLeft",
+                  "version_added": "≤37"
                 }
               ]
             },

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -10,8 +10,8 @@
               "version_added": "49"
             },
             {
-              "version_removed": "49",
               "version_added": "42",
+              "version_removed": "49",
               "notes": "Strict mode is required."
             }
           ],
@@ -58,8 +58,8 @@
                 "version_added": "49"
               },
               {
-                "version_removed": "49",
                 "version_added": "42",
+                "version_removed": "49",
                 "notes": "Strict mode is required."
               }
             ],
@@ -107,8 +107,8 @@
                 "version_added": "49"
               },
               {
-                "version_removed": "49",
                 "version_added": "42",
+                "version_removed": "49",
                 "notes": "Strict mode is required."
               }
             ],
@@ -328,8 +328,8 @@
                 "version_added": "49"
               },
               {
-                "version_removed": "49",
                 "version_added": "42",
+                "version_removed": "49",
                 "notes": "Strict mode is required."
               }
             ],

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -187,8 +187,8 @@
                 "version_added": "49"
               },
               {
-                "version_removed": "49",
                 "version_added": "42",
+                "version_removed": "49",
                 "notes": "Strict mode is required."
               }
             ],

--- a/mathml/elements/math.json
+++ b/mathml/elements/math.json
@@ -13,8 +13,8 @@
               {
                 "version_added": "24",
                 "version_removed": "25",
-                "partial_implementation": true,
                 "impl_url": "https://crbug.com/152430",
+                "partial_implementation": true,
                 "notes": "Removed in Chrome 25 because <a href='https://crbug.com/152430#c32'>code was not yet production ready</a>."
               }
             ],

--- a/webextensions/api/browsingData.json
+++ b/webextensions/api/browsingData.json
@@ -427,18 +427,18 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "notes": "<code>since</code> is not supported with the following data types: <code>cache</code>, <code>indexedDB</code>, <code>localStorage</code>, and <code>serviceWorkers</code>.",
-                  "version_added": "53"
+                  "version_added": "53",
+                  "notes": "<code>since</code> is not supported with the following data types: <code>cache</code>, <code>indexedDB</code>, <code>localStorage</code>, and <code>serviceWorkers</code>."
                 },
                 "firefox_android": [
                   {
-                    "notes": "<code>since</code> is not supported with the following data types: <code>cache</code>, <code>indexedDB</code>, <code>localStorage</code>, and <code>serviceWorkers</code>.",
-                    "version_added": "85"
+                    "version_added": "85",
+                    "notes": "<code>since</code> is not supported with the following data types: <code>cache</code>, <code>indexedDB</code>, <code>localStorage</code>, and <code>serviceWorkers</code>."
                   },
                   {
-                    "notes": "<code>since</code> is not supported with the following data types: <code>cache</code>, <code>indexedDB</code>, <code>localStorage</code>, and <code>serviceWorkers</code>.",
                     "version_added": "56",
-                    "version_removed": "79"
+                    "version_removed": "79",
+                    "notes": "<code>since</code> is not supported with the following data types: <code>cache</code>, <code>indexedDB</code>, <code>localStorage</code>, and <code>serviceWorkers</code>."
                   }
                 ],
                 "opera": "mirror",
@@ -461,18 +461,18 @@
                 "version_added": "79"
               },
               "firefox": {
-                "notes": "Specifying <code>dataTypes.history</code> will also remove download history and service workers.",
-                "version_added": "53"
+                "version_added": "53",
+                "notes": "Specifying <code>dataTypes.history</code> will also remove download history and service workers."
               },
               "firefox_android": [
                 {
-                  "notes": "Specifying <code>dataTypes.history</code> will also remove download history and service workers.",
-                  "version_added": "85"
+                  "version_added": "85",
+                  "notes": "Specifying <code>dataTypes.history</code> will also remove download history and service workers."
                 },
                 {
-                  "notes": "Specifying <code>dataTypes.history</code> will also remove download history and service workers.",
                   "version_added": "57",
-                  "version_removed": "79"
+                  "version_removed": "79",
+                  "notes": "Specifying <code>dataTypes.history</code> will also remove download history and service workers."
                 }
               ],
               "opera": "mirror",
@@ -494,18 +494,18 @@
                 "version_added": "79"
               },
               "firefox": {
-                "notes": "<code>removalOptions.since</code> is not supported.",
-                "version_added": "53"
+                "version_added": "53",
+                "notes": "<code>removalOptions.since</code> is not supported."
               },
               "firefox_android": [
                 {
-                  "notes": "<code>removalOptions.since</code> is not supported.",
-                  "version_added": "85"
+                  "version_added": "85",
+                  "notes": "<code>removalOptions.since</code> is not supported."
                 },
                 {
-                  "notes": "<code>removalOptions.since</code> is not supported.",
                   "version_added": "57",
-                  "version_removed": "79"
+                  "version_removed": "79",
+                  "notes": "<code>removalOptions.since</code> is not supported."
                 }
               ],
               "opera": "mirror",
@@ -607,8 +607,8 @@
                 "version_added": "79"
               },
               "firefox": {
-                "notes": "This function also removes download history and service workers.",
-                "version_added": "53"
+                "version_added": "53",
+                "notes": "This function also removes download history and service workers."
               },
               "firefox_android": {
                 "version_added": "85"
@@ -632,12 +632,12 @@
                 "version_added": "79"
               },
               "firefox": {
-                "notes": "<code>removalOptions.since</code> is not supported.",
-                "version_added": "57"
+                "version_added": "57",
+                "notes": "<code>removalOptions.since</code> is not supported."
               },
               "firefox_android": {
-                "notes": "<code>removalOptions.since</code> is not supported.",
-                "version_added": "85"
+                "version_added": "85",
+                "notes": "<code>removalOptions.since</code> is not supported."
               },
               "opera": "mirror",
               "safari": {

--- a/webextensions/api/contextualIdentities.json
+++ b/webextensions/api/contextualIdentities.json
@@ -127,8 +127,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "notes": "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
-                "version_added": "53"
+                "version_added": "53",
+                "notes": "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled."
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -148,11 +148,11 @@
               },
               "edge": "mirror",
               "firefox": {
+                "version_added": "53",
                 "notes": [
                   "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
                   "Before version 57, this method resolves its promise with <code>null</code> if the given identity was not found."
-                ],
-                "version_added": "53"
+                ]
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -232,8 +232,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "notes": "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
-                "version_added": "53"
+                "version_added": "53",
+                "notes": "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled."
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -253,11 +253,11 @@
               },
               "edge": "mirror",
               "firefox": {
+                "version_added": "53",
                 "notes": [
                   "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
                   "Before version 57, this method resolves its promise with <code>null</code> if the given identity was not found."
-                ],
-                "version_added": "53"
+                ]
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -277,11 +277,11 @@
               },
               "edge": "mirror",
               "firefox": {
+                "version_added": "53",
                 "notes": [
                   "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled.",
                   "Before version 57, this method resolves its promise with <code>null</code> if the given identity was not found."
-                ],
-                "version_added": "53"
+                ]
               },
               "firefox_android": "mirror",
               "opera": "mirror",

--- a/webextensions/api/cookies.json
+++ b/webextensions/api/cookies.json
@@ -79,12 +79,12 @@
                   "version_added": false
                 },
                 "safari": {
-                  "notes": "Only supports explicit.",
-                  "version_added": "14"
+                  "version_added": "14",
+                  "notes": "Only supports explicit."
                 },
                 "safari_ios": {
-                  "notes": "Only supports explicit.",
-                  "version_added": "15"
+                  "version_added": "15",
+                  "notes": "Only supports explicit."
                 }
               }
             }
@@ -208,20 +208,20 @@
               },
               "edge": "mirror",
               "firefox": {
-                "notes": "Provides access to cookies from private browsing mode and container tabs since version 52.",
-                "version_added": "45"
+                "version_added": "45",
+                "notes": "Provides access to cookies from private browsing mode and container tabs since version 52."
               },
               "firefox_android": {
                 "version_added": "48"
               },
               "opera": "mirror",
               "safari": {
-                "notes": "HTTPOnly cookies are not retrieved.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "HTTPOnly cookies are not retrieved."
               },
               "safari_ios": {
-                "notes": "HTTPOnly cookies are not retrieved.",
-                "version_added": "15"
+                "version_added": "15",
+                "notes": "HTTPOnly cookies are not retrieved."
               }
             }
           },
@@ -272,30 +272,30 @@
                 "version_added": true
               },
               "edge": {
-                "notes": "If no URL is provided, cookies are retrieved only for URLs in currently opened tabs. In Chrome, this gets all cookies on a user's machine.",
-                "version_added": "79"
+                "version_added": "79",
+                "notes": "If no URL is provided, cookies are retrieved only for URLs in currently opened tabs. In Chrome, this gets all cookies on a user's machine."
               },
               "firefox": {
-                "notes": "Before version 52, the 'tabIds' list was empty and only cookies from the default cookie store were returned. From version 52 onwards, this has been fixed and the result includes cookies from private browsing mode and container tabs.",
-                "version_added": "45"
+                "version_added": "45",
+                "notes": "Before version 52, the 'tabIds' list was empty and only cookies from the default cookie store were returned. From version 52 onwards, this has been fixed and the result includes cookies from private browsing mode and container tabs."
               },
               "firefox_android": {
                 "version_added": "48"
               },
               "opera": "mirror",
               "safari": {
+                "version_added": "14",
                 "notes": [
                   "Only the cookies in the default cookie store are retrieved.",
                   "HTTPOnly cookies are not retrieved."
-                ],
-                "version_added": "14"
+                ]
               },
               "safari_ios": {
+                "version_added": "15",
                 "notes": [
                   "Only the cookies in the default cookie store are retrieved.",
                   "HTTPOnly cookies are not retrieved."
-                ],
-                "version_added": "15"
+                ]
               }
             }
           },
@@ -347,20 +347,20 @@
               },
               "edge": "mirror",
               "firefox": {
-                "notes": "Before version 52, only the default cookie store was visible. From version 52 onwards, the cookie stores for private browsing mode and container tabs are also readable.",
-                "version_added": "45"
+                "version_added": "45",
+                "notes": "Before version 52, only the default cookie store was visible. From version 52 onwards, the cookie stores for private browsing mode and container tabs are also readable."
               },
               "firefox_android": {
                 "version_added": "48"
               },
               "opera": "mirror",
               "safari": {
-                "notes": "Always returns the same default cookie store with ID 0.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "Always returns the same default cookie store with ID 0."
               },
               "safari_ios": {
-                "notes": "Always returns the same default cookie store with ID 0.",
-                "version_added": "15"
+                "version_added": "15",
+                "notes": "Always returns the same default cookie store with ID 0."
               }
             }
           }
@@ -415,12 +415,12 @@
               },
               "edge": "mirror",
               "firefox": {
-                "notes": "Before version 56, this function did not remove cookies from private browsing mode. From version 56 onwards this is fixed.",
-                "version_added": "45"
+                "version_added": "45",
+                "notes": "Before version 56, this function did not remove cookies from private browsing mode. From version 56 onwards this is fixed."
               },
               "firefox_android": {
-                "notes": "Before version 56, this function did not remove cookies from private browsing mode. From version 56 onwards this is fixed.",
-                "version_added": "48"
+                "version_added": "48",
+                "notes": "Before version 56, this function did not remove cookies from private browsing mode. From version 56 onwards this is fixed."
               },
               "opera": "mirror",
               "safari": {
@@ -486,12 +486,12 @@
                 "version_added": false
               },
               "safari": {
-                "notes": "Only supports explicit.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "Only supports explicit."
               },
               "safari_ios": {
-                "notes": "Only supports explicit.",
-                "version_added": "15"
+                "version_added": "15",
+                "notes": "Only supports explicit."
               }
             }
           },
@@ -524,8 +524,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "notes": "Represents a cookie without a <code>SameSite</code> attribute.",
-                  "version_added": "63"
+                  "version_added": "63",
+                  "notes": "Represents a cookie without a <code>SameSite</code> attribute."
                 },
                 "firefox_android": "mirror",
                 "opera": {
@@ -590,12 +590,12 @@
               },
               "edge": "mirror",
               "firefox": {
-                "notes": "Before version 56, this function did not modify cookies in private browsing mode. From version 56 onwards this is fixed.",
-                "version_added": "45"
+                "version_added": "45",
+                "notes": "Before version 56, this function did not modify cookies in private browsing mode. From version 56 onwards this is fixed."
               },
               "firefox_android": {
-                "notes": "Before version 56, this function did not modify cookies in private browsing mode. From version 56 onwards this is fixed.",
-                "version_added": "48"
+                "version_added": "48",
+                "notes": "Before version 56, this function did not modify cookies in private browsing mode. From version 56 onwards this is fixed."
               },
               "opera": "mirror",
               "safari": {
@@ -658,12 +658,12 @@
                   "version_added": false
                 },
                 "safari": {
-                  "notes": "Only supports explicit.",
-                  "version_added": "14"
+                  "version_added": "14",
+                  "notes": "Only supports explicit."
                 },
                 "safari_ios": {
-                  "notes": "Only supports explicit.",
-                  "version_added": "15"
+                  "version_added": "15",
+                  "notes": "Only supports explicit."
                 }
               }
             }

--- a/webextensions/api/devtools.json
+++ b/webextensions/api/devtools.json
@@ -167,8 +167,8 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "notes": "The returned HAR log will be empty unless the user has previously activated the browser's network panel at least once.",
-                  "version_added": "60"
+                  "version_added": "60",
+                  "notes": "The returned HAR log will be empty unless the user has previously activated the browser's network panel at least once."
                 },
                 "firefox_android": {
                   "version_added": false
@@ -222,9 +222,9 @@
                     "version_added": "61"
                   },
                   {
-                    "notes": "This event will only start firing after the user has activated the browser's network panel at least once.",
                     "version_added": "60",
-                    "version_removed": "61"
+                    "version_removed": "61",
+                    "notes": "This event will only start firing after the user has activated the browser's network panel at least once."
                   }
                 ],
                 "firefox_android": {
@@ -375,8 +375,8 @@
                     "version_added": "79"
                   },
                   "firefox": {
-                    "notes": "This event is only fired when the user switches between sidebar panes, not when the user switches between devtools panels. See <a href='https://bugzil.la/1412317'>bug 1412317</a>.",
-                    "version_added": "57"
+                    "version_added": "57",
+                    "notes": "This event is only fired when the user switches between sidebar panes, not when the user switches between devtools panels. See <a href='https://bugzil.la/1412317'>bug 1412317</a>."
                   },
                   "firefox_android": {
                     "version_added": false
@@ -400,8 +400,8 @@
                     "version_added": "79"
                   },
                   "firefox": {
-                    "notes": "This event is only fired when the user switches between sidebar panes, not when the user switches between devtools panels. See <a href='https://bugzil.la/1412317'>bug 1412317</a>.",
-                    "version_added": "57"
+                    "version_added": "57",
+                    "notes": "This event is only fired when the user switches between sidebar panes, not when the user switches between devtools panels. See <a href='https://bugzil.la/1412317'>bug 1412317</a>."
                   },
                   "firefox_android": {
                     "version_added": false
@@ -419,16 +419,16 @@
                 "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/setExpression",
                 "support": {
                   "chrome": {
-                    "notes": "The expression must evaluate to a JavaScript object or a DOM node, or nothing is shown in the sidebar.",
-                    "version_added": true
+                    "version_added": true,
+                    "notes": "The expression must evaluate to a JavaScript object or a DOM node, or nothing is shown in the sidebar."
                   },
                   "edge": {
-                    "notes": "The expression must evaluate to a JavaScript object or a DOM node, or nothing is shown in the sidebar.",
-                    "version_added": "79"
+                    "version_added": "79",
+                    "notes": "The expression must evaluate to a JavaScript object or a DOM node, or nothing is shown in the sidebar."
                   },
                   "firefox": {
-                    "notes": "The expression must evaluate to an object that can be serialized to JSON, or nothing is shown in the sidebar. In particular, JavaScript cyclic objects and DOM nodes are not supported. See <a href='https://bugzil.la/1403130'>bug 1403130</a>.",
-                    "version_added": "57"
+                    "version_added": "57",
+                    "notes": "The expression must evaluate to an object that can be serialized to JSON, or nothing is shown in the sidebar. In particular, JavaScript cyclic objects and DOM nodes are not supported. See <a href='https://bugzil.la/1403130'>bug 1403130</a>."
                   },
                   "firefox_android": {
                     "version_added": false
@@ -448,16 +448,16 @@
                 "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/panels/ExtensionSidebarPane/setObject",
                 "support": {
                   "chrome": {
-                    "notes": "If the <code>jsonObject</code> parameter is a string, it is not displayed.",
-                    "version_added": true
+                    "version_added": true,
+                    "notes": "If the <code>jsonObject</code> parameter is a string, it is not displayed."
                   },
                   "edge": {
-                    "notes": "If the <code>jsonObject</code> parameter is a string, it is not displayed.",
-                    "version_added": "79"
+                    "version_added": "79",
+                    "notes": "If the <code>jsonObject</code> parameter is a string, it is not displayed."
                   },
                   "firefox": {
-                    "notes": "If the <code>jsonObject</code> is a string, then <code>rootTitle</code> must also be given, or <code>jsonObject</code> will not be displayed. See <a href='https://bugzil.la/1412310'>bug 1412310</a>.",
-                    "version_added": "57"
+                    "version_added": "57",
+                    "notes": "If the <code>jsonObject</code> is a string, then <code>rootTitle</code> must also be given, or <code>jsonObject</code> will not be displayed. See <a href='https://bugzil.la/1412310'>bug 1412310</a>."
                   },
                   "firefox_android": {
                     "version_added": false

--- a/webextensions/api/downloads.json
+++ b/webextensions/api/downloads.json
@@ -205,8 +205,8 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "notes": "Always given as 'safe'.",
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "Always given as 'safe'."
                 },
                 "firefox_android": {
                   "version_added": false
@@ -1565,8 +1565,8 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "notes": "<code>Referer</code> headers supported from version 70.",
-                  "version_added": "47"
+                  "version_added": "47",
+                  "notes": "<code>Referer</code> headers supported from version 70."
                 },
                 "firefox_android": {
                   "version_added": "48",
@@ -1612,13 +1612,13 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "notes": "POST is supported from version 52.",
-                  "version_added": "47"
+                  "version_added": "47",
+                  "notes": "POST is supported from version 52."
                 },
                 "firefox_android": {
-                  "notes": "POST is supported from version 52.",
                   "version_added": "48",
-                  "version_removed": "79"
+                  "version_removed": "79",
+                  "notes": "POST is supported from version 52."
                 },
                 "opera": "mirror",
                 "safari": {
@@ -1638,8 +1638,8 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "notes": "Before version 58, if this option was omitted, Firefox would never show the file chooser, regardless of the value of the browser's preference.",
-                  "version_added": "52"
+                  "version_added": "52",
+                  "notes": "Before version 58, if this option was omitted, Firefox would never show the file chooser, regardless of the value of the browser's preference."
                 },
                 "firefox_android": {
                   "version_added": false

--- a/webextensions/api/extension.json
+++ b/webextensions/api/extension.json
@@ -136,12 +136,12 @@
                 "version_added": "14"
               },
               "firefox": {
-                "notes": "If this is called from a page that is part of a private browsing window, such as a sidebar in a private window or a popup opened from a private window, then its return value will not include the extension's background page.",
-                "version_added": "45"
+                "version_added": "45",
+                "notes": "If this is called from a page that is part of a private browsing window, such as a sidebar in a private window or a popup opened from a private window, then its return value will not include the extension's background page."
               },
               "firefox_android": {
-                "notes": "If this is called from a page that is part of a private browsing window, such as a sidebar in a private window or a popup opened from a private window, then its return value will not include the extension's background page.",
-                "version_added": "48"
+                "version_added": "48",
+                "notes": "If this is called from a page that is part of a private browsing window, such as a sidebar in a private window or a popup opened from a private window, then its return value will not include the extension's background page."
               },
               "opera": "mirror",
               "safari": {
@@ -167,8 +167,8 @@
                 },
                 "firefox_android": {
                   "version_added": "48",
-                  "notes": "The property is recognized, but the filter has no effect.",
-                  "partial_implementation": true
+                  "partial_implementation": true,
+                  "notes": "The property is recognized, but the filter has no effect."
                 },
                 "opera": "mirror",
                 "safari": {
@@ -201,14 +201,14 @@
               },
               "opera": "mirror",
               "safari": {
-                "notes": "Always returns false.",
+                "version_added": "14",
                 "partial_implementation": true,
-                "version_added": "14"
+                "notes": "Always returns false."
               },
               "safari_ios": {
-                "notes": "Always returns false.",
+                "version_added": "15",
                 "partial_implementation": true,
-                "version_added": "15"
+                "notes": "Always returns false."
               }
             }
           }
@@ -229,14 +229,14 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "notes": "Always returns false.",
+                "version_added": "14",
                 "partial_implementation": true,
-                "version_added": "14"
+                "notes": "Always returns false."
               },
               "safari_ios": {
-                "notes": "Always returns false.",
+                "version_added": "15",
                 "partial_implementation": true,
-                "version_added": "15"
+                "notes": "Always returns false."
               }
             }
           }
@@ -257,14 +257,14 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "notes": "Always returns true.",
+                "version_added": "14",
                 "partial_implementation": true,
-                "version_added": "14"
+                "notes": "Always returns true."
               },
               "safari_ios": {
-                "notes": "Always returns true.",
+                "version_added": "15",
                 "partial_implementation": true,
-                "version_added": "15"
+                "notes": "Always returns true."
               }
             }
           }

--- a/webextensions/api/idle.json
+++ b/webextensions/api/idle.json
@@ -80,12 +80,12 @@
                 "version_added": "15"
               },
               "firefox": {
-                "notes": "Before version 51, Firefox always reports 'active'. After version 51, Firefox reports 'active' or 'idle' as appropriate.",
-                "version_added": "45"
+                "version_added": "45",
+                "notes": "Before version 51, Firefox always reports 'active'. After version 51, Firefox reports 'active' or 'idle' as appropriate."
               },
               "firefox_android": {
-                "notes": "Before version 51, Firefox always reports 'active'. After version 51, Firefox reports 'active' or 'idle' as appropriate.",
-                "version_added": "48"
+                "version_added": "48",
+                "notes": "Before version 51, Firefox always reports 'active'. After version 51, Firefox reports 'active' or 'idle' as appropriate."
               },
               "opera": "mirror",
               "safari": {

--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -45,8 +45,8 @@
               "edge": "mirror",
               "firefox": [
                 {
-                  "notes": "'The 'editable' context does not include password fields. Use the 'password' context for this.",
-                  "version_added": "55"
+                  "version_added": "55",
+                  "notes": "'The 'editable' context does not include password fields. Use the 'password' context for this."
                 },
                 {
                   "alternative_name": "contextMenus.ContextType",
@@ -91,8 +91,8 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "impl_url": "https://crbug.com/825443",
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://crbug.com/825443"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -117,8 +117,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "notes": "'The 'editable' context does not include password fields. Use the 'password' context for this.",
-                  "version_added": "53"
+                  "version_added": "53",
+                  "notes": "'The 'editable' context does not include password fields. Use the 'password' context for this."
                 },
                 "firefox_android": {
                   "version_added": false
@@ -227,8 +227,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "notes": "Only available at <code>menus.ContextType</code>, not at <code>contextMenus.ContextType</code>.",
-                  "version_added": "56"
+                  "version_added": "56",
+                  "notes": "Only available at <code>menus.ContextType</code>, not at <code>contextMenus.ContextType</code>."
                 },
                 "firefox_android": {
                   "version_added": false
@@ -466,8 +466,8 @@
             "support": {
               "chrome": {
                 "alternative_name": "contextMenus.create",
-                "notes": "Items that don't specify 'contexts' do not inherit contexts from their parents.",
-                "version_added": true
+                "version_added": true,
+                "notes": "Items that don't specify 'contexts' do not inherit contexts from their parents."
               },
               "edge": "mirror",
               "firefox": [
@@ -475,9 +475,9 @@
                   "version_added": "55"
                 },
                 {
-                  "notes": "Before version 53, items that don't specify 'contexts' do not inherit contexts from their parents.",
                   "alternative_name": "contextMenus.create",
-                  "version_added": "48"
+                  "version_added": "48",
+                  "notes": "Before version 53, items that don't specify 'contexts' do not inherit contexts from their parents."
                 }
               ],
               "firefox_android": {
@@ -486,8 +486,8 @@
               "opera": "mirror",
               "safari": {
                 "alternative_name": "contextMenus.create",
-                "notes": "Items that don't specify 'contexts' do not inherit contexts from their parents.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "Items that don't specify 'contexts' do not inherit contexts from their parents."
               },
               "safari_ios": {
                 "version_added": false
@@ -510,9 +510,9 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "notes": "Safari removes <code>&amp;</code> from menu items' displayed titles, but does not support invoking menu items via access keys.",
+                  "version_added": "14",
                   "partial_implementation": true,
-                  "version_added": "14"
+                  "notes": "Safari removes <code>&amp;</code> from menu items' displayed titles, but does not support invoking menu items via access keys."
                 },
                 "safari_ios": {
                   "version_added": false

--- a/webextensions/api/notifications.json
+++ b/webextensions/api/notifications.json
@@ -35,8 +35,8 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "notes": "Specifying this option doesn't throw an error, but its value is ignored.",
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "Specifying this option doesn't throw an error, but its value is ignored."
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -61,8 +61,8 @@
                 },
                 "firefox_android": "mirror",
                 "opera": {
-                  "notes": "Specifying the 'buttons' option will cause an asynchronous error on Opera.",
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "Specifying the 'buttons' option will cause an asynchronous error on Opera."
                 },
                 "safari": {
                   "version_added": false
@@ -79,13 +79,13 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "notes": "Specifying this option doesn't throw an error, but its value is ignored.",
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "Specifying this option doesn't throw an error, but its value is ignored."
                 },
                 "firefox_android": "mirror",
                 "opera": {
-                  "notes": "Specifying this option doesn't throw an error, but its value is ignored, on Opera 18 and above.",
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "Specifying this option doesn't throw an error, but its value is ignored, on Opera 18 and above."
                 },
                 "safari": {
                   "version_added": false
@@ -104,8 +104,8 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "notes": "Specifying this option doesn't throw an error, but its value is ignored.",
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "Specifying this option doesn't throw an error, but its value is ignored."
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -126,13 +126,13 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "notes": "Specifying this option doesn't throw an error, but its value is ignored.",
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "Specifying this option doesn't throw an error, but its value is ignored."
                 },
                 "firefox_android": "mirror",
                 "opera": {
-                  "notes": "Specifying this option doesn't throw an error, but its value is ignored.",
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "Specifying this option doesn't throw an error, but its value is ignored."
                 },
                 "safari": {
                   "version_added": false
@@ -149,13 +149,13 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "notes": "Specifying this option doesn't throw an error, but its value is ignored.",
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "Specifying this option doesn't throw an error, but its value is ignored."
                 },
                 "firefox_android": "mirror",
                 "opera": {
-                  "notes": "Setting 'isClickable' to false will cause an asynchronous error on Opera 19 and above. Older Opera versions throw an error synchronously if this options is given.",
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "Setting 'isClickable' to false will cause an asynchronous error on Opera 19 and above. Older Opera versions throw an error synchronously if this options is given."
                 },
                 "safari": {
                   "version_added": false
@@ -168,21 +168,21 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "notes": "On macOS only the first item is shown.",
-                  "version_added": true
+                  "version_added": true,
+                  "notes": "On macOS only the first item is shown."
                 },
                 "edge": {
-                  "notes": "On macOS only the first item is shown.",
-                  "version_added": "79"
+                  "version_added": "79",
+                  "notes": "On macOS only the first item is shown."
                 },
                 "firefox": {
-                  "notes": "Specifying this option doesn't throw an error, but its value is ignored.",
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "Specifying this option doesn't throw an error, but its value is ignored."
                 },
                 "firefox_android": "mirror",
                 "opera": {
-                  "notes": "Specifying this option doesn't throw an error, but its value is ignored.",
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "Specifying this option doesn't throw an error, but its value is ignored."
                 },
                 "safari": {
                   "version_added": false
@@ -201,8 +201,8 @@
                   "version_added": "79"
                 },
                 "firefox": {
-                  "notes": "Specifying this option doesn't throw an error, but its value is ignored.",
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "Specifying this option doesn't throw an error, but its value is ignored."
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -221,13 +221,13 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "notes": "Specifying this option doesn't throw an error, but its value is ignored.",
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "Specifying this option doesn't throw an error, but its value is ignored."
                 },
                 "firefox_android": "mirror",
                 "opera": {
-                  "notes": "Specifying this option doesn't throw an error, but its value is ignored, on Opera 17 and above.",
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "Specifying this option doesn't throw an error, but its value is ignored, on Opera 17 and above."
                 },
                 "safari": {
                   "version_added": false
@@ -248,8 +248,8 @@
                 },
                 "firefox_android": "mirror",
                 "opera": {
-                  "notes": "Specifying this option doesn't throw an error, but its value is ignored, on Opera 37 and above.",
-                  "version_added": false
+                  "version_added": false,
+                  "notes": "Specifying this option doesn't throw an error, but its value is ignored, on Opera 37 and above."
                 },
                 "safari": {
                   "version_added": false
@@ -270,16 +270,16 @@
                 "version_added": "17"
               },
               "firefox": {
-                "notes": "Only the 'basic' type is supported.",
-                "version_added": "45"
+                "version_added": "45",
+                "notes": "Only the 'basic' type is supported."
               },
               "firefox_android": {
-                "notes": "Only the 'basic' type is supported.",
-                "version_added": "48"
+                "version_added": "48",
+                "notes": "Only the 'basic' type is supported."
               },
               "opera": {
-                "notes": "Only the 'basic' type is supported.",
-                "version_added": true
+                "version_added": true,
+                "notes": "Only the 'basic' type is supported."
               },
               "safari": {
                 "version_added": false
@@ -498,8 +498,8 @@
               },
               "firefox_android": "mirror",
               "opera": {
-                "notes": "Not supported on macOS.",
-                "version_added": "25"
+                "version_added": "25",
+                "notes": "Not supported on macOS."
               },
               "safari": {
                 "version_added": false

--- a/webextensions/api/omnibox.json
+++ b/webextensions/api/omnibox.json
@@ -33,8 +33,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "notes": "'description' is interpreted as plain text, and XML markup is not recognized.",
-                "version_added": "52"
+                "version_added": "52",
+                "notes": "'description' is interpreted as plain text, and XML markup is not recognized."
               },
               "firefox_android": {
                 "version_added": false
@@ -229,8 +229,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "notes": "'description' is interpreted as plain text, and XML markup is not recognized.",
-                "version_added": "52"
+                "version_added": "52",
+                "notes": "'description' is interpreted as plain text, and XML markup is not recognized."
               },
               "firefox_android": {
                 "version_added": false

--- a/webextensions/api/pageAction.json
+++ b/webextensions/api/pageAction.json
@@ -42,8 +42,8 @@
                 "version_added": "45"
               },
               "firefox_android": {
-                "notes": "The 'tabId' parameter is ignored: the page action popup is the same for all tabs.",
-                "version_added": "50"
+                "version_added": "50",
+                "notes": "The 'tabId' parameter is ignored: the page action popup is the same for all tabs."
               },
               "opera": "mirror",
               "safari": {
@@ -96,8 +96,8 @@
                 "version_added": "45"
               },
               "firefox_android": {
-                "notes": "Before version 56, the 'tabId' parameter was ignored, and the page action was hidden for all tabs.",
-                "version_added": "50"
+                "version_added": "50",
+                "notes": "Before version 56, the 'tabId' parameter was ignored, and the page action was hidden for all tabs."
               },
               "opera": "mirror",
               "safari": {
@@ -313,8 +313,8 @@
                 "version_added": "45"
               },
               "firefox_android": {
-                "notes": "The 'tabId' parameter is ignored, and the popup is set for all tabs.",
-                "version_added": "50"
+                "version_added": "50",
+                "notes": "The 'tabId' parameter is ignored, and the popup is set for all tabs."
               },
               "opera": "mirror",
               "safari": {
@@ -415,8 +415,8 @@
                 "version_added": "45"
               },
               "firefox_android": {
-                "notes": "Before version 56, the 'tabId' parameter was ignored, and the page action was shown for all tabs.",
-                "version_added": "50"
+                "version_added": "50",
+                "notes": "Before version 56, the 'tabId' parameter was ignored, and the page action was shown for all tabs."
               },
               "opera": "mirror",
               "safari": {

--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -46,8 +46,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "notes": "Before version 78, the <code>tabId</code> and <code>windowId</code> filter properties are ignored.",
-                "version_added": "60"
+                "version_added": "60",
+                "notes": "Before version 78, the <code>tabId</code> and <code>windowId</code> filter properties are ignored."
               },
               "firefox_android": {
                 "version_added": "60"

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -11,12 +11,12 @@
               },
               "edge": "mirror",
               "firefox": {
-                "notes": "Before version 54, 'id' was the add-on's internal UUID, not the add-on ID.",
-                "version_added": "45"
+                "version_added": "45",
+                "notes": "Before version 54, 'id' was the add-on's internal UUID, not the add-on ID."
               },
               "firefox_android": {
-                "notes": "Before version 54, 'id' was the add-on's internal UUID, not the add-on ID.",
-                "version_added": "48"
+                "version_added": "48",
+                "notes": "Before version 54, 'id' was the add-on's internal UUID, not the add-on ID."
               },
               "opera": "mirror",
               "safari": {
@@ -475,12 +475,12 @@
               },
               "opera": "mirror",
               "safari": {
-                "notes": "See the documentation on developer.apple.com about native messaging in Safari.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "See the documentation on developer.apple.com about native messaging in Safari."
               },
               "safari_ios": {
-                "notes": "See the documentation on developer.apple.com about native messaging in Safari.",
-                "version_added": "15"
+                "version_added": "15",
+                "notes": "See the documentation on developer.apple.com about native messaging in Safari."
               }
             }
           }
@@ -494,12 +494,12 @@
               },
               "edge": "mirror",
               "firefox": {
-                "notes": "If this is called from a page that is part of a private browsing window, such as a sidebar in a private window or a popup opened from a private window, then it will always return <code>null</code>.",
-                "version_added": "45"
+                "version_added": "45",
+                "notes": "If this is called from a page that is part of a private browsing window, such as a sidebar in a private window or a popup opened from a private window, then it will always return <code>null</code>."
               },
               "firefox_android": {
-                "notes": "If this is called from a page that is part of a private browsing window, such as a sidebar in a private window or a popup opened from a private window, then it will always return <code>null</code>.",
-                "version_added": "48"
+                "version_added": "48",
+                "notes": "If this is called from a page that is part of a private browsing window, such as a sidebar in a private window or a popup opened from a private window, then it will always return <code>null</code>."
               },
               "opera": "mirror",
               "safari": {
@@ -673,8 +673,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/lastError",
             "support": {
               "chrome": {
-                "notes": "lastError is not an Error object. Instead, it is a plain Object with the error text as the string value of the 'message' property.",
-                "version_added": true
+                "version_added": true,
+                "notes": "lastError is not an Error object. Instead, it is a plain Object with the error text as the string value of the 'message' property."
               },
               "edge": "mirror",
               "firefox": {
@@ -685,12 +685,12 @@
               },
               "opera": "mirror",
               "safari": {
-                "notes": "<code>lastError</code> is only set if a callback is used. <code>Promise</code> results that fail will be rejected with an <code>Error</code> object.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "<code>lastError</code> is only set if a callback is used. <code>Promise</code> results that fail will be rejected with an <code>Error</code> object."
               },
               "safari_ios": {
-                "notes": "<code>lastError</code> is only set if a callback is used. <code>Promise</code> results that fail will be rejected with an <code>Error</code> object.",
-                "version_added": "15"
+                "version_added": "15",
+                "notes": "<code>lastError</code> is only set if a callback is used. <code>Promise</code> results that fail will be rejected with an <code>Error</code> object."
               }
             }
           }
@@ -768,8 +768,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "notes": "Before version 55, this event is not triggered for temporarily installed add-ons.",
-                "version_added": "52"
+                "version_added": "52",
+                "notes": "Before version 55, this event is not triggered for temporarily installed add-ons."
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -1222,12 +1222,12 @@
               },
               "opera": "mirror",
               "safari": {
-                "notes": "See the documentation on developer.apple.com about native messaging in Safari.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "See the documentation on developer.apple.com about native messaging in Safari."
               },
               "safari_ios": {
-                "notes": "See the documentation on developer.apple.com about native messaging in Safari.",
-                "version_added": "15"
+                "version_added": "15",
+                "notes": "See the documentation on developer.apple.com about native messaging in Safari."
               }
             }
           }
@@ -1272,14 +1272,14 @@
               ],
               "opera": "mirror",
               "safari": {
-                "notes": "API exists, but has no effect.",
+                "version_added": "14",
                 "partial_implementation": true,
-                "version_added": "14"
+                "notes": "API exists, but has no effect."
               },
               "safari_ios": {
-                "notes": "API exists, but has no effect.",
+                "version_added": "15",
                 "partial_implementation": true,
-                "version_added": "15"
+                "notes": "API exists, but has no effect."
               }
             }
           }

--- a/webextensions/api/sessions.json
+++ b/webextensions/api/sessions.json
@@ -61,8 +61,8 @@
                 "version_added": "79"
               },
               "firefox": {
-                "notes": "'Tab' objects in Sessions don't contain the 'url', 'title', or 'favIconUrl' properties.",
-                "version_added": "52"
+                "version_added": "52",
+                "notes": "'Tab' objects in Sessions don't contain the 'url', 'title', or 'favIconUrl' properties."
               },
               "firefox_android": {
                 "version_added": false

--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -120,8 +120,8 @@
                   "version_added": "14"
                 },
                 "firefox": {
-                  "notes": "Only supported by the <code>sync</code> storage area.",
-                  "version_added": "78"
+                  "version_added": "78",
+                  "notes": "Only supported by the <code>sync</code> storage area."
                 },
                 "firefox_android": {
                   "version_added": false
@@ -226,8 +226,8 @@
                   "version_added": true
                 },
                 "edge": {
-                  "notes": "storage is limited to 1MB per value.",
-                  "version_added": "14"
+                  "version_added": "14",
+                  "notes": "storage is limited to 1MB per value."
                 },
                 "firefox": {
                   "version_added": "45"
@@ -306,8 +306,8 @@
                 "version_added": "14"
               },
               "firefox": {
-                "notes": "The storage API is supported in content scripts from version 48.",
-                "version_added": "45"
+                "version_added": "45",
+                "notes": "The storage API is supported in content scripts from version 48."
               },
               "firefox_android": {
                 "version_added": "48"
@@ -333,12 +333,12 @@
                 "version_added": "79"
               },
               "firefox": {
+                "version_added": "57",
                 "notes": [
                   "Platform-specific storage backends, such as Windows registry keys, are not supported.",
                   "Enforcement of extension-provided storage schemas is not supported.",
                   "The <code>onChanged</code> event is not supported."
-                ],
-                "version_added": "57"
+                ]
               },
               "firefox_android": {
                 "version_added": false
@@ -411,8 +411,8 @@
                 "version_added": "15"
               },
               "firefox": {
-                "notes": "Before version 79, storage quota limits are not enforced.",
-                "version_added": "53"
+                "version_added": "53",
+                "notes": "Before version 79, storage quota limits are not enforced."
               },
               "firefox_android": {
                 "version_added": false
@@ -421,20 +421,20 @@
                 "version_added": false
               },
               "safari": {
+                "version_added": "14",
+                "partial_implementation": true,
                 "notes": [
                   "Safari does not sync items saved in the <code>sync</code> storage area, i.e. it behaves the same as the <code>local</code> storage area.",
                   "Safari 15 and 15.1 erroneously store sync items in the <code>local</code> storage area. If unable to locate sync items, check for sync items in the <code>local</code> storage area and do a one-time migration to the <code>sync</code> storage area."
-                ],
-                "partial_implementation": true,
-                "version_added": "14"
+                ]
               },
               "safari_ios": {
+                "version_added": "15",
+                "partial_implementation": true,
                 "notes": [
                   "Safari does not sync items saved in the <code>sync</code> storage area, i.e. it behaves the same as the <code>local</code> storage area.",
                   "Safari 15 and 15.1 erroneously store sync items in the <code>local</code> storage area. If unable to locate sync items, check for sync items in the <code>local</code> storage area and do a one-time migration to the <code>sync</code> storage area."
-                ],
-                "partial_implementation": true,
-                "version_added": "15"
+                ]
               }
             }
           }

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -18,9 +18,9 @@
               },
               "opera": "mirror",
               "safari": {
-                "notes": "<code>reason</code> and <code>extensionId</code> will not be populated.",
                 "version_added": "14",
-                "partial_implementation": true
+                "partial_implementation": true,
+                "notes": "<code>reason</code> and <code>extensionId</code> will not be populated."
               },
               "safari_ios": {
                 "version_added": false
@@ -916,9 +916,9 @@
                 },
                 "opera": "mirror",
                 "safari": {
-                  "notes": "<code>reason</code> and <code>extensionId</code> will not be populated.",
                   "version_added": "14",
-                  "partial_implementation": true
+                  "partial_implementation": true,
+                  "notes": "<code>reason</code> and <code>extensionId</code> will not be populated."
                 },
                 "safari_ios": {
                   "version_added": false
@@ -1378,8 +1378,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/captureVisibleTab",
             "support": {
               "chrome": {
-                "notes": "The default file format is 'jpeg'.",
-                "version_added": "5"
+                "version_added": "5",
+                "notes": "The default file format is 'jpeg'."
               },
               "edge": {
                 "version_added": "15"
@@ -1392,18 +1392,18 @@
               },
               "opera": "mirror",
               "safari": {
+                "version_added": "14",
                 "notes": [
                   "The default file format is 'jpeg'.",
                   "<code>&lt;all_urls&gt;</code> permission is optional."
-                ],
-                "version_added": "14"
+                ]
               },
               "safari_ios": {
+                "version_added": "15",
                 "notes": [
                   "The default file format is 'jpeg'.",
                   "<code>&lt;all_urls&gt;</code> permission is optional."
-                ],
-                "version_added": "15"
+                ]
               }
             }
           }
@@ -1447,14 +1447,14 @@
                   },
                   "opera": "mirror",
                   "safari": {
-                    "notes": "<code>name</code> is supported, but <code>frameId</code> is not.",
                     "version_added": "14",
-                    "partial_implementation": true
+                    "partial_implementation": true,
+                    "notes": "<code>name</code> is supported, but <code>frameId</code> is not."
                   },
                   "safari_ios": {
-                    "notes": "<code>name</code> is supported, but <code>frameId</code> is not.",
                     "version_added": "15",
-                    "partial_implementation": true
+                    "partial_implementation": true,
+                    "notes": "<code>name</code> is supported, but <code>frameId</code> is not."
                   }
                 }
               }
@@ -1707,12 +1707,12 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "notes": "Before version 57, extensions were not allowed to open 'view-source:' pages.",
-                  "version_added": "45"
+                  "version_added": "45",
+                  "notes": "Before version 57, extensions were not allowed to open 'view-source:' pages."
                 },
                 "firefox_android": {
-                  "notes": "Before version 57, extensions were not allowed to open 'view-source:' pages.",
-                  "version_added": "54"
+                  "version_added": "54",
+                  "notes": "Before version 57, extensions were not allowed to open 'view-source:' pages."
                 },
                 "opera": "mirror",
                 "safari": {
@@ -2834,9 +2834,9 @@
                   },
                   "opera": "mirror",
                   "safari": {
-                    "notes": "<code>reason</code> and <code>extensionId</code> will not be populated.",
                     "version_added": "14",
-                    "partial_implementation": true
+                    "partial_implementation": true,
+                    "notes": "<code>reason</code> and <code>extensionId</code> will not be populated."
                   },
                   "safari_ios": {
                     "version_added": false
@@ -2979,9 +2979,9 @@
                         "version_added": "62"
                       },
                       {
+                        "alternative_name": "isarticle",
                         "version_added": "61",
-                        "version_removed": "71",
-                        "alternative_name": "isarticle"
+                        "version_removed": "71"
                       }
                     ],
                     "firefox_android": {
@@ -3074,8 +3074,8 @@
                 "version_added": true
               },
               "edge": {
-                "notes": "The <code>panel</code>, <code>app</code>, <code>devtools</code> and <code>popup</code> values for <code>WindowType</code> are not supported.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "The <code>panel</code>, <code>app</code>, <code>devtools</code> and <code>popup</code> values for <code>WindowType</code> are not supported."
               },
               "firefox": {
                 "version_added": "45"
@@ -3085,12 +3085,12 @@
               },
               "opera": "mirror",
               "safari": {
-                "notes": "Pattern matching supports <code>*</code> and <code>?</code>.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "Pattern matching supports <code>*</code> and <code>?</code>."
               },
               "safari_ios": {
-                "notes": "Pattern matching supports <code>*</code> and <code>?</code>.",
-                "version_added": "15"
+                "version_added": "15",
+                "notes": "Pattern matching supports <code>*</code> and <code>?</code>."
               }
             }
           },
@@ -3250,19 +3250,19 @@
                     "version_added": "79"
                   },
                   "firefox": {
-                    "notes": "Treated as an alias for <code>queryInfo.active</code>.",
-                    "version_added": "60"
+                    "version_added": "60",
+                    "notes": "Treated as an alias for <code>queryInfo.active</code>."
                   },
                   "firefox_android": [
                     {
-                      "notes": "Treated as an alias for <code>queryInfo.active</code>.",
                       "version_added": "61",
-                      "version_removed": "79"
+                      "version_removed": "79",
+                      "notes": "Treated as an alias for <code>queryInfo.active</code>."
                     },
                     {
-                      "notes": "Treated as an alias for <code>queryInfo.active</code> except when an extension has a popup open. In this situation, <code>queryInfo.highlighted</code> will return the popup, while <code>queryInfo.active</code> will return the tab that was selected before the popup opened.",
                       "version_added": "60",
-                      "version_removed": "61"
+                      "version_removed": "61",
+                      "notes": "Treated as an alias for <code>queryInfo.active</code> except when an extension has a popup open. In this situation, <code>queryInfo.highlighted</code> will return the popup, while <code>queryInfo.active</code> will return the tab that was selected before the popup opened."
                     }
                   ],
                   "opera": "mirror",
@@ -3628,9 +3628,9 @@
                   "version_added": "81"
                 },
                 {
-                  "notes": "This function does not work on macOS.",
                   "version_added": "56",
-                  "version_removed": "81"
+                  "version_removed": "81",
+                  "notes": "This function does not work on macOS."
                 }
               ],
               "firefox_android": {

--- a/webextensions/api/webNavigation.json
+++ b/webextensions/api/webNavigation.json
@@ -11,8 +11,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "notes": "'server_redirect' is limited to top-level frames and 'client_redirect' is not supplied when redirections are created by JavaScript.",
-                "version_added": "48"
+                "version_added": "48",
+                "notes": "'server_redirect' is limited to top-level frames and 'client_redirect' is not supplied when redirections are created by JavaScript."
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -328,32 +328,32 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onBeforeNavigate",
             "support": {
               "chrome": {
-                "notes": "If the filter parameter is empty, all URLs are matched.",
-                "version_added": true
+                "version_added": true,
+                "notes": "If the filter parameter is empty, all URLs are matched."
               },
               "edge": "mirror",
               "firefox": {
+                "version_added": "45",
                 "notes": [
                   "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "45"
+                ]
               },
               "firefox_android": {
+                "version_added": "48",
                 "notes": [
                   "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "48"
+                ]
               },
               "opera": "mirror",
               "safari": {
-                "notes": "If the filter parameter is empty, all URLs are matched.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "If the filter parameter is empty, all URLs are matched."
               },
               "safari_ios": {
-                "notes": "If the filter parameter is empty, all URLs are matched.",
-                "version_added": "15"
+                "version_added": "15",
+                "notes": "If the filter parameter is empty, all URLs are matched."
               }
             }
           }
@@ -363,32 +363,32 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onCommitted",
             "support": {
               "chrome": {
-                "notes": "If the filter parameter is empty, all URLs are matched.",
-                "version_added": true
+                "version_added": true,
+                "notes": "If the filter parameter is empty, all URLs are matched."
               },
               "edge": "mirror",
               "firefox": {
+                "version_added": "45",
                 "notes": [
                   "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "45"
+                ]
               },
               "firefox_android": {
+                "version_added": "48",
                 "notes": [
                   "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "48"
+                ]
               },
               "opera": "mirror",
               "safari": {
-                "notes": "If the filter parameter is empty, all URLs are matched.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "If the filter parameter is empty, all URLs are matched."
               },
               "safari_ios": {
-                "notes": "If the filter parameter is empty, all URLs are matched.",
-                "version_added": "15"
+                "version_added": "15",
+                "notes": "If the filter parameter is empty, all URLs are matched."
               }
             }
           },
@@ -436,32 +436,32 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onCompleted",
             "support": {
               "chrome": {
-                "notes": "If the filter parameter is empty, all URLs are matched.",
-                "version_added": true
+                "version_added": true,
+                "notes": "If the filter parameter is empty, all URLs are matched."
               },
               "edge": "mirror",
               "firefox": {
+                "version_added": "45",
                 "notes": [
                   "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "45"
+                ]
               },
               "firefox_android": {
+                "version_added": "48",
                 "notes": [
                   "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "48"
+                ]
               },
               "opera": "mirror",
               "safari": {
-                "notes": "If the filter parameter is empty, all URLs are matched.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "If the filter parameter is empty, all URLs are matched."
               },
               "safari_ios": {
-                "notes": "If the filter parameter is empty, all URLs are matched.",
-                "version_added": "15"
+                "version_added": "15",
+                "notes": "If the filter parameter is empty, all URLs are matched."
               }
             }
           }
@@ -471,24 +471,24 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onCreatedNavigationTarget",
             "support": {
               "chrome": {
-                "notes": "If a blocked popup is unblocked by the user, the event is still not sent.",
-                "version_added": true
+                "version_added": true,
+                "notes": "If a blocked popup is unblocked by the user, the event is still not sent."
               },
               "edge": "mirror",
               "firefox": {
+                "version_added": "54",
                 "notes": [
                   "If the filter parameter is empty, Firefox raises an exception.",
                   "If a blocked popup is unblocked by the user, the event is then sent."
-                ],
-                "version_added": "54"
+                ]
               },
               "firefox_android": {
+                "version_added": "54",
                 "notes": [
                   "If the filter parameter is empty, Firefox raises an exception.",
                   "If a blocked popup is unblocked by the user, the event is then sent.",
                   "This event is only sent in the 'window.open()' case."
-                ],
-                "version_added": "54"
+                ]
               },
               "opera": "mirror",
               "safari": {
@@ -541,32 +541,32 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onDOMContentLoaded",
             "support": {
               "chrome": {
-                "notes": "If the filter parameter is empty, all URLs are matched.",
-                "version_added": true
+                "version_added": true,
+                "notes": "If the filter parameter is empty, all URLs are matched."
               },
               "edge": "mirror",
               "firefox": {
+                "version_added": "45",
                 "notes": [
                   "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "45"
+                ]
               },
               "firefox_android": {
+                "version_added": "48",
                 "notes": [
                   "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "48"
+                ]
               },
               "opera": "mirror",
               "safari": {
-                "notes": "If the filter parameter is empty, all URLs are matched.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "If the filter parameter is empty, all URLs are matched."
               },
               "safari_ios": {
-                "notes": "If the filter parameter is empty, all URLs are matched.",
-                "version_added": "15"
+                "version_added": "15",
+                "notes": "If the filter parameter is empty, all URLs are matched."
               }
             }
           }
@@ -576,32 +576,32 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onErrorOccurred",
             "support": {
               "chrome": {
-                "notes": "If the filter parameter is empty, all URLs are matched.",
-                "version_added": true
+                "version_added": true,
+                "notes": "If the filter parameter is empty, all URLs are matched."
               },
               "edge": "mirror",
               "firefox": {
+                "version_added": "45",
                 "notes": [
                   "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "45"
+                ]
               },
               "firefox_android": {
+                "version_added": "48",
                 "notes": [
                   "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "48"
+                ]
               },
               "opera": "mirror",
               "safari": {
-                "notes": "If the filter parameter is empty, all URLs are matched.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "If the filter parameter is empty, all URLs are matched."
               },
               "safari_ios": {
-                "notes": "If the filter parameter is empty, all URLs are matched.",
-                "version_added": "15"
+                "version_added": "15",
+                "notes": "If the filter parameter is empty, all URLs are matched."
               }
             }
           },
@@ -694,23 +694,23 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation/onReferenceFragmentUpdated",
             "support": {
               "chrome": {
-                "notes": "If the filter parameter is empty, all URLs are matched.",
-                "version_added": true
+                "version_added": true,
+                "notes": "If the filter parameter is empty, all URLs are matched."
               },
               "edge": "mirror",
               "firefox": {
+                "version_added": "45",
                 "notes": [
                   "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "45"
+                ]
               },
               "firefox_android": {
+                "version_added": "48",
                 "notes": [
                   "Filtering is supported from version 50.",
                   "If the filter parameter is empty, Firefox raises an exception."
-                ],
-                "version_added": "48"
+                ]
               },
               "opera": "mirror",
               "safari": {
@@ -767,12 +767,12 @@
               },
               "edge": "mirror",
               "firefox": {
-                "notes": "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported.",
-                "version_added": "45"
+                "version_added": "45",
+                "notes": "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
               },
               "firefox_android": {
-                "notes": "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported.",
-                "version_added": "48"
+                "version_added": "48",
+                "notes": "Although you can add listeners for this event, it will never fire because the underlying functionality is not supported."
               },
               "opera": "mirror",
               "safari": {

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -126,23 +126,23 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/RequestFilter",
             "support": {
               "chrome": {
-                "notes": "If a filter contains unrecognized values in its <code>types</code> property, <code>addListener()</code> throws an exception.",
-                "version_added": true
+                "version_added": true,
+                "notes": "If a filter contains unrecognized values in its <code>types</code> property, <code>addListener()</code> throws an exception."
               },
               "edge": {
-                "notes": "If a filter contains unrecognized values in its <code>types</code> property, <code>addListener()</code> throws an exception.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "If a filter contains unrecognized values in its <code>types</code> property, <code>addListener()</code> throws an exception."
               },
               "firefox": {
+                "version_added": "45",
                 "notes": [
                   "From Firefox 78 onwards, if a filter contains unrecognized values in its <code>types</code> property, then these values are ignored and <code>addListener()</code> proceeds.",
                   "Before Firefox 78, if a filter contains unrecognized values in its <code>types</code> property, <code>addListener()</code> throws an exception."
-                ],
-                "version_added": "45"
+                ]
               },
               "firefox_android": {
-                "notes": "If a filter contains unrecognized values in its <code>types</code> property, <code>addListener()</code> throws an exception.",
-                "version_added": "48"
+                "version_added": "48",
+                "notes": "If a filter contains unrecognized values in its <code>types</code> property, <code>addListener()</code> throws an exception."
               },
               "opera": "mirror",
               "safari": {
@@ -1420,14 +1420,14 @@
                 "version_added": "14"
               },
               "firefox": {
-                "notes": "To handle a request asynchronously, return a Promise from the listener.",
-                "version_added": "54"
+                "version_added": "54",
+                "notes": "To handle a request asynchronously, return a Promise from the listener."
               },
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "notes": "<code>extraInfoSpec</code> options are not supported.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "<code>extraInfoSpec</code> options are not supported."
               },
               "safari_ios": {
                 "version_added": false
@@ -1466,8 +1466,8 @@
                     "version_added": "14"
                   },
                   "firefox": {
-                    "notes": "Before version 57, when authenticating to a proxy server, the <code>challenger.host</code> property contains the hostname for the requested URL rather than the hostname for the proxy.",
-                    "version_added": "54"
+                    "version_added": "54",
+                    "notes": "Before version 57, when authenticating to a proxy server, the <code>challenger.host</code> property contains the hostname for the requested URL rather than the hostname for the proxy."
                   },
                   "firefox_android": "mirror",
                   "opera": "mirror",
@@ -1963,8 +1963,8 @@
               },
               "opera": "mirror",
               "safari": {
-                "notes": "<code>extraInfoSpec</code> options are not supported.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "<code>extraInfoSpec</code> options are not supported."
               },
               "safari_ios": {
                 "version_added": false
@@ -2470,25 +2470,25 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeRequest",
             "support": {
               "chrome": {
-                "notes": "Asynchronous event listeners are not supported.",
-                "version_added": true
+                "version_added": true,
+                "notes": "Asynchronous event listeners are not supported."
               },
               "edge": {
-                "notes": "Asynchronous event listeners are not supported.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "Asynchronous event listeners are not supported."
               },
               "firefox": {
-                "notes": "Asynchronous event listeners are supported from version 52.",
-                "version_added": "46"
+                "version_added": "46",
+                "notes": "Asynchronous event listeners are supported from version 52."
               },
               "firefox_android": {
-                "notes": "Asynchronous event listeners are supported from version 52.",
-                "version_added": "48"
+                "version_added": "48",
+                "notes": "Asynchronous event listeners are supported from version 52."
               },
               "opera": "mirror",
               "safari": {
-                "notes": "<code>extraInfoSpec</code> options are not supported.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "<code>extraInfoSpec</code> options are not supported."
               },
               "safari_ios": {
                 "version_added": false
@@ -2886,25 +2886,25 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeSendHeaders",
             "support": {
               "chrome": {
-                "notes": "Asynchronous event listeners are not supported.",
-                "version_added": true
+                "version_added": true,
+                "notes": "Asynchronous event listeners are not supported."
               },
               "edge": {
-                "notes": "Asynchronous event listeners are not supported.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "Asynchronous event listeners are not supported."
               },
               "firefox": {
-                "notes": "Asynchronous event listeners are supported from version 52.",
-                "version_added": "45"
+                "version_added": "45",
+                "notes": "Asynchronous event listeners are supported from version 52."
               },
               "firefox_android": {
-                "notes": "Asynchronous event listeners are supported from version 52.",
-                "version_added": "48"
+                "version_added": "48",
+                "notes": "Asynchronous event listeners are supported from version 52."
               },
               "opera": "mirror",
               "safari": {
-                "notes": "<code>extraInfoSpec</code> options are not supported.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "<code>extraInfoSpec</code> options are not supported."
               },
               "safari_ios": {
                 "version_added": false
@@ -3296,8 +3296,8 @@
               },
               "opera": "mirror",
               "safari": {
-                "notes": "<code>extraInfoSpec</code> options are not supported.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "<code>extraInfoSpec</code> options are not supported."
               },
               "safari_ios": {
                 "version_added": false
@@ -3791,8 +3791,8 @@
               },
               "opera": "mirror",
               "safari": {
-                "notes": "<code>extraInfoSpec</code> options are not supported.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "<code>extraInfoSpec</code> options are not supported."
               },
               "safari_ios": {
                 "version_added": false
@@ -4223,31 +4223,31 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onHeadersReceived",
             "support": {
               "chrome": {
-                "notes": "Asynchronous event listeners are not supported.",
-                "version_added": true
+                "version_added": true,
+                "notes": "Asynchronous event listeners are not supported."
               },
               "edge": {
-                "notes": "Asynchronous event listeners are not supported.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "Asynchronous event listeners are not supported."
               },
               "firefox": {
+                "version_added": "45",
                 "notes": [
                   "Modification of the 'Content-Type' header is supported from version 51.",
                   "Asynchronous event listeners are supported from version 52."
-                ],
-                "version_added": "45"
+                ]
               },
               "firefox_android": {
+                "version_added": "48",
                 "notes": [
                   "Modification of the 'Content-Type' header is supported from version 51.",
                   "Asynchronous event listeners are supported from version 52."
-                ],
-                "version_added": "48"
+                ]
               },
               "opera": "mirror",
               "safari": {
-                "notes": "<code>extraInfoSpec</code> options are not supported.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "<code>extraInfoSpec</code> options are not supported."
               },
               "safari_ios": {
                 "version_added": false
@@ -4754,8 +4754,8 @@
               },
               "opera": "mirror",
               "safari": {
-                "notes": "<code>extraInfoSpec</code> options are not supported.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "<code>extraInfoSpec</code> options are not supported."
               },
               "safari_ios": {
                 "version_added": false
@@ -5245,8 +5245,8 @@
               },
               "opera": "mirror",
               "safari": {
-                "notes": "<code>extraInfoSpec</code> options are not supported.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "<code>extraInfoSpec</code> options are not supported."
               },
               "safari_ios": {
                 "version_added": false

--- a/webextensions/api/windows.json
+++ b/webextensions/api/windows.json
@@ -654,12 +654,12 @@
                 "version_added": "14"
               },
               "firefox": {
+                "version_added": "45",
                 "notes": [
                   "'url' and 'tabId options can't both be set together.",
                   "The returned 'Window' object contains the 'tabs' property only from version 52 onwards.",
                   "From Firefox 86, the <code>focused: false</code> option is ignored."
-                ],
-                "version_added": "45"
+                ]
               },
               "firefox_android": {
                 "version_added": false
@@ -943,8 +943,8 @@
                     "version_added": "14"
                   },
                   "firefox": {
-                    "notes": "'url' does not accept relative paths.",
-                    "version_added": "45"
+                    "version_added": "45",
+                    "notes": "'url' does not accept relative paths."
                   },
                   "firefox_android": {
                     "version_added": false

--- a/webextensions/manifest/author.json
+++ b/webextensions/manifest/author.json
@@ -18,12 +18,12 @@
             "firefox_android": "mirror",
             "opera": "mirror",
             "safari": {
-              "notes": "Not displayed in Safari Extensions settings.",
-              "version_added": "14"
+              "version_added": "14",
+              "notes": "Not displayed in Safari Extensions settings."
             },
             "safari_ios": {
-              "notes": "Not displayed in Safari Extensions settings.",
-              "version_added": "15"
+              "version_added": "15",
+              "notes": "Not displayed in Safari Extensions settings."
             }
           }
         }

--- a/webextensions/manifest/background.json
+++ b/webextensions/manifest/background.json
@@ -84,14 +84,14 @@
               ],
               "safari_ios": [
                 {
-                  "notes": "Only non-persistent pages are supported. Requires <code>persistent: false</code> or <code>service_worker</code>.",
+                  "version_added": "15.4",
                   "partial_implementation": true,
-                  "version_added": "15.4"
+                  "notes": "Only non-persistent pages are supported. Requires <code>persistent: false</code> or <code>service_worker</code>."
                 },
                 {
-                  "notes": "Only non-persistent pages are supported. Requires <code>persistent: false</code>.",
+                  "version_added": "15",
                   "partial_implementation": true,
-                  "version_added": "15"
+                  "notes": "Only non-persistent pages are supported. Requires <code>persistent: false</code>."
                 }
               ]
             }

--- a/webextensions/manifest/browser_specific_settings.json
+++ b/webextensions/manifest/browser_specific_settings.json
@@ -34,8 +34,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "notes": "Supports <code>id</code>, <code>strict_min_version</code>, <code>strict_max_version</code>, and <code>update_url</code>update_url.",
-                "version_added": "42"
+                "version_added": "42",
+                "notes": "Supports <code>id</code>, <code>strict_min_version</code>, <code>strict_max_version</code>, and <code>update_url</code>update_url."
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -57,8 +57,8 @@
                 "version_added": false
               },
               "firefox_android": {
-                "notes": "Supports <code>strict_min_version</code> and <code>strict_max_version</code>.",
-                "version_added": "113"
+                "version_added": "113",
+                "notes": "Supports <code>strict_min_version</code> and <code>strict_max_version</code>."
               },
               "opera": "mirror",
               "safari": {
@@ -81,12 +81,12 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "notes": "Supports <code>strict_min_version</code> and <code>strict_max_version</code>.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "Supports <code>strict_min_version</code> and <code>strict_max_version</code>."
               },
               "safari_ios": {
-                "notes": "Supports <code>strict_min_version</code> and <code>strict_max_version</code>.",
-                "version_added": "15"
+                "version_added": "15",
+                "notes": "Supports <code>strict_min_version</code> and <code>strict_max_version</code>."
               }
             }
           }

--- a/webextensions/manifest/homepage_url.json
+++ b/webextensions/manifest/homepage_url.json
@@ -17,12 +17,12 @@
             "firefox_android": "mirror",
             "opera": "mirror",
             "safari": {
-              "notes": "Not displayed in Safari Extensions settings.",
-              "version_added": "14"
+              "version_added": "14",
+              "notes": "Not displayed in Safari Extensions settings."
             },
             "safari_ios": {
-              "notes": "Not displayed in Safari Extensions settings.",
-              "version_added": "15"
+              "version_added": "15",
+              "notes": "Not displayed in Safari Extensions settings."
             }
           }
         }

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -269,16 +269,16 @@
                 "version_added": "14"
               },
               "firefox": {
-                "notes": "Available as an alias to the <code>menus</code> permission.",
-                "version_added": "55"
+                "version_added": "55",
+                "notes": "Available as an alias to the <code>menus</code> permission."
               },
               "firefox_android": {
                 "version_added": false
               },
               "opera": "mirror",
               "safari": {
-                "notes": "Available as an alias to the <code>menus</code> permission.",
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "Available as an alias to the <code>menus</code> permission."
               },
               "safari_ios": {
                 "version_added": false


### PR DESCRIPTION
This PR fixes the property order in all files throughout BCD to enforce a uniform property order.  This is a bulk update performed by running the fix script in #21093.
