### PR TITLE
Update Edge data for webextensions.manifest.author

### DIFF
--- a/webextensions/manifest/author.json
+++ b/webextensions/manifest/author.json
@@ -10,7 +10,7 @@
             },
             "edge": {
               "version_added": "14",
-              "notes": "This property is required."
+              "notes": "Before Edge 79, this property was required."
             },
             "firefox": {
               "version_added": "52"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR corrects the requirement note for Microsoft Edge for the `author` property of webExtension manifest files.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/21101