### PR TITLE
fix(css): add 'fit-content' value spec to size properties

### DIFF
--- a/css/properties/block-size.json
+++ b/css/properties/block-size.json
@@ -4,7 +4,10 @@
       "block-size": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/block-size",
-          "spec_url": "https://drafts.csswg.org/css-logical/#dimension-properties",
+          "spec_url": [
+            "https://drafts.csswg.org/css-logical/#dimension-properties",
+            "https://drafts.csswg.org/css-sizing-4/#sizing-values"
+          ],
           "support": {
             "chrome": {
               "version_added": "57"

--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -4,7 +4,10 @@
       "height": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/height",
-          "spec_url": "https://drafts.csswg.org/css-sizing/#preferred-size-properties",
+          "spec_url": [
+            "https://drafts.csswg.org/css-sizing/#preferred-size-properties",
+            "https://drafts.csswg.org/css-sizing-4/#sizing-values"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/css/properties/inline-size.json
+++ b/css/properties/inline-size.json
@@ -4,7 +4,10 @@
       "inline-size": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/inline-size",
-          "spec_url": "https://drafts.csswg.org/css-logical/#dimension-properties",
+          "spec_url": [
+            "https://drafts.csswg.org/css-logical/#dimension-properties",
+            "https://drafts.csswg.org/css-sizing-4/#sizing-values"
+          ],
           "support": {
             "chrome": {
               "version_added": "57"

--- a/css/properties/max-block-size.json
+++ b/css/properties/max-block-size.json
@@ -4,7 +4,10 @@
       "max-block-size": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max-block-size",
-          "spec_url": "https://drafts.csswg.org/css-logical/#propdef-max-block-size",
+          "spec_url": [
+            "https://drafts.csswg.org/css-logical/#propdef-max-block-size",
+            "https://drafts.csswg.org/css-sizing-4/#sizing-values"
+          ],
           "support": {
             "chrome": {
               "version_added": "57"

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -4,7 +4,10 @@
       "max-height": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max-height",
-          "spec_url": "https://drafts.csswg.org/css-sizing-4/#width-height-keywords",
+          "spec_url": [
+            "https://drafts.csswg.org/css-sizing-4/#width-height-keywords",
+            "https://drafts.csswg.org/css-sizing-4/#sizing-values"
+          ],
           "support": {
             "chrome": {
               "version_added": "18"

--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -4,7 +4,10 @@
       "max-inline-size": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max-inline-size",
-          "spec_url": "https://drafts.csswg.org/css-logical/#propdef-max-inline-size",
+          "spec_url": [
+            "https://drafts.csswg.org/css-logical/#propdef-max-inline-size",
+            "https://drafts.csswg.org/css-sizing-4/#sizing-values"
+          ],
           "support": {
             "chrome": {
               "version_added": "57"

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -4,7 +4,10 @@
       "max-width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/max-width",
-          "spec_url": "https://drafts.csswg.org/css-sizing-4/#width-height-keywords",
+          "spec_url": [
+            "https://drafts.csswg.org/css-sizing-4/#width-height-keywords",
+            "https://drafts.csswg.org/css-sizing-4/#sizing-values"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/css/properties/min-block-size.json
+++ b/css/properties/min-block-size.json
@@ -4,7 +4,10 @@
       "min-block-size": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min-block-size",
-          "spec_url": "https://drafts.csswg.org/css-logical/#propdef-min-block-size",
+          "spec_url": [
+            "https://drafts.csswg.org/css-logical/#propdef-min-block-size",
+            "https://drafts.csswg.org/css-sizing-4/#sizing-values"
+          ],
           "support": {
             "chrome": {
               "version_added": "57"

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -4,7 +4,10 @@
       "min-height": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min-height",
-          "spec_url": "https://drafts.csswg.org/css-sizing/#width-height-keywords",
+          "spec_url": [
+            "https://drafts.csswg.org/css-sizing/#width-height-keywords",
+            "https://drafts.csswg.org/css-sizing-4/#sizing-values"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/css/properties/min-inline-size.json
+++ b/css/properties/min-inline-size.json
@@ -4,7 +4,10 @@
       "min-inline-size": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min-inline-size",
-          "spec_url": "https://drafts.csswg.org/css-logical/#propdef-min-inline-size",
+          "spec_url": [
+            "https://drafts.csswg.org/css-logical/#propdef-min-inline-size",
+            "https://drafts.csswg.org/css-sizing-4/#sizing-values"
+          ],
           "support": {
             "chrome": {
               "version_added": "57"

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -4,7 +4,10 @@
       "min-width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/min-width",
-          "spec_url": "https://drafts.csswg.org/css-sizing/#min-size-properties",
+          "spec_url": [
+            "https://drafts.csswg.org/css-sizing/#min-size-properties",
+            "https://drafts.csswg.org/css-sizing-4/#sizing-values"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -4,7 +4,10 @@
       "width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/width",
-          "spec_url": "https://drafts.csswg.org/css-sizing-4/#width-height-keywords",
+          "spec_url": [
+            "https://drafts.csswg.org/css-sizing-4/#width-height-keywords",
+            "https://drafts.csswg.org/css-sizing-4/#sizing-values"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
- related to https://github.com/mdn/content/pull/29849

The PR adds new sizing values specs to the size properties.
