### PR TITLE
Handle archiving Edge release notes

### DIFF
--- a/scripts/update-browser-releases/edge.ts
+++ b/scripts/update-browser-releases/edge.ts
@@ -57,19 +57,17 @@ const updateReleaseNotesIfArchived = (originalURL) => {
   const id = originalURL.split('#')[1];
 
   // Test if the original URL still works
-
   // If the files doesn't exist or the id not found in the archive
   // Keep the original file
   if (
-    !{ id } ||
+    !id ||
     !releaseNotesText ||
-    releaseNotesText.indexOf(`<h2 id="${id}">`) == -1 ||
+    releaseNotesText.indexOf(`<h2 id="${id}">`) != -1 ||
     !archivedReleaseNotesText ||
     archivedReleaseNotesText.indexOf(`<h2 id="${id}">`) == -1
   ) {
     return originalURL; // We keep the original URL
   }
-
   // Return the archived entry.
   return `https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#${id}`;
 };

--- a/scripts/update-browser-releases/edge.ts
+++ b/scripts/update-browser-releases/edge.ts
@@ -44,8 +44,8 @@ const initReleaseNoteFiles = async () => {
       chalk`{red \nArchive release note files not found for Edge (${archivedReleaseNotes.status}).`,
     );
   } else {
-  archivedReleaseNotesText = await archivedReleaseNotes.text();
-}
+    archivedReleaseNotesText = await archivedReleaseNotes.text();
+  }
 };
 
 /**
@@ -61,7 +61,7 @@ const updateReleaseNotesIfArchived = (originalURL) => {
   // If the files doesn't exist or the id not found in the archive
   // Keep the original file
   if (
-    !{id} ||
+    !{ id } ||
     !releaseNotesText ||
     releaseNotesText.indexOf(`<h2 id="${id}">`) == -1 ||
     !archivedReleaseNotesText ||
@@ -312,7 +312,7 @@ export const updateEdgeReleases = async (options) => {
           'retired',
           updateReleaseNotesIfArchived(
             edgeBCD.browsers[options.bcdBrowserName].releases[i.toString()]
-              .release_notes
+              .release_notes,
           ),
         );
       } else {

--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -115,7 +115,7 @@ const options = {
       54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71,
       72, 73, 74, 75, 76, 77, 78, 82,
     ],
-    edgeupdatesURL: 'https://edgeupdates.microsoft.com/api/products',
+    edgeupdatesURL: 'https://edgeupdates.microsoft.com/api/products?view=enterprise',
     releaseScheduleURL:
       'https://raw.githubusercontent.com/MicrosoftDocs/Edge-Enterprise/public/edgeenterprise/microsoft-edge-release-schedule.md',
   },

--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -115,7 +115,8 @@ const options = {
       54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71,
       72, 73, 74, 75, 76, 77, 78, 82,
     ],
-    edgeupdatesURL: 'https://edgeupdates.microsoft.com/api/products?view=enterprise',
+    edgeupdatesURL:
+      'https://edgeupdates.microsoft.com/api/products?view=enterprise',
     releaseScheduleURL:
       'https://raw.githubusercontent.com/MicrosoftDocs/Edge-Enterprise/public/edgeenterprise/microsoft-edge-release-schedule.md',
   },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

After some time, Microsoft moved Edge release notes to an archive page.

This PR:
- detect that this move happened, and update the edge.json file accordingly
- make sure the release note page and the archived one are read only once.

#### Test results and supporting details
Manually tested:
![Capture d’écran 2023-10-28 à 08 22 11](https://github.com/mdn/browser-compat-data/assets/1466293/72de3aed-230d-48c5-b68a-150d17039115)

#### Related issues

