### PR TITLE
Update statement comparison for better readability and fixed sorting

### DIFF
--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -32,13 +32,13 @@
               "version_added": "30"
             },
             {
-              "version_added": "12.1",
-              "version_removed": "15"
-            },
-            {
               "prefix": "WebKit",
               "version_added": "15",
               "version_removed": "57"
+            },
+            {
+              "version_added": "12.1",
+              "version_removed": "15"
             },
             {
               "prefix": "o",
@@ -51,13 +51,13 @@
               "version_added": "30"
             },
             {
-              "version_added": "12.1",
-              "version_removed": "14"
-            },
-            {
               "prefix": "WebKit",
               "version_added": "14",
               "version_removed": "49"
+            },
+            {
+              "version_added": "12.1",
+              "version_removed": "14"
             },
             {
               "prefix": "o",

--- a/api/CSSKeyframeRule.json
+++ b/api/CSSKeyframeRule.json
@@ -39,13 +39,13 @@
               "version_added": "18"
             },
             {
-              "version_added": "12",
-              "version_removed": "15"
-            },
-            {
               "prefix": "WebKit",
               "version_added": "15",
               "version_removed": "18"
+            },
+            {
+              "version_added": "12",
+              "version_removed": "15"
             }
           ],
           "opera_android": [
@@ -53,13 +53,13 @@
               "version_added": "18"
             },
             {
-              "version_added": "12",
-              "version_removed": "14"
-            },
-            {
               "prefix": "WebKit",
               "version_added": "14",
               "version_removed": "18"
+            },
+            {
+              "version_added": "12",
+              "version_removed": "14"
             }
           ],
           "safari": [

--- a/api/CSSKeyframesRule.json
+++ b/api/CSSKeyframesRule.json
@@ -39,13 +39,13 @@
               "version_added": "18"
             },
             {
-              "version_added": "12.1",
-              "version_removed": "15"
-            },
-            {
               "prefix": "WebKit",
               "version_added": "15",
               "version_removed": "18"
+            },
+            {
+              "version_added": "12.1",
+              "version_removed": "15"
             },
             {
               "prefix": "O",
@@ -58,13 +58,13 @@
               "version_added": "18"
             },
             {
-              "version_added": "12.1",
-              "version_removed": "14"
-            },
-            {
               "prefix": "WebKit",
               "version_added": "14",
               "version_removed": "18"
+            },
+            {
+              "version_added": "12.1",
+              "version_removed": "14"
             },
             {
               "prefix": "O",
@@ -140,13 +140,13 @@
                 "version_added": "28"
               },
               {
-                "version_added": "12",
-                "version_removed": "15"
-              },
-              {
                 "alternative_name": "insertRule",
                 "version_added": "15",
                 "version_removed": "31"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "15"
               }
             ],
             "opera_android": [
@@ -154,13 +154,13 @@
                 "version_added": "28"
               },
               {
-                "version_added": "12",
-                "version_removed": "14"
-              },
-              {
                 "alternative_name": "insertRule",
                 "version_added": "14",
                 "version_removed": "32"
+              },
+              {
+                "version_added": "12",
+                "version_removed": "14"
               }
             ],
             "safari": [

--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -208,10 +208,6 @@
             },
             "edge": [
               {
-                "version_added": "15",
-                "version_removed": "79"
-              },
-              {
                 "version_added": "79",
                 "version_removed": "80",
                 "flags": [
@@ -220,6 +216,10 @@
                     "name": "WebVR"
                   }
                 ]
+              },
+              {
+                "version_added": "15",
+                "version_removed": "79"
               }
             ],
             "firefox": [

--- a/api/NamedNodeMap.json
+++ b/api/NamedNodeMap.json
@@ -17,13 +17,13 @@
               "version_added": "34"
             },
             {
-              "version_added": "1",
-              "version_removed": "22"
-            },
-            {
               "alternative_name": "MozNamedAttrMap",
               "version_added": "22",
               "version_removed": "34"
+            },
+            {
+              "version_added": "1",
+              "version_removed": "22"
             }
           ],
           "firefox_android": "mirror",

--- a/api/ScreenOrientation.json
+++ b/api/ScreenOrientation.json
@@ -137,14 +137,14 @@
             ],
             "firefox_android": [
               {
-                "version_added": "43",
-                "version_removed": "79"
-              },
-              {
                 "version_added": "79",
                 "version_removed": "97",
                 "partial_implementation": true,
                 "notes": "The API exists but returns <code>NS_ERROR_UNEXPECTED</code>."
+              },
+              {
+                "version_added": "43",
+                "version_removed": "79"
               }
             ],
             "ie": {

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -72,14 +72,14 @@
                   "version_added": "15.4"
                 },
                 {
-                  "version_added": "3.1",
-                  "version_removed": "14"
-                },
-                {
                   "version_added": "14",
                   "version_removed": "15.4",
                   "partial_implementation": true,
                   "notes": "<code>local</code> is recognized but has no effect due to <a href='https://webkit.org/b/219324'>a bug</a>."
+                },
+                {
+                  "version_added": "3.1",
+                  "version_removed": "14"
                 }
               ],
               "safari_ios": [
@@ -133,14 +133,14 @@
                   "version_added": "15.4"
                 },
                 {
-                  "version_added": "5",
-                  "version_removed": "13"
-                },
-                {
                   "version_added": "13",
                   "version_removed": "15.4",
                   "partial_implementation": true,
                   "notes": "<code>local</code> is recognized but has no effect due to <a href='https://webkit.org/b/219324'>a bug</a>."
+                },
+                {
+                  "version_added": "5",
+                  "version_removed": "13"
                 }
               ],
               "safari_ios": [
@@ -148,15 +148,15 @@
                   "version_added": "15.4"
                 },
                 {
-                  "version_added": "4.2",
-                  "version_removed": "13",
-                  "notes": "If <code>-webkit-overflow-scrolling: touch</code> is set, then <code>local</code> has no effect."
-                },
-                {
                   "version_added": "13",
                   "version_removed": "15.4",
                   "partial_implementation": true,
                   "notes": "<code>local</code> is recognized but has no effect due to <a href='https://webkit.org/b/219324'>a bug</a>."
+                },
+                {
+                  "version_added": "4.2",
+                  "version_removed": "13",
+                  "notes": "If <code>-webkit-overflow-scrolling: touch</code> is set, then <code>local</code> has no effect."
                 }
               ],
               "samsunginternet_android": "mirror",

--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -30,16 +30,16 @@
                 "version_added": "81"
               },
               {
+                "prefix": "-webkit-",
+                "version_added": "49"
+              },
+              {
                 "version_added": "20",
                 "partial_implementation": true,
                 "notes": [
                   "Since Firefox 28, multi-line flexbox is supported.",
                   "Before Firefox 81, overflow with <code>*-reverse</code> is unsupported. See <a href='https://bugzil.la/1042151'>bug 1042151</a>."
                 ]
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "49"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/mask.json
+++ b/css/properties/mask.json
@@ -8,27 +8,27 @@
           "support": {
             "chrome": [
               {
-                "version_added": "1",
-                "partial_implementation": true,
-                "notes": "While the property is recognized, values applied to it don't have any effect."
-              },
-              {
                 "prefix": "-webkit-",
                 "version_added": "1",
                 "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."
+              },
+              {
+                "version_added": "1",
+                "partial_implementation": true,
+                "notes": "While the property is recognized, values applied to it don't have any effect."
               }
             ],
             "chrome_android": "mirror",
             "edge": [
               {
-                "version_added": "79",
-                "partial_implementation": true,
-                "notes": "While the property is recognized, values applied to it don't have any effect."
-              },
-              {
                 "prefix": "-webkit-",
                 "version_added": "79",
                 "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."
+              },
+              {
+                "version_added": "79",
+                "partial_implementation": true,
+                "notes": "While the property is recognized, values applied to it don't have any effect."
               },
               {
                 "version_added": "12",
@@ -48,28 +48,28 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "3.1",
-                "partial_implementation": true,
-                "notes": "While the property is recognized, values applied to it don't have any effect."
-              },
-              {
                 "prefix": "-webkit-",
                 "version_added": "3.1",
                 "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."
+              },
+              {
+                "version_added": "3.1",
+                "partial_implementation": true,
+                "notes": "While the property is recognized, values applied to it don't have any effect."
               }
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": [
               {
-                "version_added": "2",
-                "partial_implementation": true,
-                "notes": "While the property is recognized, values applied to it don't have any effect."
-              },
-              {
                 "prefix": "-webkit-",
                 "version_added": "2",
                 "notes": "The prefixed property can be used with SVG and HTML with a slightly different syntax, which allows setting the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-attachment'><code>-webkit-mask-attachment</code></a> property."
+              },
+              {
+                "version_added": "2",
+                "partial_implementation": true,
+                "notes": "While the property is recognized, values applied to it don't have any effect."
               }
             ]
           },

--- a/css/properties/scroll-snap-type.json
+++ b/css/properties/scroll-snap-type.json
@@ -26,15 +26,15 @@
                 "version_added": "99"
               },
               {
-                "version_added": "39",
-                "version_removed": "68",
-                "notes": "An earlier draft of CSS Scroll Snap without axis values."
-              },
-              {
                 "version_added": "68",
                 "version_removed": "99",
                 "partial_implementation": true,
                 "notes": "On macOS 12, scroll snapping does not complete reliably. See <a href='https://bugzil.la/1749352'>bug 1749352</a>"
+              },
+              {
+                "version_added": "39",
+                "version_removed": "68",
+                "notes": "An earlier draft of CSS Scroll Snap without axis values."
               }
             ],
             "firefox_android": [

--- a/scripts/lib/compare-statements.test.ts
+++ b/scripts/lib/compare-statements.test.ts
@@ -15,6 +15,11 @@ const tests: { input: Identifier; output: Identifier }[] = [
           chrome: [
             { version_added: '20', prefix: 'webkit' },
             {
+              version_added: '18',
+              partial_implementation: true,
+              notes: 'Fries are kind of cold',
+            },
+            {
               version_added: '10',
               version_removed: '18',
               partial_implementation: true,
@@ -46,6 +51,11 @@ const tests: { input: Identifier; output: Identifier }[] = [
           chrome: [
             { version_added: '20' },
             { version_added: '20', prefix: 'webkit' },
+            {
+              version_added: '18',
+              partial_implementation: true,
+              notes: 'Fries are kind of cold',
+            },
             {
               version_added: '12',
               flags: [

--- a/scripts/lib/compare-statements.ts
+++ b/scripts/lib/compare-statements.ts
@@ -8,10 +8,11 @@ import { SimpleSupportStatement } from '../../types/types.js';
 /**
  *
  *Sort a list of compatibility statements based upon reverse-chronological order in the following order:
- *1. Statements with only version added and/or removed (and potentially notes)
- *2. Statements with alternative names or prefixes
- *3. Statements with partial support
- *4. Statements with flags
+ * 1. Statements with only version added (and potentially notes)
+ * 2. Statements with alternative names or prefixes
+ * 3. Statements with partial support
+ * 4. Statements with flags
+ * 5. Statements with a version removed (or otherwise no support)
  * @param {SimpleSupportStatement} a - The first support statement object to perform comparison with
  * @param {SimpleSupportStatement} b - The second support statement object to perform comparison with
  * @returns {number} Direction to sort
@@ -20,46 +21,53 @@ const compareStatements = (
   a: SimpleSupportStatement,
   b: SimpleSupportStatement,
 ): number => {
-  const has = {
-    a: {
-      unsupported: a.version_removed != undefined,
-      flags: a.flags != undefined,
-      altname: a.prefix != undefined || a.alternative_name != undefined,
-      partial: a.partial_implementation != undefined,
-    },
-    b: {
-      unsupported: b.version_removed != undefined,
-      flags: b.flags != undefined,
-      altname: b.prefix != undefined || b.alternative_name != undefined,
-      partial: b.partial_implementation != undefined,
-    },
-  };
-
-  if (has.a.unsupported && !has.b.unsupported) {
+  // Has version removed
+  if (a.version_removed && !b.version_removed) {
     return 1;
   }
-  if (!has.a.unsupported && has.b.unsupported) {
+  if (!a.version_removed && b.version_removed) {
+    return -1;
+  }
+  if (
+    a.version_removed &&
+    b.version_removed &&
+    typeof a.version_removed == 'string' &&
+    typeof b.version_removed == 'string'
+  ) {
+    // If both statements have version_removed, sort by removal version
+    const cmp = compareVersions(
+      b.version_removed.replace('≤', ''),
+      a.version_removed.replace('≤', ''),
+    );
+
+    // If both statements were removed at same time, compare other parts
+    if (cmp !== 0) {
+      return cmp;
+    }
+  }
+
+  // Has flags
+  if (a.flags && !b.flags) {
+    return 1;
+  }
+  if (!a.flags && b.flags) {
     return -1;
   }
 
-  if (has.a.flags && !has.b.flags) {
+  if (a.partial_implementation && !b.partial_implementation) {
     return 1;
   }
-  if (!has.a.flags && has.b.flags) {
+  if (!a.partial_implementation && b.partial_implementation) {
     return -1;
   }
 
-  if (has.a.altname && !has.b.altname) {
+  // Alternative name
+  const a_altname = a.prefix != undefined || a.alternative_name != undefined;
+  const b_altname = b.prefix != undefined || b.alternative_name != undefined;
+  if (a_altname && !b_altname) {
     return 1;
   }
-  if (!has.a.altname && has.b.altname) {
-    return -1;
-  }
-
-  if (has.a.partial && !has.b.partial) {
-    return 1;
-  }
-  if (!has.a.partial && has.b.partial) {
+  if (!a_altname && b_altname) {
     return -1;
   }
 

--- a/test/linter/test-style.ts
+++ b/test/linter/test-style.ts
@@ -93,7 +93,7 @@ const processData = (
     logger.error(
       chalk`Statement sorting error on ${jsonDiff(
         actual,
-        expectedFeatureSorting,
+        expectedStatementSorting,
       )}`,
       { fixable: true },
     );


### PR DESCRIPTION
This PR updates the statement comparison lib to improve statement order.  The statement comparison now performs the following:

- Statements with `version_removed` are compared against each other in reverse chronological order, regardless of other factors
  - If both statements have the same `version_removed`, other factors like prefixes and partial support will be considered
- Statements with partial implementation are now sorted underneath features with prefixes/alt. names, as it was intended to be
