### PR TITLE
FF120 CredentialsContainer.minPinLength extension

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -300,6 +300,7 @@
             "minPinLength": {
               "__compat": {
                 "description": "<code>minPinLength</code> extension",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#minpinlength",
                 "support": {
                   "chrome": {
                     "version_added": "98"
@@ -307,7 +308,7 @@
                   "chrome_android": "mirror",
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": false
+                    "version_added": "120"
                   },
                   "firefox_android": "mirror",
                   "ie": {


### PR DESCRIPTION
FF120 supports the [minPinLength](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#minpinlength) WebAuth extension in https://bugzilla.mozilla.org/show_bug.cgi?id=1844450.

This adds the version and MDN URL linking to existing docs. I didn't update the experimental flag to `false` as was (incorrectly) already set that way.

Related docs work can be tracked in https://github.com/mdn/content/issues/29783