### PR TITLE
Add compat data for the Idle Detection feature

### DIFF
--- a/features/idle-detection.json
+++ b/features/idle-detection.json
@@ -1,0 +1,44 @@
+{
+  "features": {
+    "idle-detection": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "94"
+          },
+          "chrome_android": "mirror",
+          "edge": [
+            {
+              "version_added": "114"
+            },
+            {
+              "version_added": "94",
+              "version_removed": "96"
+            }
+          ],
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This shows what it might look like to track browser compat data for https://github.com/web-platform-dx/web-features.

I think we should support deriving it entirely from constituent features, or do it manually. This PR shows what it would be like if done manually for a feature.

cc @ddbeck @Elchi3 @Fyrd