### PR TITLE
Point content-visibility animation spec to css-contain-3

### DIFF
--- a/css/properties/content-visibility.json
+++ b/css/properties/content-visibility.json
@@ -49,7 +49,7 @@
         "keyframe_animatable": {
           "__compat": {
             "description": "<code>@keyframe</code> animatable",
-            "spec_url": "https://drafts.csswg.org/css-display-4/#display-animation",
+            "spec_url": "https://drafts.csswg.org/css-contain-3/#content-visibility-animation",
             "support": {
               "chrome": {
                 "version_added": "116"


### PR DESCRIPTION
I'm not sure this is right, but the [presently linked specification](https://drafts.csswg.org/css-display-4/#display-animation) says nothing about `content-visibility`, only `display` and `visibility`. Meanwhile, CSS Containment Module Level 3 [does cover the animation of `content-visibility`](https://drafts.csswg.org/css-contain-3/#content-visibility-animation) (it was [previously specified as not animatable](https://drafts.csswg.org/css-contain-2/#content-visibility)).

That said, it's possible that the original author of this data intended for the subfeature to cover something else. Perhaps @chrisdavidmills could review this change?

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

This is a follow-up to changes made in https://github.com/mdn/browser-compat-data/pull/20671. 

Prompted by a review on https://github.com/web-platform-dx/web-features/pull/280.
<!-- ✅ After submitting, review the results of the "Checks" tab! -->
