### PR TITLE
Add a cron entry to run automatically update-browser-releases

### DIFF
--- a/.github/workflows/update-browser-releases.yml
+++ b/.github/workflows/update-browser-releases.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
   schedule:
-    - cron: '0 12 * * 1-5'
+    - cron: "0 12 * * 1-5"
 
 permissions:
   contents: write

--- a/.github/workflows/update-browser-releases.yml
+++ b/.github/workflows/update-browser-releases.yml
@@ -3,6 +3,9 @@ name: Update browser releases
 on:
   workflow_dispatch:
 
+  schedule:
+    - cron: '0 12 * * 1-5'
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/update-browser-releases.yml
+++ b/.github/workflows/update-browser-releases.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
   schedule:
-    - cron: "0 12 * * 1-5"
+    - cron: "30 4 * * 1-5"
 
 permissions:
   contents: write


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

We have been using `update-browser-releases` for some time, using the dispatch event.

This PR adds a schedule entry for 4.30am every weekday (UTC). This is 5.30am CET in winter and 6.30am CEST in summer (Europe).

GitHub doesn't guarantee a precise running time, but most of the time, it runs within 30 minutes from the scheduled time.

That way, we have it running every week day before 7am (Central Europe).

#### Test results and supporting details

I tested it on the teoli2003 repo at 12.00pm, and it worked: it ran at 1.38pm (UTC+1, CET)
![image](https://github.com/mdn/browser-compat-data/assets/1466293/7f59838b-1769-4b09-9c6e-c59d12d2f905)

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
