### PR TITLE
relnote(120): Fx nightly enables CSS zoom property by default

### DIFF
--- a/css/properties/zoom.json
+++ b/css/properties/zoom.json
@@ -13,8 +13,15 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/390936"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/390936",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.zoom.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/zoom.json
+++ b/css/properties/zoom.json
@@ -14,14 +14,14 @@
             },
             "firefox": {
               "version_added": "preview",
-              "impl_url": "https://bugzil.la/390936",
               "flags": [
                 {
                   "type": "preference",
                   "name": "layout.css.zoom.enabled",
                   "value_to_set": "true"
                 }
-              ]
+              ],
+              "impl_url": "https://bugzil.la/390936"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
Nightly for 120 enables CSS `zoom` property by flipping the pref `layout.css.zoom.enabled` to `true` for Nightly only by default.

Additionally, the `-moz-transform` prop is disabled in Nightly, not making additions here as this is likely going to be removed altogether. The non-prefixed `transform` prop is supported since Fx 16. There's already [a redirect from `-moz-transform` to `transform`](https://github.com/mdn/content/blame/main/files/en-us/_redirects.txt#L307).

__Related issues and pull requests:__
- [x] Parent issue https://github.com/mdn/content/issues/29785
- [x] content https://github.com/mdn/content/pull/29815

__Revision:__

- https://hg.mozilla.org/integration/autoland/rev/facd9f92e1f5

__Bugzilla:__
- https://bugzilla.mozilla.org/show_bug.cgi?id=1855763
- https://bugzilla.mozilla.org/show_bug.cgi?id=390936

