### PR TITLE
FF120 iframe support lazy loading in nightly

### DIFF
--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -497,7 +497,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -347,8 +347,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1622090"
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
FF120 supports lazy loading of iframes in preview in https://bugzilla.mozilla.org/show_bug.cgi?id=1622090 (with expectation it will be supported by default in 121).

This updates the `loading` attribute in iframe tag and HTML element.

Related work can be tracked in https://github.com/mdn/content/issues/29780