### PR TITLE
Clarifies native message support on Android

### DIFF
--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -472,7 +472,7 @@
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "Only available to privileged extensions in <a href=\"https://mozilla.github.io/geckoview/\">GeckoView<a> 68 and later. See the <a href=\"https://firefox-source-docs.mozilla.org/mobile/android/geckoview/consumer/web-extensions.html\">GeckoView Docs</a> for additional details."
+                "notes": "Only available to privileged extensions in <a href='https://mozilla.github.io/geckoview/'>GeckoView</a> 68 and later. See the <a href='https://firefox-source-docs.mozilla.org/mobile/android/geckoview/consumer/web-extensions.html'>GeckoView Docs</a> for additional details."
               },
               "opera": "mirror",
               "safari": {
@@ -1220,7 +1220,7 @@
               },
               "firefox_android": {
                 "version_added": false,
-                "notes": "Only available to privileged extensions in <a href=\"https://mozilla.github.io/geckoview/\">GeckoView<a> 68 and later. See the <a href=\"https://firefox-source-docs.mozilla.org/mobile/android/geckoview/consumer/web-extensions.html\">GeckoView Docs</a> for additional details."
+                "notes": "Only available to privileged extensions in <a href='https://mozilla.github.io/geckoview/'>GeckoView</a> 68 and later. See the <a href='https://firefox-source-docs.mozilla.org/mobile/android/geckoview/consumer/web-extensions.html'>GeckoView Docs</a> for additional details."
               },
               "opera": "mirror",
               "safari": {

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -471,7 +471,8 @@
                 "version_added": "50"
               },
               "firefox_android": {
-                "version_added": "68"
+                "version_added": false,
+                "notes": "Only available to privileged extensions in <a href=\"https://mozilla.github.io/geckoview/\">GeckoView<a> 68 and later. See the <a href=\"https://firefox-source-docs.mozilla.org/mobile/android/geckoview/consumer/web-extensions.html\">GeckoView Docs</a> for additional details."
               },
               "opera": "mirror",
               "safari": {
@@ -1218,7 +1219,8 @@
                 "version_added": "50"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": false,
+                "notes": "Only available to privileged extensions in <a href=\"https://mozilla.github.io/geckoview/\">GeckoView<a> 68 and later. See the <a href=\"https://firefox-source-docs.mozilla.org/mobile/android/geckoview/consumer/web-extensions.html\">GeckoView Docs</a> for additional details."
               },
               "opera": "mirror",
               "safari": {


### PR DESCRIPTION
#### Summary

Add a note to Firefox for Android clarifying that `connectNative` and `sendNativeMessage` are supported, but only in GeckoView.

#### Test results and supporting details

I spoke with Firefox engineers about this issue and they confirmed the currently published information is inaccurate/incomplete. 

Messaging support for GeckoView was introduced in v68.

> Added messaging support for WebExtension. [setMessageDelegate](https://mozilla.github.io/geckoview/javadoc/mozilla-central/org/mozilla/geckoview/WebExtension.html#setMessageDelegate(org.mozilla.geckoview.WebExtension.MessageDelegate,java.lang.String)) allows embedders to listen to messages coming from a WebExtension. [Port](https://mozilla.github.io/geckoview/javadoc/mozilla-central/org/mozilla/geckoview/WebExtension.Port.html) allows bidirectional communication between the embedder and the WebExtension.
> 
> - https://mozilla.github.io/geckoview/javadoc/mozilla-central/org/mozilla/geckoview/doc-files/CHANGELOG#v68

This capability is only exposed to the GeckoView embedder. Firefox for Android does not currenlty have a way to exchange messages with other Android apps. 
