### PR TITLE
Correct Safari data for  window.open() one call per event behavior

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3287,7 +3287,7 @@
                 "version_added": "≤12.1"
               },
               "safari": {
-                "version_added": false
+                "version_added": "11"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

In the `Window.open()` BCD, there is an entry for "One `Window.open()` call per event". In other words, not only do browsers require a user gesture for `Window.open()` calls, they are also limited to one per event handler function by default, unless the user changes the browser settings. Any calls after the first one are blocked.

Safari's support for this was listed as `false`, but this isn't right. You can test this using my [simple test case](https://jsfiddle.net/chrisdavidmills/dry1k0q6/3/).

Historic Safari release notes seem hard to find, but looking at this [SO post](https://stackoverflow.com/questions/46381681/open-multiple-pop-up-windows-in-safari-11), it looks like it was introduced in Safari 11. Note that this page mentions Safari allowing multiple calls per event if you put a `setTimeout()` of more than a second between each one. I tested this as well, and it doesn't seem to be true, so I've not included that information. 

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
