### PR TITLE
Add Safari preview support for date showPicker()

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2139,10 +2139,12 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "impl_url": "https://webkit.org/b/234009"
+                "version_added": "preview"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/261703"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -2173,10 +2175,12 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "impl_url": "https://webkit.org/b/234009"
+                "version_added": "preview"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/261703"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add Safari Tech preview support for input.showPicker() on the date and datetime-local inputs.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

STP 182 docs: https://webkit.org/blog/14764/release-notes-for-safari-technology-preview-182/#:~:text=Added%20support%20for%20the%20showPicker()%20method%20for%20%3Cinput%20type%3D%22date%22%3E.

It says just date but it actually works on both date and datetime-local (I implemented this and verified in tech preview using https://demo.lukewarlow.dev/showPicker/)
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
