### PR TITLE
Updates for Chrome 120 beta

### DIFF
--- a/api/CloseWatcher.json
+++ b/api/CloseWatcher.json
@@ -34,6 +34,7 @@
       },
       "CloseWatcher": {
         "__compat": {
+          "description": "<code>CloseWatcher()</code> constructor",
           "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-closewatcher",
           "support": {
             "chrome": {

--- a/api/CloseWatcher.json
+++ b/api/CloseWatcher.json
@@ -1,0 +1,237 @@
+{
+  "api": {
+    "CloseWatcher": {
+      "__compat": {
+        "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#closewatcher",
+        "support": {
+          "chrome": {
+            "version_added": "120"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "CloseWatcher": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-closewatcher",
+          "support": {
+            "chrome": {
+              "version_added": "120"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "cancel_event": {
+        "__compat": {
+          "description": "<code>cancel</code> event",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#handler-closewatcher-oncancel",
+          "support": {
+            "chrome": {
+              "version_added": "120"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "close": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-closewatcher-close",
+          "support": {
+            "chrome": {
+              "version_added": "120"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "close_event": {
+        "__compat": {
+          "description": "<code>close</code> event",
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#handler-closewatcher-onclose",
+          "support": {
+            "chrome": {
+              "version_added": "120"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "destroy": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-closewatcher-destroy",
+          "support": {
+            "chrome": {
+              "version_added": "120"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "requestClose": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-closewatcher-requestclose",
+          "support": {
+            "chrome": {
+              "version_added": "120"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/GPUSupportedLimits.json
+++ b/api/GPUSupportedLimits.json
@@ -80,6 +80,38 @@
           }
         }
       },
+      "maxBindGroupsPlusVertexBuffers": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "120"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "maxBindingsPerBindGroup": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxbindingsperbindgroup",

--- a/api/GPUSupportedLimits.json
+++ b/api/GPUSupportedLimits.json
@@ -86,7 +86,9 @@
             "chrome": {
               "version_added": "120"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/HTMLDetailsElement.json
+++ b/api/HTMLDetailsElement.json
@@ -35,6 +35,38 @@
           "deprecated": false
         }
       },
+      "name": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "120"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "open": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLDetailsElement/open",

--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -256,6 +256,38 @@
           }
         }
       },
+      "scrollMargin": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "120"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "takeRecords": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IntersectionObserver/takeRecords",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1786,6 +1786,39 @@
           }
         }
       },
+      "login": {
+        "__compat": {
+          "spec_url": "https://fedidcg.github.io/FedCM/#dom-navigator-login",
+          "support": {
+            "chrome": {
+              "version_added": "120"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "maxTouchPoints": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/maxTouchPoints",

--- a/api/NavigatorLogin.json
+++ b/api/NavigatorLogin.json
@@ -10,7 +10,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": null
+            "version_added": false
           },
           "firefox_android": "mirror",
           "ie": {
@@ -20,7 +20,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": null
+            "version_added": false
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",

--- a/api/NavigatorLogin.json
+++ b/api/NavigatorLogin.json
@@ -1,0 +1,70 @@
+{
+  "api": {
+    "NavigatorLogin": {
+      "__compat": {
+        "spec_url": "https://fedidcg.github.io/FedCM/#navigatorlogin",
+        "support": {
+          "chrome": {
+            "version_added": "120"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": null
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": null
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "setStatus": {
+        "__compat": {
+          "spec_url": "https://fedidcg.github.io/FedCM/#dom-navigatorlogin-setstatus",
+          "support": {
+            "chrome": {
+              "version_added": "120"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/URL.json
+++ b/api/URL.json
@@ -136,7 +136,7 @@
           "spec_url": "https://url.spec.whatwg.org/#ref-for-dom-url-canparse",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "120"
             },
             "chrome_android": "mirror",
             "deno": {

--- a/css/properties/mask-clip.json
+++ b/css/properties/mask-clip.json
@@ -6,10 +6,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-clip",
           "spec_url": "https://drafts.fxtf.org/css-masking/#the-mask-clip",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "1"
-            },
+            "chrome": [
+              {
+                "version_added": "120"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/css/properties/mask-composite.json
+++ b/css/properties/mask-composite.json
@@ -7,7 +7,7 @@
           "spec_url": "https://drafts.fxtf.org/css-masking/#the-mask-composite",
           "support": {
             "chrome": {
-              "version_added": false,
+              "version_added": "120",
               "notes": "See also <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-composite'><code>-webkit-mask-composite</code></a> for a similar non-standard property that uses different keywords."
             },
             "chrome_android": "mirror",

--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -6,11 +6,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-image",
           "spec_url": "https://drafts.fxtf.org/css-masking/#the-mask-image",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "1",
-              "notes": "From version 8, Chrome added support for gradient values. Initially, Chrome supported only <code>-webkit-</code> prefixed values for gradients (such as <code>-webkit-linear-gradient()</code>). Later, support for unprefixed values was added."
-            },
+            "chrome": [
+              {
+                "version_added": "120"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1",
+                "notes": "From version 8, Chrome added support for gradient values. Initially, Chrome supported only <code>-webkit-</code> prefixed values for gradients (such as <code>-webkit-linear-gradient()</code>). Later, support for unprefixed values was added."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": [
               {

--- a/css/properties/mask-mode.json
+++ b/css/properties/mask-mode.json
@@ -7,7 +7,7 @@
           "spec_url": "https://drafts.fxtf.org/css-masking/#the-mask-mode",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "120"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -6,10 +6,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-origin",
           "spec_url": "https://drafts.fxtf.org/css-masking/#the-mask-origin",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "1"
-            },
+            "chrome": [
+              {
+                "version_added": "120"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -49,7 +54,7 @@
             "description": "<code>fill-box</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "120"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -126,7 +131,7 @@
             "description": "<code>stroke-box</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "120"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -160,7 +165,7 @@
             "description": "<code>view-box</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "120"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/mask-origin.json
+++ b/css/properties/mask-origin.json
@@ -77,7 +77,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -154,7 +154,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -188,7 +188,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/mask-position.json
+++ b/css/properties/mask-position.json
@@ -6,10 +6,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-position",
           "spec_url": "https://drafts.fxtf.org/css-masking/#the-mask-position",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "1"
-            },
+            "chrome": [
+              {
+                "version_added": "120"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": [
               {

--- a/css/properties/mask-repeat.json
+++ b/css/properties/mask-repeat.json
@@ -6,10 +6,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-repeat",
           "spec_url": "https://drafts.fxtf.org/css-masking/#the-mask-repeat",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "1"
-            },
+            "chrome": [
+              {
+                "version_added": "120"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": [
               {

--- a/css/properties/mask-size.json
+++ b/css/properties/mask-size.json
@@ -6,10 +6,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/mask-size",
           "spec_url": "https://drafts.fxtf.org/css-masking/#the-mask-size",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "4"
-            },
+            "chrome": [
+              {
+                "version_added": "120"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "4"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": [
               {


### PR DESCRIPTION
This PR is an experiment. I've run Open Web Docs' BCD collector against Chrome 120 which reached beta yesterday. We believe that when there are beta versions of browsers available it is a good time to update BCD and ideally we should do so automatically with the help of tooling. So today is the day when such a PR would be created in the cycle. I'm creating this PR manually for the moment, but in the future we hope it can be generated from a workflow.

The collector found 21 new features shipping in Chrome 120:

- api.CredentialsContainer.create.publicKey_option.extensions.minPinLength
- api.GPUSupportedLimits.maxBindGroupsPlusVertexBuffers
- api.HTMLDetailsElement.name
- api.IntersectionObserver.scrollMargin
- api.URL.canParse_static
- css.at-rules.media.scripting
- css.properties.mask-clip
- css.properties.mask-composite
- css.properties.mask-image
- css.properties.mask-mode
- css.properties.mask-origin
- css.properties.mask-origin.fill-box
- css.properties.mask-origin.stroke-box
- css.properties.mask-origin.view-box
- css.properties.mask-position
- css.properties.mask-repeat
- css.properties.mask-size
- css.types.color.light-dark
- css.types.length.lh
- css.types.length.rlh
- html.elements.details.name

We can now compare this list against the blog post that @rachelandrew published and see if we have missed things and why (or if the blog posts missed things :)). https://developer.chrome.com/blog/chrome-120-beta/

Also cc'ing @chrisdavidmills who usually works on Chrome updates. Chris, if this PR would be auto-generated, would that be reviewable for you? What would you improve? Thanks for your input which will be useful for us as we design an automated workflow here. For more information about this project, see: https://github.com/openwebdocs/project/issues/168