### PR TITLE
Skip beta version if not yet released for edge.json

### DIFF
--- a/scripts/update-browser-releases/edge.ts
+++ b/scripts/update-browser-releases/edge.ts
@@ -297,6 +297,7 @@ export const updateEdgeReleases = async (options) => {
       }
     }
   }
+
   //
   // Check that all older releases are 'retired'
   //


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The Edge Stable version is released before the new Edge Beta version. During a few days, there is no Edge Beta version.

#### Test results and supporting details

Manually tested:
![Capture d’écran 2023-11-03 à 08 02 14](https://github.com/mdn/browser-compat-data/assets/1466293/a7bf4bec-83d2-487c-9afd-af3c2bbd8694)


#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
