### PR TITLE
Add non-availability of importmap inside worker thread

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -690,7 +690,7 @@
                   "deprecated": false
                 }
               }
-            },
+            }
           },
           "module": {
             "__compat": {

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -657,7 +657,40 @@
                 "standard_track": true,
                 "deprecated": false
               }
-            }
+            },
+            "worker_support": {
+              "__compat": {
+                "description": "Available in workers",
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": "mirror",
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
           },
           "module": {
             "__compat": {


### PR DESCRIPTION
I saw on https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap that in the compat table the availability in worker threads is not listed, so this adds it.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This should add the "available in worker" threads row in the importmaps compat table. And since they are not yet available all should be "No". To be honest, I am not sure what the `mirror` attributes mean, I just took them from the `__compat` section. Help appreciated.

#### Test results and supporting details

I only tested that the JSON is valid, by copying it into my console, but I am not sure if this is all correct. It looks good, but might be all wrong, help appreciated.