### PR TITLE
Firefox 120: Add notes for `media` support in `<support>` across firefox releases

### DIFF
--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -82,7 +82,7 @@
               "firefox": [
                 {
                   "version_added": "120",
-                  "notes": "<code>media</code> is supported in <code>&lt;source&gt;</code> within <code>&lt;picture&gt;</code>, <code>&lt;audio&gt;</code>, and <code>&lt;video&gt;</code>."
+                  "notes": "Support for <code>media</code> is added back in <code>&lt;source&gt;</code> within <code>&lt;picture&gt;</code>, <code>&lt;audio&gt;</code>, and <code>&lt;video&gt;</code>."
                 },
                 {
                   "version_added": "53",
@@ -90,7 +90,7 @@
                 },
                 {
                   "version_added": "15",
-                  "notes": "Support for <code>media</code> is added back in <code>&lt;source&gt;</code> within <code>&lt;picture&gt;</code>, <code>&lt;audio&gt;</code>, and <code>&lt;video&gt;</code>."
+                  "notes": "<code>media</code> is supported in <code>&lt;source&gt;</code> within <code>&lt;picture&gt;</code>, <code>&lt;audio&gt;</code>, and <code>&lt;video&gt;</code>."
                 }
               ],
               "firefox_android": "mirror",

--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -82,15 +82,15 @@
               "firefox": [
                 {
                   "version_added": "120",
-                  "notes": "`media` is supported in `<source>` within `<picture>`, `<audio>`, and `<video>`."
+                  "notes": "`media` is supported in <code>&lt;source&gt;</code> within <code>&lt;picture&gt;</code>, <code>&lt;audio&gt;</code>, and <code>&lt;video&gt;</code>."
                 },
                 {
                   "version_added": "53",
-                  "notes": "`media` is supported in `<source>` only within `<picture>`."
+                  "notes": "`media` is supported in <code>&lt;source&gt;</code> only within <code>&lt;picture&gt;</code>."
                 },
                 {
                   "version_added": "15",
-                  "notes": "`media` is supported in `<source>` within `<picture>`, `<audio>`, and `<video>`."
+                  "notes": "Support for `media` is added back in <code>&lt;source&gt;</code> within <code>&lt;picture&gt;</code>, <code>&lt;audio&gt;</code>, and <code>&lt;video&gt;</code>."
                 }
               ],
               "firefox_android": "mirror",

--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -79,20 +79,11 @@
               "edge": {
                 "version_added": "12"
               },
-              "firefox": [
-                {
-                  "version_added": "120",
-                  "notes": "Support for <code>media</code> is added back in <code>&lt;source&gt;</code> within <code>&lt;picture&gt;</code>, <code>&lt;audio&gt;</code>, and <code>&lt;video&gt;</code>."
-                },
-                {
-                  "version_added": "53",
-                  "notes": "<code>media</code> is supported in <code>&lt;source&gt;</code> only within <code>&lt;picture&gt;</code>."
-                },
-                {
-                  "version_added": "15",
-                  "notes": "<code>media</code> is supported in <code>&lt;source&gt;</code> within <code>&lt;picture&gt;</code>, <code>&lt;audio&gt;</code>, and <code>&lt;video&gt;</code>."
-                }
-              ],
+              "firefox": {
+                "version_added": "15",
+                "impl_url": "https://bugzil.la/1836128",
+                "notes": "<code>media</code> is supported in <code>&lt;source&gt;</code> within <code>&lt;picture&gt;</code>, <code>&lt;audio&gt;</code>, and <code>&lt;video&gt;</code>. In Firefox 53-119, <code>media</code> is supported only in <code>&lt;source&gt;</code> within <code>&lt;picture&gt;</code>."
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": "9"

--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -82,15 +82,15 @@
               "firefox": [
                 {
                   "version_added": "120",
-                  "notes": "`media` is supported in <code>&lt;source&gt;</code> within <code>&lt;picture&gt;</code>, <code>&lt;audio&gt;</code>, and <code>&lt;video&gt;</code>."
+                  "notes": "<code>media</code> is supported in <code>&lt;source&gt;</code> within <code>&lt;picture&gt;</code>, <code>&lt;audio&gt;</code>, and <code>&lt;video&gt;</code>."
                 },
                 {
                   "version_added": "53",
-                  "notes": "`media` is supported in <code>&lt;source&gt;</code> only within <code>&lt;picture&gt;</code>."
+                  "notes": "<code>media</code> is supported in <code>&lt;source&gt;</code> only within <code>&lt;picture&gt;</code>."
                 },
                 {
                   "version_added": "15",
-                  "notes": "Support for `media` is added back in <code>&lt;source&gt;</code> within <code>&lt;picture&gt;</code>, <code>&lt;audio&gt;</code>, and <code>&lt;video&gt;</code>."
+                  "notes": "Support for <code>media</code> is added back in <code>&lt;source&gt;</code> within <code>&lt;picture&gt;</code>, <code>&lt;audio&gt;</code>, and <code>&lt;video&gt;</code>."
                 }
               ],
               "firefox_android": "mirror",

--- a/html/elements/source.json
+++ b/html/elements/source.json
@@ -79,9 +79,20 @@
               "edge": {
                 "version_added": "12"
               },
-              "firefox": {
-                "version_added": "15"
-              },
+              "firefox": [
+                {
+                  "version_added": "120",
+                  "notes": "`media` is supported in `<source>` within `<picture>`, `<audio>`, and `<video>`."
+                },
+                {
+                  "version_added": "53",
+                  "notes": "`media` is supported in `<source>` only within `<picture>`."
+                },
+                {
+                  "version_added": "15",
+                  "notes": "`media` is supported in `<source>` within `<picture>`, `<audio>`, and `<video>`."
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": "9"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR adds notes to indicate the evolution of support for `media` attribute in `<source>` element:

- `media` was initially supported in Firefox 15.
- In Firefox 53, its support was restricted to `<source>` elements with a `<picture>` parent.
- Now, with Firefox 120, the attribute is supported when `<source>` is a child of either `<audio>`, `<video>`, or `<picture>`, that is back to how it was originally implemented.

#### Related
https://github.com/mdn/browser-compat-data/pull/21083

Doc issue tracker: https://github.com/mdn/content/issues/29788
