### PR TITLE
Introduce namespaced tagging

### DIFF
--- a/api/IdleDetector.json
+++ b/api/IdleDetector.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector",
         "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector",
+        "tags": [
+          "webfeature:idle-detection"
+        ],
         "support": {
           "chrome": {
             "version_added": "94"
@@ -46,6 +49,9 @@
           "description": "<code>IdleDetector()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/IdleDetector",
           "spec_url": "https://wicg.github.io/idle-detection/#dom-idledetector-idledetector",
+          "tags": [
+            "webfeature:idle-detection"
+          ],
           "support": {
             "chrome": {
               "version_added": "94"
@@ -89,6 +95,9 @@
           "description": "<code>change</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/change_event",
           "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector-onchange",
+          "tags": [
+            "webfeature:idle-detection"
+          ],
           "support": {
             "chrome": {
               "version_added": "94"
@@ -132,6 +141,9 @@
           "description": "<code>requestPermission()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/requestPermission_static",
           "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector-requestpermission",
+          "tags": [
+            "webfeature:idle-detection"
+          ],
           "support": {
             "chrome": {
               "version_added": "94"
@@ -174,6 +186,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/screenState",
           "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector-screenstate",
+          "tags": [
+            "webfeature:idle-detection"
+          ],
           "support": {
             "chrome": {
               "version_added": "94"
@@ -216,6 +231,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/start",
           "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector-start",
+          "tags": [
+            "webfeature:idle-detection"
+          ],
           "support": {
             "chrome": {
               "version_added": "94"
@@ -258,6 +276,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/userState",
           "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector-userstate",
+          "tags": [
+            "webfeature:idle-detection"
+          ],
           "support": {
             "chrome": {
               "version_added": "94"

--- a/api/IdleDetector.json
+++ b/api/IdleDetector.json
@@ -5,7 +5,7 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector",
         "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector",
         "tags": [
-          "webfeature:idle-detection"
+          "web-features:idle-detection"
         ],
         "support": {
           "chrome": {
@@ -50,7 +50,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/IdleDetector",
           "spec_url": "https://wicg.github.io/idle-detection/#dom-idledetector-idledetector",
           "tags": [
-            "webfeature:idle-detection"
+            "web-features:idle-detection"
           ],
           "support": {
             "chrome": {
@@ -96,7 +96,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/change_event",
           "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector-onchange",
           "tags": [
-            "webfeature:idle-detection"
+            "web-features:idle-detection"
           ],
           "support": {
             "chrome": {
@@ -142,7 +142,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/requestPermission_static",
           "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector-requestpermission",
           "tags": [
-            "webfeature:idle-detection"
+            "web-features:idle-detection"
           ],
           "support": {
             "chrome": {
@@ -187,7 +187,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/screenState",
           "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector-screenstate",
           "tags": [
-            "webfeature:idle-detection"
+            "web-features:idle-detection"
           ],
           "support": {
             "chrome": {
@@ -232,7 +232,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/start",
           "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector-start",
           "tags": [
-            "webfeature:idle-detection"
+            "web-features:idle-detection"
           ],
           "support": {
             "chrome": {
@@ -277,7 +277,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdleDetector/userState",
           "spec_url": "https://wicg.github.io/idle-detection/#api-idledetector-userstate",
           "tags": [
-            "webfeature:idle-detection"
+            "web-features:idle-detection"
           ],
           "support": {
             "chrome": {

--- a/docs/data-guidelines/index.md
+++ b/docs/data-guidelines/index.md
@@ -5,6 +5,7 @@ This file contains general guidelines that apply to all features added to BCD. F
 
 - [API](./api.md)
 - [Browsers](./browsers.md)
+- [Tagging BCD features](./tags.md)
 
 ## Choosing a version number
 

--- a/docs/data-guidelines/tags.md
+++ b/docs/data-guidelines/tags.md
@@ -6,7 +6,7 @@ The optional `tags` property is an array of strings allowing to assign tags to a
 
 ```json
 "tags": [
-  "webfeature:idle-detection"
+  "web-features:idle-detection"
 ],
 ```
 
@@ -20,46 +20,46 @@ This document governs the list of allowed namespaces in BCD tags.
 
 The currently allowed namespaces are:
 
-- `webfeature`: A namespace to tag features belonging to a web platform feature group as defined by [web-platform-dx/web-features](https://github.com/web-platform-dx/web-features/blob/main/feature-group-definitions/README.md). This is an experimental namespace and it might change in breaking ways. Don't rely on it yet.
+- `web-features`: A namespace to tag features belonging to a web platform feature group as defined by [web-platform-dx/web-features](https://github.com/web-platform-dx/web-features/blob/main/feature-group-definitions/README.md). This is an experimental namespace and it might change in breaking ways. Don't rely on it yet.
 
-### The `webfeature` namespace
+### The `web-features` namespace
 
-The `webfeature` namespace is reserved to tag BCD features that belong to a particular [web platform feature group](https://github.com/web-platform-dx/web-features/blob/main/feature-group-definitions/README.md).
+The `web-features` namespace is reserved to tag BCD features that belong to a particular [web platform feature group](https://github.com/web-platform-dx/web-features/blob/main/feature-group-definitions/README.md).
 
-The [web-platform-dx/web-features](https://github.com/web-platform-dx/web-features) project is importing web platform feature groups using this BCD tag. If you want to create a group of BCD features and don't want it to be exported to the web-platform-dx/web-features project, don't use the `webfeature` namespace.
+The [web-platform-dx/web-features](https://github.com/web-platform-dx/web-features) project is importing web platform feature groups using this BCD tag. If you want to create a group of BCD features and don't want it to be exported to the web-platform-dx/web-features project, don't use the `web-features` namespace.
 
-#### Naming guidelines for `webfeature` tags
+#### Naming guidelines for `web-features` tags
 
-There are a few guidelines for naming `webfeature` groups:
+There are a few guidelines for naming `web-features` groups:
 
 - Prefer identifiers known to be in widespread use by web developers.
   Favor describing things as they are most-widely known, even if it's not the most technically correct option.
 
-  - 👍 Recommended: `webfeature:javascript`
-  - 👎 Not recommended: `webfeature:ecmascript`
+  - 👍 Recommended: `web-features:javascript`
+  - 👎 Not recommended: `web-features:ecmascript`
 
 - Avoid prefixing identifiers that mark a feature as specific to a technology, such as `css-` or `js-`.
   Features can and do cross such boundaries.
 
-  - 👍 Recommended: `webfeature:container-queries`
-  - 👎 Not recommended: `webfeature:css-container-queries`
+  - 👍 Recommended: `web-features:container-queries`
+  - 👎 Not recommended: `web-features:css-container-queries`
 
 - Avoid frequently-used abbreviations and nouns in identifiers, such as `api` or `web`.
 
-  - 👍 Recommended: `webfeature:navigation`
-  - 👎 Not recommended: `webfeature:navigation-api`
+  - 👍 Recommended: `web-features:navigation`
+  - 👎 Not recommended: `web-features:navigation-api`
 
 - Prefer common, descriptive noun phrases over abbreviations, metonymy, and syntax.
 
-  - 👍 Recommended: `webfeature:offscreen-canvas`
-  - 👎 Not recommended: `webfeature:offscreencanvas` (as in `OffscreenCanvas`)
-  - 👍 Recommended: `webfeature:grid`
-  - 👎 Not recommended: `webfeature:display-grid` (as in `display: grid`)
+  - 👍 Recommended: `web-features:offscreen-canvas`
+  - 👎 Not recommended: `web-features:offscreencanvas` (as in `OffscreenCanvas`)
+  - 👍 Recommended: `web-features:grid`
+  - 👎 Not recommended: `web-features:display-grid` (as in `display: grid`)
 
 - Prefer shorter identifiers to longer identifiers, as long as they're unique and unamibguous.
 
-  - 👍 Recommended: `webfeature:has`
-  - 👎 Not recommended: `webfeature:has-pseudo-class`
+  - 👍 Recommended: `web-features:has`
+  - 👎 Not recommended: `web-features:has-pseudo-class`
 
 Feature identifiers may use common suffixes (such as `-api`) to resolve naming conflicts.
 
@@ -69,13 +69,13 @@ In order to comply with these guidelines, BCD provides some tooling to help you 
 
 ### Getting a list of all features with a specific tag
 
-To see all features tagged with `"webfeature:idle-detection"`, you can use BCD's `traverse` script like this:
+To see all features tagged with `"web-features:idle-detection"`, you can use BCD's `traverse` script like this:
 
 ```js
-npm run traverse -- -t webfeature:idle-detection
+npm run traverse -- -t web-features:idle-detection
 ```
 
-This will log all the BCD paths and the total number of features tagged with `"webfeature:idle-detection"`:
+This will log all the BCD paths and the total number of features tagged with `"web-features:idle-detection"`:
 
 ```
 api.IdleDetector

--- a/docs/data-guidelines/tags.md
+++ b/docs/data-guidelines/tags.md
@@ -1,0 +1,94 @@
+# Data guidelines for tagging BCD features
+
+This file contains guidelines that are specific to the `tags` property that can be added optionally to BCD features.
+
+The optional `tags` property is an array of strings allowing to assign tags to any BCD feature. It can look like this:
+
+```json
+"tags": [
+  "webfeature:idle-detection"
+],
+```
+
+Tags are always an array and the items consist of namespaced names. A namespace must be provided (see below). The name (after the colon) can only be lowercase alphanumeric characters (`a`-`z` and `0-9`) plus the `-` character (hyphen or minus sign) as a word separator.
+
+## Tag namespaces
+
+Each tag in the `tags` array must be namespaced. This helps us to understand the purpose of the tag, lets us validate tags more easily, run linting, and perform mass-changes to all tags that belong to a namespace.
+
+This document governs the list of allowed namespaces in BCD tags.
+
+The currently allowed namespaces are:
+
+- `webfeature`: A namespace to tag features belonging to a web platform feature group as defined by [web-platform-dx/web-features](https://github.com/web-platform-dx/web-features/blob/main/feature-group-definitions/README.md). This is an experimental namespace and it might change in breaking ways. Don't rely on it yet.
+
+### The `webfeature` namespace
+
+The `webfeature` namespace is reserved to tag BCD features that belong to a particular [web platform feature group](https://github.com/web-platform-dx/web-features/blob/main/feature-group-definitions/README.md).
+
+The [web-platform-dx/web-features](https://github.com/web-platform-dx/web-features) project is importing web platform feature groups using this BCD tag. If you want to create a group of BCD features and don't want it to be exported to the web-platform-dx/web-features project, don't use the `webfeature` namespace.
+
+#### Naming guidelines for `webfeature` tags
+
+There are a few guidelines for naming `webfeature` groups:
+
+- Prefer identifiers to known to be in widespread use by web developers.
+  Favor describing things as they are most-widely known, even if it's not the most technically correct option.
+
+  - 👍 Recommended: `webfeature:javascript`
+  - 👎 Not recommended: `webfeature:ecmascript`
+
+- Avoid prefixing identifiers that mark a feature as specific to a technology, such as `css-` or `js-`.
+  Features can and do cross such boundaries.
+
+  - 👍 Recommended: `webfeature:container-queries`
+  - 👎 Not recommended: `webfeature:css-container-queries`
+
+- Avoid frequently-used abbreviations and nouns in identifiers, such as `api` or `web`.
+
+  - 👍 Recommended: `webfeature:navigation`
+  - 👎 Not recommended: `webfeature:navigation-api`
+
+- Prefer common, descriptive noun phrases over abbreviations, metonymy, and syntax.
+
+  - 👍 Recommended: `webfeature:offscreen-canvas`
+  - 👎 Not recommended: `webfeature:offscreencanvas` (as in `OffscreenCanvas`)
+  - 👍 Recommended: `webfeature:grid`
+  - 👎 Not recommended: `webfeature:display-grid` (as in `display: grid`)
+
+- Prefer shorter identifiers to longer identifiers, as long as they're unique and unamibguous.
+
+  - 👍 Recommended: `webfeature:has`
+  - 👎 Not recommended: `webfeature:has-pseudo-class`
+
+Feature identifiers may use common suffixes (such as `-api`) to resolve naming conflicts.
+
+## Working with tags
+
+In order to comply with these guidelines, BCD provides some tooling to help you work with tags.
+
+### Getting a list of all features with a specific tag
+
+To see all features tagged with `"webfeature:idle-detection"`, you can use BCD's `traverse` script like this:
+
+```js
+npm run traverse -- -t webfeature:idle-detection
+```
+
+This will log all the BCD paths and the total number of features tagged with `"webfeature:idle-detection"`:
+
+```
+api.IdleDetector
+api.IdleDetector.IdleDetector
+api.IdleDetector.change_event
+api.IdleDetector.requestPermission_static
+api.IdleDetector.screenState
+api.IdleDetector.start
+api.IdleDetector.userState
+http.headers.Permissions-Policy.idle-detection
+8
+```
+
+### Bulk editing tags
+
+Currently, BCD doesn't provide a command line tool to bulk update tags. We will provide such a tool soon.

--- a/docs/data-guidelines/tags.md
+++ b/docs/data-guidelines/tags.md
@@ -10,7 +10,7 @@ The optional `tags` property is an array of strings allowing to assign tags to a
 ],
 ```
 
-Tags are always an array and the items consist of namespaced names. A namespace must be provided (see below). The name (after the colon) can only be lowercase alphanumeric characters (`a`-`z` and `0-9`) plus the `-` character (hyphen or minus sign) as a word separator.
+Tags are always an array and the items consist of namespaced names. A namespace must be provided (see below). The name (after the colon) can only be lowercase alphanumeric characters (`a-z` and `0-9`) plus the `-` character (hyphen or minus sign) as a word separator.
 
 ## Tag namespaces
 
@@ -32,7 +32,7 @@ The [web-platform-dx/web-features](https://github.com/web-platform-dx/web-featur
 
 There are a few guidelines for naming `webfeature` groups:
 
-- Prefer identifiers to known to be in widespread use by web developers.
+- Prefer identifiers known to be in widespread use by web developers.
   Favor describing things as they are most-widely known, even if it's not the most technically correct option.
 
   - 👍 Recommended: `webfeature:javascript`

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -798,7 +798,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/idle-detection",
             "spec_url": "https://wicg.github.io/idle-detection/#api-permissions-policy",
             "tags": [
-              "webfeature:idle-detection"
+              "web-features:idle-detection"
             ],
             "support": {
               "chrome": {

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -797,6 +797,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/idle-detection",
             "spec_url": "https://wicg.github.io/idle-detection/#api-permissions-policy",
+            "tags": [
+              "webfeature:idle-detection"
+            ],
             "support": {
               "chrome": {
                 "version_added": "94"

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -174,7 +174,7 @@ The `__compat` object consists of the following:
 - An optional `tags` property which is an array of strings allowing to assign tags to the feature.
   Each tag in the array must be namespaced. The currently allowed namespaces are:
 
-  - `webfeatures`: A namespace to tag features belonging to a web platform feature group as defined by [web-platform-dx/web-features](https://github.com/web-platform-dx/web-features/blob/main/feature-group-definitions/README.md).
+  - `web-features`: A namespace to tag features belonging to a web platform feature group as defined by [web-platform-dx/web-features](https://github.com/web-platform-dx/web-features/blob/main/feature-group-definitions/README.md).
 
   For more information, see the [tagging data guidelines](/docs/data-guidelines/tags.md).
 

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -171,6 +171,13 @@ The `__compat` object consists of the following:
   Each URL must either contain a fragment identifier (e.g. `https://tc39.es/proposal-promise-allSettled/#sec-promise.allsettled`), or else must match the regular-expression pattern `^https://registry.khronos.org/webgl/extensions/[^/]+/` (e.g. `https://registry.khronos.org/webgl/extensions/ANGLE_instanced_arrays/`).
   Each URL must link to a specification published by a standards body or a formal proposal that may lead to such publication.
 
+- An optional `tags` property which is an array of strings allowing to assign tags to the feature.
+  Each tag in the array must be namespaced. The currently allowed namespaces are:
+
+  - `webfeatures`: A namespace to tag features belonging to a web platform feature group as defined by [web-platform-dx/web-features](https://github.com/web-platform-dx/web-features/blob/main/feature-group-definitions/README.md).
+
+  For more information, see the [tagging data guidelines](/docs/data-guidelines/tags.md).
+
 #### Browser identifiers
 
 The currently accepted browser identifiers should be declared in alphabetical order:

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -225,6 +225,12 @@
           "description": "An optional URL or array of URLs, each of which is for a specific part of a specification in which this feature is defined. Each URL must contain a fragment identifier.",
           "tsType": "string | string[]"
         },
+        "tags": {
+          "description": "An optional array of strings allowing to assign tags to the feature.",
+          "type": "array",
+          "minItems": 1,
+          "tsType": "string[]"
+        },
         "source_file": {
           "type": "string",
           "description": "The path to the file that defines this feature in browser-compat-data, relative to the repository root. Useful for guiding potential contributors towards the correct file to edit. This is automatically generated at build time and should never manually be specified."

--- a/scripts/lib/stringify-and-order-properties.ts
+++ b/scripts/lib/stringify-and-order-properties.ts
@@ -36,7 +36,7 @@ const propOrder = {
       'description',
       'mdn_url',
       'spec_url',
-      'matches',
+      'tags',
       'support',
       'status',
     ],

--- a/scripts/traverse.ts
+++ b/scripts/traverse.ts
@@ -230,8 +230,8 @@ if (esMain(import.meta)) {
           'Find all features in Samsung Internet that mirror data from Chrome Android',
         )
         .example(
-          'npm run traverse -- -t webfeatures:idle-detection',
-          'Find all features tagged with webfeatures:idle-detection.',
+          'npm run traverse -- -t web-features:idle-detection',
+          'Find all features tagged with web-features:idle-detection.',
         );
     },
   );

--- a/scripts/traverse.ts
+++ b/scripts/traverse.ts
@@ -14,6 +14,7 @@ import bcd from '../index.js';
  * @param {BrowserName[]} browsers The browsers to test for
  * @param {string[]} values The values to test for
  * @param {number} depth The depth to traverse
+ * @param {string} tag The tag to filter results with
  * @param {string} identifier The identifier of the current object
  * @yields {string} The feature identifier
  */
@@ -22,6 +23,7 @@ function* iterateFeatures(
   browsers: BrowserName[],
   values: string[],
   depth: number,
+  tag: string,
   identifier: string,
 ): IterableIterator<string> {
   depth--;
@@ -29,45 +31,52 @@ function* iterateFeatures(
     for (const i in obj) {
       if (!!obj[i] && typeof obj[i] == 'object' && i !== '__compat') {
         if (obj[i].__compat) {
-          const comp = obj[i].__compat.support;
-          for (const browser of browsers) {
-            let browserData = comp[browser];
-
-            if (!browserData) {
-              if (values.length == 0 || values.includes('null')) {
-                yield `${identifier}${i}`;
-              }
-              continue;
+          if (tag) {
+            const tags = obj[i].__compat.tags;
+            if (tags && tags.includes(tag)) {
+              yield `${identifier}${i}`;
             }
-            if (!Array.isArray(browserData)) {
-              browserData = [browserData];
-            }
+          } else {
+            const comp = obj[i].__compat.support;
+            for (const browser of browsers) {
+              let browserData = comp[browser];
 
-            for (const range in browserData) {
-              if (browserData[range] === 'mirror') {
-                if (values.includes('mirror')) {
-                  yield `${identifier}${i}`;
-                }
-              } else if (values.includes('nonmirror')) {
-                // If checking for non-mirrored data and it's not mirrored
-                yield `${identifier}${i}`;
-              } else if (browserData[range] === undefined) {
+              if (!browserData) {
                 if (values.length == 0 || values.includes('null')) {
                   yield `${identifier}${i}`;
                 }
-              } else if (
-                values.length == 0 ||
-                values.includes(String(browserData[range].version_added)) ||
-                values.includes(String(browserData[range].version_removed))
-              ) {
-                let f = `${identifier}${i}`;
-                if (browserData[range].prefix) {
-                  f += ` (${browserData[range].prefix} prefix)`;
+                continue;
+              }
+              if (!Array.isArray(browserData)) {
+                browserData = [browserData];
+              }
+
+              for (const range in browserData) {
+                if (browserData[range] === 'mirror') {
+                  if (values.includes('mirror')) {
+                    yield `${identifier}${i}`;
+                  }
+                } else if (values.includes('nonmirror')) {
+                  // If checking for non-mirrored data and it's not mirrored
+                  yield `${identifier}${i}`;
+                } else if (browserData[range] === undefined) {
+                  if (values.length == 0 || values.includes('null')) {
+                    yield `${identifier}${i}`;
+                  }
+                } else if (
+                  values.length == 0 ||
+                  values.includes(String(browserData[range].version_added)) ||
+                  values.includes(String(browserData[range].version_removed))
+                ) {
+                  let f = `${identifier}${i}`;
+                  if (browserData[range].prefix) {
+                    f += ` (${browserData[range].prefix} prefix)`;
+                  }
+                  if (browserData[range].alternative_name) {
+                    f += ` (as ${browserData[range].alternative_name})`;
+                  }
+                  yield f;
                 }
-                if (browserData[range].alternative_name) {
-                  f += ` (as ${browserData[range].alternative_name})`;
-                }
-                yield f;
               }
             }
           }
@@ -77,6 +86,7 @@ function* iterateFeatures(
           browsers,
           values,
           depth,
+          tag,
           identifier + i + '.',
         );
       }
@@ -90,6 +100,7 @@ function* iterateFeatures(
  * @param {string[]} browsers The browsers to traverse for
  * @param {string[]} values The version values to traverse for
  * @param {number} depth The depth to traverse
+ * @param {string} tag The tag to filter results with
  * @param {string} identifier The identifier of the current object
  * @returns {string[]} An array of the features
  */
@@ -98,10 +109,11 @@ const traverseFeatures = (
   browsers: BrowserName[],
   values: string[],
   depth: number,
+  tag: string,
   identifier: string,
 ): string[] => {
   const features = Array.from(
-    iterateFeatures(obj, browsers, values, depth, identifier),
+    iterateFeatures(obj, browsers, values, depth, tag, identifier),
   );
 
   return features.filter((item, pos) => features.indexOf(item) == pos);
@@ -113,6 +125,7 @@ const traverseFeatures = (
  * @param {BrowserName[]} browsers The browsers to traverse for
  * @param {string[]} values The version values to traverse for
  * @param {number} depth The depth to traverse
+ * @param {string} tag The tag to filter results with
  * @returns {string[]} The list of features
  */
 const main = (
@@ -130,6 +143,7 @@ const main = (
   browsers: BrowserName[] = Object.keys(bcd.browsers) as BrowserName[],
   values = ['null', 'true'],
   depth = 100,
+  tag = '',
 ): string[] => {
   const features: string[] = [];
 
@@ -140,6 +154,7 @@ const main = (
         browsers,
         values,
         depth,
+        tag,
         folders[folder] + '.',
       ),
     );
@@ -176,6 +191,13 @@ if (esMain(import.meta)) {
           nargs: 1,
           default: [],
         })
+        .option('tag', {
+          alias: 't',
+          describe: 'Filter by tag value.',
+          type: 'string',
+          nargs: 1,
+          default: '',
+        })
         .option('non-real', {
           alias: 'n',
           describe:
@@ -206,13 +228,23 @@ if (esMain(import.meta)) {
         .example(
           'npm run traverse -- -b samsunginternet_android -f mirror',
           'Find all features in Samsung Internet that mirror data from Chrome Android',
+        )
+        .example(
+          'npm run traverse -- -t webfeatures:idle-detection',
+          'Find all features tagged with webfeatures:idle-detection.',
         );
     },
   );
 
   const filter = [...argv.filter, ...(argv.nonReal ? ['true', 'null'] : [])];
 
-  const features = main(argv.folder, argv.browser, filter, argv.depth);
+  const features = main(
+    argv.folder,
+    argv.browser,
+    filter,
+    argv.depth,
+    argv.tag,
+  );
   console.log(features.join('\n'));
   console.log(features.length);
 }

--- a/test/linter/index.ts
+++ b/test/linter/index.ts
@@ -18,6 +18,7 @@ import testSchema from './test-schema.js';
 import testSpecURLs from './test-spec-urls.js';
 import testStatus from './test-status.js';
 import testStyle from './test-style.js';
+import testTags from './test-tags.js';
 import testVersions from './test-versions.js';
 
 export default new Linters([
@@ -36,5 +37,6 @@ export default new Linters([
   testSpecURLs,
   testStatus,
   testStyle,
+  testTags,
   testVersions,
 ]);

--- a/test/linter/test-tags.ts
+++ b/test/linter/test-tags.ts
@@ -1,0 +1,51 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import chalk from 'chalk-template';
+
+import { Linter, Logger, LinterData } from '../utils.js';
+import { CompatStatement } from '../../types/types.js';
+
+const allowedNamespaces = ['webfeature'];
+
+/**
+ * Process the data for spec URL errors
+ * @param {CompatStatement} data The data to test
+ * @param {Logger} logger The logger to output errors to
+ */
+const processData = (data: CompatStatement, logger: Logger): void => {
+  if (!data.tags) {
+    return;
+  }
+
+  for (const tag of data.tags) {
+    if (
+      !allowedNamespaces.some(
+        (namespace) =>
+          tag.startsWith(namespace + ':') &&
+          tag.split(':')[1].match(/^[a-z0-9-]*$/),
+      )
+    ) {
+      logger.error(
+        chalk`Invalid tag found: {bold ${tag}}. Check if:
+         - tag tag has a namespace
+         - the tag uses one of the allowed namespaces: {bold ${allowedNamespaces}}
+         - the tag name (after the namespace) uses only lowercase alphanumeric characters (a-z and 0-9) plus the - character (hyphen or minus sign)`,
+      );
+    }
+  }
+};
+
+export default {
+  name: 'Tags',
+  description: 'Ensure tags meet requirements like allowed namespaces.',
+  scope: 'feature',
+  /**
+   * Test the data
+   * @param {Logger} logger The logger to output errors to
+   * @param {LinterData} root The data to test
+   */
+  check: (logger: Logger, { data }: LinterData) => {
+    processData(data, logger);
+  },
+} as Linter;

--- a/test/linter/test-tags.ts
+++ b/test/linter/test-tags.ts
@@ -6,7 +6,7 @@ import chalk from 'chalk-template';
 import { Linter, Logger, LinterData } from '../utils.js';
 import { CompatStatement } from '../../types/types.js';
 
-const allowedNamespaces = ['webfeature'];
+const allowedNamespaces = ['web-features'];
 
 /**
  * Process the data for spec URL errors


### PR DESCRIPTION
#### Summary

This PR follows the experiment done in https://github.com/mdn/browser-compat-data/pull/21081 and introduces namespaced tags to BCD.

I've added: 
- Example tags ("web-features:idle-detection") to IdleDetector and its permission policy
- New data guideline documentation. Shamelessly stolen from @ddbeck (see https://github.com/web-platform-dx/web-features/blob/main/docs/readme.md). I think this is a good start, happy to add more.
- An addition to the compat schema and its docs (`tags` is a new schema property).
- An update to validating order (`tags` will always need to be provided at the top after `spec_urls`)
- An update to the traverse script to get lists of features that have been tagged with a specific tag. (so you can run `npm run traverse -- -t web-features:idle-detection`).
- A new tagging linter that checks if you provided a namespace with your tag, if it is one of the allowed ones and if the name of tag is only using `[a-z0-9-]`.

#### Test results and supporting details

As discussed with Daniel and in the recent BCD calls.

#### Related issues and PRs

Part of https://github.com/openwebdocs/project/issues/169