### PR TITLE
Update Safari data for VideoTrack API

### DIFF
--- a/api/VideoTrack.json
+++ b/api/VideoTrack.json
@@ -50,7 +50,8 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "7"
+            "version_added": "7",
+            "version_removed": "17"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -112,7 +113,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "7",
+              "version_removed": "17"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -175,7 +177,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "7",
+              "version_removed": "17"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -238,7 +241,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "7",
+              "version_removed": "17"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -301,7 +305,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "7",
+              "version_removed": "17"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -364,7 +369,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "7",
+              "version_removed": "17"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -420,10 +426,12 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "7",
+              "version_removed": "17"
             },
             "safari_ios": {
               "version_added": "13",
+              "version_removed": "17",
               "partial_implementation": true,
               "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `VideoTrack` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.3.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/VideoTrack
