### PR TITLE
relnote(120): Mark prefixed transition and transform props as removed in Nightly

### DIFF
--- a/css/properties/backface-visibility.json
+++ b/css/properties/backface-visibility.json
@@ -35,7 +35,8 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "10"
+                "version_added": "10",
+                "version_removed": "preview"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/perspective-origin.json
+++ b/css/properties/perspective-origin.json
@@ -35,7 +35,8 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "10"
+                "version_added": "10",
+                "version_removed": "preview"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/perspective.json
+++ b/css/properties/perspective.json
@@ -35,7 +35,8 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "10"
+                "version_added": "10",
+                "version_removed": "preview"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -35,7 +35,8 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "3.5"
+                "version_added": "3.5",
+                "version_removed": "preview"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/transform-style.json
+++ b/css/properties/transform-style.json
@@ -35,7 +35,8 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "10"
+                "version_added": "10",
+                "version_removed": "preview"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -35,6 +35,11 @@
               {
                 "prefix": "-webkit-",
                 "version_added": "49"
+              },
+              {
+                "prefix": "-moz-",
+                "version_added": "≤40",
+                "version_removed": "preview"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/transition-delay.json
+++ b/css/properties/transition-delay.json
@@ -35,7 +35,8 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "4"
+                "version_added": "4",
+                "version_removed": "preview"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/transition-duration.json
+++ b/css/properties/transition-duration.json
@@ -35,7 +35,8 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "4"
+                "version_added": "4",
+                "version_removed": "preview"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -35,7 +35,8 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "4"
+                "version_added": "4",
+                "version_removed": "preview"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -35,7 +35,8 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "4"
+                "version_added": "4",
+                "version_removed": "preview"
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -40,7 +40,8 @@
               },
               {
                 "prefix": "-moz-",
-                "version_added": "4"
+                "version_added": "4",
+                "version_removed": "preview"
               }
             ],
             "firefox_android": "mirror",


### PR DESCRIPTION
All of these vendor-prefixed props are removed in Nightly 120:

- `-moz-backface-visibility`
- `-moz-perspective-origin`
- `-moz-perspective`
- `-moz-transform-origin`
- `-moz-transform-style`
- `-moz-transform`
- `-moz-transition-delay`
- `-moz-transition-duration`
- `-moz-transition-property`
- `-moz-transition-timing-function`
- `-moz-transition`

See https://github.com/mdn/content/issues/29785