### PR TITLE
Chrome added HTTP Digest SHA-256 in v117

### DIFF
--- a/http/headers/WWW-Authenticate.json
+++ b/http/headers/WWW-Authenticate.json
@@ -126,7 +126,7 @@
               "description": "SHA2-256 digest authentication",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": 117
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",

--- a/http/headers/WWW-Authenticate.json
+++ b/http/headers/WWW-Authenticate.json
@@ -126,7 +126,7 @@
               "description": "SHA2-256 digest authentication",
               "support": {
                 "chrome": {
-                  "version_added": 117
+                  "version_added": "117"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",


### PR DESCRIPTION
#### Summary

Add HTTP Digest SHA256 for Chrome v117

#### Test results and supporting details

https://chromestatus.com/feature/5139896267702272?context=myfeatures

#### Related issues

None