### PR TITLE
Add missing `aria[Col/Row]IndexText` features for Element[Internals] API

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -1068,6 +1068,7 @@
       },
       "ariaColIndexText": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaColIndexText",
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariacolindextext",
           "support": {
             "chrome": {
@@ -2180,6 +2181,7 @@
       },
       "ariaRowIndexText": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaRowIndexText",
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariarowindextext",
           "support": {
             "chrome": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -1066,6 +1066,39 @@
           }
         }
       },
+      "ariaColIndexText": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariacolindextext",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "119"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "ariaColSpan": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/ariaColSpan",
@@ -2140,6 +2173,39 @@
           },
           "status": {
             "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ariaRowIndexText": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariarowindextext",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "119"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -273,6 +273,7 @@
       },
       "ariaColIndexText": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaColIndexText",
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariacolindextext",
           "support": {
             "chrome": {
@@ -1385,6 +1386,7 @@
       },
       "ariaRowIndexText": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaRowIndexText",
           "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariarowindextext",
           "support": {
             "chrome": {

--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -271,6 +271,39 @@
           }
         }
       },
+      "ariaColIndexText": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariacolindextext",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "119"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "ariaColSpan": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ElementInternals/ariaColSpan",
@@ -1345,6 +1378,39 @@
           },
           "status": {
             "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "ariaRowIndexText": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/aria/#dom-ariamixin-ariarowindextext",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "119"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing `ariaColIndexText` and `ariaRowIndexText` features of the `Element` and `ElementInternals` APIs. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.3.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used:
https://mdn-bcd-collector.gooborg.com/tests/api/Element/ariaColIndexText
https://mdn-bcd-collector.gooborg.com/tests/api/Element/ariaRowIndexText
https://mdn-bcd-collector.gooborg.com/tests/api/ElementInternals/ariaColIndexText
https://mdn-bcd-collector.gooborg.com/tests/api/Element/ariaRowIndexText