### PR TITLE
Add nodejs 21.0.0 release

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -467,6 +467,13 @@
           "status": "retired",
           "engine": "V8",
           "engine_version": "11.3"
+        },
+        "21.0.0": {
+          "release_date": "2023-10-17",
+          "release_notes": "https://nodejs.org/en/blog/release/v21.0.0",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "11.8"
         }
       }
     }


### PR DESCRIPTION
New nodejs release.

Needed for https://github.com/mdn/browser-compat-data/pull/20949 to pass.