### PR TITLE
Support details for webRequestAuthProvider permission

### DIFF
--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -1076,7 +1076,7 @@
             "support": {
               "chrome": {
                 "version_added": true,
-                "notes": "In Manifest V3, no longer available for most extensions (the exception being policy-installed extensions). However, as of Chrome 108, can be used with \"webRequestAuthProvider\" permissions to ehable the supply of credentials asynchronously."
+                "notes": "In Manifest V3, no longer available for most extensions (the exception being policy-installed extensions)."
               },
               "edge": {
                 "version_added": "14"

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -1059,7 +1059,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": false,
-                "notes": "Support planned, see <a href='https://bugzil.la/1820569'>bug 1820569</a>."
+                "impl_url": "https://bugzil.la/1820569"
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -1076,7 +1076,7 @@
             "support": {
               "chrome": {
                 "version_added": true,
-                "notes": "In Manifest V3, no longer available for most extensions (the exception being policy-installed extensions). Use the declarativeNetRequest API instead."
+                "notes": "In Manifest V3, no longer available for most extensions (the exception being policy-installed extensions). Use the <code>declarativeNetRequest</code> API instead."
               },
               "edge": {
                 "version_added": "14"

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -1076,7 +1076,7 @@
             "support": {
               "chrome": {
                 "version_added": true,
-                "notes": "In Manifest V3, no longer available for most extensions (the exception being policy-installed extensions)."
+                "notes": "In Manifest V3, no longer available for most extensions (the exception being policy-installed extensions). Use the declarativeNetRequest API instead."
               },
               "edge": {
                 "version_added": "14"

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -1049,12 +1049,34 @@
             }
           }
         },
+        "webRequestAuthProvider": {
+          "__compat": {
+            "description": "<code>webRequestAuthProvider</code>",
+            "support": {
+              "chrome": {
+                "version_added": "108"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "notes": "Support planned, see <a href='https://bugzil.la/1820569'>bug 1820569</a>."
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "webRequestBlocking": {
           "__compat": {
             "description": "<code>webRequestBlocking</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": true,
+                "notes": "In Manifest V3, no longer available for most extensions (the exception being policy-installed extensions). However, as of Chrome 108, can be used with \"webRequestAuthProvider\" permissions to ehable the supply of credentials asynchronously."
               },
               "edge": {
                 "version_added": "14"


### PR DESCRIPTION
### Description

- Adds the webRequestAuthProvider permission to the permissions manifest key.
- Add a note about support for webRequestBlocking permission in Chrome

### Motivation

Provide documentation for the Chrome permission.

### Related issues and pull requests

Related content update in https://github.com/mdn/content/pull/30188
Fixes [#21586](https://github.com/mdn/content/issues/21586)
