### PR TITLE
Add CSS Scrollbars support in Chrome 121

### DIFF
--- a/css/properties/scrollbar-color.json
+++ b/css/properties/scrollbar-color.json
@@ -7,15 +7,7 @@
           "spec_url": "https://drafts.csswg.org/css-scrollbars/#scrollbar-color",
           "support": {
             "chrome": {
-              "version_added": "118",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ],
-              "impl_url": "https://crbug.com/891944"
+              "version_added": "121"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -35,7 +27,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,

--- a/css/properties/scrollbar-width.json
+++ b/css/properties/scrollbar-width.json
@@ -7,14 +7,7 @@
           "spec_url": "https://drafts.csswg.org/css-scrollbars/#scrollbar-width",
           "support": {
             "chrome": {
-              "version_added": "115",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": "121"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -34,7 +27,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": false
+            }
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Mark `scrollbar-width` and `scrollbar-color` as supported in Chrome 121.

But not Android WebView

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Chrome Status Entry: https://chromestatus.com/feature/5665308343795712

This is explicitly not enabled on Android WebView.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
