### PR TITLE
webNavigation.TransitionType updates

### DIFF
--- a/webextensions/api/webNavigation.json
+++ b/webextensions/api/webNavigation.json
@@ -69,7 +69,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "49"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -127,7 +127,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "49"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -146,7 +146,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "49"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -261,7 +261,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "49"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",


### PR DESCRIPTION
#### Summary

Add details about the addition of support for` typed`, `generated`, `keyword`,  and `auto_bookmark` in Firefox, 49 as part of [Bug 1263723](https://bugzilla.mozilla.org/show_bug.cgi?id=1263723) WebNavigation API should keep track of the user interaction with the urlbar and set transition types and qualifiers accordingly.

#### Related issues

Fixes #9019
