### PR TITLE
Remove 404 indeterminate MDN link from HTMLInputElement

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -884,7 +884,6 @@
       },
       "indeterminate": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement/indeterminate",
           "spec_url": "https://html.spec.whatwg.org/multipage/input.html#dom-input-indeterminate",
           "support": {
             "chrome": {


### PR DESCRIPTION
This leads to a broken link in https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement#browser_compatibility which I tried to follow.