### PR TITLE
Update Safari version 17.1 (current) and 17.2 (beta)

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -272,15 +272,21 @@
         "17": {
           "release_date": "2023-09-26",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
-          "engine_version": "616"
+          "engine_version": "616.1.27"
         },
         "17.1": {
+          "release_date": "2023-10-25",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17_1-release-notes",
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "616.2.9"
+        },
+        "17.2":  {
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17_2-release-notes",
           "status": "beta",
           "engine": "WebKit"
-        }
       }
     }
   }

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -283,7 +283,7 @@
           "engine": "WebKit",
           "engine_version": "616.2.9"
         },
-        "17.2":  {
+        "17.2": {
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17_2-release-notes",
           "status": "beta",
           "engine": "WebKit"

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -287,6 +287,7 @@
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17_2-release-notes",
           "status": "beta",
           "engine": "WebKit"
+        }
       }
     }
   }


### PR DESCRIPTION
Manually updated.

@jensimmons:
Is there a way to find the engine version without looking at Safari's "About" Window? And the release date I see in the [About the security content of Safari 17.1](https://support.apple.com/en-US/HT213986). Unfortunately, I can't "guess" this URL to extract the release date (not in the easy-to-guess release note page).

If we can have these two pieces of data (even on web pages that we could scrap), we could automate the creation of this PR! (Like we did for Firefox, Chrome, and Edge)