### PR TITLE
Add Samsung 23.0

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -267,7 +267,7 @@
         },
         "22.0": {
           "release_date": "2023-07-14",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "111"
         },

--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -270,6 +270,12 @@
           "status": "current",
           "engine": "Blink",
           "engine_version": "111"
+        },
+        "23.0": {
+          "release_date": "2023-10-18",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "115"
         }
       }
     }


### PR DESCRIPTION
@matatk told me earlier today that Samsung 23.0 is stable!

It's based on Chromium 115 per https://medium.com/samsung-internet-dev/samsung-internet-v23-0-stable-coming-with-enhanced-security-and-convenience-1839a1af5dd3

I took the release date from Wikipedia: https://en.wikipedia.org/wiki/Samsung_Internet#Version_history