### PR TITLE
Add constructor to WebKitPoint

### DIFF
--- a/api/WebKitPoint.json
+++ b/api/WebKitPoint.json
@@ -39,6 +39,46 @@
           "deprecated": true
         }
       },
+      "WebKitPoint": {
+        "__compat": {
+          "description": "<code>WebKitPoint()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": "2",
+              "version_removed": "39"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "12",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": "2",
+              "version_removed": "39"
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
+          }
+        }
+      },
       "x": {
         "__compat": {
           "support": {


### PR DESCRIPTION
Gone everywhere except WebKit.
WebKit proof: https://github.com/WebKit/WebKit/blob/main/Source/WebCore/page/WebKitPoint.idl

Found by Open Web Docs' [mdn-bcd-collector](https://github.com/openwebdocs/mdn-bcd-collector) 10.4.0.