### PR TITLE
Mark `color-scheme: only` supported since Chrome 98

### DIFF
--- a/css/properties/color-scheme.json
+++ b/css/properties/color-scheme.json
@@ -71,10 +71,15 @@
           "__compat": {
             "description": "<code>only light</code> keyword",
             "support": {
-              "chrome": {
-                "version_added": "81",
-                "version_removed": "85"
-              },
+              "chrome": [
+                {
+                  "version_added": "98"
+                },
+                {
+                  "version_added": "81",
+                  "version_removed": "85"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/css/properties/color-scheme.json
+++ b/css/properties/color-scheme.json
@@ -38,9 +38,15 @@
           "__compat": {
             "description": "<code>only dark</code> keyword",
             "support": {
-              "chrome": {
-                "version_added": "81"
-              },
+              "chrome": [
+                {
+                  "version_added": "98"
+                },
+                {
+                  "version_added": "81",
+                  "version_removed": "85"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
Support for the `only` keyword was shipped in Chrome 98:
https://chromiumdash.appspot.com/commit/3ef68395dfbc9df94714ddddd838e4e70866e599