### PR TITLE
Support for the name attribute for details is in Safari 17.2

### DIFF
--- a/html/elements/details.json
+++ b/html/elements/details.json
@@ -59,7 +59,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
+                "version_added": "17.2",
                 "impl_url": "https://webkit.org/b/262187"
               },
               "safari_ios": "mirror",


### PR DESCRIPTION
> HTML
> New Features
> Added support for the name attribute in the `<details>` element. (114677170)

https://developer.apple.com/documentation/safari-release-notes/safari-17_2-release-notes

