### PR TITLE
Chrome 111 also support "of" syntax in `:nth-last-child`

### DIFF
--- a/css/selectors/nth-last-child.json
+++ b/css/selectors/nth-last-child.json
@@ -81,8 +81,7 @@
             "description": "<code>of &lt;selector&gt;</code> syntax",
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/304163"
+                "version_added": "111"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This was missed in https://github.com/mdn/browser-compat-data/pull/18852.