### PR TITLE
Add Set.keys properly

### DIFF
--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -743,6 +743,48 @@
             }
           }
         },
+        "keys": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/keys",
+            "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.keys",
+            "support": {
+              "chrome": {
+                "version_added": "38"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.0"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "24"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "0.12.0"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "8"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "size": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/size",
@@ -887,68 +929,32 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/values",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.values",
             "support": {
-              "chrome": [
-                {
-                  "version_added": "38"
-                },
-                {
-                  "alternative_name": "keys",
-                  "version_added": "38"
-                }
-              ],
+              "chrome": {
+                "version_added": "38"
+              },
               "chrome_android": "mirror",
-              "deno": [
-                {
-                  "version_added": "1.0"
-                },
-                {
-                  "alternative_name": "keys",
-                  "version_added": "1.0"
-                }
-              ],
-              "edge": [
-                {
-                  "version_added": "12"
-                },
-                {
-                  "alternative_name": "keys",
-                  "version_added": "12"
-                }
-              ],
-              "firefox": [
-                {
-                  "version_added": "24"
-                },
-                {
-                  "alternative_name": "keys",
-                  "version_added": "24"
-                }
-              ],
+              "deno": {
+                "version_added": "1.0"
+              },
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "24"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
-              "nodejs": [
-                {
-                  "version_added": "0.12.0"
-                },
-                {
-                  "alternative_name": "keys",
-                  "version_added": "0.12.0"
-                }
-              ],
+              "nodejs": {
+                "version_added": "0.12.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": [
-                {
-                  "version_added": "8"
-                },
-                {
-                  "alternative_name": "keys",
-                  "version_added": "8"
-                }
-              ],
+              "safari": {
+                "version_added": "8"
+              },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"


### PR DESCRIPTION
Given Set.keys has its own MDN page and is more like an alias to Set.values, I think it makes sense to have its own entry. (The collector proposed this and I agree)

I can send a PR to update https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/set/keys/index.md which currently added a manual spec url and queries the compat data from javascript.builtins.Set.values instead of javascript.builtins.Set.keys