### PR TITLE
Fix Safari support for api.HTMLElement.nonce

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -1631,11 +1631,11 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "16"
+                "version_added": "15.4"
               },
               {
                 "version_added": "10",
-                "version_removed": "16",
+                "version_removed": "15.4",
                 "partial_implementation": true,
                 "notes": "The property is defined only for its useful elements: <code>&lt;link&gt;</code>, <code>&lt;script&gt;</code>, and <code>&lt;style&gt;</code>; it is undefined for all other elements."
               }


### PR DESCRIPTION
#### Summary

Correct support for api.HTMLElement.nonce which was updated on a guess.

#### Test results and supporting details

Internal records show that this was shipped in Safari 15.4.

#### Related issues

- See https://github.com/mdn/browser-compat-data/pull/20994
- https://github.com/WebKit/WebKit/commit/76edb54f4cdb672dbcfcd78e3fcd5416e980f7df
- https://bugs.webkit.org/show_bug.cgi?id=179728