### PR TITLE
Add Safari support for tabs.toggleReaderMode

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -3804,7 +3804,7 @@
               },
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4"
               },
               "safari_ios": "mirror"
             }


### PR DESCRIPTION
#### Summary

tabs.toggleReaderMode support was added in Safari 16.4.

#### Test results and supporting details

- See https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes#Safari-Extensions

> - Added support for toggleReaderMode to the tabs API.

