### PR TITLE
Fix Safari font-face.font-feature-settings support

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -510,7 +510,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "10"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Safari added support for `font-feature-settings` in `@font-face`.

Internal records show this shipped with Safari 10 on iOS 10 and macOS 10.12.

#### Test results and supporting details

- https://bugs.webkit.org/show_bug.cgi?id=63796
- https://bugs.webkit.org/show_bug.cgi?id=134332
- https://bugs.webkit.org/show_bug.cgi?id=147722