### PR TITLE
Restore FF116 HTMLVideoElement.disablePictureInPicture

### DIFF
--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -91,7 +91,10 @@
             "firefox": {
               "version_added": "116",
               "partial_implementation": true,
-              "notes": "The disable PiP button that overlays the video is hidden, but the user can still enable PiP."
+              "notes": [
+                "Hides the button to disable picture-in-picture (PiP) that overlays the video, but the user can still enable PiP.",
+                "The property is undefined but still has an effect if set.",
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -92,8 +92,8 @@
               "version_added": "116",
               "partial_implementation": true,
               "notes": [
-                "Hides the button to disable picture-in-picture (PiP) that overlays the video, but the user can still enable PiP.",
-                "The property is undefined but still has an effect if set.",
+                "The property is undefined, but still has an effect if set to a value.",
+                "When this property is set to <code>true</code>, the overlay button to disable picture-in-picture (PiP) is hidden, but the user can still enable PiP."
               ]
             },
             "firefox_android": "mirror",

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -90,6 +90,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "116",
+              "partial_implementation": true,
               "notes": "The disable PiP button that overlays the video is hidden, but the user can still enable PiP."
             },
             "firefox_android": "mirror",

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -89,7 +89,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "116",
+              "notes": "The disable PiP button that overlays the video is hidden, but the user can still enable PiP."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
`api.HTMLVideoElement.disablePictureInPicture` was added to FF116 but the entry was reverted in #21029 because the value is not in the WebIDL or testable. Apparently this is actually present:

From [the issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1832154#c9):

> As far as I can tell, we do intend to be passing this test. We'll file a separate bug to update the appropriate WebIDL, and I think that should take care of this.
> Note though that we provide an implementation of the attribute behavior that is deliberately not spec-compliant, and we have no plans to change that. I would assume that the compatibility data needs to reflect this fact.

AND the spec difference are:

> So, there's two things:
> - We implement the disablePictureInPicture attribute, but none of the rest of the PIP spec.
> - Our implementation of disablePictureInPicture does not fully disable picture-in-picture; we'll hide our usual button that overlays the video, but still allow the user to override.

All I have done is add a note _The disable PiP button that overlays the video is hidden, but the user can still enable PiP_ and marked as partial implementation. FYI @Elchi3 @queengooborg 