### PR TITLE
Fixed Safari 16.4 decalarativeNetRequest support

### DIFF
--- a/webextensions/api/declarativeNetRequest.json
+++ b/webextensions/api/declarativeNetRequest.json
@@ -116,7 +116,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "16.4"
               },
               "safari_ios": "mirror"
             }
@@ -944,7 +944,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "16.4"
                 },
                 "safari_ios": "mirror"
               }
@@ -1565,7 +1565,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": "preview"
+                  "version_added": "16.4"
                 },
                 "safari_ios": "mirror"
               }
@@ -1583,7 +1583,7 @@
                   "firefox_android": "mirror",
                   "opera": "mirror",
                   "safari": {
-                    "version_added": "preview"
+                    "version_added": "16.4"
                   },
                   "safari_ios": "mirror"
                 }


### PR DESCRIPTION
#### Summary

Fixes missing feature support for Safari 16.4 in declarativeNetRequest.

#### Test results and supporting details

- Reported by internal engineering.
- See [Safari 16.4 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes)