### PR TITLE
Deprecate `FileReader.readAsBinaryString()`

### DIFF
--- a/api/FileReader.json
+++ b/api/FileReader.json
@@ -656,7 +656,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

deprecate `FileReader.readAsBinaryString()`, as the standard has suggest to use `FileReader.readAsArrayBuffer()` instead:

![image](https://github.com/mdn/browser-compat-data/assets/95597335/c2d1be3c-b681-4329-a8fe-4bd2aa89d2f2)

see https://w3c.github.io/FileAPI/#readAsBinaryString

also reference to [`FileReaderSync.readAsBinaryString()`](https://developer.mozilla.org/en-US/docs/Web/API/FileReaderSync/readAsBinaryString), which has already deprecate in #5353 
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
