### PR TITLE
added support for web streams `deflate-raw` compression in node

### DIFF
--- a/api/CompressionStream.json
+++ b/api/CompressionStream.json
@@ -149,7 +149,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "21.2.0"
               },
               "opera": "mirror",
               "opera_android": "mirror",

--- a/api/DecompressionStream.json
+++ b/api/DecompressionStream.json
@@ -149,7 +149,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "21.2.0"
               },
               "opera": "mirror",
               "opera_android": "mirror",

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -478,7 +478,7 @@
         "21.2.0": {
           "release_date": "2023-11-14",
           "release_notes": "https://nodejs.org/en/blog/release/v21.2.0",
-          "status": "retired",
+          "status": "current",
           "engine": "V8",
           "engine_version": "11.8"
         }

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -474,6 +474,13 @@
           "status": "retired",
           "engine": "V8",
           "engine_version": "11.8"
+        },
+        "21.2.0": {
+          "release_date": "2023-11-14",
+          "release_notes": "https://nodejs.org/en/blog/release/v21.2.0",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "11.8"
         }
       }
     }


### PR DESCRIPTION

#### Summary

`deflate-raw` is now a  valid parameter for both `CompressionStream` and `DecompressionStream` constructors in node


#### Test results and supporting details

node release notes
see: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V21.md#21.2.0

node commit implementing the change:
https://github.com/nodejs/node/commit/91f37d1dc3

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
