### PR TITLE
docs(opera): updated current browsers release

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -784,14 +784,21 @@
         "104": {
           "release_date": "2023-10-23",
           "release_notes": "https://blogs.opera.com/desktop/2023/10/opera-104-stable/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "118"
         },
         "105": {
-          "status": "beta",
+          "release_date": "2023-11-14",
+          "release_notes": "https://blogs.opera.com/desktop/2023/11/opera-105-stable/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "119"
+        },
+        "106": {
+          "status": "beta",
+          "engine": "Blink",
+          "engine_version": "120"
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Updated current Operas browser data, as version 105 has been release on 14th of November:

https://blogs.opera.com/desktop/2023/11/opera-105-stable/

And Opera Beta currently already provides the upcoming version 106 with Chromium-Version 120

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->