### PR TITLE
Clear-Site-Data - Safari 17

### DIFF
--- a/http/headers/Clear-Site-Data.json
+++ b/http/headers/Clear-Site-Data.json
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -58,7 +58,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -205,7 +205,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": {

--- a/http/headers/Clear-Site-Data.json
+++ b/http/headers/Clear-Site-Data.json
@@ -208,9 +208,7 @@
                 "version_added": "17"
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": {
-                "version_added": "8.0"
-              },
+              "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {


### PR DESCRIPTION
Fixes #21208

So from the above link we can see that Safari 17 adds support for **at least** `executionContext` and `clear`. This adds the top level feature version and also for `executionContext`. I left the others false because there is no evidence on support either way. Better than nothing IMO.