### PR TITLE
FF121 iframe/HTMLIFrameElement supports loading property

### DIFF
--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -530,7 +530,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "121"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -379,7 +379,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "121"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
FF121 supports [`<iframe>` `loading` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#loading) (and API version) in https://bugzilla.mozilla.org/show_bug.cgi?id=1860729. This just updates the two records appropriately. 
These went into preview in 120 (see #21126)

Related docs work can be tracked in https://github.com/mdn/content/issues/30340