### PR TITLE
FF121 Showpicker in preview

### DIFF
--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -854,14 +854,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "121",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "dom.select.showPicker.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This follows on from #20852

Looking at the https://bugzilla.mozilla.org/show_bug.cgi?id=1854112 ,  `HTMLSelectElement` showPicker  was enabled on nightly, so this changes the release to "preview".

Related docs work in https://github.com/mdn/content/issues/30336