### PR TITLE
commands.onCommand add tab

### DIFF
--- a/webextensions/api/commands.json
+++ b/webextensions/api/commands.json
@@ -173,7 +173,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1843866"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",

--- a/webextensions/api/commands.json
+++ b/webextensions/api/commands.json
@@ -139,6 +139,50 @@
                 "version_added": "15"
               }
             }
+          },
+          "name": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "79"
+                },
+                "firefox": {
+                  "version_added": "48"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            }
+          },
+          "tab": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
           }
         },
         "reset": {


### PR DESCRIPTION
#### Summary

Add support details for the `tab` property returned by `commands.onCommand`. 

### Motivation

To add details of this new Chrome feature

### Related issues and pull requests

Fixes [#29555](https://github.com/mdn/content/issues/29555)
Related MDN update in https://github.com/mdn/content/pull/30387