### PR TITLE
FF121 Custom State in Custom Elements

### DIFF
--- a/api/CustomStateSet.json
+++ b/api/CustomStateSet.json
@@ -2,6 +2,7 @@
   "api": {
     "CustomStateSet": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomStateSet",
         "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#customstateset",
         "support": {
           "chrome": {
@@ -10,7 +11,14 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "121",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "dom.element.customstateset.enabled",
+                "value_to_set": "true"
+              }
+            ]
           },
           "firefox_android": "mirror",
           "ie": {
@@ -34,6 +42,7 @@
       },
       "add": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomStateSet/add",
           "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#dom-customstateset-add",
           "support": {
             "chrome": {
@@ -42,7 +51,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "121",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.customstateset.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -67,6 +83,8 @@
       },
       "clear": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomStateSet/clear",
+          "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#customstateset",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -74,7 +92,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "121",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.customstateset.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -99,6 +124,8 @@
       },
       "delete": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomStateSet/delete",
+          "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#customstateset",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -106,7 +133,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "121",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.customstateset.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -131,6 +165,8 @@
       },
       "entries": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomStateSet/entries",
+          "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#customstateset",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -138,7 +174,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "121",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.customstateset.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -163,6 +206,8 @@
       },
       "forEach": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomStateSet/forEach",
+          "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#customstateset",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -170,7 +215,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "121",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.customstateset.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -195,6 +247,8 @@
       },
       "has": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomStateSet/has",
+          "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#customstateset",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -202,7 +256,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "121",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.customstateset.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -227,6 +288,8 @@
       },
       "keys": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomStateSet/keys",
+          "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#customstateset",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -234,7 +297,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "121",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.customstateset.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -259,6 +329,8 @@
       },
       "size": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomStateSet/size",
+          "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#customstateset",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -266,7 +338,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "121",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.customstateset.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -291,6 +370,8 @@
       },
       "values": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomStateSet/values",
+          "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#customstateset",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -298,7 +379,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "121",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.customstateset.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {
@@ -323,6 +411,7 @@
       },
       "@@iterator": {
         "__compat": {
+          "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#customstateset",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -330,7 +419,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "121",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.customstateset.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -1973,7 +1973,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "121",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.customstateset.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF121 adds support for the [Custom State Pseudo Class](https://wicg.github.io/custom-state-pseudo-class) spec in https://bugzilla.mozilla.org/show_bug.cgi?id=1861466 behind a preference. 

This updates [`CustomStateSet`](https://developer.mozilla.org/en-US/docs/Web/API/CustomStateSet) with support info and MDN + spec links. It also updates [`ElementInternals.states`](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals/states) with the preference info.

There isn't any specific feature for the pseudo class itself - at least not obvious and not in the original updates to this #10976

Related docs work can be tracked in https://github.com/mdn/content/issues/30339