### PR TITLE
chore(ci): Do not run 'Update browser releases' workflow on forks

### DIFF
--- a/.github/workflows/update-browser-releases.yml
+++ b/.github/workflows/update-browser-releases.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   update:
+    if: github.repository == 'mdn/browser-compat-data'
     name: Update browser releases
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
#### Summary

This workflow runs on forks which is causing failed build notifications. Adding a check that only lets the job run if the repo is `mdn/browser-compat-data`.

#### Test results and supporting details

* Failed runs: https://github.com/bsmth/browser-compat-data/actions/workflows/update-browser-releases.yml
* Example content config: https://github.com/mdn/content/blob/main/.github/workflows/pr-test.yml#L20

#### Related issues

* https://github.com/mdn/content/pull/24626
* https://github.com/mdn/content/pull/21771
