### PR TITLE
Fix engine_version for Safari 15

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -178,7 +178,7 @@
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15-release-notes",
           "status": "retired",
           "engine": "WebKit",
-          "engine_version": "612.1.29"
+          "engine_version": "612.1.27"
         },
         "15.1": {
           "release_date": "2021-10-25",


### PR DESCRIPTION
The `engine_version` is 612.1.27 according to the official https://developer.apple.com/tutorials/data/documentation/safari-release-notes.json 

![Capture d’écran 2023-11-20 à 10 09 10](https://github.com/mdn/browser-compat-data/assets/1466293/dc8dae4b-b6f0-4716-bd6f-ce3aa82cf9cd)

That's the only one that was incorrect.