### PR TITLE
Add IdentityProvider.close()

### DIFF
--- a/api/IdentityProvider.json
+++ b/api/IdentityProvider.json
@@ -33,8 +33,43 @@
           "deprecated": false
         }
       },
+      "close_static": {
+        "__compat": {
+          "description": "<code>close()</code> static method",
+          "spec_url": "https://fedidcg.github.io/FedCM/#dom-identityprovider-close",
+          "support": {
+            "chrome": {
+              "version_added": "120"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getUserInfo_static": {
         "__compat": {
+          "description": "<code>getUserInfo()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdentityProvider/getUserInfo_static",
           "spec_url": "https://fedidcg.github.io/FedCM/#dom-identityprovider-getuserinfo",
           "support": {


### PR DESCRIPTION
Seems to have come with the other Login-related APIs: https://source.chromium.org/search?q=FedCmIdpSigninStatus%20lang:idl&ss=chromium%2Fchromium%2Fsrc