### PR TITLE
Correct WebAssembly statics

### DIFF
--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -41,9 +41,10 @@
           "deprecated": false
         }
       },
-      "compile": {
+      "compile_static": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/compile",
+          "description": "<code>compile()</code> static method",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/compile_static",
           "spec_url": "https://webassembly.github.io/spec/js-api/#dom-webassembly-compile",
           "support": {
             "chrome": {
@@ -83,9 +84,10 @@
           }
         }
       },
-      "compileStreaming": {
+      "compileStreaming_static": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/compileStreaming",
+          "description": "<code>compileStreaming()</code> static method",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/compileStreaming_static",
           "spec_url": "https://webassembly.github.io/spec/web-api/#dom-webassembly-compilestreaming",
           "support": {
             "chrome": {
@@ -127,9 +129,10 @@
           }
         }
       },
-      "instantiate": {
+      "instantiate_static": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/instantiate",
+          "description": "<code>instantiate()</code> static method",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/instantiate_static",
           "spec_url": "https://webassembly.github.io/spec/js-api/#dom-webassembly-instantiate",
           "support": {
             "chrome": {
@@ -169,9 +172,10 @@
           }
         }
       },
-      "instantiateStreaming": {
+      "instantiateStreaming_static": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/instantiateStreaming",
+          "description": "<code>instantiateStreaming()</code> static method",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/instantiateStreaming_static",
           "spec_url": "https://webassembly.github.io/spec/web-api/#dom-webassembly-instantiatestreaming",
           "support": {
             "chrome": {
@@ -213,9 +217,10 @@
           }
         }
       },
-      "validate": {
+      "validate_static": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/validate",
+          "description": "<code>validate()</code> static method",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/validate_static",
           "spec_url": "https://webassembly.github.io/spec/js-api/#dom-webassembly-validate",
           "support": {
             "chrome": {

--- a/webassembly/api/Module.json
+++ b/webassembly/api/Module.json
@@ -85,9 +85,10 @@
             }
           }
         },
-        "customSections": {
+        "customSections_static": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Module/customSections",
+            "description": "<code>customSections()</code> static method",
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Module/customSections_static",
             "spec_url": "https://webassembly.github.io/spec/js-api/#dom-module-customsections",
             "support": {
               "chrome": {
@@ -127,9 +128,10 @@
             }
           }
         },
-        "exports": {
+        "exports_static": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Module/exports",
+            "description": "<code>exports()</code> static method",
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Module/exports_static",
             "spec_url": "https://webassembly.github.io/spec/js-api/#dom-module-exports",
             "support": {
               "chrome": {
@@ -169,9 +171,10 @@
             }
           }
         },
-        "imports": {
+        "imports_static": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Module/imports",
+            "description": "<code>imports()</code> static method",
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/JavaScript_interface/Module/imports_static",
             "spec_url": "https://webassembly.github.io/spec/js-api/#dom-module-imports",
             "support": {
               "chrome": {


### PR DESCRIPTION
The WebAssembly statics should follow the convention for static members: https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/api.md#static-api-members

Needs a PR on the content side which I can open.