### PR TITLE
Add HTMLTemplateElement.shadowRootMode

### DIFF
--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -70,6 +70,39 @@
             "deprecated": false
           }
         }
+      },
+      "shadowRootMode": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#dom-template-shadowrootmode",
+          "support": {
+            "chrome": {
+              "version_added": "111"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Chrome 111 confirmed by https://chromestatus.com/feature/5161240576393216
Safari 16.4 confirmed by https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes

Follow-up to https://github.com/mdn/browser-compat-data/pull/19334 and https://github.com/mdn/browser-compat-data/pull/18855