### PR TITLE
Add speak-as property, update speak for Safari 11.1

### DIFF
--- a/css/properties/speak-as.json
+++ b/css/properties/speak-as.json
@@ -1,22 +1,18 @@
 {
   "css": {
     "properties": {
-      "speak": {
+      "speak-as": {
         "__compat": {
-          "spec_url": "https://drafts.csswg.org/css-speech-1/#speaking-props-speak",
+          "spec_url": "https://drafts.csswg.org/css-speech-1/#speaking-props-speak-as",
           "support": {
             "chrome": {
-              "version_added": "≤80",
-              "partial_implementation": true,
-              "notes": "The implementation is not compliant with the specification, see <a href='https://crbug.com/1283584'>bug 1283584</a>."
+              "version_added": false
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "≤80"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false,
-              "impl_url": "https://bugzil.la/1748064"
+              "impl_url": "https://bugzil.la/1748068"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -33,7 +29,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
The collector found that these are supported in Safari.
See https://bugs.webkit.org/show_bug.cgi?id=180361
