### PR TITLE
Remove obsolete Webextension features; enable lint

### DIFF
--- a/test/linter/test-obsolete.ts
+++ b/test/linter/test-obsolete.ts
@@ -23,7 +23,7 @@ const categoriesToCheck = [
   // 'svg',
   'webassembly',
   // 'webdriver',
-  // 'webextensions'
+  'webextensions',
 ];
 
 /**

--- a/webextensions/api/downloads.json
+++ b/webextensions/api/downloads.json
@@ -1653,28 +1653,6 @@
             }
           }
         },
-        "drag": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/drag",
-            "support": {
-              "chrome": {
-                "version_added": true,
-                "version_removed": "77",
-                "notes": "Removed to fix a security problem. See <a href='https://crbug.com/986043'>Chromium Issue 986043</a> Security: Malicious Extension can ignore SOP, with only `downloads` permission."
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "opera": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror"
-            }
-          }
-        },
         "erase": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/downloads/erase",

--- a/webextensions/manifest/manifest_version.json
+++ b/webextensions/manifest/manifest_version.json
@@ -24,27 +24,6 @@
             }
           }
         },
-        "v1": {
-          "__compat": {
-            "description": "Version 1",
-            "support": {
-              "chrome": {
-                "version_added": "4",
-                "version_removed": "21"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "opera": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror"
-            }
-          }
-        },
         "v2": {
           "__compat": {
             "description": "Version 2",

--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -622,33 +622,6 @@
               }
             }
           },
-          "textcolor": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "55",
-                  "version_removed": "70",
-                  "notes": [
-                    "Before Firefox 59, the RGB array form was not supported for this property.",
-                    "Before Firefox 63, this property was required.",
-                    "Use <code>tab_background_text</code> instead."
-                  ]
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror"
-              }
-            }
-          },
           "toolbar": {
             "__compat": {
               "support": {
@@ -1013,29 +986,6 @@
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "55"
-                },
-                "firefox_android": {
-                  "version_added": false
-                },
-                "opera": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror"
-              }
-            }
-          },
-          "headerURL": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "55",
-                  "version_removed": "70",
-                  "notes": "Use <code>theme_frame</code> instead."
                 },
                 "firefox_android": {
                   "version_added": false

--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -51,33 +51,6 @@
               "safari_ios": "mirror"
             }
           },
-          "accentcolor": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "55",
-                  "version_removed": "70",
-                  "notes": [
-                    "Before Firefox 59, the RGB array form was not supported for this property.",
-                    "Before Firefox 63, this property was required.",
-                    "Use <code>frame</code> instead."
-                  ]
-                },
-                "firefox_android": {
-                  "version_added": "65"
-                },
-                "opera": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror"
-              }
-            }
-          },
           "bookmark_text": {
             "__compat": {
               "support": {


### PR DESCRIPTION
I didn't know the linter for our irrelevance check isn't running on all folders yet.
This PR removes features we consider irrelevant as they are gone everywhere for more than two years.
It enables the linter for the webextensions/ folder.

See https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features for the BCD data rule.

Setting "needs content update" as this at least also makes the https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/downloads/drag page irrelevant.