### PR TITLE
Add support for Safari in update-browser-releases

### DIFF
--- a/scripts/update-browser-releases/chrome.ts
+++ b/scripts/update-browser-releases/chrome.ts
@@ -117,6 +117,7 @@ export const updateChromiumReleases = async (options) => {
         data[value].releaseDate,
         key,
         releaseNotesURL,
+        '',
       );
     } else {
       // New entry
@@ -128,6 +129,7 @@ export const updateChromiumReleases = async (options) => {
         options.browserEngine,
         data[value].releaseDate,
         releaseNotesURL,
+        data[value].version,
       );
     }
   }
@@ -149,6 +151,7 @@ export const updateChromiumReleases = async (options) => {
           chromeBCD.browsers[options.bcdBrowserName].releases[i.toString()]
             .release_date,
           'retired',
+          '',
           '',
         );
       } else {
@@ -172,6 +175,7 @@ export const updateChromiumReleases = async (options) => {
         .release_date,
       'planned',
       '',
+      '',
     );
   } else {
     // New entry
@@ -183,6 +187,7 @@ export const updateChromiumReleases = async (options) => {
       options.browserEngine,
       '',
       '',
+      plannedVersion,
     );
   }
 

--- a/scripts/update-browser-releases/edge.ts
+++ b/scripts/update-browser-releases/edge.ts
@@ -290,6 +290,7 @@ export const updateEdgeReleases = async (options) => {
           data[value]?.versionDate,
           key,
           releaseNotesURL,
+          '',
         );
       } else {
         // New entry
@@ -301,6 +302,7 @@ export const updateEdgeReleases = async (options) => {
           options.browserEngine,
           data[value]?.versionDate,
           releaseNotesURL,
+          data[value].version,
         );
       }
     }
@@ -327,6 +329,7 @@ export const updateEdgeReleases = async (options) => {
             edgeBCD.browsers[options.bcdBrowserName].releases[i.toString()]
               .release_notes,
           ),
+          '',
         );
       } else {
         // There is a retired version missing. Edgeupdates doesn't list them.
@@ -358,6 +361,7 @@ export const updateEdgeReleases = async (options) => {
       releaseDate,
       'planned',
       '',
+      '',
     );
   } else {
     // New entry
@@ -368,6 +372,7 @@ export const updateEdgeReleases = async (options) => {
       'planned',
       options.browserEngine,
       releaseDate,
+      '',
       '',
     );
   }

--- a/scripts/update-browser-releases/firefox.ts
+++ b/scripts/update-browser-releases/firefox.ts
@@ -67,7 +67,6 @@ export const updateFirefoxReleases = async (options) => {
       const releasedFirefoxVersions = await firefoxVersions.json();
 
       // Extract the current stable version and its release date
-
       Object.entries(releasedFirefoxVersions).forEach(([key]) => {
         if (parseFloat(key) > stableRelease) {
           stableRelease = parseFloat(key);
@@ -90,6 +89,7 @@ export const updateFirefoxReleases = async (options) => {
         data[value].releaseDate,
         key,
         releaseNotesURL,
+        '',
       );
     } else {
       // New entry
@@ -101,6 +101,7 @@ export const updateFirefoxReleases = async (options) => {
         'Gecko',
         data[value].releaseDate,
         releaseNotesURL,
+        data[value].version,
       );
     }
   }
@@ -138,6 +139,7 @@ export const updateFirefoxReleases = async (options) => {
         entry.release_date,
         'esr',
         '',
+        '',
       );
     } else if (parseFloat(key) < stableRelease) {
       result += updateBrowserEntry(
@@ -147,6 +149,7 @@ export const updateFirefoxReleases = async (options) => {
         entry.release_date,
         'retired',
         '',
+        '',
       );
     }
   });
@@ -154,7 +157,7 @@ export const updateFirefoxReleases = async (options) => {
   //
   // Add a planned version entry
   //
-  const planned = stableRelease + 3;
+  const planned = Number(data[options.nightlyBranch].version) + 1;
   // Get the JSON for the planned version train
   const trainInfo = await fetch(`${options.firefoxScheduleURL}${planned}`);
   const train = await trainInfo.json();
@@ -167,6 +170,7 @@ export const updateFirefoxReleases = async (options) => {
       train.release.substring(0, 10),
       'planned',
       '',
+      '',
     );
   } else {
     // New entry
@@ -176,8 +180,9 @@ export const updateFirefoxReleases = async (options) => {
       planned,
       'planned',
       'Gecko',
-      train.release.substring(0, 10), // Remove the time part
+      train.release?.substring(0, 10), // Remove the time part
       await getFirefoxReleaseNotesURL(planned),
+      planned,
     );
   }
 

--- a/scripts/update-browser-releases/firefox.ts
+++ b/scripts/update-browser-releases/firefox.ts
@@ -22,7 +22,7 @@ const getFirefoxReleaseNotesURL = async (version) => {
 };
 
 /**
- * updateFirefoxFile - Update the json file listing the browser version of a chromium entry
+ * updateFirefoxFile - Update the json file listing the browser version of a firefox entry
  * @param {object} options The list of options for this type of chromiums.
  * @returns {string} The log of what has been generated (empty if nothing)
  */

--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -72,15 +72,10 @@ const updateWebview = argv['webview'] || updateAllBrowsers;
 const updateFirefox = argv['firefox'] || updateAllBrowsers;
 const updateEdge = argv['edge'] || updateAllBrowsers;
 const updateSafari = argv['safari'] || updateAllBrowsers;
-console.log('Safari:', updateSafari, argv['safari']);
-console.log('Firefox:', updateFirefox, argv['firefox']);
 const updateAllDevices =
   argv['alldevices'] || !(argv['mobile'] || argv['desktop']);
-  console.log('allDevices: ', updateAllDevices);
 const updateMobile = argv['mobile'] || updateAllDevices;
 const updateDesktop = argv['desktop'] || updateAllDevices;
-console.log('desktop: ', updateDesktop, argv['desktop']);
-
 
 const options = {
   chrome_desktop: {
@@ -219,13 +214,11 @@ if (updateFirefox && updateMobile) {
 }
 
 if (updateSafari && updateDesktop) {
-  console.log('Safari desktop');
   const add = await updateSafariReleases(options.safari_desktop);
   result += (result && add ? '\n' : '') + add;
 }
 
 if (updateSafari && updateMobile) {
-  console.log('Safari iOS');
   const add = await updateSafariReleases(options.safari_ios);
   result += (result && add ? '\n' : '') + add;
 }

--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -60,16 +60,27 @@ const argv = yargs(process.argv.slice(2))
 // Read arguments
 const updateAllBrowsers =
   argv['all'] ||
-  !(argv['chrome'] || argv['webview'] || argv['firefox'] || argv['edge']);
+  !(
+    argv['chrome'] ||
+    argv['webview'] ||
+    argv['firefox'] ||
+    argv['edge'] ||
+    argv['safari']
+  );
 const updateChrome = argv['chrome'] || updateAllBrowsers;
 const updateWebview = argv['webview'] || updateAllBrowsers;
 const updateFirefox = argv['firefox'] || updateAllBrowsers;
 const updateEdge = argv['edge'] || updateAllBrowsers;
 const updateSafari = argv['safari'] || updateAllBrowsers;
+console.log('Safari:', updateSafari, argv['safari']);
+console.log('Firefox:', updateFirefox, argv['firefox']);
 const updateAllDevices =
   argv['alldevices'] || !(argv['mobile'] || argv['desktop']);
+  console.log('allDevices: ', updateAllDevices);
 const updateMobile = argv['mobile'] || updateAllDevices;
 const updateDesktop = argv['desktop'] || updateAllDevices;
+console.log('desktop: ', updateDesktop, argv['desktop']);
+
 
 const options = {
   chrome_desktop: {
@@ -161,13 +172,17 @@ const options = {
     browserName: 'Safari for Desktop',
     bcdFile: './browsers/safari.json',
     bcdBrowserName: 'safari',
-    releaseNoteJSON: 'https://developer.apple.com/tutorials/data/documentation/safari-release-notes.json',
+    releaseNoteJSON:
+      'https://developer.apple.com/tutorials/data/documentation/safari-release-notes.json',
+    releaseNoteURLBase: 'https://developer.apple.com',
   },
   safari_ios: {
     browserName: 'Safari for iOS',
     bcdFile: './browsers/safari_ios.json',
     bcdBrowserName: 'safari_ios',
-    releaseNoteJSON: 'https://developer.apple.com/tutorials/data/documentation/safari-release-notes.json',
+    releaseNoteJSON:
+      'https://developer.apple.com/tutorials/data/documentation/safari-release-notes.json',
+    releaseNoteURLBase: 'https://developer.apple.com',
   },
 };
 
@@ -204,11 +219,13 @@ if (updateFirefox && updateMobile) {
 }
 
 if (updateSafari && updateDesktop) {
+  console.log('Safari desktop');
   const add = await updateSafariReleases(options.safari_desktop);
   result += (result && add ? '\n' : '') + add;
 }
 
 if (updateSafari && updateMobile) {
+  console.log('Safari iOS');
   const add = await updateSafariReleases(options.safari_ios);
   result += (result && add ? '\n' : '') + add;
 }

--- a/scripts/update-browser-releases/index.ts
+++ b/scripts/update-browser-releases/index.ts
@@ -5,6 +5,7 @@ import yargs from 'yargs';
 import { updateChromiumReleases } from './chrome.js';
 import { updateEdgeReleases } from './edge.js';
 import { updateFirefoxReleases } from './firefox.js';
+import { updateSafariReleases } from './safari.js';
 
 const argv = yargs(process.argv.slice(2))
   .usage('Usage: npm run update-browser-releases -- (flags)')
@@ -25,6 +26,11 @@ const argv = yargs(process.argv.slice(2))
   })
   .option('firefox', {
     describe: 'Update Mozilla Firefox',
+    type: 'boolean',
+    group: 'Engine selection:',
+  })
+  .option('safari', {
+    describe: 'Update Apple Safari',
     type: 'boolean',
     group: 'Engine selection:',
   })
@@ -59,6 +65,7 @@ const updateChrome = argv['chrome'] || updateAllBrowsers;
 const updateWebview = argv['webview'] || updateAllBrowsers;
 const updateFirefox = argv['firefox'] || updateAllBrowsers;
 const updateEdge = argv['edge'] || updateAllBrowsers;
+const updateSafari = argv['safari'] || updateAllBrowsers;
 const updateAllDevices =
   argv['alldevices'] || !(argv['mobile'] || argv['desktop']);
 const updateMobile = argv['mobile'] || updateAllDevices;
@@ -150,6 +157,18 @@ const options = {
     firefoxScheduleURL:
       'https://whattrainisitnow.com/api/release/schedule/?version=',
   },
+  safari_desktop: {
+    browserName: 'Safari for Desktop',
+    bcdFile: './browsers/safari.json',
+    bcdBrowserName: 'safari',
+    releaseNoteJSON: 'https://developer.apple.com/tutorials/data/documentation/safari-release-notes.json',
+  },
+  safari_ios: {
+    browserName: 'Safari for iOS',
+    bcdFile: './browsers/safari_ios.json',
+    bcdBrowserName: 'safari_ios',
+    releaseNoteJSON: 'https://developer.apple.com/tutorials/data/documentation/safari-release-notes.json',
+  },
 };
 
 let result = '';
@@ -181,6 +200,16 @@ if (updateFirefox && updateDesktop) {
 
 if (updateFirefox && updateMobile) {
   const add = await updateFirefoxReleases(options.firefox_android);
+  result += (result && add ? '\n' : '') + add;
+}
+
+if (updateSafari && updateDesktop) {
+  const add = await updateSafariReleases(options.safari_desktop);
+  result += (result && add ? '\n' : '') + add;
+}
+
+if (updateSafari && updateMobile) {
+  const add = await updateSafariReleases(options.safari_ios);
   result += (result && add ? '\n' : '') + add;
 }
 

--- a/scripts/update-browser-releases/safari.ts
+++ b/scripts/update-browser-releases/safari.ts
@@ -21,7 +21,9 @@ const extractReleaseData = (str) => {
     str,
   );
   if (!result) {
-    console.warn(chalk`{yellow A release string for Safari is not parsable (${str}'). Skipped.`);
+    console.warn(
+      chalk`{yellow A release string for Safari is not parsable (${str}'). Skipped.`,
+    );
     return null;
   }
   return {
@@ -51,7 +53,9 @@ export const updateSafariReleases = async (options) => {
   //
   const releaseNoteFile = await fetch(`${options.releaseNoteJSON}`);
   if (releaseNoteFile.status !== 200) {
-    console.error( chalk`{red \nRelease note file not found at Apple (${options.releaseNoteJSON}).}`);
+    console.error(
+      chalk`{red \nRelease note file not found at Apple (${options.releaseNoteJSON}).}`,
+    );
     return '';
   }
   const safariRelease = JSON.parse(await releaseNoteFile.text());
@@ -90,9 +94,13 @@ export const updateSafariReleases = async (options) => {
     } else {
       // Check old engine value (should not change, but let's check)
       if (
-        !(releaseData.version in safariBCD.browsers[options.bcdBrowserName].releases)
+        !(
+          releaseData.version in
+          safariBCD.browsers[options.bcdBrowserName].releases
+        )
       ) {
-        if (Number(releaseData.version) > 15) { // We know that version past Safari 15 matches iOS versions too
+        if (Number(releaseData.version) > 15) {
+          // We know that version past Safari 15 matches iOS versions too
           console.warn(
             chalk`{yellow Old version ${releaseData.version} not found in BCD file}`,
           );
@@ -170,21 +178,21 @@ export const updateSafariReleases = async (options) => {
   //
   // Replace all old entries with 'retired'
   //
-  Object.entries(
-    safariBCD.browsers[options.bcdBrowserName].releases
-  ).forEach(([key, entry]) => {
-    if (parseFloat(key) < stableRelease) {
-      result += updateBrowserEntry(
-        safariBCD,
-        options.bcdBrowserName,
-        key,
-        entry['release_date'],
-        'retired',
-        '',
-        '',
-      );
-    }
-  });
+  Object.entries(safariBCD.browsers[options.bcdBrowserName].releases).forEach(
+    ([key, entry]) => {
+      if (parseFloat(key) < stableRelease) {
+        result += updateBrowserEntry(
+          safariBCD,
+          options.bcdBrowserName,
+          key,
+          entry['release_date'],
+          'retired',
+          '',
+          '',
+        );
+      }
+    },
+  );
 
   //
   // Write the update browser's json to file

--- a/scripts/update-browser-releases/safari.ts
+++ b/scripts/update-browser-releases/safari.ts
@@ -1,0 +1,171 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+import * as fs from 'node:fs';
+
+import chalk from 'chalk-template';
+
+import stringify from '../lib/stringify-and-order-properties.js';
+
+import { newBrowserEntry, updateBrowserEntry } from './utils.js';
+
+import type { ReleaseStatement } from '../../types/types.js';
+
+const extractReleaseData = (str) => {
+  // Released September 18, 2023 — Version 17 (19616.1.27)
+  console.log(str);
+  const result =
+    /Released (.*) .* Version (.*) (Beta )?\((.*)\)/.exec(str);
+  if (!result) {
+    return null;
+  }
+  console.log(`Date: ${result[1]}`);
+  console.log(`Version: ${result[2]}`);
+  console.log(`Beta: ${result[3]? true : false}`);
+  console.log(`Engine version: ${result[4].substring(2)}`);
+  return {
+    date: result[1],
+    version: result[2],
+    beta: result[3]? true : false,
+    engine: result[4].substring(2),
+  };
+};
+
+/**
+ * updateSafariFile - Update the json file listing the browser version of a safari entry
+ * @param {object} options The list of options for this type of chromiums.
+ * @returns {string} The log of what has been generated (empty if nothing)
+ */
+export const updateSafariReleases = async (options) => {
+  let result = '';
+  //
+  // Get the firefox.json from the local BCD
+  //
+  const file = fs.readFileSync(`${options.bcdFile}`);
+  const safariBCD = JSON.parse(file.toString());
+
+  //
+  // Read JSON of release notes
+  //
+  const releaseNoteFile = await fetch(`${options.releaseNoteJSON}`);
+  if (releaseNoteFile.status !== 200) {
+    throw chalk`{red \nRelease note file not found at Apple (${options.releaseNoteJSON}).}`;
+  }
+  const safariRelease = JSON.parse(await releaseNoteFile.text());
+
+  //
+  // Compute stable and beta release number
+  //
+  let stableRelease;
+  let betaRelease;
+
+  const releases = safariRelease['references']
+  for (const id in releases) {
+    const releaseData = extractReleaseData(releases[id].abstract[0].text);
+    if (!releaseData) {
+      console.warn(chalk`{yellow Release string from Apple not understandable (${releases[id].abstract[0].text})}`);
+      continue;
+    }
+    if (releaseData.beta) {
+      betaRelease = releaseData;
+    } else if (releaseData.version > stableRelease.version) {
+      stableRelease = releaseData;
+    } else {
+      // Check old engine value (should not change, but let's check)
+      const engineStored =
+        safariBCD[options.bcdBrowserName].releases[releaseData.version].engine;
+      if (releaseData.engine !== engineStored) {
+        // Differs!
+        console.warn(
+          chalk`{yellow Engine for ${releaseData.version} (${releaseData.engine}) doesn't match engine stored (${engineStored})}`,
+        );
+      }
+    }
+  }
+
+  //
+  // Update stable release
+  //
+  if (
+    safariBCD[options.bcdBrowserName].releases[stableRelease.release].version
+  ) {
+    result += updateBrowserEntry(
+      safariBCD,
+      options.bcdBrowserName,
+      stableRelease.version,
+      stableRelease.release_date,
+      'current',
+      stableRelease.releaseNote,
+      stableRelease.engineVersion,
+    );
+  } else {
+    result += newBrowserEntry(
+      safariBCD,
+      options.bcdBrowserName,
+      stableRelease.version,
+      stableRelease.release_date,
+      'current',
+      stableRelease.releaseNote,
+      'WebKit',
+      stableRelease.engineVersion,
+    );
+  }
+
+  //
+  // Update beta release
+  //
+  if (safariBCD[options.bcdBrowserName].releases[betaRelease.release].version) {
+    result += updateBrowserEntry(
+      safariBCD,
+      options.bcdBrowserName,
+      betaRelease.version,
+      betaRelease.release_date,
+      'beta',
+      betaRelease.releaseNote,
+      betaRelease.engineVersion,
+    );
+  } else {
+    result += newBrowserEntry(
+      safariBCD,
+      options.bcdBrowserName,
+      betaRelease.version,
+      betaRelease.release_date,
+      'beta',
+      betaRelease.releaseNote,
+      'WebKit',
+      betaRelease.engineVersion,
+    );
+  }
+
+  //
+  // Replace all old entries with 'retired'
+  //
+  Object.entries(
+    safariBCD.browsers[options.bcdBrowserName].releases as {
+      [version: string]: ReleaseStatement;
+    },
+  ).forEach(([key, entry]) => {
+    if (parseFloat(key) < stableRelease) {
+      result += updateBrowserEntry(
+        safariBCD,
+        options.bcdBrowserName,
+        key,
+        entry.release_date,
+        'retired',
+        '',
+        '',
+      );
+    }
+  });
+
+  //
+  // Write the update browser's json to file
+  //
+  fs.writeFileSync(`./${options.bcdFile}`, stringify(safariBCD) + '\n');
+
+  // Returns the log
+  if (result) {
+    result = `### Updates for ${options.browserName}${result}`;
+  }
+  return result;
+};

--- a/scripts/update-browser-releases/safari.ts
+++ b/scripts/update-browser-releases/safari.ts
@@ -9,25 +9,28 @@ import stringify from '../lib/stringify-and-order-properties.js';
 
 import { newBrowserEntry, updateBrowserEntry } from './utils.js';
 
-import type { ReleaseStatement } from '../../types/types.js';
-
+/**
+ * extractReleaseData - Extract release info from string given by Apple
+ * @param {string} str The string with release inforormation
+ *            E.g., Released September 18, 2023 — Version 17 (19616.1.27)
+ * @returns {object} Data for the release
+ */
 const extractReleaseData = (str) => {
-  // Released September 18, 2023 — Version 17 (19616.1.27)
   console.log(str);
-  const result =
-    /Released (.*) .* Version (.*) (Beta )?\((.*)\)/.exec(str);
+  // Note: \s is needed as some spaces in Apple source are non-breaking
+  const result = /Released\s(.*)\s.*\sVersion\s(.*?)\s(beta\s)?\((.*)\)/.exec(
+    str,
+  );
   if (!result) {
+    console.log(chalk`{yellow A release string for Safari is not parsable (${str}'). Skipped.`);
     return null;
   }
-  console.log(`Date: ${result[1]}`);
-  console.log(`Version: ${result[2]}`);
-  console.log(`Beta: ${result[3]? true : false}`);
-  console.log(`Engine version: ${result[4].substring(2)}`);
   return {
-    date: result[1],
+    date: new Date(`${result[1]} UTC`).toISOString().substring(0, 10),
     version: result[2],
-    beta: result[3]? true : false,
+    beta: Boolean(result[3]),
     engine: result[4].substring(2),
+    releaseNote: '',
   };
 };
 
@@ -43,13 +46,15 @@ export const updateSafariReleases = async (options) => {
   //
   const file = fs.readFileSync(`${options.bcdFile}`);
   const safariBCD = JSON.parse(file.toString());
+  console.log(safariBCD);
 
   //
   // Read JSON of release notes
   //
   const releaseNoteFile = await fetch(`${options.releaseNoteJSON}`);
   if (releaseNoteFile.status !== 200) {
-    throw chalk`{red \nRelease note file not found at Apple (${options.releaseNoteJSON}).}`;
+    console.error( chalk`{red \nRelease note file not found at Apple (${options.releaseNoteJSON}).}`);
+    return '';
   }
   const safariRelease = JSON.parse(await releaseNoteFile.text());
 
@@ -59,21 +64,47 @@ export const updateSafariReleases = async (options) => {
   let stableRelease;
   let betaRelease;
 
-  const releases = safariRelease['references']
+  const releases = safariRelease['references'];
   for (const id in releases) {
-    const releaseData = extractReleaseData(releases[id].abstract[0].text);
-    if (!releaseData) {
-      console.warn(chalk`{yellow Release string from Apple not understandable (${releases[id].abstract[0].text})}`);
+    if (releases[id].kind !== 'article') {
       continue;
     }
+    const releaseData = extractReleaseData(releases[id].abstract[0].text);
+
+    if (!releaseData) {
+      console.warn(
+        chalk`{yellow Release string from Apple not understandable (${releases[id].abstract[0].text})}`,
+      );
+      continue;
+    }
+
+    // Compute release note
+    if (releases[id].url) {
+      releaseData.releaseNote = `${options.releaseNoteURLBase}${releases[id].url}`;
+    } else {
+      releaseData.releaseNote = '';
+    }
+
     if (releaseData.beta) {
       betaRelease = releaseData;
-    } else if (releaseData.version > stableRelease.version) {
+    } else if (!stableRelease || releaseData.version > stableRelease.version) {
       stableRelease = releaseData;
     } else {
       // Check old engine value (should not change, but let's check)
+      console.log(`'${releaseData.version}'`);
+      console.log(Number(releaseData.version) in safariBCD.browsers[options.bcdBrowserName].releases);
+      if (
+        !(releaseData.version in safariBCD.browsers[options.bcdBrowserName].releases)
+      ) {
+        console.warn(
+          chalk`{yellow Old version ${releaseData.version} not found in BCD file}`,
+        );
+        continue;
+      }
       const engineStored =
-        safariBCD[options.bcdBrowserName].releases[releaseData.version].engine;
+        safariBCD.browsers[options.bcdBrowserName].releases[releaseData.version]
+          .engine_version;
+      console.log (`Detected: ${releaseData.engine}; Stored: ${engineStored}`);
       if (releaseData.engine !== engineStored) {
         // Differs!
         console.warn(
@@ -87,13 +118,13 @@ export const updateSafariReleases = async (options) => {
   // Update stable release
   //
   if (
-    safariBCD[options.bcdBrowserName].releases[stableRelease.release].version
+    safariBCD.browsers[options.bcdBrowserName].releases[stableRelease.version]
   ) {
     result += updateBrowserEntry(
       safariBCD,
       options.bcdBrowserName,
       stableRelease.version,
-      stableRelease.release_date,
+      stableRelease.date,
       'current',
       stableRelease.releaseNote,
       stableRelease.engineVersion,
@@ -103,10 +134,10 @@ export const updateSafariReleases = async (options) => {
       safariBCD,
       options.bcdBrowserName,
       stableRelease.version,
-      stableRelease.release_date,
       'current',
-      stableRelease.releaseNote,
       'WebKit',
+      stableRelease.date,
+      stableRelease.releaseNote,
       stableRelease.engineVersion,
     );
   }
@@ -114,26 +145,28 @@ export const updateSafariReleases = async (options) => {
   //
   // Update beta release
   //
-  if (safariBCD[options.bcdBrowserName].releases[betaRelease.release].version) {
+  if (
+    safariBCD.browsers[options.bcdBrowserName].releases[betaRelease.version]
+  ) {
     result += updateBrowserEntry(
       safariBCD,
       options.bcdBrowserName,
       betaRelease.version,
-      betaRelease.release_date,
+      '',
       'beta',
-      betaRelease.releaseNote,
-      betaRelease.engineVersion,
+      '',
+      '',
     );
   } else {
     result += newBrowserEntry(
       safariBCD,
       options.bcdBrowserName,
       betaRelease.version,
-      betaRelease.release_date,
       'beta',
-      betaRelease.releaseNote,
       'WebKit',
-      betaRelease.engineVersion,
+      '',
+      stableRelease.releaseNote,
+      '',
     );
   }
 
@@ -141,9 +174,7 @@ export const updateSafariReleases = async (options) => {
   // Replace all old entries with 'retired'
   //
   Object.entries(
-    safariBCD.browsers[options.bcdBrowserName].releases as {
-      [version: string]: ReleaseStatement;
-    },
+    safariBCD.browsers[options.bcdBrowserName].releases
   ).forEach(([key, entry]) => {
     if (parseFloat(key) < stableRelease) {
       result += updateBrowserEntry(

--- a/scripts/update-browser-releases/utils.ts
+++ b/scripts/update-browser-releases/utils.ts
@@ -23,7 +23,7 @@ export const newBrowserEntry = (
   engine,
   releaseDate,
   releaseNotesURL,
-  engineVersion = null,
+  engineVersion,
 ) => {
   const release = (json.browsers[browser].releases[version] = new Object());
   if (releaseDate) {
@@ -34,9 +34,9 @@ export const newBrowserEntry = (
   }
   release['status'] = status;
   release['engine'] = engine;
-  release['engine_version'] = engineVersion
-    ? engineVersion
-    : version.toString();
+  if (engineVersion) {
+    release['engine_version'] = engineVersion;
+  }
   return chalk`{yellow \n- New release detected for {bold ${browser}}: Version {bold ${version}} as a {bold ${status}} release.}`;
 };
 
@@ -66,7 +66,7 @@ export const updateBrowserEntry = (
     result += chalk`{cyan \n- New status for {bold ${browser} ${version}}: {bold ${status}}, previously ${entry['status']}.}`;
     entry['status'] = status;
   }
-  if (entry['release_date'] !== releaseDate) {
+  if (releaseDate && entry['release_date'] !== releaseDate) {
     result += chalk`{cyan \n- New release date for {bold ${browser} ${version}}: {bold ${releaseDate}}, previously ${entry['release_date']}.}`;
     entry['release_date'] = releaseDate;
   }

--- a/scripts/update-browser-releases/utils.ts
+++ b/scripts/update-browser-releases/utils.ts
@@ -12,6 +12,7 @@ import chalk from 'chalk-template';
  * @param {string} engine name of the engine
  * @param {string} releaseDate new release date
  * @param {string} releaseNotesURL url of the release notes
+ * @param {string} engineVersion the version of the engine
  * @returns {string} Text describing what has has been added
  */
 export const newBrowserEntry = (
@@ -22,6 +23,7 @@ export const newBrowserEntry = (
   engine,
   releaseDate,
   releaseNotesURL,
+  engineVersion = null,
 ) => {
   const release = (json.browsers[browser].releases[version] = new Object());
   if (releaseDate) {
@@ -32,7 +34,9 @@ export const newBrowserEntry = (
   }
   release['status'] = status;
   release['engine'] = engine;
-  release['engine_version'] = version.toString();
+  release['engine_version'] = engineVersion
+    ? engineVersion
+    : version.toString();
   return chalk`{yellow \n- New release detected for {bold ${browser}}: Version {bold ${version}} as a {bold ${status}} release.}`;
 };
 
@@ -44,6 +48,7 @@ export const newBrowserEntry = (
  * @param {string} releaseDate new release date
  * @param {string} status new status
  * @param {string} releaseNotesURL url of the release notes
+ * @param {string} engineVersion the version of the engine
  * @returns {string} Text describing what has has been updated
  */
 export const updateBrowserEntry = (
@@ -53,6 +58,7 @@ export const updateBrowserEntry = (
   releaseDate,
   status,
   releaseNotesURL,
+  engineVersion,
 ) => {
   const entry = json.browsers[browser].releases[version];
   let result = '';
@@ -67,6 +73,11 @@ export const updateBrowserEntry = (
   if (releaseNotesURL && entry['release_notes'] !== releaseNotesURL) {
     result += chalk`{cyan \n- New release notes for {bold ${browser} ${version}}: {bold ${releaseNotesURL}}, previously ${entry['release_notes']}.}`;
     entry['release_notes'] = releaseNotesURL;
+  }
+
+  if (engineVersion && entry['engine_version'] != engineVersion) {
+    result += chalk`{cyan \n- New engine version for {bold ${browser} ${version}}: {bold ${engineVersion}}, previously ${entry['engine_version']}.}`;
+    entry['engineVersion'] = engineVersion;
   }
 
   return result;


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add support to update 'safari.json' and 'safari_ios.json' based on the data given by Apple

#### Test results and supporting details

Manually tested

Note:
- No warning message is raised for old Safari iOS version (≤15) if they don't exist, as discussed during the BCD meeting
- The way to calculate the next Firefox planned has been fixed (didn't work on release day, now it does).

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
