### PR TITLE
[CSS] Add FX121 and Safari 15 support for text-indent `each-line` and `hanging`

### DIFF
--- a/css/properties/text-indent.json
+++ b/css/properties/text-indent.json
@@ -42,8 +42,8 @@
         },
         "each-line": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-text/#valdef-text-indent-each-line",
             "description": "<code>each-line</code>",
+            "spec_url": "https://drafts.csswg.org/css-text/#valdef-text-indent-each-line",
             "support": {
               "chrome": {
                 "version_added": false
@@ -76,8 +76,8 @@
         },
         "hanging": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-text/#valdef-text-indent-hanging",
             "description": "<code>hanging</code>",
+            "spec_url": "https://drafts.csswg.org/css-text/#valdef-text-indent-hanging",
             "support": {
               "chrome": {
                 "version_added": false

--- a/css/properties/text-indent.json
+++ b/css/properties/text-indent.json
@@ -42,6 +42,7 @@
         },
         "each-line": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text/#valdef-text-indent-each-line",
             "description": "<code>each-line</code>",
             "support": {
               "chrome": {
@@ -50,7 +51,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "121"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -60,7 +61,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -75,6 +76,7 @@
         },
         "hanging": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text/#valdef-text-indent-hanging",
             "description": "<code>hanging</code>",
             "support": {
               "chrome": {
@@ -83,7 +85,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "121"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -93,7 +95,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "15"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

In the BCD, adds FX121 and Safari 15 support for text-indent `each-line` and `hanging`.

#### Related issues

Parent issue: https://github.com/mdn/content/issues/30337

The three relevant PRs:
1.
2.
3. 
