### PR TITLE
Firefox 120 supports WasmGC

### DIFF
--- a/webassembly/garbage-collection.json
+++ b/webassembly/garbage-collection.json
@@ -10,7 +10,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "120"
           },
           "firefox_android": "mirror",
           "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 120 supports WasmGC

[Release notes](https://www.mozilla.org/en-US/firefox/120.0beta/releasenotes/#:~:text=WebAssembly%20GC%20is%20now%20enabled%20by%20default%2C%20which%20allows%20new%20languages%2C%20such%20as%20Dart%20or%20Kotlin%2C%20to%20run%20on%20Firefox.%20This%20makes%20it%20possible%20for%20reference%20cycles%20between%20the%20guest%20language%20and%20host%20browser%20to%20be%20collected.)
