### PR TITLE
Firefox 120 removed Window.sizeToContent

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6105,10 +6105,12 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "120"
             },
             "firefox_android": {
               "version_added": "4",
+              "version_removed": "120",
               "notes": "This method has no effect as a page is always in a tab."
             },
             "ie": {


### PR DESCRIPTION
Found by the Open Web Docs BCD collector.
See https://bugzilla.mozilla.org/show_bug.cgi?id=1855348