### PR TITLE
Remove scroll-timeline-attachment/view-timeline-attachment references

### DIFF
--- a/css/properties/scroll-timeline.json
+++ b/css/properties/scroll-timeline.json
@@ -7,9 +7,7 @@
           "spec_url": "https://drafts.csswg.org/scroll-animations/#scroll-timeline-shorthand",
           "support": {
             "chrome": {
-              "version_added": "115",
-              "partial_implementation": true,
-              "notes": "<code>scroll-timeline-attachment</code> not included in shorthand."
+              "version_added": "115"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/view-timeline.json
+++ b/css/properties/view-timeline.json
@@ -7,9 +7,7 @@
           "spec_url": "https://drafts.csswg.org/scroll-animations/#view-timeline-shorthand",
           "support": {
             "chrome": {
-              "version_added": "115",
-              "partial_implementation": true,
-              "notes": "<code>view-timeline-attachment</code> not included in shorthand."
+              "version_added": "115"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
_(👋 Hi, Chrome DevRel here)_

At one point in time the mentioned `scroll-timeline-attachment` and `view-timeline-attachment` properties were part of the spec but these have since been removed. The functionality got replaced by the `timeline-scope` property.

- Resolution to add `scroll/view-timeline-attachment`: https://github.com/w3c/csswg-drafts/issues/7759#issuecomment-1476312797
- Resolution to remove `scroll/view-timeline-attachment` and add `timeline-scope` instead: https://github.com/w3c/csswg-drafts/issues/7759#issuecomment-1551709286

This PR removes references to those properties. No browser ever shipped support for these `scroll/view-timeline-attachment` properties – they never made it past being part of an editor’s draft.