### PR TITLE
updated firefox version added for :has()

### DIFF
--- a/css/selectors/has.json
+++ b/css/selectors/has.json
@@ -13,15 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "103",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.has-selector.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "impl_url": "https://bugzil.la/418039"
+              "version_added": "121"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
#### Summary

Updated the version added for `:has()` selector in Firefox

#### Test results and supporting details

Tested in Firefox Beta

#### Related issues

- [[CSS] Enable :has on Release #30335](https://github.com/mdn/content/issues/30335)
- [Content PR](https://github.com/mdn/content/pull/30456)