### PR TITLE
Chrome OS -> ChromeOS

### DIFF
--- a/api/BarcodeDetector.json
+++ b/api/BarcodeDetector.json
@@ -9,7 +9,7 @@
             {
               "version_added": "88",
               "partial_implementation": true,
-              "notes": "Supported on Chrome OS and macOS only."
+              "notes": "Supported on ChromeOS and macOS only."
             },
             {
               "version_added": "83",
@@ -63,7 +63,7 @@
               {
                 "version_added": "88",
                 "partial_implementation": true,
-                "notes": "Supported on Chrome OS and macOS only."
+                "notes": "Supported on ChromeOS and macOS only."
               },
               {
                 "version_added": "83",
@@ -117,7 +117,7 @@
               {
                 "version_added": "88",
                 "partial_implementation": true,
-                "notes": "Supported on Chrome OS and macOS only."
+                "notes": "Supported on ChromeOS and macOS only."
               },
               {
                 "version_added": "83",
@@ -172,7 +172,7 @@
               {
                 "version_added": "88",
                 "partial_implementation": true,
-                "notes": "Supported on Chrome OS and macOS only."
+                "notes": "Supported on ChromeOS and macOS only."
               },
               {
                 "version_added": "83",

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -390,12 +390,12 @@
                 "chrome": [
                   {
                     "version_added": "81",
-                    "notes": "Chrome OS and Windows"
+                    "notes": "ChromeOS and Windows"
                   },
                   {
                     "version_added": "75",
                     "partial_implementation": true,
-                    "notes": "Chrome OS only"
+                    "notes": "ChromeOS only"
                   }
                 ],
                 "chrome_android": {
@@ -587,12 +587,12 @@
                 "chrome": [
                   {
                     "version_added": "81",
-                    "notes": "Chrome OS and Windows"
+                    "notes": "ChromeOS and Windows"
                   },
                   {
                     "version_added": "75",
                     "partial_implementation": true,
-                    "notes": "Chrome OS only"
+                    "notes": "ChromeOS only"
                   }
                 ],
                 "chrome_android": {
@@ -857,12 +857,12 @@
                 "chrome": [
                   {
                     "version_added": "81",
-                    "notes": "Chrome OS and Windows"
+                    "notes": "ChromeOS and Windows"
                   },
                   {
                     "version_added": "75",
                     "partial_implementation": true,
-                    "notes": "Chrome OS only"
+                    "notes": "ChromeOS only"
                   }
                 ],
                 "chrome_android": {

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -197,7 +197,7 @@
             "support": {
               "chrome": {
                 "version_added": "74",
-                "notes": "On Windows and Chrome OS the entire system audio can be captured, but on Linux and macOS only the audio of a tab can be captured."
+                "notes": "On Windows and ChromeOS the entire system audio can be captured, but on Linux and macOS only the audio of a tab can be captured."
               },
               "chrome_android": {
                 "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -449,7 +449,7 @@
             "chrome": {
               "version_added": "89",
               "partial_implementation": true,
-              "notes": "Only supported on Chrome OS and Windows, see <a href='https://crbug.com/770595'>bug 770595</a> and <a href='https://crbug.com/1144920'>bug 1144920</a>."
+              "notes": "Only supported on ChromeOS and Windows, see <a href='https://crbug.com/770595'>bug 770595</a> and <a href='https://crbug.com/1144920'>bug 1144920</a>."
             },
             "chrome_android": {
               "version_added": "75"
@@ -2145,7 +2145,7 @@
           "support": {
             "chrome": {
               "version_added": "2",
-              "notes": "Earlier versions of Chrome incorrectly return true when a tab is first opened, but it starts reporting the correct connectivity status after the first network event. Windows: 11, macOS: 14, Chrome OS: 13, Linux: Always returns <code>true</code>. For history, see <a href='https://crbug.com/7469'>crbug.com/7469</a>."
+              "notes": "Earlier versions of Chrome incorrectly return true when a tab is first opened, but it starts reporting the correct connectivity status after the first network event. Windows: 11, macOS: 14, ChromeOS: 13, Linux: Always returns <code>true</code>. For history, see <a href='https://crbug.com/7469'>crbug.com/7469</a>."
             },
             "chrome_android": {
               "version_added": "18"
@@ -4129,7 +4129,7 @@
             "chrome": {
               "version_added": "89",
               "partial_implementation": true,
-              "notes": "Only supported on Chrome OS and Windows, see <a href='https://crbug.com/770595'>bug 770595</a> and <a href='https://crbug.com/1144920'>bug 1144920</a>."
+              "notes": "Only supported on ChromeOS and Windows, see <a href='https://crbug.com/770595'>bug 770595</a> and <a href='https://crbug.com/1144920'>bug 1144920</a>."
             },
             "chrome_android": {
               "version_added": "61"

--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -177,7 +177,7 @@
           "support": {
             "chrome": {
               "version_added": "61",
-              "notes": "Only supported in Chrome OS"
+              "notes": "Only supported in ChromeOS"
             },
             "chrome_android": {
               "version_added": "38"
@@ -337,7 +337,7 @@
           "support": {
             "chrome": {
               "version_added": "61",
-              "notes": "Only supported in Chrome OS"
+              "notes": "Only supported in ChromeOS"
             },
             "chrome_android": {
               "version_added": "38"


### PR DESCRIPTION
This PR changes all instances where "Chrome OS" is mentioned to say "ChromeOS", as is the correct spelling per Google's webpages and documentation.  Fixes #21313 (indirectly).
