### PR TITLE
Update Chrome support for Managed Configuration API

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1829,7 +1829,7 @@
           "spec_url": "https://wicg.github.io/WebApiDevice/managed_config/#dom-navigator-managed",
           "support": {
             "chrome": {
-              "version_added": "119"
+              "version_added": "91"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/NavigatorManagedData.json
+++ b/api/NavigatorManagedData.json
@@ -5,7 +5,7 @@
         "spec_url": "https://wicg.github.io/WebApiDevice/managed_config/#navigatormanageddata",
         "support": {
           "chrome": {
-            "version_added": "119"
+            "version_added": "91"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -37,7 +37,7 @@
           "spec_url": "https://wicg.github.io/WebApiDevice/managed_config/#dom-navigatormanageddata-getmanagedconfiguration",
           "support": {
             "chrome": {
-              "version_added": "119"
+              "version_added": "91"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR is a follow-up to #21294 that corrects the version numbers set for the Managed Configuration API for Chrome, as confirmed by the [mdn-bcd-collector project](https://mdn-bcd-collector.gooborg.com), v10.4.0.
