### PR TITLE
Update Chromium data for css.properties.clip-path.fill_and_stroke_box

### DIFF
--- a/css/properties/clip-path.json
+++ b/css/properties/clip-path.json
@@ -131,7 +131,7 @@
             "description": "<code>fill-box</code> and <code>stroke-box</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "119"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `fill_and_stroke_box` member of the `clip-path` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.4.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/clip-path/fill_and_stroke_box
