### PR TITLE
Update Chromium data for font-variant CSS property

### DIFF
--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -182,7 +182,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "111"
+                "version_added": "110"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -214,7 +214,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "111"
+                "version_added": "110"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `font-variant` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.4.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/font-variant
