### PR TITLE
Update Chromium data for css.properties.list-style.symbols

### DIFF
--- a/css/properties/list-style.json
+++ b/css/properties/list-style.json
@@ -46,7 +46,7 @@
             "spec_url": "https://drafts.csswg.org/css-counter-styles/#symbols-function",
             "support": {
               "chrome": {
-                "version_added": "91"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `symbols` member of the `list-style` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.4.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/list-style/symbols

Additional Notes: The data was previously updated in #19526, but the test has since been fixed in https://github.com/openwebdocs/mdn-bcd-collector/commit/0ec6ee2345e5f1968ef67cafc2cc390bd9756835.
