### PR TITLE
Add missing javascript.builtins.Atomics.wake feature

### DIFF
--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -588,6 +588,44 @@
             }
           }
         },
+        "wake": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "≤80",
+                "version_removed": "86"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "78"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "xor": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/xor",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing `wake` member of the `Atomics` JavaScript builtin. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.4.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/javascript/builtins/Atomics/wake
