### PR TITLE
Enable irrelevance linting for MathML

### DIFF
--- a/mathml/attribute_values.json
+++ b/mathml/attribute_values.json
@@ -3,6 +3,7 @@
     "attribute_values": {
       "named_space": {
         "__compat": {
+          "description": "Named spaces (e.g. <code>thinmathspace</code> to mean 3/18em)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths",
           "support": {
             "chrome": {
@@ -44,7 +45,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "70"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/mathml/elements/maction.json
+++ b/mathml/elements/maction.json
@@ -68,39 +68,6 @@
               "deprecated": true
             }
           },
-          "restyle": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "1",
-                  "version_removed": "9"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
-              }
-            }
-          },
           "statusline": {
             "__compat": {
               "support": {

--- a/mathml/elements/mpadded.json
+++ b/mathml/elements/mpadded.json
@@ -175,7 +175,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "70"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/mathml/elements/mtable.json
+++ b/mathml/elements/mtable.json
@@ -386,41 +386,6 @@
                 "deprecated": true
               }
             }
-          },
-          "nonzero_unitless_values": {
-            "__compat": {
-              "description": "Nonzero unitless values (e.g. 5 to mean 500%)",
-              "mdn_url": "https://developer.mozilla.org/docs/Web/MathML/Attribute/Values#legacy_mathml_lengths",
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "13",
-                  "version_removed": "70"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": false,
-                "deprecated": true
-              }
-            }
           }
         }
       }

--- a/test/linter/test-obsolete.ts
+++ b/test/linter/test-obsolete.ts
@@ -19,7 +19,7 @@ const categoriesToCheck = [
   // 'html',
   // 'http',
   // 'javascript',
-  // 'mathml',
+  'mathml',
   // 'svg',
   'webassembly',
   // 'webdriver',


### PR DESCRIPTION
Enables our linter to check for irrelevant features for the `mathml/` folder. See the BCD data guideline about removal of features gone everywhere for more than two years: https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features

This means complete removal of
- `mathml.elements.maction.actiontype.restyle`
- `mathml.elements.mtable.width.nonzero_unitless_values`

Drive-by updates to:
- `mathml.attribute_values.nonzero_unitless_values` to say removed in Fx70 (consistent with other data)
- `mathml.elements.mpadded.lspace.nonzero_unitless_values` to say removed in Fx70 (consistent with other data)
- `mathml.attribute_values.named_space` to add a description