### PR TITLE
Remove alternative_name: pageX/YOffset from scrollX/Y

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -5530,67 +5530,30 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/scrollX",
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-window-scrollx",
           "support": {
-            "chrome": [
-              {
-                "version_added": "1"
-              },
-              {
-                "alternative_name": "pageXOffset",
-                "version_added": "1"
-              }
-            ],
+            "chrome": {
+              "version_added": "1"
+            },
             "chrome_android": "mirror",
-            "edge": [
-              {
-                "version_added": "12"
-              },
-              {
-                "alternative_name": "pageXOffset",
-                "version_added": "12"
-              }
-            ],
-            "firefox": [
-              {
-                "version_added": "1"
-              },
-              {
-                "alternative_name": "pageXOffset",
-                "version_added": "1"
-              }
-            ],
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
             "firefox_android": "mirror",
             "ie": {
-              "alternative_name": "pageXOffset",
-              "version_added": "9"
+              "version_added": false
             },
             "oculus": "mirror",
-            "opera": [
-              {
-                "version_added": "9.6"
-              },
-              {
-                "alternative_name": "pageXOffset",
-                "version_added": "4"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "10.1"
-              },
-              {
-                "alternative_name": "pageXOffset",
-                "version_added": "10.1"
-              }
-            ],
-            "safari": [
-              {
-                "version_added": "1"
-              },
-              {
-                "alternative_name": "pageXOffset",
-                "version_added": "1"
-              }
-            ],
+            "opera": {
+              "version_added": "9.6"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
+            "safari": {
+              "version_added": "1"
+            },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -5642,67 +5605,31 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/scrollY",
           "spec_url": "https://drafts.csswg.org/cssom-view/#dom-window-scrolly",
           "support": {
-            "chrome": [
-              {
-                "version_added": "1"
-              },
-              {
-                "alternative_name": "pageYOffset",
-                "version_added": "1"
-              }
-            ],
+            "chrome": {
+              "version_added": "1"
+            },
             "chrome_android": "mirror",
-            "edge": [
-              {
-                "version_added": "12"
-              },
-              {
-                "alternative_name": "pageYOffset",
-                "version_added": "12"
-              }
-            ],
-            "firefox": [
-              {
-                "version_added": "1"
-              },
-              {
-                "alternative_name": "pageYOffset",
-                "version_added": "1"
-              }
-            ],
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
             "firefox_android": "mirror",
             "ie": {
               "alternative_name": "pageYOffset",
               "version_added": "9"
             },
             "oculus": "mirror",
-            "opera": [
-              {
-                "version_added": "9.6"
-              },
-              {
-                "alternative_name": "pageYOffset",
-                "version_added": "4"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "10.1"
-              },
-              {
-                "alternative_name": "pageYOffset",
-                "version_added": "10.1"
-              }
-            ],
-            "safari": [
-              {
-                "version_added": "1"
-              },
-              {
-                "alternative_name": "pageYOffset",
-                "version_added": "1"
-              }
-            ],
+            "opera": {
+              "version_added": "9.6"
+            },
+            "opera_android": {
+              "version_added": "10.1"
+            },
+            "safari": {
+              "version_added": "1"
+            },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Given that pageX/YOffset have their own spec links, MDN pages, and BCD entries, it's probably right to remove them from `alternative_name`. MDN already mentions alternative names from both side, so no change is needed there.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Fixes #21247