### PR TITLE
Firefox 74+ for Android supports allow attribute.

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -88,9 +88,7 @@
               "firefox": {
                 "version_added": "74"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

By https://github.com/mdn/browser-compat-data/commit/7295c5639475f06bf0e51cb8dc231d3abebc5331, Firefox desktop updates allow attribute data. But this supports on Android too.

#### Test results and supporting details

https://bugzilla.mozilla.org/show_bug.cgi?id=1617219.

#### Related issues