### PR TITLE
Update Safari releases according to Apple release notes

### DIFF
--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -200,7 +200,7 @@
           "engine_version": "612.4.9"
         },
         "15.4": {
-          "release_date": "2021-03-14",
+          "release_date": "2022-03-14",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes",
           "status": "retired",
           "engine": "WebKit",
@@ -221,7 +221,7 @@
           "engine_version": "613.3.9"
         },
         "16": {
-          "release_date": "2023-09-12",
+          "release_date": "2022-09-12",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes",
           "status": "retired",
           "engine": "WebKit",

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -235,7 +235,7 @@
           "engine_version": "614.2.9"
         },
         "16.2": {
-          "release_date": "2022-10-24",
+          "release_date": "2022-12-13",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_2-release-notes",
           "status": "retired",
           "engine": "WebKit",

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -132,22 +132,22 @@
           "engine_version": "605.1.33"
         },
         "12": {
-          "release_date": "2018-09-24",
-          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_release_notes",
+          "release_date": "2018-09-17",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-12-release-notes",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "606.1.36"
         },
         "12.1": {
           "release_date": "2019-03-25",
-          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_1_release_notes",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-12_1-release-notes",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "607.1.40"
         },
         "13": {
           "release_date": "2019-09-19",
-          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_release_notes",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-13-release-notes",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "608.2.11"
@@ -200,7 +200,7 @@
           "engine_version": "612.4.9"
         },
         "15.4": {
-          "release_date": "2022-03-15",
+          "release_date": "2021-03-14",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes",
           "status": "retired",
           "engine": "WebKit",
@@ -221,7 +221,7 @@
           "engine_version": "613.3.9"
         },
         "16": {
-          "release_date": "2022-09-12",
+          "release_date": "2023-09-12",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes",
           "status": "retired",
           "engine": "WebKit",
@@ -235,7 +235,7 @@
           "engine_version": "614.2.9"
         },
         "16.2": {
-          "release_date": "2022-12-13",
+          "release_date": "2022-10-24",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_2-release-notes",
           "status": "retired",
           "engine": "WebKit",
@@ -270,7 +270,7 @@
           "engine_version": "615.3.12"
         },
         "17": {
-          "release_date": "2023-09-26",
+          "release_date": "2023-09-18",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes",
           "status": "retired",
           "engine": "WebKit",
@@ -286,7 +286,8 @@
         "17.2": {
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17_2-release-notes",
           "status": "beta",
-          "engine": "WebKit"
+          "engine": "WebKit",
+          "engine_version": "617.1.11"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -105,7 +105,7 @@
         },
         "12": {
           "release_date": "2018-09-17",
-          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_12_release_notes",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-12-release-notes",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "606.1.36"
@@ -119,7 +119,7 @@
         },
         "13": {
           "release_date": "2019-09-19",
-          "release_notes": "https://developer.apple.com/documentation/safari_release_notes/safari_13_release_notes",
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-13-release-notes",
           "status": "retired",
           "engine": "WebKit",
           "engine_version": "608.2.11"
@@ -172,7 +172,7 @@
           "engine_version": "612.4.9"
         },
         "15.4": {
-          "release_date": "2022-03-15",
+          "release_date": "2021-03-14",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes",
           "status": "retired",
           "engine": "WebKit",
@@ -193,7 +193,7 @@
           "engine_version": "613.3.9"
         },
         "16": {
-          "release_date": "2022-09-12",
+          "release_date": "2023-09-12",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes",
           "status": "retired",
           "engine": "WebKit",
@@ -207,7 +207,7 @@
           "engine_version": "614.2.9"
         },
         "16.2": {
-          "release_date": "2022-12-13",
+          "release_date": "2022-10-24",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_2-release-notes",
           "status": "retired",
           "engine": "WebKit",
@@ -242,7 +242,7 @@
           "engine_version": "615.3.12"
         },
         "17": {
-          "release_date": "2023-09-26",
+          "release_date": "2023-09-18",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes",
           "status": "retired",
           "engine": "WebKit",
@@ -258,7 +258,8 @@
         "17.2": {
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17_2-release-notes",
           "status": "beta",
-          "engine": "WebKit"
+          "engine": "WebKit",
+          "engine_version": "617.1.11"
         }
       }
     }

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -172,7 +172,7 @@
           "engine_version": "612.4.9"
         },
         "15.4": {
-          "release_date": "2021-03-14",
+          "release_date": "2022-03-14",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-15_4-release-notes",
           "status": "retired",
           "engine": "WebKit",
@@ -193,7 +193,7 @@
           "engine_version": "613.3.9"
         },
         "16": {
-          "release_date": "2023-09-12",
+          "release_date": "2022-09-12",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes",
           "status": "retired",
           "engine": "WebKit",

--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -207,7 +207,7 @@
           "engine_version": "614.2.9"
         },
         "16.2": {
-          "release_date": "2022-10-24",
+          "release_date": "2022-12-13",
           "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-16_2-release-notes",
           "status": "retired",
           "engine": "WebKit",


### PR DESCRIPTION
This is the output of the updated Safari script in https://github.com/mdn/browser-compat-data/pull/21325