### PR TITLE
Add note about support for interpolation of registered custom properties in Fx

### DIFF
--- a/api/CSS.json
+++ b/api/CSS.json
@@ -1732,7 +1732,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "notes": "Does not yet support interpolation of registered custom properties. See <a href='https://bugzil.la/1846516'>bug 1846516</a>."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/CSSPropertyRule.json
+++ b/api/CSSPropertyRule.json
@@ -11,7 +11,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "preview",
+            "notes": "Does not yet support interpolation of registered custom properties. See <a href='https://bugzil.la/1846516'>bug 1846516</a>."
           },
           "firefox_android": "mirror",
           "ie": {

--- a/css/at-rules/property.json
+++ b/css/at-rules/property.json
@@ -13,7 +13,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "notes": "Does not yet support interpolation of registered custom properties. See <a href='https://bugzil.la/1846516'>bug 1846516</a>."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This note might be useful to set expectations about this feature for now.

I am setting this at the following level which I think is most accurate:

- css.at-rules.property
- api.CSS.registerProperty_static
- api.CSSPropertyRule

#### Related issues

- One person caught out by this here: https://github.com/mdn/browser-compat-data/pull/20346#issuecomment-1741439650
- Bug: https://bugzil.la/1846516
- Plans to ship: https://bugzilla.mozilla.org/show_bug.cgi?id=1864818
