### PR TITLE
 mark experimental false of `Navigator.deviceMemory` and `Device-Memory`

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -859,7 +859,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/http/headers/Device-Memory.json
+++ b/http/headers/Device-Memory.json
@@ -34,7 +34,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

According to spec data, the `Navigator.deviceMemory` property and `Device-Memory` http header has been supported by Chrome and Opera without any flags or prefixes, so it is time to mark `experimental` as `false`

See also `WorkerNavigator.deviceMemory`, which mark `experimental` as `false`

Related With https://github.com/mdn/content/pull/30538

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
