### PR TITLE
FF121 Update WebTransportBidirectionalStream to use WebTransportSend/RecieveStream 

### DIFF
--- a/api/WebTransportBidirectionalStream.json
+++ b/api/WebTransportBidirectionalStream.json
@@ -77,7 +77,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "121"
+                "version_added": "114"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -145,7 +145,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "121"
+                "version_added": "114"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/api/WebTransportBidirectionalStream.json
+++ b/api/WebTransportBidirectionalStream.json
@@ -65,6 +65,40 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "returns_WebTransportReceiveStream": {
+          "__compat": {
+            "description": "Returns <code>WebTransportReceiveStream</code> (earlier spec returned <code>WritableStream</code>)",
+            "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportbidirectionalstream-readable",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "121"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "writable": {
@@ -98,6 +132,40 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "returns_WebTransportSendStream": {
+          "__compat": {
+            "description": "Returns <code>WebTransportReceiveStream</code> (earlier spec returned <code>WritableStream</code>)",
+            "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportbidirectionalstream-readable",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "121"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/api/WebTransportBidirectionalStream.json
+++ b/api/WebTransportBidirectionalStream.json
@@ -136,7 +136,7 @@
         },
         "returns_WebTransportSendStream": {
           "__compat": {
-            "description": "Returns <code>WebTransportReceiveStream</code> (earlier spec returned <code>WritableStream</code>)",
+            "description": "Returns <code>WebTransportSendStream</code> (earlier spec returned <code>WritableStream</code>)",
             "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportbidirectionalstream-readable",
             "support": {
               "chrome": {


### PR DESCRIPTION
This follows on from #21333 which added support for `WebTransportSendStream` in 114.

The  `WebTransportSendStream` interface is returned by `WebTransportBidirectionalStream.writable` in the spec, and `WebTransportReceiveStream` is returned by `WebTransportBidirectionalStream.readable`. You can see that `WebTransportSendStream` and `WebTransportSendStream` are supported by FF114 (nightly) using the BCD collectors - such as https://mdn-bcd-collector.gooborg.com/tests/api/WebTransportSendStream but are not supported in current Chrome.

What this does is update the `WebTransportBidirectionalStream` `readable` and `writable` features with a subfeature indicating the new return type.

Note that `WebTransportSendStream` should also be returned by  `createUnidirectionalStream()` but this is not implemented anywhere - the method feature has a note. 

This is related to docs work in https://github.com/mdn/content/issues/30481