### PR TITLE
webrequest.onbeforesendheaders frameAncestors

### DIFF
--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -2952,6 +2952,25 @@
                 }
               }
             },
+            "frameAncestors": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": true
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
             "frameId": {
               "__compat": {
                 "support": {


### PR DESCRIPTION
#### Summary

Add to the browser compatibility details to complement the documentation update in https://github.com/mdn/content/pull/29873

frameAncestors was added to onBeforeRequest in version 58, according to the release notes and BCD. Was also added to onHeadersReceived in version 58 according to the BCD. Cannot find any information to confirm when it is to onbeforesendheaders

