### PR TITLE
showPicker for <input type=time> supports on Firefox/Android

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2271,7 +2271,9 @@
               "firefox": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "101"
+              },
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

showPicker for `<input type=time>` supports on Firefox/Android 101+

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

When I test showPicker implementation by https://wontfix.net/bugs/showpicker.html, Firefox/Android shows picker on `<input type="time">` since Firefox/Android has the picker for this type.

I verified on Firefox/Android 101.

#### Related issues

- https://bugzilla.mozilla.org/show_bug.cgi?id=1745005
