### PR TITLE
Chrome unprefixed :autofill in version 110

### DIFF
--- a/css/selectors/autofill.json
+++ b/css/selectors/autofill.json
@@ -7,10 +7,15 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:autofill",
           "spec_url": "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-autofill",
           "support": {
-            "chrome": {
-              "prefix": "-webkit-",
-              "version_added": "1"
-            },
+            "chrome": [
+              {
+                "version_added": "110"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "1"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": [


### PR DESCRIPTION
Found by the Open Web Docs BCD collector.

Landed behind a flag in 96 and was enabled in 110.
https://chromium.googlesource.com/chromium/src/+/9e7150f3ce82bebfc04d315a83fc3b32166e6a3e
https://storage.googleapis.com/chromium-find-releases-static/9e7.html#9e7150f3ce82bebfc04d315a83fc3b32166e6a3e