### PR TITLE
Update auto-issue-close text

### DIFF
--- a/.github/workflows/close-incomplete-issues.yml
+++ b/.github/workflows/close-incomplete-issues.yml
@@ -16,8 +16,8 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           labels: "invalid :no_entry_sign:"
           comment: |
-            This issue was automatically closed because the template has not been properly filled out. A summary has not been added to the title of the issue.
+            This issue was automatically closed because the title was left as the default, and a summary was not added.
 
-            If this has been closed in error, edit the title and/or body, and post a follow-up comment.
+            If this is not a spam issue, please replace the `<SUMMARIZE THE PROBLEM>` part of the title with a short summary of the reported issue, and then post a follow-up comment.  A maintainer will review your issue and reopen it if needed.
           normalize-newlines: true
           title-contains: "<SUMMARIZE THE PROBLEM>"


### PR DESCRIPTION
This PR updates the auto-close bot's text for better clarity about what the issue reporter needs to do if their issue was closed in error.