### PR TITLE
Firefox 121 ships wasm tail calls

### DIFF
--- a/webassembly/tail-calls.json
+++ b/webassembly/tail-calls.json
@@ -10,7 +10,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "121"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -27,7 +27,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }


### PR DESCRIPTION
Found by the Open Web Docs BCD Collector.

Confirmed by https://bugzilla.mozilla.org/show_bug.cgi?id=1846789