### PR TITLE
Chrome 114 ships wasm extended-const

### DIFF
--- a/webassembly/extended-constant-expressions.json
+++ b/webassembly/extended-constant-expressions.json
@@ -5,7 +5,7 @@
         "spec_url": "https://github.com/WebAssembly/extended-const/blob/main/proposals/extended-const/Overview.md",
         "support": {
           "chrome": {
-            "version_added": false
+            "version_added": "114"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -27,7 +27,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }


### PR DESCRIPTION
Found by the Open Web Docs BCD Collector.

Confirmed by https://chromestatus.com/feature/5131077456232448