### PR TITLE
Update Safari data for fullscreen CSS selector

### DIFF
--- a/css/selectors/fullscreen.json
+++ b/css/selectors/fullscreen.json
@@ -37,10 +37,15 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "alternative_name": ":-webkit-full-screen",
-              "version_added": "6"
-            },
+            "safari": [
+              {
+                "version_added": "16.4"
+              },
+              {
+                "alternative_name": ":-webkit-full-screen",
+                "version_added": "6"
+              }
+            ],
             "safari_ios": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `fullscreen` CSS selector. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.5.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/selectors/fullscreen

Additional Notes: The collector produced the range of 15.6> ≤16.5 due to lack of testing capacity for Safari 16.x at the moment.  Safari 16.4 was guesstimated by mirroring from api.Element.requestFullscreen.
