### PR TITLE
Add missing closed-and-open CSS selector feature

### DIFF
--- a/css/selectors/closed.json
+++ b/css/selectors/closed.json
@@ -1,0 +1,39 @@
+{
+  "css": {
+    "selectors": {
+      "closed": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/selectors-4/#open-state",
+          "support": {
+            "chrome": {
+              "version_added": "114"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/open.json
+++ b/css/selectors/open.json
@@ -1,0 +1,39 @@
+{
+  "css": {
+    "selectors": {
+      "open": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/selectors-4/#open-state",
+          "support": {
+            "chrome": {
+              "version_added": "114"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing `closed-and-open` CSS selector. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.5.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/selectors/closed-and-open
