### PR TITLE
Update Chromium data for view-transition CSS selectors

### DIFF
--- a/css/selectors/view-transition-group.json
+++ b/css/selectors/view-transition-group.json
@@ -8,7 +8,7 @@
           "spec_url": "https://drafts.csswg.org/css-view-transitions/#::view-transition-group",
           "support": {
             "chrome": {
-              "version_added": "111"
+              "version_added": "109"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/selectors/view-transition-image-pair.json
+++ b/css/selectors/view-transition-image-pair.json
@@ -8,7 +8,7 @@
           "spec_url": "https://drafts.csswg.org/css-view-transitions/#::view-transition-image-pair",
           "support": {
             "chrome": {
-              "version_added": "111"
+              "version_added": "109"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/selectors/view-transition-new.json
+++ b/css/selectors/view-transition-new.json
@@ -8,7 +8,7 @@
           "spec_url": "https://drafts.csswg.org/css-view-transitions/#::view-transition-new",
           "support": {
             "chrome": {
-              "version_added": "111"
+              "version_added": "109"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/selectors/view-transition-old.json
+++ b/css/selectors/view-transition-old.json
@@ -8,7 +8,7 @@
           "spec_url": "https://drafts.csswg.org/css-view-transitions/#::view-transition-old",
           "support": {
             "chrome": {
-              "version_added": "111"
+              "version_added": "109"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/selectors/view-transition.json
+++ b/css/selectors/view-transition.json
@@ -8,7 +8,7 @@
           "spec_url": "https://drafts.csswg.org/css-view-transitions/#selectordef-view-transition",
           "support": {
             "chrome": {
-              "version_added": "111"
+              "version_added": "109"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `view-transition` CSS selectors. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.5.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used:
https://mdn-bcd-collector.gooborg.com/tests/css/selectors/view-transition
https://mdn-bcd-collector.gooborg.com/tests/css/selectors/view-transition-group
https://mdn-bcd-collector.gooborg.com/tests/css/selectors/view-transition-image-pair
https://mdn-bcd-collector.gooborg.com/tests/css/selectors/view-transition-new
https://mdn-bcd-collector.gooborg.com/tests/css/selectors/view-transition-old
