### PR TITLE
Update Chromium data for future CSS selector

### DIFF
--- a/css/selectors/future.json
+++ b/css/selectors/future.json
@@ -8,7 +8,7 @@
           "spec_url": "https://drafts.csswg.org/selectors/#the-future-pseudo",
           "support": {
             "chrome": {
-              "version_added": "≤83"
+              "version_added": "23"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/selectors/future.json
+++ b/css/selectors/future.json
@@ -8,7 +8,7 @@
           "spec_url": "https://drafts.csswg.org/selectors/#the-future-pseudo",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "≤83"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -30,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `future` CSS selector. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.5.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/selectors/future
