### PR TITLE
Update Chromium data for past CSS selector

### DIFF
--- a/css/selectors/past.json
+++ b/css/selectors/past.json
@@ -8,7 +8,7 @@
           "spec_url": "https://drafts.csswg.org/selectors/#the-past-pseudo",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "≤83"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -30,7 +30,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/selectors/past.json
+++ b/css/selectors/past.json
@@ -8,7 +8,7 @@
           "spec_url": "https://drafts.csswg.org/selectors/#the-past-pseudo",
           "support": {
             "chrome": {
-              "version_added": "≤83"
+              "version_added": "23"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `past` CSS selector. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.5.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/selectors/past
