### PR TITLE
Use .replaceAll() instead of .replace() in string sanitization

### DIFF
--- a/scripts/release/utils.ts
+++ b/scripts/release/utils.ts
@@ -87,7 +87,7 @@ export const getRefDate = (ref: string, querySafe = false): string => {
   const rawDateString = exec(`git log -1 --format=%aI ${ref}`);
 
   if (querySafe) {
-    return rawDateString.replace('+', '%2B');
+    return rawDateString.replaceAll('+', '%2B');
   }
   return rawDateString;
 };


### PR DESCRIPTION
This PR swaps a call to `.replace()` with `.replaceAll()` in string sanitization, preventing potential issues.
