### PR TITLE
Fix Chrome update script

### DIFF
--- a/scripts/update-browser-releases/chrome.ts
+++ b/scripts/update-browser-releases/chrome.ts
@@ -89,48 +89,50 @@ export const updateChromiumReleases = async (options) => {
   for (const [key, value] of channels) {
     // Extract the useful data
     const versionData = versions[value];
-    data[value] = {};
-    data[value].version = versionData.version;
-    data[value].releaseDate = versionData.stable_date.substring(0, 10); // Remove the time part;
+    if (versionData) {
+      data[value] = {};
+      data[value].version = versionData.version;
+      data[value].releaseDate = versionData.stable_date.substring(0, 10); // Remove the time part;
 
-    // Update the JSON in memory
-    let releaseNotesURL;
-    try {
-      releaseNotesURL = await getReleaseNotesURL(
-        versionData.version,
-        data[value].releaseDate,
-        options.releaseNoteCore,
-        value,
-      );
-    } catch (str) {
-      result += str;
-    }
+      // Update the JSON in memory
+      let releaseNotesURL;
+      try {
+        releaseNotesURL = await getReleaseNotesURL(
+          data[value].version,
+          data[value].releaseDate,
+          options.releaseNoteCore,
+          value,
+        );
+      } catch (str) {
+        result += str;
+      }
 
-    if (
-      chromeBCD.browsers[options.bcdBrowserName].releases[data[value].version]
-    ) {
-      // The entry already exists
-      result += updateBrowserEntry(
-        chromeBCD,
-        options.bcdBrowserName,
-        data[value].version,
-        data[value].releaseDate,
-        key,
-        releaseNotesURL,
-        '',
-      );
-    } else {
-      // New entry
-      result += newBrowserEntry(
-        chromeBCD,
-        options.bcdBrowserName,
-        data[value].version,
-        key,
-        options.browserEngine,
-        data[value].releaseDate,
-        releaseNotesURL,
-        data[value].version,
-      );
+      if (
+        chromeBCD.browsers[options.bcdBrowserName].releases[data[value].version]
+      ) {
+        // The entry already exists
+        result += updateBrowserEntry(
+          chromeBCD,
+          options.bcdBrowserName,
+          data[value].version,
+          data[value].releaseDate,
+          key,
+          releaseNotesURL,
+          '',
+        );
+      } else {
+        // New entry
+        result += newBrowserEntry(
+          chromeBCD,
+          options.bcdBrowserName,
+          data[value].version,
+          key,
+          options.browserEngine,
+          data[value].releaseDate,
+          releaseNotesURL,
+          data[value].version,
+        );
+      }
     }
   }
 
@@ -165,30 +167,32 @@ export const updateChromiumReleases = async (options) => {
   //
   // Add a planned version entry
   //
-  const plannedVersion = (data[options.nightlyBranch].version + 1).toString();
-  if (chromeBCD.browsers[options.bcdBrowserName].releases[plannedVersion]) {
-    result += updateBrowserEntry(
-      chromeBCD,
-      options.bcdBrowserName,
-      plannedVersion,
-      chromeBCD.browsers[options.bcdBrowserName].releases[plannedVersion]
-        .release_date,
-      'planned',
-      '',
-      '',
-    );
-  } else {
-    // New entry
-    result += newBrowserEntry(
-      chromeBCD,
-      options.bcdBrowserName,
-      plannedVersion,
-      'planned',
-      options.browserEngine,
-      '',
-      '',
-      plannedVersion,
-    );
+  if (data[options.nightlyBranch]) {
+    const plannedVersion = (data[options.nightlyBranch].version + 1).toString();
+    if (chromeBCD.browsers[options.bcdBrowserName].releases[plannedVersion]) {
+      result += updateBrowserEntry(
+        chromeBCD,
+        options.bcdBrowserName,
+        plannedVersion,
+        chromeBCD.browsers[options.bcdBrowserName].releases[plannedVersion]
+          .release_date,
+        'planned',
+        '',
+        '',
+      );
+    } else {
+      // New entry
+      result += newBrowserEntry(
+        chromeBCD,
+        options.bcdBrowserName,
+        plannedVersion,
+        'planned',
+        options.browserEngine,
+        '',
+        '',
+        plannedVersion,
+      );
+    }
   }
 
   //


### PR DESCRIPTION
The Chrome script assumes that the data would always have all channels. However, currently, the data has no info for canary... https://chromestatus.com/api/v0/channels

See the failed build: https://github.com/mdn/browser-compat-data/actions/runs/7028052289/job/19129489635

I've added two if conditions to first check if the data is there. line 92 and line 170. The rest is prettier indent. 