### PR TITLE
Firefox Android: Mirror a few more CSS features

### DIFF
--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -270,9 +270,7 @@
               "firefox": {
                 "version_added": "71"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/css/properties/letter-spacing.json
+++ b/css/properties/letter-spacing.json
@@ -56,9 +56,7 @@
               "firefox": {
                 "version_added": "72"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": "9"
               },

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -3206,9 +3206,7 @@
               "firefox": {
                 "version_added": "33"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -85,9 +85,7 @@
               "firefox": {
                 "version_added": "72"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": "9"
               },

--- a/css/selectors/marker.json
+++ b/css/selectors/marker.json
@@ -49,9 +49,7 @@
               "firefox": {
                 "version_added": "80"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/css/types/image.json
+++ b/css/types/image.json
@@ -1770,9 +1770,7 @@
                 "version_added": false,
                 "notes": "See <a href='https://bugzil.la/703217'>bug 703217</a>."
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
If you run `npm run traverse css -- -b firefox_android -f false` you find 8 features that are currently marked false:
Except for font-smooth (it says that it only works on macOS) and for -moz-window-inactive (not sure if it works in android), these features should all mirror the support from firefox desktop.

css.properties.font-smooth
css.properties.grid-template-rows.subgrid
css.properties.letter-spacing.svg
css.properties.list-style-type.tibetan
css.properties.word-spacing.svg
css.selectors.-moz-window-inactive
css.selectors.marker.animation_and_transition_support
css.types.image.image

btw, to see all CSS features that are not mirrored from Firefox Desktop, run: `npm run traverse css -- -b firefox_android -f nonmirror`. It spits out 95 features and upon spot checking these are legit as there are differences between Fx desktop and Fx Android.

 I've briefly looked into other folders (e.g. api, `npm run traverse api -- -b firefox_android -f nonmirror`) and there are more results. Many seem valid as FxAndroid doesn't support the GPU API, for example. More investigation might be needed, though. We can look into running the collector on FxAndroid hopefully.

cc @ddbeck 