### PR TITLE
Add hidden to tabs.Tab

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -740,6 +740,25 @@
               }
             }
           },
+          "hidden": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "59"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "highlighted": {
             "__compat": {
               "support": {


### PR DESCRIPTION
#### Summary

Add details for the `hidden` property to `tabs.Tab`.

#### Test results and supporting details

Added in Firefox 59 by https://bugzilla.mozilla.org/show_bug.cgi?id=1423725 and documented as included in Android in  mozilla-central/mobile/android/components/extensions/schemas/tabs.json [line 195](https://searchfox.org/mozilla-central/rev/996f5bf0b9a32aa0620a841abb9531625fe916aa/mobile/android/components/extensions/schemas/tabs.json#195) although the corresponding `hide` and `show` methods aren't available in Android.

#### Related issues

Fixes #12265
