### PR TITLE
Safari 17.2 supports :highlight; removes HTMLInputElement.search_event

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1608,7 +1608,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "2"
+              "version_added": "2",
+              "version_removed": "17.2"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/selectors/highlight.json
+++ b/css/selectors/highlight.json
@@ -25,7 +25,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17.2"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/selectors/highlight.json
+++ b/css/selectors/highlight.json
@@ -32,7 +32,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
This is a followup to https://github.com/mdn/browser-compat-data/pull/21267.

The Open Web Docs BCD collector v10.5.2 can now detect compat data changes for events and CSS selectors. Running it again with Safari 17.2 beta revealed two more changes:

- `api.HTMLInputElement.serach_event` (removed in 17.2, belongs to the removal of `api.HTMLInputElement.incremental`)
- `css.selectors.highlight` (added in 17.2 and part of the CSS Custom Highlight API which is talked about in the [release notes](https://developer.apple.com/documentation/safari-release-notes/safari-17_2-release-notes).)

(cc @jdatapple) 