### PR TITLE
Safari on iOS -> iOS/iPadOS

### DIFF
--- a/browsers/safari_ios.json
+++ b/browsers/safari_ios.json
@@ -1,7 +1,7 @@
 {
   "browsers": {
     "safari_ios": {
-      "name": "Safari on iOS",
+      "name": "iOS/iPadOS",
       "type": "mobile",
       "upstream": "safari",
       "accepts_flags": true,


### PR DESCRIPTION
This PR updates the display name for Safari on iOS to say just "iOS/iPadOS".

iOS browsers (Chrome, Firefox, Safari, etc.) all use Safari as the underlying engine regardless of the app, but developers may not know this, and as such, [report compatibility issues with Chrome on iOS](https://github.com/mdn/browser-compat-data/issues/21308) without knowing that it's not _actually_ Chrome, just Safari with a Chrome UI.  To avoid this confusion, this PR replaces the display name of "Safari on iOS" to just say "iOS" (and mention "iPadOS").

Fixes #17241.