### PR TITLE
Update Node.js version for import attributes

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1351,7 +1351,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "21.0.0"
+                "version_added": "20.10.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -1390,7 +1390,7 @@
                   "version_added": false
                 },
                 "nodejs": {
-                  "version_added": "21.0.0"
+                  "version_added": "20.10.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Node.js backported this feature from 21 to 20.10

#### Test results and supporting details

```
Documents/misc/node-import-attributes via ⬢ v20.10.0 
➜ node --version
v20.10.0

Documents/misc/node-import-attributes via ⬢ v20.10.0 
➜ bat index.mjs a.json
───────┬────────────────────────────────────────────────────────────────────────
       │ File: index.mjs
───────┼────────────────────────────────────────────────────────────────────────
   1   │ import x from "./a.json" with { type: "json" }
   2   │ console.log(x);
   3   │ 
───────┴────────────────────────────────────────────────────────────────────────
───────┬────────────────────────────────────────────────────────────────────────
       │ File: a.json
───────┼────────────────────────────────────────────────────────────────────────
   1   │ 3
───────┴────────────────────────────────────────────────────────────────────────

Documents/misc/node-import-attributes via ⬢ v20.10.0 
➜ node index.mjs
3
(node:25522) ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
```

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
