### PR TITLE
mark `partitioned` option in `CookieStore` interface as standard

### DIFF
--- a/api/CookieStore.json
+++ b/api/CookieStore.json
@@ -109,6 +109,7 @@
         "partitioned_option": {
           "__compat": {
             "description": "<code>partitioned</code> option",
+            "spec_url": "https://wicg.github.io/cookie-store/#dom-cookiestoredeleteoptions-partitioned",
             "support": {
               "chrome": {
                 "version_added": "114"
@@ -176,6 +177,7 @@
         "partitioned_return_property": {
           "__compat": {
             "description": "<code>partitioned</code> in return value",
+            "spec_url": "https://wicg.github.io/cookie-store/#dom-cookielistitem-partitioned",
             "support": {
               "chrome": {
                 "version_added": "114"
@@ -243,6 +245,7 @@
         "partitioned_return_property": {
           "__compat": {
             "description": "<code>partitioned</code> in return value",
+            "spec_url": "https://wicg.github.io/cookie-store/#dom-cookielistitem-partitioned",
             "support": {
               "chrome": {
                 "version_added": "114"
@@ -310,6 +313,7 @@
         "partitioned_option": {
           "__compat": {
             "description": "<code>partitioned</code> option",
+            "spec_url": "https://wicg.github.io/cookie-store/#dom-cookieinit-partitioned",
             "support": {
               "chrome": {
                 "version_added": "114"

--- a/api/CookieStore.json
+++ b/api/CookieStore.json
@@ -134,7 +134,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }
@@ -201,7 +201,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }
@@ -268,7 +268,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }
@@ -335,7 +335,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -383,6 +383,7 @@
       "cookiechange_event": {
         "__compat": {
           "description": "<code>cookiechange</code> event",
+          "spec_url": "https://wicg.github.io/cookie-store/#dom-serviceworkerglobalscope-oncookiechange",
           "support": {
             "chrome": {
               "version_added": "87"
@@ -408,7 +409,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

mark `partitioned` option in `CookieStore` interface as standard, see spec https://wicg.github.io/cookie-store/ , as they have been added to spec yet

also mark `ServiceWorkerGlobalScope cookiechange event` as standard, which also added in spec yet, and add `apec_url` for it

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
