### PR TITLE
CSS rx and ry not supported in Safari 17

### DIFF
--- a/css/properties/rx.json
+++ b/css/properties/rx.json
@@ -24,7 +24,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": false,
-              "notes": "The value is recognized, but has no effect. This property is only recognized as an attribute applied to the SVG element.  See <a href='https://webkit.org/b/266090'>bug 266090</a>."
+              "notes": "The value is recognized, but has no effect. This property is only recognized as an attribute applied to the SVG element. See <a href='https://webkit.org/b/266090'>bug 266090</a>."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/rx.json
+++ b/css/properties/rx.json
@@ -23,7 +23,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "false"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/rx.json
+++ b/css/properties/rx.json
@@ -23,7 +23,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "false"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/rx.json
+++ b/css/properties/rx.json
@@ -23,7 +23,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The value is recognized, but has no effect. This property is only recognized as an attribute applied to the SVG element.  See <a href='https://webkit.org/b/266090'>bug 266090</a>."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/ry.json
+++ b/css/properties/ry.json
@@ -24,7 +24,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": false,
-              "notes": "The value is recognized, but has no effect. This property is only recognized as an attribute applied to the SVG element.  See <a href='https://webkit.org/b/266090'>bug 266090</a>."
+              "notes": "The value is recognized, but has no effect. This property is only recognized as an attribute applied to the SVG element. See <a href='https://webkit.org/b/266090'>bug 266090</a>."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/ry.json
+++ b/css/properties/ry.json
@@ -23,7 +23,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "false"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/ry.json
+++ b/css/properties/ry.json
@@ -23,7 +23,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "false"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/ry.json
+++ b/css/properties/ry.json
@@ -23,7 +23,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "notes": "The value is recognized, but has no effect. This property is only recognized as an attribute applied to the SVG element.  See <a href='https://webkit.org/b/266090'>bug 266090</a>."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
Safari does not support these two properties in CSS.  Note the blue `<rect>` element in this codepen: https://codepen.io/sidewayss/pen/GRPgqvG
AFAICT all of the other SVG geometry CSS properties work in all the browsers except `rx` and `ry` in Safari. The codepen tests those two along with `x`, `y` and `r`, `cx`, and `cy` for `<circle>`.

caniuse.com:
https://caniuse.com/?search=rx
https://caniuse.com/?search=ry

There are no MDN docs pages for these as CSS properties, only as SVG attributes. Those pages ([here](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/rx) and [here](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/ry)) mention that in SVG 2 the CSS properties exist, but there is no browser support matrix on those pages.

Screenshots of desktop browsers (I tested some mobile browsers too, but didn't take pics):
Safari 17:
![css-r-Safari](https://github.com/mdn/browser-compat-data/assets/15235202/4b4f7d5e-8999-491f-b0fa-aca83c7fb2a5)

Chrome 119:
![css-r-Chrome](https://github.com/mdn/browser-compat-data/assets/15235202/0decdd13-35e8-4e0f-8b24-2b9afe151bfe)

Firefox 120:
![css-r-Firefox](https://github.com/mdn/browser-compat-data/assets/15235202/8e912979-4534-43fc-a8f3-23a711789e1a)

Opera 105:
![css-r-Opera](https://github.com/mdn/browser-compat-data/assets/15235202/6c6b3b98-63f6-4eda-9f15-db3b2e11b87b)