### PR TITLE
Update NodeJS data for api.URLSearchParams.size

### DIFF
--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -701,9 +701,15 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": "19.0.0"
-            },
+            "nodejs": [
+              {
+                "version_added": "19.8.0"
+              },
+              {
+                "version_added": "18.16.0",
+                "version_removed": "19.0.0"
+              }
+            ],
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -419,6 +419,13 @@
           "engine": "V8",
           "engine_version": "10.1"
         },
+        "18.16.0": {
+          "release_date": "2023-04-13",
+          "release_notes": "https://nodejs.org/en/blog/release/v18.16.0/",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "10.1"
+        },
         "18.17.0": {
           "release_date": "2023-07-18",
           "release_notes": "https://nodejs.org/en/blog/release/v18.17.0/",
@@ -436,6 +443,13 @@
         "19.7.0": {
           "release_date": "2023-02-21",
           "release_notes": "https://nodejs.org/en/blog/release/v19.7.0",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "10.8"
+        },
+        "19.8.0": {
+          "release_date": "2023-03-14",
+          "release_notes": "https://nodejs.org/en/blog/release/v19.8.0",
           "status": "retired",
           "engine": "V8",
           "engine_version": "10.8"


### PR DESCRIPTION
This PR updates and corrects version values for NodeJS for the `size` member of the `URLSearchParams` API. This fixes #20414.  Versions come from the Node.js docs: https://nodejs.org/api/url.html#urlsearchparamssize
