### PR TITLE
Update Firefox data for html.elements.input.type_range.vertical_orientation

### DIFF
--- a/html/elements/input/range.json
+++ b/html/elements/input/range.json
@@ -107,11 +107,13 @@
                   "notes": "The slider can be oriented vertically by setting the <code>writing-mode: bt-lr</code> style on the <code>input</code> element."
                 },
                 "firefox": {
-                  "version_added": false,
+                  "version_added": "≤72",
                   "impl_url": [
                     "https://bugzil.la/840820",
                     "https://bugzil.la/981916"
-                  ]
+                  ],
+                  "partial_implementation": true,
+                  "notes": "Supported using the non-standard <code>orient=\"vertical\"</code> attribute."
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `type_range.vertical_orientation` member of the `input` HTML element. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/range#using_the_orient_attribute

Additional Notes: Fixes #21359.
