### PR TITLE
Update Chromium data for api.Document.domain

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2554,7 +2554,10 @@
           "support": {
             "chrome": {
               "version_added": "1",
-              "notes": "From Chrome 110, <code>domain</code> is available by opt-in via `Origin-keyed agent clusters` <a href='https://origin-agent-cluster-demo.dev'></a>. See this <a href='https://chromestatus.com/feature/5428079583297536'>chromestatus entry</a>."
+              "notes": [
+                "From Chrome 110, <code>domain</code> is available by opt-in via `Origin-keyed agent clusters` <a href='https://origin-agent-cluster-demo.dev'></a>. See this <a href='https://chromestatus.com/feature/5428079583297536'>chromestatus entry</a>.",
+                "From Chrome 115, this property is read-only."
+              ]
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `domain` member of the `Document` API. This fixes #21221, which contains the supporting evidence for this change.
