### PR TITLE
Update Edge data for api.PushManager.subscribe

### DIFF
--- a/api/PushManager.json
+++ b/api/PushManager.json
@@ -297,11 +297,10 @@
               "version_added": "42",
               "notes": "The <code>options</code> parameter with a <code>applicationServerKey</code> value is required."
             },
-            "chrome_android": {
-              "version_added": "42"
-            },
+            "chrome_android": "mirror",
             "edge": {
-              "version_added": "17"
+              "version_added": "17",
+              "notes": "The <code>options</code> parameter with a <code>applicationServerKey</code> value is required."
             },
             "firefox": {
               "version_added": "44",


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `subscribe` member of the `PushManager` API. This copies the notes from Chrome.

Additional Notes: Fixes #21135.
