### PR TITLE
Add Origin-Agent-Cluster HTTP header

### DIFF
--- a/http/headers/Origin-Agent-Cluster.json
+++ b/http/headers/Origin-Agent-Cluster.json
@@ -1,0 +1,40 @@
+{
+  "http": {
+    "headers": {
+      "Origin-Agent-Cluster": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Origin-Agent-Cluster",
+          "spec_url": "https://html.spec.whatwg.org/multipage/browsers.html#origin-agent-cluster",
+          "support": {
+            "chrome": {
+              "version_added": "90"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
See also https://github.com/mdn/content/pull/30743, https://web.dev/articles/origin-agent-cluster.

Uses the same support data as for https://developer.mozilla.org/en-US/docs/Web/API/Window/originAgentCluster (https://github.com/mdn/browser-compat-data/commit/7aa11f1c73888260917eafae516192d11bf96caf).