### PR TITLE
Remove broken links for html.manifest.note_taking

### DIFF
--- a/html/manifest/note_taking.json
+++ b/html/manifest/note_taking.json
@@ -40,7 +40,6 @@
         },
         "new_note_url": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/note_taking/new_note_url",
             "spec_url": "https://wicg.github.io/manifest-incubations/#new_note_url-member",
             "support": {
               "chrome": {

--- a/html/manifest/note_taking.json
+++ b/html/manifest/note_taking.json
@@ -3,7 +3,6 @@
     "manifest": {
       "note_taking": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/Manifest/note_taking",
           "spec_url": "https://wicg.github.io/manifest-incubations/#note_taking-member",
           "support": {
             "chrome": {


### PR DESCRIPTION
This PR removes two broken links from BCD.  Fixes #20698, fixes #20699.