### PR TITLE
Add stroked HTML text compatibility info for CSS `paint-order` property

### DIFF
--- a/css/properties/paint-order.json
+++ b/css/properties/paint-order.json
@@ -7,7 +7,9 @@
           "spec_url": "https://svgwg.org/svg2-draft/painting.html#PaintOrder",
           "support": {
             "chrome": {
-              "version_added": "35"
+              "version_added": "35",
+              "partial_implementation": true,
+              "notes": "Does not affect stroked HTML text, see <a href='https://crbug.com/815111'>Issue 815111</a>"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -23,9 +25,16 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "8"
-            },
+            "safari": [
+              {
+                "version_added": "11"
+              },
+              {
+                "version_added": "8",
+                "partial_implementation": true,
+                "notes": "Does not affect stroked HTML text, see <a href='https://webkit.org/b/168601'>Bug 168601</a>"
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"


### PR DESCRIPTION
Browser support for CSS `paint-order` on HTML text differs between browsers. This is because as originally specified, the property had a restriction saying that it should only apply to SVG. That restriction has since been removed, see https://github.com/w3c/fxtf-drafts/issues/107

Support for `paint-order` on HTML text was included along with the initial support for `paint-order` in Firefox 60, see https://bugs.webkit.org/show_bug.cgi?id=168601

Support for `paint-order` on HTML text was added to WebKit in https://github.com/WebKit/WebKit/commit/73a116fe7ce0dffc4856bb8dc3986e49308df943 which was included in WebKit 604. According to browsers/safari.json, this corresponds to Safari 11.

Support for `paint-order` on HTML text in Chromium is still pending: https://bugs.chromium.org/p/chromium/issues/detail?id=815111

Fixes #17951
Fixes #19154