### PR TITLE
Update Firefox data for html.elements.script.async

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -54,7 +54,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "3.6"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `async` member of the `script` HTML element. This fixes #19633, which contains the supporting evidence for this change.
