### PR TITLE
Update Firefox data for css.properties.height.fit-content

### DIFF
--- a/css/properties/height.json
+++ b/css/properties/height.json
@@ -52,9 +52,15 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "94"
-              },
+              "firefox": [
+                {
+                  "version_added": "94"
+                },
+                {
+                  "prefix": "-moz-",
+                  "version_added": "41"
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `fit-content` member of the `height` CSS property. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code:

```

CSS.supports("height", "-moz-fit-content");

```

This fixes #6626.
