### PR TITLE
Update Safari iOS data for html.global_attributes.inputmode

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -822,7 +822,8 @@
               "version_added": false
             },
             "safari_ios": {
-              "version_added": "12.2"
+              "version_added": "12.2",
+              "notes": "Before iOS 13, <code>inputmode=\"none\"</code> had no effect."
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `inputmode` member of the `global_attributes` HTML feature. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code:

```

<input type="text" inputmode="none" />

```

This fixes #7186.
