### PR TITLE
Update Chrome Android data for api.Element.dblclick_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -3830,9 +3830,7 @@
             "chrome": {
               "version_added": "1"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },


### PR DESCRIPTION
This PR updates and corrects version values for Chrome Android for the `dblclick_event` member of the `Element` API. This fixes #8904, which contains the supporting evidence for this change.
