### PR TITLE
Add missing api.OffscreenCanvas.getContext.webgpu_context feature

### DIFF
--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -355,6 +355,47 @@
             }
           }
         },
+        "webgpu_context": {
+          "__compat": {
+            "description": "<code>webgpu</code> context",
+            "spec_url": "https://gpuweb.github.io/gpuweb/#canvas-getcontext",
+            "support": {
+              "chrome": {
+                "version_added": "113",
+                "notes": "Currently supported on ChromeOS, macOS, and Windows only."
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "preview",
+                "partial_implementation": true,
+                "notes": "Currently supported on Linux and Windows only."
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "2d_context": {
           "__compat": {
             "description": "<code>2d</code> context",


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing `getContext.webgpu_context` member of the `OffscreenCanvas` API. The data was mirrored from api.HTMLCanvasElement.getContext.webgpu_context.  This fixes #9815.
