### PR TITLE
Add Node.js support data for groupBy() (#21429)

### DIFF
--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -439,7 +439,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "21.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -822,7 +822,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "21.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
#### Summary

With Node.js v21.0.0, the V8 engine [updated to v11.8](https://nodejs.org/en/blog/announcements/v21-release-announce#v8-118), this aligns with Chrome 118 and adds both [Map.groupBy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/groupBy) and [Object.groupBy()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/groupBy)

#### Test results and supporting details

#### Related issues

Fixes #21429
