### PR TITLE
http.sec-ch-ua(firefox): added tracking bugzilla

### DIFF
--- a/http/headers/Sec-CH-UA.json
+++ b/http/headers/Sec-CH-UA.json
@@ -13,7 +13,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/935216"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

I have added buzgilla to `http.headers.Sec-CH-UA`.
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details
test: N/A

tracker: [bugzilla.mozilla.org/show_bug.cgi?id=935216](https://bugzilla.mozilla.org/show_bug.cgi?id=935216)


#### Related issues

Fixes #21354
