### PR TITLE
Update Safari data for http.headers.Access-Control-Expose-Headers.wildcard

### DIFF
--- a/http/headers/Access-Control-Expose-Headers.json
+++ b/http/headers/Access-Control-Expose-Headers.json
@@ -66,7 +66,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "13"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `wildcard` member of the `Access-Control-Expose-Headers` HTTP header. The data comes from a commit in the browser's source code, mapped to a version number using available tooling or via the commit timestamp.

Commit: https://github.com/WebKit/WebKit/commit/6e529bd3f615bbb4a9eab03069be705e623c7b6a

Additional Notes: Fixes #11232.
