### PR TITLE
Rename all subfeatures for api.KeyboardEvent.getModifierState

### DIFF
--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -273,9 +273,9 @@
             "deprecated": false
           }
         },
-        "accel_parameter": {
+        "key_parameter_accel": {
           "__compat": {
-            "description": "<code>\"Accel\"</code> as a parameter",
+            "description": "<code>\"Accel\"</code> as <code>key</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "48"
@@ -308,9 +308,9 @@
             }
           }
         },
-        "alt_parameter": {
+        "key_parameter_alt": {
           "__compat": {
-            "description": "<code>\"Alt\"</code> as a parameter",
+            "description": "<code>\"Alt\"</code> as <code>key</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "30"
@@ -343,9 +343,9 @@
             }
           }
         },
-        "altgraph_parameter": {
+        "key_parameter_altgraph": {
           "__compat": {
-            "description": "<code>\"AltGraph\"</code> as a parameter",
+            "description": "<code>\"AltGraph\"</code> as <code>key</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "48"
@@ -376,9 +376,9 @@
             }
           }
         },
-        "capslock_parameter": {
+        "key_parameter_capslock": {
           "__compat": {
-            "description": "<code>\"CapsLock\"</code> as a parameter",
+            "description": "<code>\"CapsLock\"</code> as <code>key</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "48"
@@ -411,9 +411,9 @@
             }
           }
         },
-        "control_parameter": {
+        "key_parameter_control": {
           "__compat": {
-            "description": "<code>\"Control\"</code> as a parameter",
+            "description": "<code>\"Control\"</code> as <code>key</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "30"
@@ -446,9 +446,9 @@
             }
           }
         },
-        "fn_parameter": {
+        "key_parameter_fn": {
           "__compat": {
-            "description": "<code>\"Fn\"</code> as a parameter",
+            "description": "<code>\"Fn\"</code> as <code>key</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "48"
@@ -479,9 +479,9 @@
             }
           }
         },
-        "meta_parameter": {
+        "key_parameter_meta": {
           "__compat": {
-            "description": "<code>\"Meta\"</code> as a parameter",
+            "description": "<code>\"Meta\"</code> as <code>key</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "30"
@@ -512,9 +512,9 @@
             }
           }
         },
-        "numlock_parameter": {
+        "key_parameter_numlock": {
           "__compat": {
-            "description": "<code>\"NumLock\"</code> as a parameter",
+            "description": "<code>\"NumLock\"</code> as <code>key</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "48"
@@ -547,9 +547,9 @@
             }
           }
         },
-        "os_parameter": {
+        "key_parameter_os": {
           "__compat": {
-            "description": "<code>\"OS\"</code> as a parameter",
+            "description": "<code>\"OS\"</code> as <code>key</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "48"
@@ -590,9 +590,9 @@
             }
           }
         },
-        "scrolllock_parameter": {
+        "key_parameter_scrolllock": {
           "__compat": {
-            "description": "<code>\"ScrollLock\"</code> as a parameter",
+            "description": "<code>\"ScrollLock\"</code> as <code>key</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "48"
@@ -633,9 +633,9 @@
             }
           }
         },
-        "shift_parameter": {
+        "key_parameter_shift": {
           "__compat": {
-            "description": "<code>\"Shift\"</code> as a parameter",
+            "description": "<code>\"Shift\"</code> as <code>key</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "30"
@@ -668,9 +668,9 @@
             }
           }
         },
-        "symbol_parameter": {
+        "key_parameter_symbol": {
           "__compat": {
-            "description": "<code>\"Symbol\"</code> as a parameter",
+            "description": "<code>\"Symbol\"</code> as <code>key</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "48"


### PR DESCRIPTION
This PR renames the subfeatures of `api.KeyboardEvent.getModifierState` to reflect our usual conventions better, changing the current `<value>_parameter` to `key_parameter_<value>`.  This fixes #11295.
