### PR TITLE
Add notes about tooltips in Chrome for setCustomValidity()

### DIFF
--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -592,7 +592,8 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-setcustomvalidity-dev",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "This method only updates the validation error popup, not the tooltip that appears when hovering the mouse over the element, see <a href='https://crbug.com/828757'>Chrome bug 828757</a>."
             },
             "chrome_android": "mirror",
             "edge": {

--- a/api/HTMLFieldSetElement.json
+++ b/api/HTMLFieldSetElement.json
@@ -324,7 +324,8 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-setcustomvalidity-dev",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "This method only updates the validation error popup, not the tooltip that appears when hovering the mouse over the element, see <a href='https://crbug.com/828757'>Chrome bug 828757</a>."
             },
             "chrome_android": "mirror",
             "edge": {

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -1870,7 +1870,8 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-setcustomvalidity",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "This method only updates the validation error popup, not the tooltip that appears when hovering the mouse over the element, see <a href='https://crbug.com/828757'>Chrome bug 828757</a>."
             },
             "chrome_android": "mirror",
             "edge": {

--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -749,7 +749,8 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-setcustomvalidity-dev",
           "support": {
             "chrome": {
-              "version_added": "10"
+              "version_added": "10",
+              "notes": "This method only updates the validation error popup, not the tooltip that appears when hovering the mouse over the element, see <a href='https://crbug.com/828757'>Chrome bug 828757</a>."
             },
             "chrome_android": "mirror",
             "edge": {

--- a/api/HTMLOutputElement.json
+++ b/api/HTMLOutputElement.json
@@ -367,7 +367,8 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-setcustomvalidity-dev",
           "support": {
             "chrome": {
-              "version_added": "9"
+              "version_added": "9",
+              "notes": "This method only updates the validation error popup, not the tooltip that appears when hovering the mouse over the element, see <a href='https://crbug.com/828757'>Chrome bug 828757</a>."
             },
             "chrome_android": "mirror",
             "edge": {

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -805,7 +805,8 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-setcustomvalidity-dev",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "This method only updates the validation error popup, not the tooltip that appears when hovering the mouse over the element, see <a href='https://crbug.com/828757'>Chrome bug 828757</a>."
             },
             "chrome_android": "mirror",
             "edge": {

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -952,7 +952,8 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-setcustomvalidity-dev",
           "support": {
             "chrome": {
-              "version_added": "4"
+              "version_added": "4",
+              "notes": "This method only updates the validation error popup, not the tooltip that appears when hovering the mouse over the element, see <a href='https://crbug.com/828757'>Chrome bug 828757</a>."
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR fixes #11342 by adding a note about how `setCustomValidity()` does not change the tooltip on hover when called.
