### PR TITLE
Update Chromium data for api.MediaDevices.getDisplayMedia.audio_capture_support

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -197,15 +197,12 @@
             "support": {
               "chrome": {
                 "version_added": "74",
-                "notes": "On Windows and ChromeOS the entire system audio can be captured, but on Linux and macOS only the audio of a tab can be captured."
+                "notes": "On Windows and ChromeOS, the entire system audio can be captured when sharing an entire screen. On Linux and macOS, only the audio of a tab can be captured."
               },
               "chrome_android": {
                 "version_added": false
               },
-              "edge": {
-                "version_added": "≤79",
-                "notes": "On Windows, the entire system audio can be captured, but on Linux and macOS only the audio of a tab can be captured."
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
@@ -214,10 +211,7 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": "62",
-                "notes": "On Windows, the entire system audio can be captured, but on Linux and macOS only the audio of a tab can be captured."
-              },
+              "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
                 "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `getDisplayMedia.audio_capture_support` member of the `MediaDevices` API. This fixes #11732 by updating the notes accordingly.
