### PR TITLE
Update Firefox data for mask-composite CSS property

### DIFF
--- a/css/properties/-webkit-mask-composite.json
+++ b/css/properties/-webkit-mask-composite.json
@@ -13,7 +13,7 @@
               "version_added": "18"
             },
             "firefox": {
-              "version_added": "53"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/mask-composite.json
+++ b/css/properties/mask-composite.json
@@ -15,9 +15,15 @@
               "version_added": "18",
               "version_removed": "79"
             },
-            "firefox": {
-              "version_added": "53"
-            },
+            "firefox": [
+              {
+                "version_added": "53"
+              },
+              {
+                "prefix": "-webkit-",
+                "version_added": "53"
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `mask-composite` CSS property. This fixes #11885, which contains the supporting evidence for this change.
