### PR TITLE
Update Chromium data for api.NavigatorManagedData.managedconfigurationchange_event

### DIFF
--- a/api/NavigatorManagedData.json
+++ b/api/NavigatorManagedData.json
@@ -71,7 +71,7 @@
           "spec_url": "https://wicg.github.io/WebApiDevice/managed_config/#onmanagedconfigurationchange-attribute",
           "support": {
             "chrome": {
-              "version_added": "119"
+              "version_added": "91"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `managedconfigurationchange_event` member of the `NavigatorManagedData` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.5.2).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/NavigatorManagedData/managedconfigurationchange_event
