### PR TITLE
Update Firefox data for api.Window.deviceorientationabsolute_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1129,7 +1129,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "110"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `deviceorientationabsolute_event` member of the `Window` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.5.2).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Window/deviceorientationabsolute_event

Additional Notes: This fixes #19988.
