### PR TITLE
Update Safari iOS data for api.HTMLInputElement.webkitdirectory

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2869,7 +2869,9 @@
             "safari": {
               "version_added": "11.1"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `webkitdirectory` member of the `HTMLInputElement` API. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code: https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/webkitdirectory

Additional Notes: This fixes #11982.
