### PR TITLE
Update Safari data for api.InputEvent.InputEvent

### DIFF
--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -58,9 +58,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10.1",
-              "partial_implementation": true,
-              "notes": "The <code>inputEventInit</code> parameter is not supported. See <a href='https://webkit.org/b/170416'>bug 170416</a>."
+              "version_added": "10.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `InputEvent` member of the `InputEvent` API. This fixes #12163, which contains the supporting evidence for this change.
