### PR TITLE
`:read-write` and `:read-only`: fix unprefixed Firefox for Android support

### DIFF
--- a/css/selectors/read-only.json
+++ b/css/selectors/read-only.json
@@ -26,10 +26,7 @@
                 "version_added": "1.5"
               }
             ],
-            "firefox_android": {
-              "prefix": "-moz-",
-              "version_added": "4"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },

--- a/css/selectors/read-write.json
+++ b/css/selectors/read-write.json
@@ -26,10 +26,7 @@
                 "version_added": "1.5"
               }
             ],
-            "firefox_android": {
-              "prefix": "-moz-",
-              "version_added": "4"
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Turn on mirroring for `:read-write` and `:read-only` for Firefox for Android.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

I tested this in the current release of Firefox for Android and it works fine.

This looks like an oversight from the time when Firefox for Android wasn't doing releases. It works in current releases and I can't find any evidence it was specifically unsupported in Firefox for Android.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Discovered in the course of https://github.com/web-platform-dx/web-features/pull/462.
