### PR TITLE
`HTMLDialogElement`: correct `cancel` event for Chrome for Android

### DIFF
--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -45,9 +45,7 @@
             "chrome": {
               "version_added": "37"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": "98"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Correct a likely incorrect lack-of-mirroring divergence between Chrome and Chrome for Android.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

> OK, so it's about the `cancel` event. https://mdn-bcd-collector.gooborg.com/tests/api/HTMLDialogElement doesn't have a test for that, I think because `oncancel` is on `GlobalEventHanders`.
> 
> I've checked the Chromium source and don't see anything special about the cancel event. I think BCD is wrong […]

_Originally posted by @foolip in https://github.com/web-platform-dx/web-features/pull/455#discussion_r1413518428_
            

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

- https://github.com/web-platform-dx/web-features/pull/455
