### PR TITLE
Add compat data for secure payment confirmation

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -150,7 +150,7 @@
             },
             "appidExclude": {
               "__compat": {
-                "description": "<code>appidExclude</code> extension",
+                "description": "<a href='https://developer.mozilla.org/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#appidexclude'><code>appidExclude</code></a> extension",
                 "spec_url": "https://w3c.github.io/webauthn/#sctn-appid-exclude-extension",
                 "support": {
                   "chrome": {
@@ -190,7 +190,7 @@
             },
             "credProps": {
               "__compat": {
-                "description": "<code>credProps</code> extension",
+                "description": "<a href='https://developer.mozilla.org/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#credprops'><code>credProps</code></a> extension",
                 "spec_url": "https://w3c.github.io/webauthn/#sctn-authenticator-credential-properties-extension",
                 "support": {
                   "chrome": {
@@ -228,7 +228,7 @@
             },
             "credProtect": {
               "__compat": {
-                "description": "<code>credProtect</code> extension",
+                "description": "<a href='https://developer.mozilla.org/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#credprotect'><code>credProtect</code></a> extension",
                 "support": {
                   "chrome": {
                     "version_added": "76"
@@ -263,7 +263,7 @@
             },
             "largeBlob": {
               "__compat": {
-                "description": "<code>largeBlob</code> extension",
+                "description": "<a href='https://developer.mozilla.org/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#largeblob'><code>largeBlob</code></a> extension",
                 "spec_url": "https://w3c.github.io/webauthn/#sctn-large-blob-extension",
                 "support": {
                   "chrome": {
@@ -299,8 +299,7 @@
             },
             "minPinLength": {
               "__compat": {
-                "description": "<code>minPinLength</code> extension",
-                "mdn_url": "https://developer.mozilla.org/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#minpinlength",
+                "description": "<a href='https://developer.mozilla.org/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#minpinlength'><code>minPinLength</code></a> extension",
                 "support": {
                   "chrome": {
                     "version_added": "98"
@@ -309,6 +308,42 @@
                   "edge": "mirror",
                   "firefox": {
                     "version_added": "120"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": {
+                    "version_added": false
+                  }
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "payment": {
+              "__compat": {
+                "description": "<a href='https://developer.mozilla.org/docs/Web/API/Web_Authentication_API/WebAuthn_extensions#payment'><code>payment</code></a> extension",
+                "spec_url": "https://w3c.github.io/secure-payment-confirmation/#sctn-payment-extension-registration",
+                "support": {
+                  "chrome": {
+                    "version_added": "95"
+                  },
+                  "chrome_android": "mirror",
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": false
                   },
                   "firefox_android": "mirror",
                   "ie": {

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -101,6 +101,47 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "secure_payment_confirmation_method": {
+          "__compat": {
+            "description": "<a href='https://developer.mozilla.org/docs/Web/API/Payment_Request_API/Concepts#secure-payment-confirmation'><code>secure-payment-confirmation</code></a> method",
+            "support": {
+              "chrome": {
+                "version_added": "95"
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "abort": {


### PR DESCRIPTION
Adds compat data for secure payment confirmation.

Supersedes https://github.com/mdn/browser-compat-data/pull/20583, using the same data as in that PR, but as additions to https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/create (for the WebAuth extension) and https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest/PaymentRequest (for the new payment method.

I've also added links to docs for all the other WebAuth extensions. The data for `minPinLength` was doing that using `mdn_url` but that didn't work because fragments seem to get ignored there (?).