### PR TITLE
Fix prefix linter

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -3615,7 +3615,7 @@
                 "version_added": "71"
               },
               {
-                "alternative_name": "webkitfullscreenchange",
+                "prefix": "webkit",
                 "version_added": "15"
               }
             ],
@@ -3625,7 +3625,7 @@
                 "version_added": "79"
               },
               {
-                "alternative_name": "webkitfullscreenchange",
+                "prefix": "webkit",
                 "version_added": "12"
               },
               {
@@ -3638,7 +3638,7 @@
                 "version_added": "64"
               },
               {
-                "alternative_name": "mozfullscreenchange",
+                "prefix": "moz",
                 "version_added": "10"
               }
             ],
@@ -3653,7 +3653,7 @@
                 "version_added": "58"
               },
               {
-                "alternative_name": "webkitfullscreenchange",
+                "prefix": "webkit",
                 "version_added": "15"
               },
               {
@@ -3666,7 +3666,7 @@
                 "version_added": "50"
               },
               {
-                "alternative_name": "webkitfullscreenchange",
+                "prefix": "webkit",
                 "version_added": "14"
               },
               {
@@ -3679,12 +3679,12 @@
                 "version_added": "16.4"
               },
               {
-                "alternative_name": "webkitfullscreenchange",
+                "prefix": "webkit",
                 "version_added": "5.1"
               }
             ],
             "safari_ios": {
-              "alternative_name": "webkitfullscreenchange",
+              "prefix": "webkit",
               "version_added": "12",
               "partial_implementation": true,
               "notes": "Only available on iPad, not on iPhone."
@@ -3695,7 +3695,7 @@
                 "version_added": "71"
               },
               {
-                "alternative_name": "webkitfullscreenchange",
+                "prefix": "webkit",
                 "version_added": "≤37"
               }
             ]
@@ -3903,7 +3903,7 @@
                 "version_added": "71"
               },
               {
-                "alternative_name": "webkitfullscreenerror",
+                "prefix": "webkit",
                 "version_added": "18"
               }
             ],
@@ -3913,7 +3913,7 @@
                 "version_added": "79"
               },
               {
-                "alternative_name": "webkitfullscreenerror",
+                "prefix": "webkit",
                 "version_added": "12"
               },
               {
@@ -3926,7 +3926,7 @@
                 "version_added": "64"
               },
               {
-                "alternative_name": "mozfullscreenerror",
+                "prefix": "moz",
                 "version_added": "10"
               }
             ],
@@ -3941,7 +3941,7 @@
                 "version_added": "58"
               },
               {
-                "alternative_name": "webkitfullscreenerror",
+                "prefix": "webkit",
                 "version_added": "15"
               },
               {
@@ -3954,7 +3954,7 @@
                 "version_added": "50"
               },
               {
-                "alternative_name": "webkitfullscreenerror",
+                "prefix": "webkit",
                 "version_added": "14"
               },
               {
@@ -3967,12 +3967,12 @@
                 "version_added": "16.4"
               },
               {
-                "alternative_name": "webkitfullscreenerror",
+                "prefix": "webkit",
                 "version_added": "6"
               }
             ],
             "safari_ios": {
-              "alternative_name": "webkitfullscreenerror",
+              "prefix": "webkit",
               "version_added": "12",
               "partial_implementation": true,
               "notes": "Only available on iPad, not on iPhone."
@@ -3983,7 +3983,7 @@
                 "version_added": "71"
               },
               {
-                "alternative_name": "webkitfullscreenerror",
+                "prefix": "webkit",
                 "version_added": "≤37"
               }
             ]

--- a/api/Element.json
+++ b/api/Element.json
@@ -4095,7 +4095,7 @@
                 "version_added": "71"
               },
               {
-                "alternative_name": "webkitfullscreenchange",
+                "prefix": "webkit",
                 "version_added": "15"
               }
             ],
@@ -4105,7 +4105,7 @@
                 "version_added": "79"
               },
               {
-                "alternative_name": "webkitfullscreenchange",
+                "prefix": "webkit",
                 "version_added": "12"
               },
               {
@@ -4118,7 +4118,7 @@
                 "version_added": "64"
               },
               {
-                "alternative_name": "mozfullscreenchange",
+                "prefix": "moz",
                 "version_added": "10"
               }
             ],
@@ -4132,7 +4132,7 @@
                 "version_added": "58"
               },
               {
-                "alternative_name": "webkitfullscreenchange",
+                "prefix": "webkit",
                 "version_added": "15"
               },
               {
@@ -4145,7 +4145,7 @@
                 "version_added": "50"
               },
               {
-                "alternative_name": "webkitfullscreenchange",
+                "prefix": "webkit",
                 "version_added": "14"
               },
               {
@@ -4174,7 +4174,7 @@
                 "version_added": "71"
               },
               {
-                "alternative_name": "webkitfullscreenchange",
+                "prefix": "webkit",
                 "version_added": "≤37"
               }
             ]
@@ -4197,7 +4197,7 @@
                 "version_added": "71"
               },
               {
-                "alternative_name": "webkitfullscreenerror",
+                "prefix": "webkit",
                 "version_added": "18"
               }
             ],
@@ -4207,7 +4207,7 @@
                 "version_added": "79"
               },
               {
-                "alternative_name": "webkitfullscreenerror",
+                "prefix": "webkit",
                 "version_added": "12"
               },
               {
@@ -4220,7 +4220,7 @@
                 "version_added": "64"
               },
               {
-                "alternative_name": "mozfullscreenerror",
+                "prefix": "moz",
                 "version_added": "10"
               }
             ],
@@ -4234,7 +4234,7 @@
                 "version_added": "58"
               },
               {
-                "alternative_name": "webkitfullscreenerror",
+                "prefix": "webkit",
                 "version_added": "15"
               },
               {
@@ -4247,7 +4247,7 @@
                 "version_added": "50"
               },
               {
-                "alternative_name": "webkitfullscreenerror",
+                "prefix": "webkit",
                 "version_added": "14"
               },
               {
@@ -4276,7 +4276,7 @@
                 "version_added": "71"
               },
               {
-                "alternative_name": "webkitfullscreenerror",
+                "prefix": "webkit",
                 "version_added": "≤37"
               }
             ]
@@ -6404,7 +6404,7 @@
                 "version_added": "12"
               },
               {
-                "alternative_name": "mspointercancel",
+                "prefix": "ms",
                 "version_added": "12",
                 "version_removed": "79"
               }
@@ -6420,7 +6420,7 @@
                 "version_added": "11"
               },
               {
-                "alternative_name": "mspointercancel",
+                "prefix": "ms",
                 "version_added": "10"
               }
             ],
@@ -6459,7 +6459,7 @@
                 "version_added": "12"
               },
               {
-                "alternative_name": "mspointerdown",
+                "prefix": "ms",
                 "version_added": "12",
                 "version_removed": "79"
               }
@@ -6475,7 +6475,7 @@
                 "version_added": "11"
               },
               {
-                "alternative_name": "mspointerdown",
+                "prefix": "ms",
                 "version_added": "10"
               }
             ],
@@ -6514,7 +6514,7 @@
                 "version_added": "12"
               },
               {
-                "alternative_name": "mspointerenter",
+                "prefix": "ms",
                 "version_added": "12",
                 "version_removed": "79"
               }
@@ -6530,7 +6530,7 @@
                 "version_added": "11"
               },
               {
-                "alternative_name": "mspointerenter",
+                "prefix": "ms",
                 "version_added": "10"
               }
             ],
@@ -6569,7 +6569,7 @@
                 "version_added": "12"
               },
               {
-                "alternative_name": "mspointerleave",
+                "prefix": "ms",
                 "version_added": "12",
                 "version_removed": "79"
               }
@@ -6585,7 +6585,7 @@
                 "version_added": "11"
               },
               {
-                "alternative_name": "mspointerleave",
+                "prefix": "ms",
                 "version_added": "10"
               }
             ],
@@ -6624,7 +6624,7 @@
                 "version_added": "12"
               },
               {
-                "alternative_name": "mspointermove",
+                "prefix": "ms",
                 "version_added": "12",
                 "version_removed": "79"
               }
@@ -6640,7 +6640,7 @@
                 "version_added": "11"
               },
               {
-                "alternative_name": "mspointermove",
+                "prefix": "ms",
                 "version_added": "10"
               }
             ],
@@ -6679,7 +6679,7 @@
                 "version_added": "12"
               },
               {
-                "alternative_name": "mspointerout",
+                "prefix": "ms",
                 "version_added": "12",
                 "version_removed": "79"
               }
@@ -6695,7 +6695,7 @@
                 "version_added": "11"
               },
               {
-                "alternative_name": "mspointerout",
+                "prefix": "ms",
                 "version_added": "10"
               }
             ],
@@ -6734,7 +6734,7 @@
                 "version_added": "12"
               },
               {
-                "alternative_name": "mspointerover",
+                "prefix": "ms",
                 "version_added": "12",
                 "version_removed": "79"
               }
@@ -6750,7 +6750,7 @@
                 "version_added": "11"
               },
               {
-                "alternative_name": "mspointerover",
+                "prefix": "ms",
                 "version_added": "10"
               }
             ],
@@ -6827,7 +6827,7 @@
                 "version_added": "12"
               },
               {
-                "alternative_name": "mspointerup",
+                "prefix": "ms",
                 "version_added": "12",
                 "version_removed": "79"
               }
@@ -6843,7 +6843,7 @@
                 "version_added": "11"
               },
               {
-                "alternative_name": "mspointerup",
+                "prefix": "ms",
                 "version_added": "10"
               }
             ],
@@ -9295,7 +9295,7 @@
                 "version_added": "26"
               },
               {
-                "alternative_name": "webkittransitionend",
+                "prefix": "webkit",
                 "version_added": "1"
               }
             ],
@@ -9305,7 +9305,7 @@
                 "version_added": "18"
               },
               {
-                "alternative_name": "webkittransitionend",
+                "prefix": "webkit",
                 "version_added": "79"
               },
               {
@@ -9330,11 +9330,11 @@
                 "version_added": "12.1"
               },
               {
-                "alternative_name": "webkittransitionend",
+                "prefix": "webkit",
                 "version_added": "15"
               },
               {
-                "alternative_name": "otransitionend",
+                "prefix": "o",
                 "version_added": "11.6",
                 "version_removed": "15"
               }
@@ -9344,11 +9344,11 @@
                 "version_added": "12.1"
               },
               {
-                "alternative_name": "webkittransitionend",
+                "prefix": "webkit",
                 "version_added": "14"
               },
               {
-                "alternative_name": "otransitionend",
+                "prefix": "o",
                 "version_added": "12",
                 "version_removed": "14"
               }
@@ -9358,7 +9358,7 @@
                 "version_added": "7"
               },
               {
-                "alternative_name": "webkittransitionend",
+                "prefix": "webkit",
                 "version_added": "4"
               }
             ],

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -874,7 +874,7 @@
                 "version_added": "46"
               },
               {
-                "alternative_name": "webkitresourcetimingbufferfull",
+                "prefix": "webkit",
                 "version_added": "22",
                 "version_removed": "57"
               }

--- a/api/Screen.json
+++ b/api/Screen.json
@@ -658,7 +658,7 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "alternative_name": "msorientationchange",
+              "prefix": "ms",
               "version_added": "12",
               "version_removed": "79"
             },
@@ -666,11 +666,11 @@
               "version_added": false
             },
             "firefox_android": {
-              "alternative_name": "mozorientationchange",
+              "prefix": "moz",
               "version_added": "14"
             },
             "ie": {
-              "alternative_name": "msorientationchange",
+              "prefix": "ms",
               "version_added": "11"
             },
             "oculus": "mirror",

--- a/test/linter/test-prefix.ts
+++ b/test/linter/test-prefix.ts
@@ -45,8 +45,7 @@ const processData = (
     return;
   }
 
-  const featureParts = feature.split('.');
-  const featureName = featureParts[featureParts.length - 1];
+  const featureName = feature.split('.').at(-1);
   const strippedFeatureName = featureName.replace(/_(event|static)/, '');
 
   for (const support of Object.values(data.support)) {

--- a/test/linter/test-prefix.ts
+++ b/test/linter/test-prefix.ts
@@ -45,7 +45,9 @@ const processData = (
     return;
   }
 
-  const featureName = feature.split('.')[-1];
+  const featureParts = feature.split('.');
+  const featureName = featureParts[featureParts.length - 1];
+  const strippedFeatureName = featureName.replace(/_(event|static)/, '');
 
   for (const support of Object.values(data.support)) {
     const supportStatements = Array.isArray(support) ? support : [support];
@@ -67,16 +69,20 @@ const processData = (
           chalk`Prefix is set to {bold ${statement.prefix}}, which is invalid for ${category}`,
         );
       }
-      if (
-        statement.alternative_name &&
-        statement.alternative_name.endsWith(featureName)
-      ) {
-        logger.error(
-          chalk`Use {bold "prefix": "${statement.alternative_name.replace(
-            featureName,
-            '',
-          )}"} instead of {bold "alternative_name": "statement.alternative_name"}`,
-        );
+      if (statement.alternative_name) {
+        const altNameMatchesPrefix = prefixes.find((p) => {
+          const prefixedName = `${p}${strippedFeatureName}`;
+          return [
+            prefixedName,
+            ':' + prefixedName,
+            '::' + prefixedName,
+          ].includes(statement.alternative_name);
+        });
+        if (altNameMatchesPrefix) {
+          logger.error(
+            chalk`Use {bold "prefix": "${altNameMatchesPrefix}"} instead of {bold "alternative_name": "${statement.alternative_name}"}`,
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
This PR fixes a bug with the prefix linter regarding alternative names that are just prefixes, as well as expands its capabilities to handle events, static methods and CSS selectors.
