### PR TITLE
Update Firefox data for api.Window.unhandledrejection_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6397,7 +6397,8 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": "69"
+              "version_added": "69",
+              "notes": "<code>event.preventDefault()</code> does not prevent Firefox from logging the error message in the console, see <a href='https://bugzil.la/1642147'>bug 1642147</a>."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `unhandledrejection_event` member of the `Window` API. This fixes #12750, which contains the supporting evidence for this change.
