### PR TITLE
Update Opera data for css.properties.align-items.flex_context.start_end

### DIFF
--- a/css/properties/align-items.json
+++ b/css/properties/align-items.json
@@ -274,13 +274,8 @@
                   "version_added": false
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": "79",
-                  "notes": "Before version 79, this value is recognized, but has no effect."
-                },
-                "opera_android": {
-                  "version_added": false
-                },
+                "opera": "mirror",
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": "15.4"
                 },


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `flex_context.start_end` member of the `align-items` CSS property. This sets Opera to mirror from Chrome.
