### PR TITLE
Update Opera data for css.properties.justify-content.flex_context.start_end

### DIFF
--- a/css/properties/justify-content.json
+++ b/css/properties/justify-content.json
@@ -240,13 +240,8 @@
                   "version_added": false
                 },
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": "79",
-                  "notes": "Before version 79, this value is recognized, but has no effect."
-                },
-                "opera_android": {
-                  "version_added": false
-                },
+                "opera": "mirror",
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": "15.4"
                 },


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `flex_context.start_end` member of the `justify-content` CSS property. This sets Opera to mirror from Chrome.
