### PR TITLE
Add Chromium versions for svg.attributes.presentation.fill-rule

### DIFF
--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -601,7 +601,7 @@
             "spec_url": "https://svgwg.org/svg2-draft/painting.html#WindingRule",
             "support": {
               "chrome": {
-                "version_added": null
+                "version_added": "≤15"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `fill-rule` member of the `presentation` SVG attribute. This fixes #13385, which contains the supporting evidence for this change.
