### PR TITLE
Add Firefox versions for svg.attributes.presentation.fill-rule

### DIFF
--- a/svg/attributes/presentation.json
+++ b/svg/attributes/presentation.json
@@ -606,7 +606,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": null
+                "version_added": "18"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR replaces `true`/`null` values with exact version numbers (or `false`) for Firefox and Firefox Android for the `fill-rule` member of the `presentation` SVG attribute. This fixes #13385, which contains the supporting evidence for this change.
