### PR TITLE
Update Chromium data for html.elements.td.rowspan.rowspan_zero

### DIFF
--- a/html/elements/td.json
+++ b/html/elements/td.json
@@ -357,7 +357,7 @@
               "description": "<code>rowspan</code> attribute with value <code>0</code> (extend to the end of the row group)",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "65"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `rowspan.rowspan_zero` member of the `td` HTML element. The data comes from a commit in the browser's source code, mapped to a version number using available tooling or via the commit timestamp.

Commit: https://chromiumdash.appspot.com/commit/93609285fd2b0f7fef0d27ad1cf2eca4b9956fc8

Additional Notes: Fixes #14282.
