### PR TITLE
Update Chromium data for javascript.builtins.Intl.DateTimeFormat.DateTimeFormat.options_parameter.options_timeZoneName_parameter.extended_values

### DIFF
--- a/javascript/builtins/Intl/DateTimeFormat.json
+++ b/javascript/builtins/Intl/DateTimeFormat.json
@@ -642,12 +642,12 @@
                     "deprecated": false
                   }
                 },
-                "options_timeZoneName_parameter_iana": {
+                "extended_values": {
                   "__compat": {
-                    "description": "IANA time zone names in <code>options.timeZoneName</code> option",
+                    "description": "<code>shortGeneric</code>/<code>longGeneric</code>/<code>shortOffset</code>/<code>longOffset</code> as <code>options.timeZoneName</code> option",
                     "support": {
                       "chrome": {
-                        "version_added": false
+                        "version_added": "95"
                       },
                       "chrome_android": "mirror",
                       "deno": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `DateTimeFormat.DateTimeFormat.options_parameter.options_timeZoneName_parameter.extended_values` member of the `Intl` JavaScript builtin. This fixes #14586, which contains the supporting evidence for this change.

Additional Notes: This also renames the feature to better represent what it is (it's not IANA time zone names).  Also fixes #15396, fixes #18405.
