### PR TITLE
Rename DateTimeFormat().options_timeZone_parameter_iana feature

### DIFF
--- a/javascript/builtins/Intl/DateTimeFormat.json
+++ b/javascript/builtins/Intl/DateTimeFormat.json
@@ -554,7 +554,7 @@
                     "deprecated": false
                   }
                 },
-                "options_timeZone_parameter_iana": {
+                "iana_time_zones": {
                   "__compat": {
                     "description": "IANA time zone names in <code>options.timeZone</code> option",
                     "support": {


### PR DESCRIPTION
This PR renames the `options_timeZone_parameter_iana` subfeature deep within the data of the `DateTimeFormat()` constructor to `iana_time_zones`.  This is because it is a subfeature of `options_timeZone_parameter`, so it is redundant to re-specify the parent feature's name.
