### PR TITLE
Update all browsers data for css.types.image.*-gradient

### DIFF
--- a/css/types/image.json
+++ b/css/types/image.json
@@ -413,8 +413,7 @@
                 },
                 "firefox": [
                   {
-                    "version_added": "16",
-                    "notes": "Before Firefox 36, gradients weren't applied on the pre-multiplied color space, leading to shades of grey unexpectedly appearing when used with transparency."
+                    "version_added": "16"
                   },
                   {
                     "prefix": "-webkit-",
@@ -632,6 +631,39 @@
                 }
               }
             },
+            "premultiplied_gradients": {
+              "__compat": {
+                "description": "Gradients applied to pre-multiplied color space (prevents grays from appearing in gradients with transparency)",
+                "support": {
+                  "chrome": {
+                    "version_added": "29"
+                  },
+                  "chrome_android": "mirror",
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "36"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "15"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
             "to": {
               "__compat": {
                 "description": "<code>to</code> keyword",
@@ -735,8 +767,7 @@
                 },
                 "firefox": [
                   {
-                    "version_added": "16",
-                    "notes": "Before Firefox 36, gradients weren't applied on the pre-multiplied color space, leading to shades of grey unexpectedly appearing when used with transparency."
+                    "version_added": "16"
                   },
                   {
                     "prefix": "-webkit-",
@@ -821,54 +852,20 @@
                   "edge": {
                     "version_added": "12"
                   },
-                  "firefox": [
-                    {
-                      "version_added": "16",
-                      "notes": "Before Firefox 36, gradients weren't applied on the pre-multiplied color space, leading to shades of grey unexpectedly appearing when used with transparency."
-                    },
-                    {
-                      "prefix": "-webkit-",
-                      "version_added": "49"
-                    },
-                    {
-                      "prefix": "-moz-",
-                      "version_added": "10",
-                      "notes": "Since Firefox 42, the prefixed version of gradients can be disabled by setting <code>layout.css.prefixes.gradients</code> to <code>false</code>."
-                    }
-                  ],
-                  "firefox_android": [
-                    {
-                      "version_added": "16"
-                    },
-                    {
-                      "prefix": "-moz-",
-                      "version_added": "10"
-                    }
-                  ],
+                  "firefox": {
+                    "version_added": "10"
+                  },
+                  "firefox_android": "mirror",
                   "ie": {
                     "version_added": "10"
                   },
                   "oculus": "mirror",
-                  "opera": [
-                    {
-                      "version_added": "15"
-                    },
-                    {
-                      "prefix": "-o-",
-                      "version_added": "11.6",
-                      "version_removed": "15"
-                    }
-                  ],
-                  "opera_android": [
-                    {
-                      "version_added": "14"
-                    },
-                    {
-                      "prefix": "-o-",
-                      "version_added": "12",
-                      "version_removed": "14"
-                    }
-                  ],
+                  "opera": {
+                    "version_added": "11.6"
+                  },
+                  "opera_android": {
+                    "version_added": "12"
+                  },
                   "safari": {
                     "version_added": "7"
                   },
@@ -1005,6 +1002,39 @@
                   "opera_android": "mirror",
                   "safari": {
                     "version_added": "7"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "premultiplied_gradients": {
+              "__compat": {
+                "description": "Gradients applied to pre-multiplied color space (prevents grays from appearing in gradients with transparency)",
+                "support": {
+                  "chrome": {
+                    "version_added": "29"
+                  },
+                  "chrome_android": "mirror",
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "36"
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "15"
                   },
                   "safari_ios": "mirror",
                   "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `*-gradient` member of the `image` CSS value type. This adds a `premultiplied_gradients` subfeature to all three gradient types, as all browsers (not just Firefox) had this issue in the past.  In a way, this fixes #14598.

Test Code:
```html
<div id="test"></div>
<style>
	body {
		background-color: black;
	}
	#test {
		height: 100vh;
		background: linear-gradient(to bottom, red, rgba(255, 255, 255, 0));
	}
</style>
```

If the gradient started to transition into white, then premultiplication was not performed.  If the gradient faded perfectly to black, premultiplication was performed properly.
