### PR TITLE
Update Edge data for webextensions.manifest.manifest_version.v3

### DIFF
--- a/webextensions/manifest/manifest_version.json
+++ b/webextensions/manifest/manifest_version.json
@@ -55,9 +55,7 @@
               "chrome": {
                 "version_added": "88"
               },
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "109"
               },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `v3` member of the `manifest_version` Web Extensions manifest property. This fixes #14658, which contains the supporting evidence for this change.
