### PR TITLE
Update Firefox data for api.Element.focus_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -3970,6 +3970,7 @@
               {
                 "version_added": "6",
                 "version_removed": "24",
+                "partial_implementation": true,
                 "notes": "The interface for this event is <a href='https://developer.mozilla.org/docs/Web/API/Event'><code>Event</code></a>, not <a href='https://developer.mozilla.org/docs/Web/API/FocusEvent'><code>FocusEvent</code></a>."
               }
             ],


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `focus_event` member of the `Element` API. This fixes #14814, which contains the supporting evidence for this change.
