### PR TITLE
Update NodeJS data for javascript.statements.import

### DIFF
--- a/javascript/operators/import.json
+++ b/javascript/operators/import.json
@@ -22,10 +22,17 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": "13.2.0",
-              "notes": "Dynamic <code>import</code> can be used in either CommonJS or ES module files, to import either CommonJS or ES module files. See Node's <a href='https://nodejs.org/api/esm.html#esm_import_expressions'>ECMAScript Modules documentation</a> for more details."
-            },
+            "nodejs": [
+              {
+                "version_added": "13.2.0",
+                "notes": "Dynamic <code>import</code> can be used in either CommonJS or ES module files, to import either CommonJS or ES module files. See Node's <a href='https://nodejs.org/api/esm.html#esm_import_expressions'>ECMAScript Modules documentation</a> for more details."
+              },
+              {
+                "version_added": "12.17.0",
+                "version_removed": "13.0.0",
+                "notes": "Dynamic <code>import</code> can be used in either CommonJS or ES module files, to import either CommonJS or ES module files. See Node's <a href='https://nodejs.org/api/esm.html#esm_import_expressions'>ECMAScript Modules documentation</a> for more details."
+              }
+            ],
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1178,10 +1178,17 @@
             "ie": {
               "version_added": false
             },
-            "nodejs": {
-              "version_added": "13.2.0",
-              "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
-            },
+            "nodejs": [
+              {
+                "version_added": "13.2.0",
+                "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
+              },
+              {
+                "version_added": "12.17.0",
+                "version_removed": "13.0.0",
+                "notes": "Modules must either have a filename ending in <code>.mjs</code>, or the nearest parent <code>package.json</code> file must contain <code>\"type\": \"module\"</code>. See Node's <a href='https://nodejs.org/api/esm.html#esm_enabling'>ECMAScript Modules documentation</a> for more details."
+              }
+            ],
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for NodeJS for the `import` member of the `statements` JavaScript feature. This fixes #15123, which contains the supporting evidence for this change.
