### PR TITLE
Update Safari iOS data for caret-color CSS property

### DIFF
--- a/css/properties/caret-color.json
+++ b/css/properties/caret-color.json
@@ -24,11 +24,7 @@
             "safari": {
               "version_added": "11.1"
             },
-            "safari_ios": {
-              "version_added": "11.3",
-              "partial_implementation": true,
-              "notes": "While the property is recognized, implementation is incomplete. The color of the caret does not always match the color set for the element in focus. See <a href='https://webkit.org/b/177489'>bug 177489</a>."
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `caret-color` CSS property. This fixes #15128, which contains the supporting evidence for this change.

Additional Notes: The behavior described had not been seen in any version of Safari iOS I had tested.  Additionally, the commit that fixed the bug landed in iOS 11.3.
