### PR TITLE
Update Firefox data for http.headers.Set-Cookie.SameSite.Lax_default

### DIFF
--- a/http/headers/Set-Cookie.json
+++ b/http/headers/Set-Cookie.json
@@ -260,14 +260,7 @@
                   "version_added": "86"
                 },
                 "firefox": {
-                  "version_added": "69",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "network.cookie.sameSite.laxByDefault",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "96"
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `SameSite.Lax_default` member of the `Set-Cookie` HTTP header. This fixes #15246, which contains the supporting evidence for this change.
