### PR TITLE
Add missing css.types.length.em feature

### DIFF
--- a/css/types/length.json
+++ b/css/types/length.json
@@ -198,9 +198,6 @@
                 "version_added": "1"
               },
               "firefox_android": "mirror",
-              "ie": {
-                "version_added": "9"
-              },
               "oculus": "mirror",
               "opera": {
                 "version_added": "3.5"

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -183,6 +183,49 @@
             }
           }
         },
+        "em": {
+          "__compat": {
+            "description": "<code>em</code> unit",
+            "support": {
+              "chrome": {
+                "version_added": "4"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "3.6"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "9"
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": "11.6"
+              },
+              "opera_android": {
+                "version_added": "12"
+              },
+              "safari": {
+                "version_added": "5"
+              },
+              "safari_ios": {
+                "version_added": "4"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": "2"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "ex": {
           "__compat": {
             "description": "<code>ex</code> unit",

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -198,6 +198,9 @@
                 "version_added": "1"
               },
               "firefox_android": "mirror",
+              "ie": {
+                "version_added": null
+              },
               "oculus": "mirror",
               "opera": {
                 "version_added": "3.5"

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -203,7 +203,7 @@
                 "version_added": "3.5"
               },
               "opera_android": {
-                "version_added": "10."
+                "version_added": "10.1"
               },
               "safari": {
                 "version_added": "1"

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -199,7 +199,7 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": null
+                "version_added": "3"
               },
               "oculus": "mirror",
               "opera": {

--- a/css/types/length.json
+++ b/css/types/length.json
@@ -188,14 +188,14 @@
             "description": "<code>em</code> unit",
             "support": {
               "chrome": {
-                "version_added": "4"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "3.6"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -203,20 +203,18 @@
               },
               "oculus": "mirror",
               "opera": {
-                "version_added": "11.6"
+                "version_added": "3.5"
               },
               "opera_android": {
-                "version_added": "12"
+                "version_added": "10."
               },
               "safari": {
-                "version_added": "5"
+                "version_added": "1"
               },
-              "safari_ios": {
-                "version_added": "4"
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": {
-                "version_added": "2"
+                "version_added": "1"
               }
             },
             "status": {


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing `em` member of the `length` CSS value type. This mirrors the data from `rem` (which is probably accurate enough for our needs).  Fixes #15293.
