### PR TITLE
Update Chromium data for hyphens CSS property

### DIFF
--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -190,10 +190,175 @@
         },
         "language_amharic": {
           "__compat": {
-            "description": "Hyphenation dictionary for Ahmaric and Ethiopic script (am, am-*, mul-ethi)",
+            "description": "Hyphenation dictionary for Ahmaric (am, am-*)",
             "support": {
               "chrome": {
                 "version_added": "112"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_armenian": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Armenian (hy, hy-*)",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_assamese": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Assamese (as, as-*)",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_basque": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Basque (be, be-*)",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_belarusian": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Belarusian (be, be-*)",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_bengali": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Bengali (bn, bn-*)",
+            "support": {
+              "chrome": {
+                "version_added": "87"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -259,7 +424,7 @@
             "description": "Hyphenation dictionary for Bulgarian (bg, bg-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -325,7 +490,7 @@
             "description": "Hyphenation dictionary for Croatian (hr, hr-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -341,6 +506,39 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "9.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_cyrillic_mongolian": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Mongolian (Cyrillic) (mn-cyrl, mn-cyrl-*)",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -424,7 +622,7 @@
             "description": "Hyphenation dictionary for Danish (da, da-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -564,12 +762,78 @@
             "description": "Hyphenation dictionary for Estonian (et, et-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": "8"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_ethiopic_script_mul": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Ethiopic script (mul-ethi, mul-ethi-*)",
+            "support": {
+              "chrome": {
+                "version_added": "112"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_ethiopic_script_und": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Ethiopic script (und-ethi, und-ethi-*)",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
@@ -630,7 +894,7 @@
             "description": "Hyphenation dictionary for French (fr, fr-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -729,7 +993,7 @@
             "description": "Hyphenation dictionary for German, Reformed Orthography of 1996 (de, de-1996, de-DE, de-AT, de-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -762,7 +1026,7 @@
             "description": "Hyphenation dictionary for German, Swiss Orthography (de-CH, de-CH-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -795,7 +1059,7 @@
             "description": "Hyphenation dictionary for German, Traditional Orthography of 1901 (de-1901, de-AT-1901, de-DE-1901)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -823,12 +1087,78 @@
             }
           }
         },
+        "language_gujarati": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Gujarati (gu, gu-*)",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_hindi": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Hindi (hi, hi-*)",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "language_hungarian": {
           "__compat": {
             "description": "Hyphenation dictionary for Hungarian (hu, hu-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -922,6 +1252,39 @@
             }
           }
         },
+        "language_irish": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Irish (ga, ga-*)",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "language_italian": {
           "__compat": {
             "description": "Hyphenation dictionary for Italian (it, it-*)",
@@ -943,6 +1306,39 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "5.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_kannada": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Kannada (kn, kn-*)",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -993,7 +1389,7 @@
             "description": "Hyphenation dictionary for Latin (la, la-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1087,6 +1483,72 @@
             }
           }
         },
+        "language_malayalam": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Malayalam (ml, ml-*)",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_marathi": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Marathi (mr, mr-*)",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "language_modern_greek": {
           "__compat": {
             "description": "Hyphenation dictionary for Modern Greek (el, el-*)",
@@ -1158,7 +1620,7 @@
             "description": "Hyphenation dictionary for Norwegian (Nynorsk) (nn, nn-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1193,7 +1655,7 @@
             "description": "Hyphenation dictionary for Norwegian (Bokmål) (no, no-*, nb, nb-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1209,6 +1671,72 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "5.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_old_slavonic": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Old Slavonic (cu, cu-*)",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_oriya": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Oriya (or, or-*)",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -1259,7 +1787,7 @@
             "description": "Hyphenation dictionary for Portuguese (pt, pt-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1321,6 +1849,39 @@
             }
           }
         },
+        "language_punjabi": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Punjabi/Panjabi (pa, pa-*)",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "language_russian": {
           "__compat": {
             "description": "Hyphenation dictionary for Russian (ru, ru-*)",
@@ -1359,7 +1920,7 @@
             "description": "Hyphenation dictionary for Slovenian (sl, sl-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1392,7 +1953,7 @@
             "description": "Hyphenation dictionary for Spanish (es, es-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1453,6 +2014,72 @@
             }
           }
         },
+        "language_tamil": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Tamil (ta, ta-*)",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_telugu": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Telugu (te, te-*)",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "language_turkish": {
           "__compat": {
             "description": "Hyphenation dictionary for Turkish (tr, tr-*)",
@@ -1474,6 +2101,39 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "5.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_turkmen": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Turkmen (tk, tk-*)",
+            "support": {
+              "chrome": {
+                "version_added": "87"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -1557,7 +2217,7 @@
             "description": "Hyphenation dictionary for Welsh (cy, cy-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "87"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -127,12 +127,78 @@
             "description": "Hyphenation dictionary for Afrikaans (af, af-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "112"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": "8"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_albanian": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Albanian (sq, sq-*)",
+            "support": {
+              "chrome": {
+                "version_added": "112"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_amharic": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Ahmaric and Ethiopic script (am, am-*, mul-ethi)",
+            "support": {
+              "chrome": {
+                "version_added": "112"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
@@ -292,7 +358,7 @@
             "description": "Hyphenation dictionary for Czech (cs, cs-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "112"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -308,6 +374,39 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "9.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_czechoslovak": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Czechoslovak (sk, sk-*)",
+            "support": {
+              "chrome": {
+                "version_added": "112"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -358,7 +457,7 @@
             "description": "Hyphenation dictionary for Dutch (nl, nl-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "112"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -564,12 +663,45 @@
             "description": "Hyphenation dictionary for Galician (gl, gl-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "112"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": "9"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_georgian": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Georgian (ka, ka-*)",
+            "support": {
+              "chrome": {
+                "version_added": "112"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
@@ -795,7 +927,7 @@
             "description": "Hyphenation dictionary for Italian (it, it-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "112"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -889,17 +1021,83 @@
             }
           }
         },
+        "language_latvian": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Latvian (lv, lv-*)",
+            "support": {
+              "chrome": {
+                "version_added": "112"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "language_lithuanian": {
           "__compat": {
             "description": "Hyphenation dictionary for Lithuanian (lt, lt-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "112"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": "8"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_modern_greek": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Modern Greek (el, el-*)",
+            "support": {
+              "chrome": {
+                "version_added": "112"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1128,7 +1326,7 @@
             "description": "Hyphenation dictionary for Russian (ru, ru-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "112"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1227,7 +1425,7 @@
             "description": "Hyphenation dictionary for Swedish (sv, sv-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "112"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -1293,7 +1491,7 @@
             "description": "Hyphenation dictionary for Ukrainian (uk, uk-*)",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "112"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `hyphens` CSS property. The data comes from a commit in the browser's source code, mapped to a version number using available tooling or via the commit timestamp.

Commit: 
(Chrome 87; as, be, bg, bn, cu, cy, da, de-1901, de-1996, de-ch-1901, en-gb, en-us, es, et, eu, fr, ga, gu, hi, hr, hu, hy, kn, la, ml, mn-cyrl, mr, nb, nn, or, pa, pt, sl, ta, te, tk, und-ethi): https://chromiumdash.appspot.com/commit/6607bfa1ce9656569ea9330bb7f1fb3058aad920
(Chrome 112; af, am, cs, el, gl, it, ka, lt, lv, nl, ru, sk, sq, sv, uk, mul-ethi): https://chromiumdash.appspot.com/commit/0720c691bcdc16a9438e249642aeabbe498c2da4

Additional Notes: This fixes #18172, fixes #18987, fixes #21272.
