### PR TITLE
Add missing api.SVGGeometryElement.isPointInFill.point_parameter_DOMPoint feature

### DIFF
--- a/api/SVGGeometryElement.json
+++ b/api/SVGGeometryElement.json
@@ -363,6 +363,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "point_parameter_DOMPoint": {
+          "__compat": {
+            "description": "Accepts a <code>DOMPoint</code> as <code>point</code> parameter",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "69"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "12"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "isPointInStroke": {
@@ -398,6 +431,39 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "point_parameter_DOMPoint": {
+          "__compat": {
+            "description": "Accepts a <code>DOMPoint</code> as <code>point</code> parameter",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "69"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "12"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing `isPointInFill.point_parameter_DOMPoint` member of the `SVGGeometryElement` API. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code:

```
<svg
  viewBox="0 0 100 100"
  width="150"
  height="150"
  xmlns="http://www.w3.org/2000/svg">
  <circle
	id="circle"
	cx="50"
	cy="50"
	r="45"
	fill="white"
	stroke="blue"
	stroke-width="10" />
</svg>

<p id="usedSVGPoint"><code>DOMPoint()</code> failed and <code>SVGPoint</code> was used instead.</p>

<script>
	var svg = document.getElementsByTagName("svg")[0];
	var circle = document.getElementById("circle");
	var points = [["10", "10"], ["40", "30"]];

	for (var i = 0; i < points.length; i++) {
		var point = points[i];
		var isPointInFill;
		try {
			var pointObj = new DOMPoint(point[0], point[1]);
			isPointInFill = circle.isPointInFill(pointObj);
		} catch(e) {
			var pointObj = svg.createSVGPoint();
			pointObj.x = point[0];
			pointObj.y = point[1];
			isPointInFill = circle.isPointInFill(pointObj);
			document.getElementById('usedSVGPoint').style.display = 'block';
		}

		console.log(`Point at ${point[0]},${point[1]}: ${isPointInFill}`);

		svg.innerHTML += `<circle cx="${point[0]}" cy="${point[1]}" r="5" fill="${isPointInFill ? "seagreen" : "red"}" />`;
	}
</script>
```

Fixes #15662.
