### PR TITLE
Update Firefox data for html.elements.input.type_datetime-local

### DIFF
--- a/html/elements/input/datetime-local.json
+++ b/html/elements/input/datetime-local.json
@@ -16,7 +16,8 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "93"
+                "version_added": "93",
+                "notes": "Firefox only displays a date picker and does not display a time picker, see <a href='https://bugzil.la/1726108'>bug 1726108</a>."
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/elements/input/datetime-local.json
+++ b/html/elements/input/datetime-local.json
@@ -19,7 +19,9 @@
                 "version_added": "93",
                 "notes": "Firefox only displays a date picker and does not display a time picker, see <a href='https://bugzil.la/1726108'>bug 1726108</a>."
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "93"
+              },
               "ie": {
                 "version_added": false
               },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `type_datetime-local` member of the `input` HTML element. This fixes #16138, which contains the supporting evidence for this change.
