### PR TITLE
Update Safari data for html.elements.input.type_datetime-local

### DIFF
--- a/html/elements/input/datetime-local.json
+++ b/html/elements/input/datetime-local.json
@@ -30,7 +30,8 @@
                 "version_added": "11"
               },
               "safari": {
-                "version_added": "14.1"
+                "version_added": "14.1",
+                "notes": "Safari only displays a date picker and does not display a time picker."
               },
               "safari_ios": {
                 "version_added": "5"


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `type_datetime-local` member of the `input` HTML element. Related to #16138 (see https://github.com/mdn/browser-compat-data/issues/21103#issuecomment-1840599505).

Additional Notes: 
