### PR TITLE
Update Firefox data for api.AudioContext.createMediaStreamSource

### DIFF
--- a/api/AudioContext.json
+++ b/api/AudioContext.json
@@ -340,7 +340,8 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "25"
+              "version_added": "25",
+              "notes": "If a sample rate is specified for the audio context, it must match the sample rate of the stream, otherwise this method will fail."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `createMediaStreamSource` member of the `AudioContext` API. This fixes #16213, which contains the supporting evidence for this change.
