### PR TITLE
Update Chromium data for api.Document.domain

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2554,7 +2554,7 @@
           "support": {
             "chrome": {
               "version_added": "1",
-              "notes": "From Chrome 110, <code>domain</code> is available by opt-in via `Origin-keyed agent clusters` <a href='https://origin-agent-cluster-demo.dev'></a>. See this <a href='https://chromestatus.com/feature/5428079583297536'>chromestatus entry</a>."
+              "notes": "Since Chrome 115, setting <code>domain</code> has no effect, unless the website has opted into <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers/Origin-Agent-Cluster'>origin-keyed agent clusters</a>."
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `domain` member of the `Document` API. This updates the note introduced in #18500 to a) better explain the new behavior, b) fix the version number (see https://chromestatus.com/feature/5428079583297536), c) remove an empty link to a demo, and d) link to an MDN article explaining origin-keyed agent clusters, not a ChromeStatus page.

Additional Notes: This fixes #21221.
