### PR TITLE
Don't apply "needs triage" labels by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/data-problem.yml
+++ b/.github/ISSUE_TEMPLATE/data-problem.yml
@@ -1,7 +1,6 @@
 name: "Data problem"
 title: "<NAME THE FEATURE> - <SUMMARIZE THE PROBLEM>"
 description: Report incorrect, incomplete, or missing data
-labels: ["needs triage 🔎"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,6 +1,6 @@
 name: "Enhancement"
 description: An enhancement to BCD's infrastructure
-labels: ["needs triage 🔎", "enhancement :1st_place_medal:"]
+labels: ["enhancement :1st_place_medal:"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/infra-problem.yml
+++ b/.github/ISSUE_TEMPLATE/infra-problem.yml
@@ -1,6 +1,5 @@
 name: "Infrastructure/Linter Problem"
 description: Report issues with infrastructure, including scripts and linters
-labels: ["needs triage 🔎"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
This PR removes the automatic assigning of "needs triage" labels from BCD issues, as discussed in the last BCD call.

(Self-merging since it was already approved during the call.)
