### PR TITLE
Fix update-browser-releases.yml to update only browser files

### DIFF
--- a/.github/workflows/update-browser-releases.yml
+++ b/.github/workflows/update-browser-releases.yml
@@ -42,6 +42,7 @@ jobs:
           signoff: false
           branch: browser-releases
           delete-branch: true
+          add-paths: browsers/*.json # Only include files in that directory
           title: "Update browser releases"
           body: |
             The output of the `update-browser-releases` script is:


### PR DESCRIPTION
We got a `package-lock.json` file added to the PR (because BCD is not using the latest minor version of typescript yet) in #21504.

We want to restrict the generated PR to only contain json files from the browsers/ directory. This PR fixes this.