### PR TITLE
Add spec_url for Window.credentialless

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -982,7 +982,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }

--- a/api/Window.json
+++ b/api/Window.json
@@ -956,6 +956,7 @@
       "credentialless": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/credentialless",
+          "spec_url": "https://wicg.github.io/anonymous-iframe/#dom-window-credentialless",
           "support": {
             "chrome": {
               "version_added": "110"


### PR DESCRIPTION
It was missing (likely because the spec was not in the w3c list at the time of creation of the original addition).