### PR TITLE
Update Firefox data for http.headers.Permissions-Policy.fullscreen

### DIFF
--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -574,12 +574,9 @@
               "edge": "mirror",
               "firefox": {
                 "alternative_name": "Feature-Policy: fullscreen",
-                "version_added": "74",
+                "version_added": "80",
                 "partial_implementation": true,
-                "notes": [
-                  "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>).",
-                  "Before Firefox 80, applying <code>fullscreen</code> to an <code>&lt;iframe&gt;</code> (i.e. via the <code>allow</code> attribute) does not work unless the <code>allowfullscreen</code> attribute is also present."
-                ]
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1694922'>bug 1694922</a>)."
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `fullscreen` member of the `Permissions-Policy` HTTP header. This fixes #16537, which contains the supporting evidence for this change.
