### PR TITLE
Update Safari data for css.properties.user-select.text

### DIFF
--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -256,14 +256,10 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "2",
-                "partial_implementation": true,
-                "notes": "Allows typing in the <code>&lt;html&gt;</code> container."
+                "version_added": "2"
               },
               "safari_ios": {
-                "version_added": "3",
-                "partial_implementation": true,
-                "notes": "Allows typing in the <code>&lt;html&gt;</code> container."
+                "version_added": "3"
               },
               "samsunginternet_android": "mirror",
               "webview_android": {


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `text` member of the `user-select` CSS property. This fixes #16566, which contains the supporting evidence for this change.

Additional Notes: Although the note doesn't make too much sense, I can't type or add any content in Safari 11.1+.
