### PR TITLE
Update Safari data for html.global_attributes.hidden

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -660,7 +660,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "5.1"
+              "version_added": "5.1",
+              "notes": "This attribute has no effect on <code>&lt;option&gt;</code> elements."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `hidden` member of the `global_attributes` HTML feature. This fixes #16619, which contains the supporting evidence for this change.

Additional Notes: The reporter states this is an iOS issue, but it affects Safari Desktop as well.
