### PR TITLE
Remove redundant flag data

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -206,22 +206,10 @@
               "version_removed": "80",
               "notes": "Currently supported only by Google Daydream."
             },
-            "edge": [
-              {
-                "version_added": "79",
-                "version_removed": "80",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "WebVR"
-                  }
-                ]
-              },
-              {
-                "version_added": "15",
-                "version_removed": "79"
-              }
-            ],
+            "edge": {
+              "version_added": "15",
+              "version_removed": "79"
+            },
             "firefox": [
               {
                 "version_added": "98",

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -160,20 +160,7 @@
           "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-sanitize",
           "support": {
             "chrome": {
-              "version_added": "93",
-              "version_removed": "119",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                },
-                {
-                  "type": "preference",
-                  "name": "sanitizer-api",
-                  "value_to_set": "enabled"
-                }
-              ]
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -191,9 +178,7 @@
             "ie": {
               "version_added": false
             },
-            "oculus": {
-              "version_added": false
-            },
+            "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {


### PR DESCRIPTION
This PR removes redundant flag data from BCD.  Required for #21512 to pass.
