### PR TITLE
Remove api.Sanitizer.sanitizeFor from BCD

### DIFF
--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -209,50 +209,6 @@
             "deprecated": false
           }
         }
-      },
-      "sanitizeFor": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sanitizer/sanitizeFor",
-          "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-sanitizefor",
-          "support": {
-            "chrome": {
-              "version_added": "93",
-              "version_removed": "119",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "enable-experimental-web-platform-features",
-                  "value_to_set": "enabled"
-                }
-              ]
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": {
-              "version_added": false
-            },
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
This PR removes the `sanitizeFor` member of the `Sanitizer` API from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.5.2).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Sanitizer/sanitizeFor

Additional Notes: Required for #21512 to pass.
