### PR TITLE
Add data for getDisplayMedia() monitorTypeSurfaces option

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -269,6 +269,42 @@
             }
           }
         },
+        "monitorTypeSurfaces_option": {
+          "__compat": {
+            "description": "<code>monitorTypeSurfaces</code> option",
+            "spec_url": "https://w3c.github.io/mediacapture-screen-share/#dom-displaymediastreamoptions-monitortypesurfaces",
+            "support": {
+              "chrome": {
+                "version_added": "119"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "preferCurrentTab_option": {
           "__compat": {
             "description": "<code>preferCurrentTab</code> option",

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -275,7 +275,8 @@
             "spec_url": "https://w3c.github.io/mediacapture-screen-share/#dom-displaymediastreamoptions-monitortypesurfaces",
             "support": {
               "chrome": {
-                "version_added": "119"
+                "version_added": "119",
+                "notes": "Default value = <code>include</code>"
               },
               "chrome_android": {
                 "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 119 adds desktop-only support for the [`getDisplayMedia()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia) `monitorTypeSurfaces` option (see https://chromestatus.com/feature/5558622137876480). This PR adds BCD for it.

Other useful links:

- See https://screen-sharing-controls.glitch.me/ for a demo.
- See https://developer.chrome.com/docs/web-platform/screen-sharing-controls/#monitorTypeSurfaces for an explanation of its purpose

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
