### PR TITLE
linear() is in Safari 17.2

### DIFF
--- a/css/types/easing-function.json
+++ b/css/types/easing-function.json
@@ -100,7 +100,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
The linear function is supported in Safari 17.2, and in Safari Technology Preview 176+.