### PR TITLE
Mention flag support for irrelevant feature removal

### DIFF
--- a/docs/data-guidelines/index.md
+++ b/docs/data-guidelines/index.md
@@ -79,10 +79,11 @@ This guideline was proposed in [#6906](https://github.com/mdn/browser-compat-dat
 Features can be removed from BCD if it is considered irrelevant. A feature can be considered irrelevant if any of these conditions are met:
 
 - a feature was never implemented in any browser.
+- a feature is not available behind a flag in the latest stable browser release.
 - a feature was implemented and has since been removed from all browsers dating back two or more years ago.
 - a feature is unsupported in all releases in the past five years.
 
-This guideline was proposed in [#6018](https://github.com/mdn/browser-compat-data/pull/6018) and updated in [#10619](https://github.com/mdn/browser-compat-data/pull/10619).
+This guideline was proposed in [#6018](https://github.com/mdn/browser-compat-data/pull/6018) and updated in [#10619](https://github.com/mdn/browser-compat-data/pull/10619) and [#21521](https://github.com/mdn/browser-compat-data/pull/21521).
 
 ## Removal of irrelevant flag data
 


### PR DESCRIPTION
This PR updates the guidelines for irrelevant feature removal to specify a feature can be removed if it's no longer available behind a flag in the latest stable browser release.