### PR TITLE
Update Safari data for api.CredentialsContainer.preventSilentAccess

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -771,10 +771,17 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "17",
-              "notes": "From Safari 13 to Safari 16.5, this method existed, but always rejected with a <code>NotSupportedError</code> exception."
-            },
+            "safari": [
+              {
+                "version_added": "17"
+              },
+              {
+                "version_added": "13",
+                "version_removed": "17",
+                "partial_implementation": true,
+                "notes": "This method exists, but always rejected with a <code>NotSupportedError</code> exception."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -772,7 +772,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "13"
+              "version_added": "17",
+              "notes": "From Safari 13 to Safari 16.5, this method existed, but always rejected with a <code>NotSupportedError</code> exception."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `preventSilentAccess` member of the `CredentialsContainer` API. This fixes #16794, which contains the supporting evidence for this change.
