### PR TITLE
Update Safari data for api.EventTarget.addEventListener.options_parameter.options_passive_parameter_default_true_touch

### DIFF
--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -349,7 +349,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "11.1"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `addEventListener.options_parameter.options_passive_parameter_default_true_touch` member of the `EventTarget` API. The data comes from a commit in the browser's source code, mapped to a version number using available tooling or via the commit timestamp.

Commit: https://github.com/WebKit/WebKit/commit/513e72181713132ad1147abb4866ce2d93257b4a

Additional Notes: Fixes #16835.
