### PR TITLE
Update identifiers/descriptions for import attributes/assertions

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1243,9 +1243,9 @@
             }
           }
         },
-        "import_attribues_assert": {
+        "import_assertions": {
           "__compat": {
-            "description": "Import attributes (`assert` syntax)",
+            "description": "Import attributes with <code>assert</code> syntax (formerly import assertions)",
             "support": {
               "chrome": {
                 "version_added": "91"
@@ -1287,7 +1287,7 @@
           },
           "type_json": {
             "__compat": {
-              "description": "import assert {type: json}",
+              "description": "<code>assert {type: 'json'}</code>",
               "support": {
                 "chrome": {
                   "version_added": "91"
@@ -1337,7 +1337,7 @@
         },
         "import_attributes": {
           "__compat": {
-            "description": "Import attributes",
+            "description": "Import attributes (<code>with</code> syntax)",
             "support": {
               "chrome": {
                 "version_added": false,
@@ -1377,7 +1377,7 @@
           },
           "type_json": {
             "__compat": {
-              "description": "import with <code>{type: 'json'}</code>",
+              "description": "<code>with {type: 'json'}</code>",
               "support": {
                 "chrome": {
                   "version_added": false


### PR DESCRIPTION
This PR updates the data for the import assertions and import attributes features.  This renames `import_attribues_assert` back to `import_assertions` to better represent its previous name (and fix a typo in the process), as well as include the name "import assertions" in the description.  Additionally, this improves the descriptions of the subfeatures.
