### PR TITLE
Correct omnibox.key to omnibox.keyword

### DIFF
--- a/webextensions/manifest/omnibox.json
+++ b/webextensions/manifest/omnibox.json
@@ -24,7 +24,7 @@
             "safari_ios": "mirror"
           }
         },
-        "key": {
+        "keyword": {
           "__compat": {
             "support": {
               "chrome": {


### PR DESCRIPTION
#### Summary

`omnibox.key` corrected to `omnibox.keyword`

See:
-    https://searchfox.org/mozilla-central/source/browser/components/extensions/schemas/omnibox.json#15.
 -   https://developer.chrome.com/docs/extensions/reference/api/omnibox#manifest

#### Related issues

Fixes [#21525](https://github.com/mdn/browser-compat-data/issues/21525)