### PR TITLE
Update Chromium data for SVGGeometryElement API

### DIFF
--- a/api/SVGGeometryElement.json
+++ b/api/SVGGeometryElement.json
@@ -335,7 +335,8 @@
           "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__isPointInFill",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": "33",
+              "notes": "The element this method is called for must be in the DOM; otherwise, this method will always return <code>false</code>."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -371,7 +372,8 @@
           "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__isPointInStroke",
           "support": {
             "chrome": {
-              "version_added": "33"
+              "version_added": "33",
+              "notes": "The element this method is called for must be in the DOM; otherwise, this method will always return <code>false</code>."
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `SVGGeometryElement` API. This fixes https://github.com/mdn/browser-compat-data/issues/16965, which contains the supporting evidence for this change.