### PR TITLE
Remove api.Permissions.permission_speaker-selection from BCD

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -637,40 +637,6 @@
           }
         }
       },
-      "permission_speaker-selection": {
-        "__compat": {
-          "description": "<code>speaker-selection</code> permission",
-          "spec_url": "https://w3c.github.io/mediacapture-output/#dfn-speaker-selection",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "92"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "permission_storage-access": {
         "__compat": {
           "description": "<code>storage-access</code> permission",


### PR DESCRIPTION
This PR removes the `permission_speaker-selection` member of the `Permissions` API from BCD. Firefox, the only browser marked with support, doesn't actually support this.  This fixes #17033, which contains the supporting evidence.

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Permissions/permission_speaker-selection
