### PR TITLE
Update NodeJS data for webassembly.api.instantiateStreaming_static feature

### DIFF
--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -196,7 +196,7 @@
               "version_added": false
             },
             "nodejs": {
-              "version_added": false
+              "version_added": "18.1.0"
             },
             "oculus": "mirror",
             "opera": {


### PR DESCRIPTION
This PR updates and corrects version values for NodeJS for the `webassembly.api.instantiateStreaming_static` feature. This fixes #17150, which contains the supporting evidence for this change.
