### PR TITLE
Update Chromium data for css.at-rules.media.hover

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -680,21 +680,14 @@
                 "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": "28"
-              },
-              "opera_android": {
-                "version_added": "28"
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
                 "version_added": "9"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "38",
-                "notes": "Before Chrome 41, the implementation was buggy and reported <code>(hover: none)</code> on non-touch-based computers with a mouse/trackpad. See <a href='https://crbug.com/441613'>bug 441613</a>."
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `hover` member of the `media` CSS at-rule. This sets derivatives to mirror from upstream.
