### PR TITLE
Update Firefox data for scroll-snap-type CSS property

### DIFF
--- a/css/properties/scroll-snap-type.json
+++ b/css/properties/scroll-snap-type.json
@@ -29,7 +29,7 @@
                 "version_added": "68",
                 "version_removed": "99",
                 "partial_implementation": true,
-                "notes": "On macOS 12, scroll snapping does not complete reliably. See <a href='https://bugzil.la/1749352'>bug 1749352</a>"
+                "notes": "On macOS Monterey, scroll snapping does not complete reliably. See <a href='https://bugzil.la/1749352'>bug 1749352</a>."
               },
               {
                 "version_added": "39",


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `scroll-snap-type` CSS property. This replaces the macOS version number with the formal name for consistency.
