### PR TITLE
Add missing css.selectors.selection.text-decoration feature

### DIFF
--- a/css/selectors/selection.json
+++ b/css/selectors/selection.json
@@ -48,6 +48,40 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "text-decoration": {
+          "__compat": {
+            "description": "Supports the <code>text-decoration</code> property",
+            "support": {
+              "chrome": {
+                "version_added": "105"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1612598"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing `text-decoration` member of the `selection` CSS selector. The data comes from manual testing, running test code through BrowserStack, SauceLabs and custom VMs.

Test Code:

```html
<style>
    p::selection {
        color: seagreen;
        background-color: white;
        text-decoration: underline;
    }
</style>

<p>Lorem ipsum dolor sit amet</p>
```

Fixes #17817.
