### PR TITLE
Rename background-position-[x/y] two_value_syntax to side-relative_values

### DIFF
--- a/css/properties/background-position-x.json
+++ b/css/properties/background-position-x.json
@@ -40,7 +40,7 @@
         },
         "side-relative_values": {
           "__compat": {
-            "description": "Side-relative offset values (such as <code>bottom 10%</code>)",
+            "description": "Side-relative values (such as <code>bottom 10%</code>)",
             "support": {
               "chrome": {
                 "version_added": false

--- a/css/properties/background-position-x.json
+++ b/css/properties/background-position-x.json
@@ -38,9 +38,9 @@
             "deprecated": false
           }
         },
-        "two_value_syntax": {
+        "side-relative_values": {
           "__compat": {
-            "description": "Two-value syntax (support for offsets from any edge)",
+            "description": "Side-relative offset values (such as <code>bottom 10%</code>)",
             "support": {
               "chrome": {
                 "version_added": false

--- a/css/properties/background-position-y.json
+++ b/css/properties/background-position-y.json
@@ -40,7 +40,7 @@
         },
         "side-relative_values": {
           "__compat": {
-            "description": "Side-relative offset values (such as <code>bottom 10%</code>)",
+            "description": "Side-relative values (such as <code>bottom 10%</code>)",
             "support": {
               "chrome": {
                 "version_added": false

--- a/css/properties/background-position-y.json
+++ b/css/properties/background-position-y.json
@@ -38,9 +38,9 @@
             "deprecated": false
           }
         },
-        "2_value_syntax": {
+        "side-relative_values": {
           "__compat": {
-            "description": "Two-value syntax (support for offsets from any edge)",
+            "description": "Side-relative offset values (such as <code>bottom 10%</code>)",
             "support": {
               "chrome": {
                 "version_added": false


### PR DESCRIPTION
This PR renames the `two_value_syntax` subfeature of the `background-position-x` and `background-position-y` CSS properties to `side-relative_values`, as discussed in https://github.com/mdn/content/pull/30858#issuecomment-1846800972.
