### PR TITLE
fix: http -> https

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/prettierrc",
+  "$schema": "https://json.schemastore.org/prettierrc",
   "singleQuote": true,
   "trailingComma": "all",
   "overrides": [

--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -548,7 +548,7 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&amp;b=false</code>, <code>pathname</code> would return <code>'/x?a=true&amp;b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&amp;b=false'</code> respectively. This has now been fixed."
+              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>https://z.com/x?a=true&amp;b=false</code>, <code>pathname</code> would return <code>'/x?a=true&amp;b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&amp;b=false'</code> respectively. This has now been fixed."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -953,7 +953,7 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&amp;b=false</code>, <code>pathname</code> would return <code>'/x?a=true&amp;b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&amp;b=false'</code> respectively. This has now been fixed."
+              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>https://z.com/x?a=true&amp;b=false</code>, <code>pathname</code> would return <code>'/x?a=true&amp;b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&amp;b=false'</code> respectively. This has now been fixed."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -432,7 +432,7 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&amp;b=false</code>, <code>pathname</code> would return <code>'/x?a=true&amp;b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&amp;b=false'</code> respectively. This has now been fixed."
+              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>https://z.com/x?a=true&amp;b=false</code>, <code>pathname</code> would return <code>'/x?a=true&amp;b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&amp;b=false'</code> respectively. This has now been fixed."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -797,7 +797,7 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>http://z.com/x?a=true&amp;b=false</code>, <code>pathname</code> would return <code>'/x?a=true&amp;b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&amp;b=false'</code> respectively. This has now been fixed."
+              "notes": "Before Firefox 53, the <code>pathname</code> and <code>search</code> <code>HTMLHyperlinkElementUtils</code> properties returned the wrong parts of the URL. For example, for a URL of <code>https://z.com/x?a=true&amp;b=false</code>, <code>pathname</code> would return <code>'/x?a=true&amp;b=false'</code> and <code>search</code> would return '', rather than <code>'/x'</code> and <code>'?a=true&amp;b=false'</code> respectively. This has now been fixed."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Location.json
+++ b/api/Location.json
@@ -358,7 +358,7 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Before Firefox 53, the <code>pathname</code> property returned wrong parts of the URL. For example, for a URL of http://z.com/x?a=true&amp;b=false, <code>pathname</code> would return \"/x?a=true&amp;b=false\" rather than \"/x\"."
+              "notes": "Before Firefox 53, the <code>pathname</code> property returned wrong parts of the URL. For example, for a URL of https://z.com/x?a=true&amp;b=false, <code>pathname</code> would return \"/x?a=true&amp;b=false\" rather than \"/x\"."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -577,7 +577,7 @@
             },
             "firefox": {
               "version_added": "1",
-              "notes": "Before Firefox 53, the <code>search</code> property returned wrong parts of the URL. For example, for a URL of http://z.com/x?a=true&amp;b=false, <code>search</code> would return \"\", rather than \"?a=true&amp;b=false\"."
+              "notes": "Before Firefox 53, the <code>search</code> property returned wrong parts of the URL. For example, for a URL of https://z.com/x?a=true&amp;b=false, <code>search</code> would return \"\", rather than \"?a=true&amp;b=false\"."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/schema",
 
   "definitions": {
     "browser_type": {

--- a/schemas/browsers.schema.json
+++ b/schemas/browsers.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "https://json-schema.org/schema#",
 
   "definitions": {
     "browser_type": {

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "https://json-schema.org/schema#",
 
   "definitions": {
     "simple_support_statement": {

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/schema",
 
   "definitions": {
     "simple_support_statement": {


### PR DESCRIPTION
The PR replaces `http` with `https`. It's better to use `https` were ever possible.