### PR TITLE
fix spec-url of `URL` interface

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -3,7 +3,7 @@
     "URL": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL",
-        "spec_url": "https://url.spec.whatwg.org/#api",
+        "spec_url": "https://url.spec.whatwg.org/#url",
         "support": {
           "chrome": [
             {
@@ -74,7 +74,7 @@
         "__compat": {
           "description": "<code>URL()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/URL",
-          "spec_url": "https://url.spec.whatwg.org/#constructors",
+          "spec_url": "https://url.spec.whatwg.org/#dom-url-url",
           "support": {
             "chrome": {
               "version_added": "19"
@@ -133,7 +133,7 @@
         "__compat": {
           "description": "<code>canParse()</code> static method",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/URL/canParse_static",
-          "spec_url": "https://url.spec.whatwg.org/#ref-for-dom-url-canparse",
+          "spec_url": "https://url.spec.whatwg.org/#dom-url-canparse",
           "support": {
             "chrome": {
               "version_added": "120"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the spec-url of `URL` interface should be with hash `#url`, not `#api`

also normalize the spec-url of `URL.canParse()` and `URL()` to keep same with others

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
