### PR TITLE
Update Safari data for css.selectors.before.animation_and_transition_support

### DIFF
--- a/css/selectors/before.json
+++ b/css/selectors/before.json
@@ -134,7 +134,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "≤10.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `animation_and_transition_support` member of the `before` CSS selector. This fixes #18109, which contains the supporting evidence for this change.
