### PR TITLE
Fix bug links

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2596,7 +2596,7 @@
           "support": {
             "chrome": {
               "version_added": "1",
-              "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
+              "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>bug 759947</a>."
             },
             "chrome_android": "mirror",
             "edge": {
@@ -2612,11 +2612,11 @@
             "oculus": "mirror",
             "opera": {
               "version_added": "≤12.1",
-              "notes": "Before Opera 53, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
+              "notes": "Before Opera 53, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>bug 759947</a>."
             },
             "opera_android": {
               "version_added": "≤12.1",
-              "notes": "Before Opera Android 47, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
+              "notes": "Before Opera Android 47, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>bug 759947</a>."
             },
             "safari": {
               "version_added": "4"
@@ -2625,7 +2625,7 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "≤37",
-              "notes": "Before WebView 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
+              "notes": "Before WebView 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>bug 759947</a>."
             }
           },
           "status": {
@@ -2642,7 +2642,7 @@
           "support": {
             "chrome": {
               "version_added": "43",
-              "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
+              "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>bug 759947</a>."
             },
             "chrome_android": "mirror",
             "edge": [
@@ -4046,7 +4046,7 @@
               {
                 "version_added": "13.1",
                 "partial_implementation": true,
-                "notes": "Implements an older version of the specification, see Webkit bug <a href='https://webkit.org/b/179536'>179536</a>."
+                "notes": "Implements an older version of the specification, see <a href='https://webkit.org/b/179536'>bug 179536</a>."
               }
             ],
             "safari_ios": "mirror",
@@ -6811,13 +6811,13 @@
               {
                 "version_added": "14",
                 "partial_implementation": true,
-                "notes": "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>."
+                "notes": "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See <a href='https://webkit.org/b/116769'>bug 116769</a>, <a href='https://webkit.org/b/151234'>bug 151234</a>, <a href='https://webkit.org/b/151610'>bug 151610</a>, and <a href='https://webkit.org/b/194897'>bug 194897</a>."
               },
               {
                 "version_added": "10.1",
                 "partial_implementation": true,
                 "notes": [
-                  "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>.",
+                  "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See <a href='https://webkit.org/b/116769'>bug 116769</a>, <a href='https://webkit.org/b/151234'>bug 151234</a>, <a href='https://webkit.org/b/151610'>bug 151610</a>, and <a href='https://webkit.org/b/194897'>bug 194897</a>.",
                   "Before Safari 14, the event does not bubble, so <code>document.addEventListener('visibilitychange', ...)</code> works, but <code>window.addEventListener('visibilitychange', ...)</code> does not."
                 ]
               },

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2754,7 +2754,7 @@
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "Not available due to <a href='https://crbug.com/648286'>a limitation in Android</a>."
+              "notes": "Not available due to a limitation in Android, see <a href='https://crbug.com/648286'>bug 648286</a>."
             },
             "edge": {
               "version_added": "17"
@@ -2764,7 +2764,7 @@
             },
             "firefox_android": {
               "version_added": false,
-              "notes": "Not available due to a limitation in Android (see <a href='https://bugzil.la/1473346'>bug 1473346</a>)."
+              "notes": "Not available due to a limitation in Android,see <a href='https://bugzil.la/1473346'>bug 1473346</a>."
             },
             "ie": {
               "version_added": false

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2764,7 +2764,7 @@
             },
             "firefox_android": {
               "version_added": false,
-              "notes": "Not available due to a limitation in Android,see <a href='https://bugzil.la/1473346'>bug 1473346</a>."
+              "notes": "Not available due to a limitation in Android, see <a href='https://bugzil.la/1473346'>bug 1473346</a>."
             },
             "ie": {
               "version_added": false

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4000,7 +4000,7 @@
           "support": {
             "chrome": {
               "version_added": "39",
-              "notes": "Starting in Chrome 59, this method cannot send a <code>Blob</code> whose type is not CORS safelisted. This is a temporary change until a mitigation can be found for the security issues that this creates. For more information see <a href='https://crbug.com/720283'>bug 720283</a>."
+              "notes": "Starting in Chrome 59, this method cannot send a <code>Blob</code> whose type is not CORS safelisted. This is a temporary change until a mitigation can be found for the security issues that this creates. For more information, see <a href='https://crbug.com/720283'>bug 720283</a>."
             },
             "chrome_android": {
               "version_added": "42",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4004,7 +4004,7 @@
             },
             "chrome_android": {
               "version_added": "42",
-              "notes": "Starting in Chrome 59, this method cannot send a <code>Blob</code> whose type is not CORS safelisted. This is a temporary change until a mitigation can be found for the security issues that this creates. For more information see <a href='https://crbug.com/720283'>bug 720283</a>."
+              "notes": "Starting in Chrome 59, this method cannot send a <code>Blob</code> whose type is not CORS safelisted. This is a temporary change until a mitigation can be found for the security issues that this creates. For more information, see <a href='https://crbug.com/720283'>bug 720283</a>."
             },
             "edge": {
               "version_added": "14"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4026,7 +4026,7 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "40",
-              "notes": "Starting in Chrome 59, this method cannot send a <code>Blob</code> whose type is not CORS safelisted. This is a temporary change until a mitigation can be found for the security issues that this creates. For more information see <a href='https://crbug.com/720283'>bug 720283</a>."
+              "notes": "Starting in Chrome 59, this method cannot send a <code>Blob</code> whose type is not CORS safelisted. This is a temporary change until a mitigation can be found for the security issues that this creates. For more information, see <a href='https://crbug.com/720283'>bug 720283</a>."
             }
           },
           "status": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2185,7 +2185,7 @@
           "support": {
             "chrome": {
               "version_added": "2",
-              "notes": "Earlier versions of Chrome incorrectly return true when a tab is first opened, but it starts reporting the correct connectivity status after the first network event. Windows: 11, macOS: 14, ChromeOS: 13, Linux: Always returns <code>true</code>. For history, see <a href='https://crbug.com/7469'>crbug.com/7469</a>."
+              "notes": "Earlier versions of Chrome incorrectly return true when a tab is first opened, but it starts reporting the correct connectivity status after the first network event. Windows: 11, macOS: 14, ChromeOS: 13, Linux: Always returns <code>true</code>. For history, see <a href='https://crbug.com/7469'>bug 7469</a>."
             },
             "chrome_android": {
               "version_added": "18"
@@ -4000,11 +4000,11 @@
           "support": {
             "chrome": {
               "version_added": "39",
-              "notes": "Starting in Chrome 59, this method cannot send a <code>Blob</code> whose type is not CORS safelisted. This is a temporary change until a mitigation can be found for the security issues that this creates. For more information see <a href='https://crbug.com/720283'>Chrome bug 720283</a>."
+              "notes": "Starting in Chrome 59, this method cannot send a <code>Blob</code> whose type is not CORS safelisted. This is a temporary change until a mitigation can be found for the security issues that this creates. For more information see <a href='https://crbug.com/720283'>bug 720283</a>."
             },
             "chrome_android": {
               "version_added": "42",
-              "notes": "Starting in Chrome 59, this method cannot send a <code>Blob</code> whose type is not CORS safelisted. This is a temporary change until a mitigation can be found for the security issues that this creates. For more information see <a href='https://crbug.com/720283'>Chrome bug 720283</a>."
+              "notes": "Starting in Chrome 59, this method cannot send a <code>Blob</code> whose type is not CORS safelisted. This is a temporary change until a mitigation can be found for the security issues that this creates. For more information see <a href='https://crbug.com/720283'>bug 720283</a>."
             },
             "edge": {
               "version_added": "14"
@@ -4017,25 +4017,16 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "26",
-              "notes": "Starting in Opera 46, this method cannot send a <code>Blob</code> whose type is not CORS safelisted. This is a temporary change until a mitigation can be found for the security issues that this creates. For more information see <a href='https://crbug.com/720283'>Chrome bug 720283</a>."
-            },
-            "opera_android": {
-              "version_added": "26",
-              "notes": "Starting in Opera 46, this method cannot send a <code>Blob</code> whose type is not CORS safelisted. This is a temporary change until a mitigation can be found for the security issues that this creates. For more information see <a href='https://crbug.com/720283'>Chrome bug 720283</a>."
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": "11.1"
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "4.0",
-              "notes": "Starting in Samsung Internet 7.0, this method cannot send a <code>Blob</code> whose type is not CORS safelisted. This is a temporary change until a mitigation can be found for the security issues that this creates. For more information see <a href='https://crbug.com/720283'>Chrome bug 720283</a>."
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "40",
-              "notes": "Starting in Chrome 59, this method cannot send a <code>Blob</code> whose type is not CORS safelisted. This is a temporary change until a mitigation can be found for the security issues that this creates. For more information see <a href='https://crbug.com/720283'>Chrome bug 720283</a>."
+              "notes": "Starting in Chrome 59, this method cannot send a <code>Blob</code> whose type is not CORS safelisted. This is a temporary change until a mitigation can be found for the security issues that this creates. For more information see <a href='https://crbug.com/720283'>bug 720283</a>."
             }
           },
           "status": {
@@ -4452,7 +4443,7 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes <code>navigator.usb</code>, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "notes": "WebView exposes <code>navigator.usb</code>, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
             }
           },
           "status": {

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -1063,7 +1063,7 @@
             },
             "safari_ios": {
               "version_added": false,
-              "notes": "This property is exposed but is not implemented. See <a href='https://webkit.org/b/258922'>WebKit bug 258922</a>."
+              "notes": "This property is exposed but is not implemented. See <a href='https://webkit.org/b/258922'>bug 258922</a>."
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -1169,7 +1169,7 @@
             },
             "chrome_android": {
               "version_added": "53",
-              "notes": "<a href='https://crbug.com/971422'>Does not work</a> on Android O or later regardless of Chrome version."
+              "notes": "Does not work on Android O or later regardless of Chrome version, see <a href='https://crbug.com/971422'>bug 971422</a>."
             },
             "edge": "mirror",
             "firefox": {
@@ -1181,18 +1181,12 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": "41",
-              "notes": "<a href='https://crbug.com/971422'>Does not work</a> on Android O or later regardless of Chrome version."
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
             "safari_ios": "mirror",
-            "samsunginternet_android": {
-              "version_added": "6.0",
-              "notes": "<a href='https://crbug.com/971422'>Does not work</a> on Android O or later regardless of Chrome version."
-            },
+            "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false
             }

--- a/api/PointerEvent.json
+++ b/api/PointerEvent.json
@@ -401,14 +401,14 @@
               "chrome": {
                 "version_added": "64",
                 "partial_implementation": true,
-                "notes": "<code>movementX</code> and <code>movementY</code> are not fractional, see <a href='https://crbug.com/802067'>Chromium bug 802067</a>."
+                "notes": "<code>movementX</code> and <code>movementY</code> are not fractional, see <a href='https://crbug.com/802067'>bug 802067</a>."
               },
               "chrome_android": "mirror",
               "edge": [
                 {
                   "version_added": "79",
                   "partial_implementation": true,
-                  "notes": "<code>movementX</code> and <code>movementY</code> are not fractional, see <a href='https://crbug.com/802067'>Chromium bug 802067</a>."
+                  "notes": "<code>movementX</code> and <code>movementY</code> are not fractional, see <a href='https://crbug.com/802067'>bug 802067</a>."
                 },
                 {
                   "version_added": "12",

--- a/api/Range.json
+++ b/api/Range.json
@@ -549,7 +549,7 @@
             },
             "safari": {
               "version_added": "1",
-              "notes": "Since August 2015 this method is a no-op in <a href='https://webkit.org/b/148454'>WebKit-based browsers</a>."
+              "notes": "Starting in Safari 10, this method is a no-op and has no effect, see <a href='https://webkit.org/b/148454'>bug 148454</a>."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -146,7 +146,7 @@
           "support": {
             "chrome": {
               "version_added": "53",
-              "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
+              "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>bug 759947</a>."
             },
             "chrome_android": "mirror",
             "edge": {
@@ -161,10 +161,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": "41",
-              "notes": "Before Opera Android 47, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "10.1"
             },
@@ -185,7 +182,7 @@
           "support": {
             "chrome": {
               "version_added": "53",
-              "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>issue 759947</a>."
+              "notes": "Before Chrome 66, this method returned <code>null</code> when the element was a child of a host node. See <a href='https://crbug.com/759947'>bug 759947</a>."
             },
             "chrome_android": "mirror",
             "edge": {

--- a/api/URL.json
+++ b/api/URL.json
@@ -115,7 +115,7 @@
               {
                 "version_added": "6",
                 "partial_implementation": true,
-                "notes": "In Safari 14 and earlier, calling the <code>URL</code> constructor with a base URL whose value is <code>undefined</code> causes Safari to throw a <code>TypeError</code>; see <a href='https://webkit.org/b/216841'>WebKit bug 216841</a>."
+                "notes": "Before Safari 14.1, calling the <code>URL</code> constructor with a base URL whose value is <code>undefined</code> caused Safari to throw a <code>TypeError</code>, see <a href='https://webkit.org/b/216841'>bug 216841</a>."
               }
             ],
             "safari_ios": "mirror",

--- a/api/USB.json
+++ b/api/USB.json
@@ -30,7 +30,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
           }
         },
         "status": {

--- a/api/USBAlternateInterface.json
+++ b/api/USBAlternateInterface.json
@@ -30,7 +30,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
           }
         },
         "status": {

--- a/api/USBConfiguration.json
+++ b/api/USBConfiguration.json
@@ -30,7 +30,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
           }
         },
         "status": {

--- a/api/USBConnectionEvent.json
+++ b/api/USBConnectionEvent.json
@@ -30,7 +30,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
           }
         },
         "status": {

--- a/api/USBDevice.json
+++ b/api/USBDevice.json
@@ -30,7 +30,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
           }
         },
         "status": {

--- a/api/USBEndpoint.json
+++ b/api/USBEndpoint.json
@@ -30,7 +30,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
           }
         },
         "status": {

--- a/api/USBInTransferResult.json
+++ b/api/USBInTransferResult.json
@@ -30,7 +30,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
           }
         },
         "status": {

--- a/api/USBInterface.json
+++ b/api/USBInterface.json
@@ -30,7 +30,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
           }
         },
         "status": {

--- a/api/USBIsochronousInTransferPacket.json
+++ b/api/USBIsochronousInTransferPacket.json
@@ -30,7 +30,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
           }
         },
         "status": {

--- a/api/USBIsochronousInTransferResult.json
+++ b/api/USBIsochronousInTransferResult.json
@@ -30,7 +30,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
           }
         },
         "status": {

--- a/api/USBIsochronousOutTransferPacket.json
+++ b/api/USBIsochronousOutTransferPacket.json
@@ -30,7 +30,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
           }
         },
         "status": {

--- a/api/USBIsochronousOutTransferResult.json
+++ b/api/USBIsochronousOutTransferResult.json
@@ -30,7 +30,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
           }
         },
         "status": {

--- a/api/USBOutTransferResult.json
+++ b/api/USBOutTransferResult.json
@@ -30,7 +30,7 @@
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": false,
-            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+            "notes": "WebView exposes this interface, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
           }
         },
         "status": {

--- a/api/Window.json
+++ b/api/Window.json
@@ -2268,7 +2268,7 @@
             },
             "safari_ios": {
               "version_added": "1",
-              "notes": "This property returns the height of the <a href='https://developer.mozilla.org/docs/Glossary/visual_viewport'>visual viewport</a> instead of the layout viewport. See <a href='https://webkit.org/b/174362'>this bug</a> for details."
+              "notes": "This property returns the height of the <a href='https://developer.mozilla.org/docs/Glossary/visual_viewport'>visual viewport</a> instead of the layout viewport. See <a href='https://webkit.org/b/174362'>bug 174362</a> for details."
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -2315,7 +2315,7 @@
             },
             "safari_ios": {
               "version_added": "1",
-              "notes": "This property returns the width of the <a href='https://developer.mozilla.org/docs/Glossary/visual_viewport'>visual viewport</a> instead of the layout viewport. See <a href='https://webkit.org/b/174362'>this bug</a> for details."
+              "notes": "This property returns the width of the <a href='https://developer.mozilla.org/docs/Glossary/visual_viewport'>visual viewport</a> instead of the layout viewport. See <a href='https://webkit.org/b/174362'>bug 174362</a> for details."
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -832,7 +832,7 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false,
-              "notes": "WebView exposes <code>navigator.usb</code>, but does not support WebUSB. See <a href='https://crbug.com/933055'>Chromium bug 933055</a>."
+              "notes": "WebView exposes <code>navigator.usb</code>, but does not support WebUSB. See <a href='https://crbug.com/933055'>bug 933055</a>."
             }
           },
           "status": {

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -75,7 +75,7 @@
                   "version_added": "14",
                   "version_removed": "15.4",
                   "partial_implementation": true,
-                  "notes": "<code>local</code> is recognized but has no effect due to <a href='https://webkit.org/b/219324'>a bug</a>."
+                  "notes": "<code>local</code> is recognized but has no effect. See <a href='https://webkit.org/b/219324'>bug 219324</a>."
                 },
                 {
                   "version_added": "3.1",
@@ -136,7 +136,7 @@
                   "version_added": "13",
                   "version_removed": "15.4",
                   "partial_implementation": true,
-                  "notes": "<code>local</code> is recognized but has no effect due to <a href='https://webkit.org/b/219324'>a bug</a>."
+                  "notes": "<code>local</code> is recognized but has no effect. See <a href='https://webkit.org/b/219324'>bug 219324</a>."
                 },
                 {
                   "version_added": "5",
@@ -151,7 +151,7 @@
                   "version_added": "13",
                   "version_removed": "15.4",
                   "partial_implementation": true,
-                  "notes": "<code>local</code> is recognized but has no effect due to <a href='https://webkit.org/b/219324'>a bug</a>."
+                  "notes": "<code>local</code> is recognized but has no effect. See <a href='https://webkit.org/b/219324'>bug 219324</a>."
                 },
                 {
                   "version_added": "4.2",

--- a/css/properties/contain.json
+++ b/css/properties/contain.json
@@ -84,7 +84,7 @@
             "support": {
               "chrome": {
                 "version_added": "52",
-                "notes": "Before Chrome 115, style containment did not affect quotes, see <a href='https://crbug.com/882385'>Chromium bug 882385</a>)."
+                "notes": "Before Chrome 115, style containment did not affect quotes, see <a href='https://crbug.com/882385'>bug 882385</a>."
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -100,7 +100,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "15.4",
-                "notes": "Style containment does not affect quotes, see <a href='https://webkit.org/b/232083'>WebKit bug 232083</a>)."
+                "notes": "Style containment does not affect quotes, see <a href='https://webkit.org/b/232083'>bug 232083</a>."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/paint-order.json
+++ b/css/properties/paint-order.json
@@ -9,7 +9,7 @@
             "chrome": {
               "version_added": "35",
               "partial_implementation": true,
-              "notes": "Does not affect stroked HTML text, see <a href='https://crbug.com/815111'>Issue 815111</a>"
+              "notes": "Does not affect stroked HTML text, see <a href='https://crbug.com/815111'>bug 815111</a>"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -32,7 +32,7 @@
               {
                 "version_added": "8",
                 "partial_implementation": true,
-                "notes": "Does not affect stroked HTML text, see <a href='https://webkit.org/b/168601'>Bug 168601</a>"
+                "notes": "Does not affect stroked HTML text, see <a href='https://webkit.org/b/168601'>bug 168601</a>"
               }
             ],
             "safari_ios": "mirror",

--- a/css/properties/print-color-adjust.json
+++ b/css/properties/print-color-adjust.json
@@ -11,7 +11,7 @@
               "version_added": "17",
               "notes": [
                 "Chrome does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants.",
-                "Before version 26, if background images are clipped (for example, when using <code>background-image</code> sprites) and <code>-webkit-print-color-adjust</code> is set to <code>exact</code>, then backgrounds will appear distorted when printed. Solid backgrounds and background images that are not clipped (i.e., backgrounds that have narrower and shorter than the element to which they are applied) are printed correctly. See <a href='https://crbug.com/131054'>Chromium bug 131054</a>."
+                "Before version 26, if background images are clipped (for example, when using <code>background-image</code> sprites) and <code>-webkit-print-color-adjust</code> is set to <code>exact</code>, then backgrounds will appear distorted when printed. Solid backgrounds and background images that are not clipped (i.e., backgrounds that have narrower and shorter than the element to which they are applied) are printed correctly. See <a href='https://crbug.com/131054'>bug 131054</a>."
               ]
             },
             "chrome_android": "mirror",
@@ -60,7 +60,7 @@
               "version_added": "1.0",
               "notes": [
                 "Samsung Internet does not print backgrounds of the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/body'><code>&lt;body&gt;</code></a> element. If this property is set to <code>exact</code> for the <code>&lt;body&gt;</code> element, it will apply only to its descendants.",
-                "In version 1, if background images are clipped (for example, when using <code>background-image</code> sprites) and <code>-webkit-print-color-adjust</code> is set to <code>exact</code>, then backgrounds will appear distorted when printed. Solid backgrounds and background images that are not clipped (i.e., backgrounds that have narrower and shorter than the element to which they are applied) are printed correctly. See <a href='https://crbug.com/131054'>Chromium bug 131054</a>."
+                "In version 1, if background images are clipped (for example, when using <code>background-image</code> sprites) and <code>-webkit-print-color-adjust</code> is set to <code>exact</code>, then backgrounds will appear distorted when printed. Solid backgrounds and background images that are not clipped (i.e., backgrounds that have narrower and shorter than the element to which they are applied) are printed correctly. See <a href='https://crbug.com/131054'>bug 131054</a>."
               ]
             },
             "webview_android": {

--- a/css/properties/text-decoration-thickness.json
+++ b/css/properties/text-decoration-thickness.json
@@ -14,7 +14,7 @@
                 "version_added": "87",
                 "version_removed": "89",
                 "partial_implementation": true,
-                "notes": "The <code>text-decoration-thickness</code> property does not work unless either <code>text-underline-offset</code> is set to something other than <code>auto</code> or <code>text-decoration-color</code> is set to something other than <code>currentColor</code>. See <a href='https://crbug.com/1154537'>Chromium bug 1154537</a>."
+                "notes": "The <code>text-decoration-thickness</code> property does not work unless either <code>text-underline-offset</code> is set to something other than <code>auto</code> or <code>text-decoration-color</code> is set to something other than <code>currentColor</code>. See <a href='https://crbug.com/1154537'>bug 1154537</a>."
               }
             ],
             "chrome_android": "mirror",

--- a/css/properties/text-rendering.json
+++ b/css/properties/text-rendering.json
@@ -10,7 +10,7 @@
               "version_added": "4",
               "notes": [
                 "This property is only supported on Windows and Linux.",
-                "Initial versions had bugs on Windows and Linux that broke font substitution, small-caps, letter-spacing or caused text to overlap.  See <a href='https://crbug.com/114719'>bug 114719</a>, <a href='https://crbug.com/51973'>bug 51973</a>, <a href='https://crbug.com/55458'>bug 55458</a>, <a href='https://crbug.com/149548'>bug 149548</a>."
+                "Initial versions had bugs on Windows and Linux that broke font substitution, small-caps, letter-spacing or caused text to overlap. See <a href='https://crbug.com/114719'>bug 114719</a>, <a href='https://crbug.com/51973'>bug 51973</a>, <a href='https://crbug.com/55458'>bug 55458</a>, <a href='https://crbug.com/149548'>bug 149548</a>."
               ]
             },
             "chrome_android": "mirror",

--- a/css/properties/text-rendering.json
+++ b/css/properties/text-rendering.json
@@ -10,7 +10,7 @@
               "version_added": "4",
               "notes": [
                 "This property is only supported on Windows and Linux.",
-                "Initial versions had bugs on Windows and Linux that broke <a href='https://crbug.com/114719'>font substitution</a>, <a href='https://crbug.com/51973'>small-caps</a>, <a href='https://crbug.com/55458'>letter-spacing</a> or caused <a href='https://crbug.com/149548'>text to overlap</a>."
+                "Initial versions had bugs on Windows and Linux that broke font substitution, small-caps, letter-spacing or caused text to overlap.  See <a href='https://crbug.com/114719'>bug 114719</a>, <a href='https://crbug.com/51973'>bug 51973</a>, <a href='https://crbug.com/55458'>bug 55458</a>, <a href='https://crbug.com/149548'>bug 149548</a>."
               ]
             },
             "chrome_android": "mirror",
@@ -80,7 +80,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "5",
-                "notes": "Safari treats <code>auto</code> as <code>optimizeSpeed</code>. See <a href='https://webkit.org/b/41363'>WebKit bug 41363</a>."
+                "notes": "Safari treats <code>auto</code> as <code>optimizeSpeed</code>. See <a href='https://webkit.org/b/41363'>bug 41363</a>."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/text-transform.json
+++ b/css/properties/text-transform.json
@@ -8,7 +8,7 @@
           "support": {
             "chrome": {
               "version_added": "1",
-              "notes": "The <code>text-transform</code> property does not work for <code>::first-line</code> pseudo-elements (nor for the one-colon syntax). See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
+              "notes": "The <code>text-transform</code> property does not work for <code>::first-line</code> pseudo-elements (nor for the one-colon syntax). See <a href='https://crbug.com/129669'>bug 129669</a>."
             },
             "chrome_android": "mirror",
             "edge": {
@@ -24,14 +24,14 @@
             "oculus": "mirror",
             "opera": {
               "version_added": "7",
-              "notes": "Since Opera 15, the <code>text-transform</code> property does not work for <code>::first-line</code> pseudo-elements (nor for the one-colon syntax). See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
+              "notes": "Since Opera 15, the <code>text-transform</code> property does not work for <code>::first-line</code> pseudo-elements (nor for the one-colon syntax). See <a href='https://crbug.com/129669'>bug 129669</a>."
             },
             "opera_android": {
               "version_added": "11"
             },
             "safari": {
               "version_added": "1",
-              "notes": "The <code>text-transform</code> property does not work for <code>::first-line</code> pseudo-elements (also not for the old one-colon syntax). See <a href='https://webkit.org/b/3409'>WebKit bug 3409</a>."
+              "notes": "The <code>text-transform</code> property does not work for <code>::first-line</code> pseudo-elements (also not for the old one-colon syntax). See <a href='https://webkit.org/b/3409'>bug 3409</a>."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/selectors/any-link.json
+++ b/css/selectors/any-link.json
@@ -96,7 +96,7 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": false,
-                "notes": "Safari currently matches <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/220740'>Bug: 220740</a>."
+                "notes": "Safari currently matches <code>&lt;link&gt;</code> elements with link pseudo-classes. See <a href='https://webkit.org/b/220740'>bug 220740</a>."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/selectors/first-line.json
+++ b/css/selectors/first-line.json
@@ -10,12 +10,12 @@
             "chrome": [
               {
                 "version_added": "1",
-                "notes": "Before Chrome 62, the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
+                "notes": "Before Chrome 62, the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>bug 129669</a>."
               },
               {
                 "alternative_name": ":first-line",
                 "version_added": "1",
-                "notes": "Before Chrome 62, the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
+                "notes": "Before Chrome 62, the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>bug 129669</a>."
               }
             ],
             "chrome_android": "mirror",
@@ -51,34 +51,34 @@
             "opera": [
               {
                 "version_added": "7",
-                "notes": "From Opera 15 to Opera 49 (exclusive), the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> or <code>:first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
+                "notes": "From Opera 15 to Opera 49 (exclusive), the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> or <code>:first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>bug 129669</a>."
               },
               {
                 "alternative_name": ":first-line",
                 "version_added": "3.5",
-                "notes": "From Opera 15 to Opera 49 (exclusive), the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> or <code>:first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
+                "notes": "From Opera 15 to Opera 49 (exclusive), the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> or <code>:first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>bug 129669</a>."
               }
             ],
             "opera_android": [
               {
                 "version_added": "10.1",
-                "notes": "From Opera 15 to Opera 49 (exclusive), the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> or <code>:first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
+                "notes": "From Opera 15 to Opera 49 (exclusive), the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> or <code>:first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>bug 129669</a>."
               },
               {
                 "alternative_name": ":first-line",
                 "version_added": "10.1",
-                "notes": "From Opera 15 to Opera 49 (exclusive), the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> or <code>:first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
+                "notes": "From Opera 15 to Opera 49 (exclusive), the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> or <code>:first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>bug 129669</a>."
               }
             ],
             "safari": [
               {
                 "version_added": "1",
-                "notes": "The <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work for <code>::first-line</code> or <code>:first-line</code> pseudo-elements. See <a href='https://webkit.org/b/3409'>WebKit bug 3409</a>."
+                "notes": "The <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work for <code>::first-line</code> or <code>:first-line</code> pseudo-elements. See <a href='https://webkit.org/b/3409'>bug 3409</a>."
               },
               {
                 "alternative_name": ":first-line",
                 "version_added": "1",
-                "notes": "The <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work for <code>::first-line</code> or <code>:first-line</code> pseudo-elements. See <a href='https://webkit.org/b/3409'>WebKit bug 3409</a>."
+                "notes": "The <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work for <code>::first-line</code> or <code>:first-line</code> pseudo-elements. See <a href='https://webkit.org/b/3409'>bug 3409</a>."
               }
             ],
             "safari_ios": "mirror",
@@ -86,12 +86,12 @@
             "webview_android": [
               {
                 "version_added": "≤37",
-                "notes": "Before WebView 62, the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
+                "notes": "Before WebView 62, the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>bug 129669</a>."
               },
               {
                 "alternative_name": ":first-line",
                 "version_added": "≤37",
-                "notes": "Before WebView 62, the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>Chromium bug 129669</a>."
+                "notes": "Before WebView 62, the <a href='https://developer.mozilla.org/docs/Web/CSS/text-transform'><code>text-transform</code></a> property does not work on <code>::first-line</code> pseudo-elements. See <a href='https://crbug.com/129669'>bug 129669</a>."
               }
             ]
           },

--- a/css/selectors/in-range.json
+++ b/css/selectors/in-range.json
@@ -12,7 +12,7 @@
           "support": {
             "chrome": {
               "version_added": "10",
-              "notes": "Before Chrome 52, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>Chromium bug 602568</a>). In Chrome 52, it was changed to only match enabled read-write inputs."
+              "notes": "Before Chrome 52, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>bug 602568</a>). In Chrome 52, it was changed to only match enabled read-write inputs."
             },
             "chrome_android": "mirror",
             "edge": {
@@ -31,11 +31,11 @@
             "oculus": "mirror",
             "opera": {
               "version_added": "11",
-              "notes": "Before Opera 39, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>Chromium bug 602568</a>). In Opera 39, it was changed to only match enabled read-write inputs."
+              "notes": "Before Opera 39, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>bug 602568</a>). In Opera 39, it was changed to only match enabled read-write inputs."
             },
             "opera_android": {
               "version_added": "11",
-              "notes": "Before Opera 39, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>Chromium bug 602568</a>). In Opera 39, it was changed to only match enabled read-write inputs."
+              "notes": "Before Opera 39, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>bug 602568</a>). In Opera 39, it was changed to only match enabled read-write inputs."
             },
             "safari": {
               "version_added": "5.1",
@@ -44,11 +44,11 @@
             "safari_ios": "mirror",
             "samsunginternet_android": {
               "version_added": "1.0",
-              "notes": "Before version 6.0, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>Chromium bug 602568</a>). In version 6.0, it was changed to only match enabled read-write inputs."
+              "notes": "Before version 6.0, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>bug 602568</a>). In version 6.0, it was changed to only match enabled read-write inputs."
             },
             "webview_android": {
               "version_added": "2.2",
-              "notes": "Before version 52, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>Chromium bug 602568</a>). In version 52, it was changed to only match enabled read-write inputs."
+              "notes": "Before version 52, <code>:in-range</code> matched disabled and read-only inputs (see <a href='https://crbug.com/602568'>bug 602568</a>). In version 52, it was changed to only match enabled read-write inputs."
             }
           },
           "status": {

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -186,7 +186,7 @@
             "support": {
               "chrome": {
                 "version_added": "1",
-                "notes": "Chrome does not defer scripts with the <code>defer</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>) - <a href='https://crbug.com/611136'>Chromium Issue #611136</a>, <a href='https://crbug.com/874749'>Chromium Issue #874749</a>"
+                "notes": "Chrome does not defer scripts with the <code>defer</code> attribute when the page is served as XHTML (<code>application/xhtml+xml</code>), see <a href='https://crbug.com/611136'>bug 611136</a> and <a href='https://crbug.com/874749'>bug 874749</a>"
               },
               "chrome_android": "mirror",
               "edge": {

--- a/javascript/builtins/Intl/DateTimeFormat.json
+++ b/javascript/builtins/Intl/DateTimeFormat.json
@@ -818,7 +818,7 @@
               "support": {
                 "chrome": {
                   "version_added": "57",
-                  "notes": "Before version 71, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 71 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>Chromium bug 865351</a>."
+                  "notes": "Before version 71, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 71 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>bug 865351</a>."
                 },
                 "chrome_android": "mirror",
                 "deno": {
@@ -839,18 +839,18 @@
                 "nodejs": {
                   "version_added": "8.0.0",
                   "notes": [
-                    "Before version 12.0.0, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 12.0.0 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>Chromium bug 865351</a>.",
+                    "Before version 12.0.0, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 12.0.0 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>bug 865351</a>.",
                     "Before version 13.0.0, only the locale data for <code>en-US</code> is available by default. See <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat'>the <code>DateTimeFormat()</code> constructor</a> for more details."
                   ]
                 },
                 "oculus": "mirror",
                 "opera": {
                   "version_added": "44",
-                  "notes": "Before version 58, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 58 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>Chromium bug 865351</a>."
+                  "notes": "Before version 58, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 58 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>bug 865351</a>."
                 },
                 "opera_android": {
                   "version_added": "43",
-                  "notes": "Before version 50, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 50 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>Chromium bug 865351</a>."
+                  "notes": "Before version 50, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 50 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>bug 865351</a>."
                 },
                 "safari": {
                   "version_added": "11"
@@ -858,7 +858,7 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": {
                   "version_added": "7.0",
-                  "notes": "Before version 71, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 71 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>Chromium bug 865351</a>."
+                  "notes": "Before version 71, <code>formatToParts()</code> returned an object with an incorrectly cased type key of <code>dayperiod</code>. Version 71 and later use the specification defined <code>dayPeriod</code>. See <a href='https://crbug.com/865351'>bug 865351</a>."
                 },
                 "webview_android": "mirror"
               },

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -313,7 +313,7 @@
                 "version_added": "14",
                 "version_removed": "14.1",
                 "partial_implementation": true,
-                "notes": "Doesn't support public static fields. See WebKit bug <a href='https://webkit.org/b/194095'>194095</a>."
+                "notes": "Doesn't support public static fields. See <a href='https://webkit.org/b/194095'>bug 194095</a>."
               }
             ],
             "safari_ios": "mirror",

--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -207,7 +207,7 @@
                 "support": {
                   "chrome": {
                     "version_added": false,
-                    "notes": "See <a href='https://crbug.com/1271527'>Issue 1271527: Propagate errors from scripting.executeScript to InjectionResult</a>."
+                    "impl_url": "https://crbug.com/1271527"
                   },
                   "edge": "mirror",
                   "firefox": {


### PR DESCRIPTION
This PR fixes various bug links throughout our data to conform to the standard format we use.  These were caught by the linter fixes introduced in #21544.

api.Range.detach: Safari 10 version found from commit in bug link, https://github.com/WebKit/WebKit/commit/75f2f181dc4752fd76abad9591874ac81bd2395c / https://trac.webkit.org/changeset/189182/webkit
