### PR TITLE
Cleanup bug text and prefixes

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6825,7 +6825,7 @@
                 "version_added": "7",
                 "partial_implementation": true,
                 "notes": [
-                  "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>bug 116769</a>, <a href='https://webkit.org/b/151234'>bug 151234</a>, <a href='https://webkit.org/b/151610'>bug 151610</a>, and <a href='https://webkit.org/b/194897'>bug 194897</a>.",
+                  "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See <a href='https://webkit.org/b/116769'>bug 116769</a>, <a href='https://webkit.org/b/151234'>bug 151234</a>, <a href='https://webkit.org/b/151610'>bug 151610</a>, and <a href='https://webkit.org/b/194897'>bug 194897</a>.",
                   "Before Safari 14, the event does not bubble, so <code>document.addEventListener('visibilitychange', ...)</code> works, but <code>window.addEventListener('visibilitychange', ...)</code> does not.",
                   "The <code>onvisibilitychange</code> event handler property is not supported."
                 ]

--- a/api/Document.json
+++ b/api/Document.json
@@ -3060,7 +3060,7 @@
             ],
             "firefox_android": "mirror",
             "ie": {
-              "alternative_name": "msExitFullscreen",
+              "prefix": "ms",
               "version_added": "11"
             },
             "oculus": "mirror",
@@ -3761,7 +3761,7 @@
             ],
             "firefox_android": "mirror",
             "ie": {
-              "alternative_name": "msFullscreenElement",
+              "prefix": "ms",
               "version_added": "11"
             },
             "oculus": "mirror",
@@ -3855,7 +3855,7 @@
             ],
             "firefox_android": "mirror",
             "ie": {
-              "alternative_name": "msFullscreenEnabled",
+              "prefix": "ms",
               "version_added": "11"
             },
             "oculus": "mirror",
@@ -6825,7 +6825,7 @@
                 "version_added": "7",
                 "partial_implementation": true,
                 "notes": [
-                  "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>116769</a>, <a href='https://webkit.org/b/151234'>151234</a>, <a href='https://webkit.org/b/151610'>151610</a>, and <a href='https://webkit.org/b/194897'>194897</a>.",
+                  "Doesn't fire the <code>visibilitychange</code> event when navigating away from a document, so also include code to check for the <code>pagehide</code> event (which does fire for that case in all current browsers). See WebKit bugs <a href='https://webkit.org/b/116769'>bug 116769</a>, <a href='https://webkit.org/b/151234'>bug 151234</a>, <a href='https://webkit.org/b/151610'>bug 151610</a>, and <a href='https://webkit.org/b/194897'>bug 194897</a>.",
                   "Before Safari 14, the event does not bubble, so <code>document.addEventListener('visibilitychange', ...)</code> works, but <code>window.addEventListener('visibilitychange', ...)</code> does not.",
                   "The <code>onvisibilitychange</code> event handler property is not supported."
                 ]

--- a/api/Element.json
+++ b/api/Element.json
@@ -7415,7 +7415,7 @@
               }
             ],
             "ie": {
-              "alternative_name": "msRequestFullscreen",
+              "prefix": "ms",
               "version_added": "11"
             },
             "oculus": "mirror",

--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2796,7 +2796,7 @@
             },
             "chrome_android": {
               "version_added": false,
-              "notes": "Not available due to <a href='https://crbug.com/648286'>a limitation in Android</a>."
+              "notes": "Not available due to a limitation in Android, see <a href='https://crbug.com/648286'>bug 648286</a>."
             },
             "edge": {
               "version_added": "17"
@@ -2806,7 +2806,7 @@
             },
             "firefox_android": {
               "version_added": false,
-              "notes": "Not available due to a limitation in Android (see <a href='https://bugzil.la/1473346'>bug 1473346</a>)."
+              "notes": "Not available due to a limitation in Android, see <a href='https://bugzil.la/1473346'>bug 1473346</a>."
             },
             "ie": {
               "version_added": false

--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -770,7 +770,7 @@
                   "version_added": "42"
                 },
                 {
-                  "alternative_name": "mozPriority",
+                  "prefix": "moz",
                   "version_added": "29"
                 }
               ],


### PR DESCRIPTION
This PR cleans up some more bug links, and replaces alt. names with prefixes where they're supposed to be.  Caught by the fixed linters in #21544.
