### PR TITLE
Update Safari data for html.global_attributes.hidden.until-found_value

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -698,7 +698,8 @@
               },
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/238266"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `hidden.until-found_value` member of the `global_attributes` HTML feature. This fixes #18337, which contains the supporting evidence for this change.

Additional Notes: The Firefox bug was not added as was mentioned in the issue, because it has been unconfirmed since it was opened two years ago.
