### PR TITLE
Update Safari data for http.headers.Content-Security-Policy.report-to

### DIFF
--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -856,7 +856,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `report-to` member of the `Content-Security-Policy` HTTP header. The data comes from a commit in the browser's source code, mapped to a version number using available tooling or via the commit timestamp.

Commit: https://github.com/WebKit/WebKit/commit/42f5a93823a7f087a800cd65c6bc0551dbeb55d3

Additional Notes: This fixes #18442.
