### PR TITLE
Update Chrome/Safari data for html.elements.select.size

### DIFF
--- a/html/elements/select.json
+++ b/html/elements/select.json
@@ -236,7 +236,9 @@
               "chrome": {
                 "version_added": "1"
               },
-              "chrome_android": "mirror",
+              "chrome_android": {
+                "version_added": false
+              },
               "edge": {
                 "version_added": "12"
               },
@@ -253,7 +255,9 @@
               "safari": {
                 "version_added": "3"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": false
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `size` member of the `select` HTML element. This fixes #18513, which contains the supporting evidence for this change.

Additional Notes: This was checked manually in Chrome and Firefox on Android, and Safari on iOS.
