### PR TITLE
Update Safari data for api.MediaTrackSettings.displaySurface

### DIFF
--- a/api/MediaTrackSettings.json
+++ b/api/MediaTrackSettings.json
@@ -248,7 +248,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "11.1"
+              "version_added": "16.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `displaySurface` member of the `MediaTrackSettings` API. This fixes #18536, which contains the supporting evidence for this change.
