### PR TITLE
Update WebView data for javascript.statements.export

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -545,9 +545,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": false
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -589,9 +587,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": false
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
This PR updates and corrects version values for WebView Android for the `export` member of the `statements` JavaScript feature. This fixes #18711, which contains the supporting evidence for this change.
