### PR TITLE
Fix MDN URL for Nesting selector

### DIFF
--- a/css/selectors/nesting.json
+++ b/css/selectors/nesting.json
@@ -4,7 +4,7 @@
       "nesting": {
         "__compat": {
           "description": "Nesting selector (<code>&</code>)",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Nesting_selectors",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Nesting_selector",
           "spec_url": "https://drafts.csswg.org/css-nesting/#nest-selector",
           "tags": [
             "web-features:nesting"


### PR DESCRIPTION
This PR fixes the MDN URL for the Nesting selector.  This fixes Fyrd/caniuse#6917.
