### PR TITLE
Update Firefox data for Sec-GPC HTTP header

### DIFF
--- a/http/headers/Sec-GPC.json
+++ b/http/headers/Sec-GPC.json
@@ -12,7 +12,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "120",
-              "notes": "Opt-in to GPC by setting the preference <code>privacy.globalprivacycontrol.enabled</code> to <code>true</code>."
+              "notes": "Opt-in to GPC using the Website Privacy Preference setting (<code>about:preferences#privacy</code>) checkbox 'Tell websites not to sell or share my data', or by setting the preference <code>privacy.globalprivacycontrol.enabled</code> to <code>true</code>."
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `Sec-GPC` HTTP header. This is a follow-up to #21083, where the note was updated in the Navigator API, but not the HTTP header.
