### PR TITLE
Update Safari data for http.headers.Content-Security-Policy.script-src-elem

### DIFF
--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -1175,7 +1175,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `script-src-elem` member of the `Content-Security-Policy` HTTP header. This fixes #18911, which contains the supporting evidence for this change.
