### PR TITLE
Update Chrome/Safari data for css.properties.filter.svg

### DIFF
--- a/css/properties/filter.json
+++ b/css/properties/filter.json
@@ -93,7 +93,7 @@
             "description": "On SVG elements",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "≤53"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -108,7 +108,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "≤10.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `svg` member of the `filter` CSS property. This fixes #18917, which contains the supporting evidence for this change.
