### PR TITLE
Add missing javascript.builtins.Error.cause.displayed_in_console feature

### DIFF
--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -248,6 +248,46 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "displayed_in_console": {
+            "__compat": {
+              "description": "Cause is displayed in console",
+              "support": {
+                "chrome": {
+                  "version_added": false,
+                  "impl_url": "https://crbug.com/1211260"
+                },
+                "chrome_android": "mirror",
+                "deno": {
+                  "version_added": "1.13"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "91"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "nodejs": {
+                  "version_added": "16.9.0"
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": false
+              }
+            }
           }
         },
         "columnNumber": {


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing `cause.displayed_in_console` member of the `Error` JavaScript builtin. This fixes #19004, which contains the supporting evidence for this change.
