### PR TITLE
Fix unittest for browser presence linter

### DIFF
--- a/test/linter/test-browsers-presence.test.ts
+++ b/test/linter/test-browsers-presence.test.ts
@@ -44,7 +44,7 @@ describe('test-browsers-presence', () => {
   });
 
   it('should log an error if a required browser is missing', () => {
-    delete data.support['chrome'];
+    delete data.support.chrome;
 
     test.check(logger, { data, path: { category } });
     assert.equal(logger.messages.length, 1);


### PR DESCRIPTION
This PR fixes the unittest for the browser presence linter.  Self-merging since this fixes a failing CI run.
