### PR TITLE
Update Chromium data for api.RTCRtpSender.setParameters.parameters_degradationPreference_parameter

### DIFF
--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -219,7 +219,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpSender/getParameters#degradationpreference",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "83"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -596,7 +596,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCRtpSender/setParameters#degradationpreference",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "83"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `setParameters.parameters_degradationPreference_parameter` member of the `RTCRtpSender` API. This fixes #19235, which contains the supporting evidence for this change.
