### PR TITLE
Update Safari data for api.Navigator.setAppBadge

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4137,7 +4137,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "17",
-              "notes": "Badging is supported for web apps saved to the Dock in Safari 17 on the macOS Sonoma beta"
+              "notes": "Badging is supported for installed web apps on macOS Sonoma and higher."
             },
             "safari_ios": {
               "version_added": "16.4"


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `setAppBadge` member of the `Navigator` API. This sets the note to be the same as clearAppBadge().
