### PR TITLE
Update Safari data for http.headers.Content-Security-Policy.prefetch-src

### DIFF
--- a/http/headers/Content-Security-Policy.json
+++ b/http/headers/Content-Security-Policy.json
@@ -752,7 +752,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
+                "version_added": "16.3",
                 "impl_url": "https://webkit.org/b/185070"
               },
               "safari_ios": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `prefetch-src` member of the `Content-Security-Policy` HTTP header. This fixes #19400, which contains the supporting evidence for this change.
