### PR TITLE
Update Chromium data for webextensions.api.dns.resolve

### DIFF
--- a/webextensions/api/dns.json
+++ b/webextensions/api/dns.json
@@ -7,7 +7,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/dns/resolve",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "18"
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `resolve` member of the `dns` Web Extensions interface. This fixes #19912, which contains the supporting evidence for this change.
