### PR TITLE
Update NodeJS data for javascript.builtins.WeakRef.symbol_as_target

### DIFF
--- a/javascript/builtins/WeakRef.json
+++ b/javascript/builtins/WeakRef.json
@@ -141,7 +141,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "20.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for NodeJS for the `symbol_as_target` member of the `WeakRef` JavaScript builtin. This fixes #20278, which contains the supporting evidence for this change.
