### PR TITLE
FF122 HTMLInputElement inputs Week, Month supported

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2254,7 +2254,10 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": [
                 {
                   "version_added": "122"
                 },
@@ -2263,7 +2266,6 @@
                   "version_removed": "112"
                 }
               ],
-              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },
@@ -2330,7 +2332,10 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": [
                 {
                   "version_added": "122"
                 },
@@ -2339,7 +2344,6 @@
                   "version_removed": "112"
                 }
               ],
-              "firefox_android": "mirror",
               "ie": {
                 "version_added": false
               },

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2259,7 +2259,7 @@
               },
               "firefox_android": [
                 {
-                  "version_added": "122"
+                  "version_added": "121"
                 },
                 {
                   "version_added": "101",
@@ -2337,7 +2337,7 @@
               },
               "firefox_android": [
                 {
-                  "version_added": "122"
+                  "version_added": "121"
                 },
                 {
                   "version_added": "101",

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2254,9 +2254,15 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
+              "firefox": [
+                {
+                  "version_added": "122"
+                },
+                {
+                  "version_added": "101",
+                  "version_removed": "112"
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -2324,9 +2330,15 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
+              "firefox": [
+                {
+                  "version_added": "122"
+                },
+                {
+                  "version_added": "101",
+                  "version_removed": "112"
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false


### PR DESCRIPTION
BCD says FF does not support week/month input types. However according to https://bugzilla.mozilla.org/show_bug.cgi?id=1853797#c18 it used to, and this has been restored in FF122. 

I am confirming that this applies to both Android and desktop

Fixes #21524.