### PR TITLE
modulepreload is in Safari 17

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -861,7 +861,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": null
+                  "version_added": 17
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -861,7 +861,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": 17
+                  "version_added": "17"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Adding support data for `rel="modulepreload"` which is in Safari 17.

#### Test results and supporting details

https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes

