### PR TITLE
Update Node.js support statuses

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -268,7 +268,7 @@
         "14.8.0": {
           "release_date": "2020-08-11",
           "release_notes": "https://nodejs.org/en/blog/release/v14.8.0/",
-          "status": "esr",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "8.4"
         },
@@ -373,7 +373,7 @@
         "16.17.0": {
           "release_date": "2022-08-16",
           "release_notes": "https://nodejs.org/en/blog/release/v16.17.0/",
-          "status": "esr",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "9.4"
         },


### PR DESCRIPTION
This PR updates the statuses for the Node.js releases.  Data comes from https://nodejs.org/en/about/previous-releases.
