### PR TITLE
Update Safari imagesrcset and imagesizes

### DIFF
--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -376,7 +376,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "13"
+              "version_added": "17.2"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -409,7 +409,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "13"
+              "version_added": "17.2"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -320,7 +320,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "13"
+                "version_added": "17.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -352,7 +352,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "13"
+                "version_added": "17.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Responsive preloads (`imagesrcset` and `imagesizes`) was enabled in Safari 17.2 but was incorrectly marked as supported from Safari 13.

This was changed in #21267 due to this comment: https://github.com/mdn/browser-compat-data/pull/21267#issuecomment-1830521858 but I'm not sure what that is based upon. It was behind a flag for a while, but wasn't enabled by default until 17.2 and [MDN encourages removal of flag details after it goes to stable](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-flag-data). @jdatapple  @Elchi3 any comments here?

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

WPT here shows it isn't enabled on stable (currently still 17.1): https://wpt.fyi/results/preload/link-header-preload-imagesrcset.html?label=stable&label=master&aligned

<img width="1446" alt="image" src="https://github.com/mdn/browser-compat-data/assets/10931297/8794a739-8ee1-4c05-bd42-c632ea96293e">

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

It is enabled in Safari Preview https://wpt.fyi/results/preload/link-header-preload-imagesrcset.html?label=experimental&label=master&aligned and is enabled in 17.2:
https://webkit.org/blog/14787/webkit-features-in-safari-17-2/

<img width="903" alt="image" src="https://github.com/mdn/browser-compat-data/assets/10931297/7c11b7b5-0f46-4114-a3a8-c2f3bf9b398b">

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Last updated in #21267

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
