### PR TITLE
[css-color] add relative `color()`

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -82,6 +82,40 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "relative_syntax": {
+            "__compat": {
+              "description": "Relative <code>color()</code>",
+              "spec_url": "https://drafts.csswg.org/css-color-5/#relative-color-function",
+              "support": {
+                "chrome": {
+                  "version_added": "119"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "16.4"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "color-contrast": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Add relative `color()` as it was overlooked in https://github.com/mdn/browser-compat-data/pull/21583

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

https://wpt.fyi/results/css/css-color/parsing/color-valid-relative-color.html?label=master&label=experimental&aligned&q=relative

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

see : https://github.com/mdn/browser-compat-data/pull/21583#issuecomment-1851661789

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
