### PR TITLE
Use import attributes rather than assertions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ yarn add @mdn/browser-compat-data
 Then, you can import BCD into your project with either `import` or `require()`:
 
 ```js
-// ESM with Import Assertions (NodeJS 16+)
-import bcd from '@mdn/browser-compat-data' assert { type: 'json' };
+// ESM with Import Attributes (NodeJS 20+)
+import bcd from '@mdn/browser-compat-data' with { type: 'json' };
 // ...or...
 const { default: bcd } = await import('@mdn/browser-compat-data', {
-  assert: { type: 'json' },
+  with: { type: 'json' },
 });
 
 // ...or...
@@ -48,14 +48,17 @@ const bcd = require('@mdn/browser-compat-data');
 You can import `@mdn/browser-compat-data` using a CDN.
 
 ```js
-import bcd from 'https://unpkg.com/@mdn/browser-compat-data' assert { type: 'json' };
+import bcd from 'https://unpkg.com/@mdn/browser-compat-data' with { type: 'json' };
 // ...or...
 const { default: bcd } = await import(
   'https://unpkg.com/@mdn/browser-compat-data',
   {
-    assert: { type: 'json' },
+    with: { type: 'json' },
   }
 );
+// ...or...
+const bcd = await fetch('https://unpkg.com/@mdn/browser-compat-data')
+  .then(response => response.json());
 ```
 
 ### Other Languages


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

The import `assert` syntax is eventually going to be removed, so developers should use the future-proof `with` version. `with` is already supported in Safari, Deno and Node.js, and it will be soon supported in Chrome (it's already implemented behind a flag).