### PR TITLE
Add a group for WebGPU features

### DIFF
--- a/api/GPU.json
+++ b/api/GPU.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPU",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpu-interface",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPU/getPreferredCanvasFormat",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpu-getpreferredcanvasformat",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -85,6 +91,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPU/requestAdapter",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpu-requestadapter",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -162,6 +171,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPU/wgslLanguageFeatures",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpu-wgsllanguagefeatures",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "115",

--- a/api/GPUAdapter.json
+++ b/api/GPUAdapter.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUAdapter",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpu-adapter",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUAdapter/features",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuadapter-features",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -85,6 +91,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUAdapter/isFallbackAdapter",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuadapter-isfallbackadapter",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -126,6 +135,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUAdapter/limits",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuadapter-limits",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -167,6 +179,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUAdapter/requestAdapterInfo",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuadapter-requestadapterinfo",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -208,6 +223,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUAdapter/requestDevice",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuadapter-requestdevice",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUAdapterInfo.json
+++ b/api/GPUAdapterInfo.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUAdapterInfo",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpu-adapterinfo",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUAdapterInfo/architecture",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-architecture",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -85,6 +91,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUAdapterInfo/description",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-description",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -126,6 +135,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUAdapterInfo/device",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-device",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -167,6 +179,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUAdapterInfo/vendor",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuadapterinfo-vendor",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUBindGroup.json
+++ b/api/GPUBindGroup.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUBindGroup",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpubindgroup",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUBindGroup/label",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUBindGroupLayout.json
+++ b/api/GPUBindGroupLayout.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUBindGroupLayout",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpubindgrouplayout",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUBindGroupLayout/label",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUBuffer.json
+++ b/api/GPUBuffer.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUBuffer",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpubuffer",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUBuffer/destroy",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpubuffer-destroy",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -85,6 +91,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUBuffer/getMappedRange",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpubuffer-getmappedrange",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -126,6 +135,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUBuffer/label",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -167,6 +179,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUBuffer/mapAsync",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpubuffer-mapasync",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -208,6 +223,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUBuffer/mapState",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpubuffer-mapstate",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -249,6 +267,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUBuffer/size",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpubuffer-size",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -290,6 +311,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUBuffer/unmap",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpubuffer-unmap",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -331,6 +355,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUBuffer/usage",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpubuffer-usage",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUCanvasContext.json
+++ b/api/GPUCanvasContext.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCanvasContext",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpucanvascontext",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCanvasContext/canvas",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-canvas",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -85,6 +91,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCanvasContext/configure",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-configure",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -129,6 +138,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCanvasContext/getCurrentTexture",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-getcurrenttexture",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -170,6 +182,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCanvasContext/unconfigure",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucanvascontext-unconfigure",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUCommandBuffer.json
+++ b/api/GPUCommandBuffer.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCommandBuffer",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpucommandbuffer",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCommandBuffer/label",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUCommandEncoder.json
+++ b/api/GPUCommandEncoder.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCommandEncoder",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpucommandencoder",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCommandEncoder/beginComputePass",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-begincomputepass",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -85,6 +91,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCommandEncoder/beginRenderPass",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-beginrenderpass",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -126,6 +135,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCommandEncoder/clearBuffer",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-clearbuffer",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -167,6 +179,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCommandEncoder/copyBufferToBuffer",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-copybuffertobuffer",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -208,6 +223,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCommandEncoder/copyBufferToTexture",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-copybuffertotexture",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -249,6 +267,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCommandEncoder/copyTextureToBuffer",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-copytexturetobuffer",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -290,6 +311,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCommandEncoder/copyTextureToTexture",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-copytexturetotexture",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -331,6 +355,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCommandEncoder/finish",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-finish",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -372,6 +399,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCommandEncoder/insertDebugMarker",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudebugcommandsmixin-insertdebugmarker",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -413,6 +443,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCommandEncoder/label",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -454,6 +487,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCommandEncoder/popDebugGroup",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudebugcommandsmixin-popdebuggroup",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -495,6 +531,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCommandEncoder/pushDebugGroup",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudebugcommandsmixin-pushdebuggroup",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -536,6 +575,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCommandEncoder/resolveQuerySet",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-resolvequeryset",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -577,6 +619,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCommandEncoder/writeTimestamp",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-writetimestamp",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUCompilationInfo.json
+++ b/api/GPUCompilationInfo.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCompilationInfo",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpucompilationinfo",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCompilationInfo/messages",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucompilationinfo-messages",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUCompilationMessage.json
+++ b/api/GPUCompilationMessage.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCompilationMessage",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpucompilationmessage",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCompilationMessage/length",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucompilationmessage-length",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -85,6 +91,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCompilationMessage/lineNum",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucompilationmessage-linenum",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -126,6 +135,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCompilationMessage/linePos",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucompilationmessage-linepos",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -167,6 +179,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCompilationMessage/message",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucompilationmessage-message",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -208,6 +223,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCompilationMessage/offset",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucompilationmessage-offset",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -249,6 +267,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUCompilationMessage/type",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucompilationmessage-type",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUComputePassEncoder.json
+++ b/api/GPUComputePassEncoder.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUComputePassEncoder",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpucomputepassencoder",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUComputePassEncoder/dispatchWorkgroups",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucomputepassencoder-dispatchworkgroups",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -85,6 +91,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUComputePassEncoder/dispatchWorkgroupsIndirect",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucomputepassencoder-dispatchworkgroupsindirect",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -131,6 +140,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUComputePassEncoder/end",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucomputepassencoder-end",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -172,6 +184,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUComputePassEncoder/insertDebugMarker",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudebugcommandsmixin-insertdebugmarker",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -213,6 +228,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUComputePassEncoder/label",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -254,6 +272,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUComputePassEncoder/popDebugGroup",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudebugcommandsmixin-popdebuggroup",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -295,6 +316,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUComputePassEncoder/pushDebugGroup",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudebugcommandsmixin-pushdebuggroup",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -336,6 +360,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUComputePassEncoder/setBindGroup",
           "spec_url": "https://gpuweb.github.io/gpuweb/#programmable-passes-bind-groups",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -377,6 +404,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUComputePassEncoder/setPipeline",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpucomputepassencoder-setpipeline",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUComputePipeline.json
+++ b/api/GPUComputePipeline.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUComputePipeline",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpucomputepipeline",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUComputePipeline/getBindGroupLayout",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpupipelinebase-getbindgrouplayout",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -85,6 +91,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUComputePipeline/label",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpudevice",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/createBindGroup",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbindgroup",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -85,6 +91,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/createBindGroupLayout",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbindgrouplayout",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -126,6 +135,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/createBuffer",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-createbuffer",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -167,6 +179,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/createCommandEncoder",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-createcommandencoder",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -208,6 +223,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/createComputePipeline",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-createcomputepipeline",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -249,6 +267,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/createComputePipelineAsync",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-createcomputepipelineasync",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -290,6 +311,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/createPipelineLayout",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-createpipelinelayout",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -331,6 +355,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/createQuerySet",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-createqueryset",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -368,6 +395,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/createRenderBundleEncoder",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-createrenderbundleencoder",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -409,6 +439,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/createRenderPipeline",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-createrenderpipeline",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -450,6 +483,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/createRenderPipelineAsync",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-createrenderpipelineasync",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -491,6 +527,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/createSampler",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-createsampler",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -532,6 +571,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/createShaderModule",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-createshadermodule",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -573,6 +615,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/createTexture",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-createtexture",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -614,6 +659,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/destroy",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-destroy",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -655,6 +703,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/features",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-features",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -696,6 +747,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/importExternalTexture",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-importexternaltexture",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -772,6 +826,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/label",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -813,6 +870,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/limits",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-limits",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -854,6 +914,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/lost",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-lost",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -895,6 +958,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/popErrorScope",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-poperrorscope",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -936,6 +1002,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/pushErrorScope",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-pusherrorscope",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -977,6 +1046,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/queue",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-queue",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -1019,6 +1091,9 @@
           "description": "<code>uncapturederror</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDevice/uncapturederror_event",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevice-onuncapturederror",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUDeviceLostInfo.json
+++ b/api/GPUDeviceLostInfo.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDeviceLostInfo",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpudevicelostinfo",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDeviceLostInfo/message",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevicelostinfo-message",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -85,6 +91,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUDeviceLostInfo/reason",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudevicelostinfo-reason",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUError.json
+++ b/api/GPUError.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUError",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpuerror",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -40,6 +43,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUError/message",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuerror-message",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUExternalTexture.json
+++ b/api/GPUExternalTexture.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUExternalTexture",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpuexternaltexture",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -40,6 +43,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUExternalTexture/label",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUInternalError.json
+++ b/api/GPUInternalError.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUInternalError",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpuinternalerror",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -41,6 +44,9 @@
           "description": "<code>GPUInternalError()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUInternalError/GPUInternalError",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuinternalerror-gpuinternalerror",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUOutOfMemoryError.json
+++ b/api/GPUOutOfMemoryError.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUOutOfMemoryError",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpuoutofmemoryerror",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -45,6 +48,9 @@
           "description": "<code>GPUOutOfMemoryError()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUOutOfMemoryError/GPUOutOfMemoryError",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuoutofmemoryerror-gpuoutofmemoryerror",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUPipelineError.json
+++ b/api/GPUPipelineError.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUPipelineError",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpupipelineerror",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -41,6 +44,9 @@
           "description": "<code>GPUPipelineError()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUPipelineError/GPUPipelineError",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpupipelineerror-constructor",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -113,6 +119,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUPipelineError/reason",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpupipelineerror-reason",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUPipelineLayout.json
+++ b/api/GPUPipelineLayout.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUPipelineLayout",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpupipelinelayout",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUPipelineLayout/label",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUQuerySet.json
+++ b/api/GPUQuerySet.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUQuerySet",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpuqueryset",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUQuerySet/count",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuqueryset-count",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -85,6 +91,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUQuerySet/destroy",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuqueryset-destroy",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -126,6 +135,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUQuerySet/label",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -167,6 +179,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUQuerySet/type",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuqueryset-type",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUQueue.json
+++ b/api/GPUQueue.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUQueue",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpu-queue",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUQueue/copyExternalImageToTexture",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuqueue-copyexternalimagetotexture",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -120,6 +126,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUQueue/label",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -161,6 +170,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUQueue/onSubmittedWorkDone",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuqueue-onsubmittedworkdone",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -198,6 +210,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUQueue/submit",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuqueue-submit",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -239,6 +254,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUQueue/writeBuffer",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuqueue-writebuffer",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -280,6 +298,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUQueue/writeTexture",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuqueue-writetexture",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPURenderBundle.json
+++ b/api/GPURenderBundle.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderBundle",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpurenderbundle",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -40,6 +43,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderBundle/label",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPURenderBundleEncoder.json
+++ b/api/GPURenderBundleEncoder.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderBundleEncoder",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpurenderbundle",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderBundleEncoder/draw",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-draw",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -85,6 +91,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderBundleEncoder/drawIndexed",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-drawindexed",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -126,6 +135,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderBundleEncoder/drawIndexedIndirect",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-drawindexedindirect",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -172,6 +184,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderBundleEncoder/drawIndirect",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-drawindirect",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -218,6 +233,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderBundleEncoder/finish",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurenderbundleencoder-finish",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -259,6 +277,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderBundleEncoder/insertDebugMarker",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudebugcommandsmixin-insertdebugmarker",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -300,6 +321,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderBundleEncoder/label",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -337,6 +361,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderBundleEncoder/popDebugGroup",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudebugcommandsmixin-popdebuggroup",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -378,6 +405,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderBundleEncoder/pushDebugGroup",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudebugcommandsmixin-pushdebuggroup",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -419,6 +449,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderBundleEncoder/setBindGroup",
           "spec_url": "https://gpuweb.github.io/gpuweb/#programmable-passes-bind-groups",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -460,6 +493,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderBundleEncoder/setIndexBuffer",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-setindexbuffer",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -501,6 +537,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderBundleEncoder/setPipeline",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-setpipeline",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -542,6 +581,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderBundleEncoder/setVertexBuffer",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-setvertexbuffer",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPURenderPassEncoder.json
+++ b/api/GPURenderPassEncoder.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpurenderpassencoder",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder/beginOcclusionQuery",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-beginocclusionquery",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -81,6 +87,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder/draw",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-draw",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -122,6 +131,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder/drawIndexed",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-drawindexed",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -163,6 +175,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder/drawIndexedIndirect",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-drawindexedindirect",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -209,6 +224,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder/drawIndirect",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-drawindirect",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -255,6 +273,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder/end",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-end",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -296,6 +317,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder/endOcclusionQuery",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-endocclusionquery",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -333,6 +357,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder/executeBundles",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-executebundles",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -374,6 +401,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder/insertDebugMarker",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudebugcommandsmixin-insertdebugmarker",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -415,6 +445,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder/label",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -456,6 +489,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder/popDebugGroup",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudebugcommandsmixin-popdebuggroup",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -497,6 +533,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder/pushDebugGroup",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpudebugcommandsmixin-pushdebuggroup",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -538,6 +577,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder/setBindGroup",
           "spec_url": "https://gpuweb.github.io/gpuweb/#programmable-passes-bind-groups",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -579,6 +621,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder/setBlendConstant",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-setblendconstant",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -620,6 +665,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder/setIndexBuffer",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-setindexbuffer",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -661,6 +709,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder/setPipeline",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-setpipeline",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -702,6 +753,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder/setScissorRect",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-setscissorrect",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -743,6 +797,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder/setStencilReference",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-setstencilreference",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -784,6 +841,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder/setVertexBuffer",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-setvertexbuffer",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -861,6 +921,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder/setViewport",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurenderpassencoder-setviewport",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPURenderPipeline.json
+++ b/api/GPURenderPipeline.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPipeline",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpurenderpipeline",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPipeline/getBindGroupLayout",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpupipelinebase-getbindgrouplayout",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -85,6 +91,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPipeline/label",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUSampler.json
+++ b/api/GPUSampler.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSampler",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpusampler",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSampler/label",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUShaderModule.json
+++ b/api/GPUShaderModule.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUShaderModule",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpushadermodule",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUShaderModule/getCompilationInfo",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpushadermodule-getcompilationinfo",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -85,6 +91,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUShaderModule/label",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUSupportedFeatures.json
+++ b/api/GPUSupportedFeatures.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedFeatures",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpu-supportedfeatures",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -43,6 +46,9 @@
       "entries": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#gpusupportedfeatures",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113"
@@ -78,6 +84,9 @@
       "forEach": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#gpusupportedfeatures",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113"
@@ -113,6 +122,9 @@
       "has": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#gpusupportedfeatures",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113"
@@ -148,6 +160,9 @@
       "keys": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#gpusupportedfeatures",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113"
@@ -183,6 +198,9 @@
       "size": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#gpusupportedfeatures",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113"
@@ -218,6 +236,9 @@
       "values": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#gpusupportedfeatures",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113"
@@ -253,6 +274,9 @@
       "@@iterator": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#gpusupportedfeatures",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113"

--- a/api/GPUSupportedLimits.json
+++ b/api/GPUSupportedLimits.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpusupportedlimits",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -43,6 +46,9 @@
       "maxBindGroups": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxbindgroups",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -82,6 +88,10 @@
       },
       "maxBindGroupsPlusVertexBuffers": {
         "__compat": {
+          "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxbindgroupsplusvertexbuffers",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "120"
@@ -117,6 +127,9 @@
       "maxBindingsPerBindGroup": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxbindingsperbindgroup",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -157,6 +170,9 @@
       "maxBufferSize": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxbuffersize",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -193,6 +209,9 @@
       "maxColorAttachmentBytesPerSample": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcolorattachmentbytespersample",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -229,6 +248,9 @@
       "maxColorAttachments": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcolorattachments",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -265,6 +287,9 @@
       "maxComputeInvocationsPerWorkgroup": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeinvocationsperworkgroup",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -301,6 +326,9 @@
       "maxComputeWorkgroupSizeX": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupsizex",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -337,6 +365,9 @@
       "maxComputeWorkgroupSizeY": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupsizey",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -373,6 +404,9 @@
       "maxComputeWorkgroupSizeZ": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupsizez",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -409,6 +443,9 @@
       "maxComputeWorkgroupsPerDimension": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupsperdimension",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -445,6 +482,9 @@
       "maxComputeWorkgroupStorageSize": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxcomputeworkgroupstoragesize",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -481,6 +521,9 @@
       "maxDynamicStorageBuffersPerPipelineLayout": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxdynamicstoragebuffersperpipelinelayout",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -517,6 +560,9 @@
       "maxDynamicUniformBuffersPerPipelineLayout": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxdynamicuniformbuffersperpipelinelayout",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -553,6 +599,9 @@
       "maxInterStageShaderComponents": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxinterstageshadercomponents",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -589,6 +638,9 @@
       "maxInterStageShaderVariables": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxinterstageshadervariables",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -625,6 +677,9 @@
       "maxSampledTexturesPerShaderStage": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxsampledtexturespershaderstage",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -661,6 +716,9 @@
       "maxSamplersPerShaderStage": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxsamplerspershaderstage",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -697,6 +755,9 @@
       "maxStorageBufferBindingSize": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragebufferbindingsize",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -733,6 +794,9 @@
       "maxStorageBuffersPerShaderStage": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragebufferspershaderstage",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -769,6 +833,9 @@
       "maxStorageTexturesPerShaderStage": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxstoragetexturespershaderstage",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -805,6 +872,9 @@
       "maxTextureArrayLayers": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxtexturearraylayers",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -841,6 +911,9 @@
       "maxTextureDimension1D": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxtexturedimension1d",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -877,6 +950,9 @@
       "maxTextureDimension2D": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxtexturedimension2d",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -913,6 +989,9 @@
       "maxTextureDimension3D": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxtexturedimension3d",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -949,6 +1028,9 @@
       "maxUniformBufferBindingSize": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxuniformbufferbindingsize",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -985,6 +1067,9 @@
       "maxUniformBuffersPerShaderStage": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxuniformbufferspershaderstage",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -1021,6 +1106,9 @@
       "maxVertexAttributes": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxvertexattributes",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -1057,6 +1145,9 @@
       "maxVertexBufferArrayStride": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxvertexbufferarraystride",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -1093,6 +1184,9 @@
       "maxVertexBuffers": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-maxvertexbuffers",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -1129,6 +1223,9 @@
       "minStorageBufferOffsetAlignment": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-minstoragebufferoffsetalignment",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -1165,6 +1262,9 @@
       "minUniformBufferOffsetAlignment": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpusupportedlimits-minuniformbufferoffsetalignment",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUTexture.json
+++ b/api/GPUTexture.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUTexture",
         "spec_url": "https://gpuweb.github.io/gpuweb/#texture-interface",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUTexture/createView",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputexture-createview",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -85,6 +91,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUTexture/depthOrArrayLayers",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputexture-depthorarraylayers",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -126,6 +135,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUTexture/destroy",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputexture-destroy",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -167,6 +179,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUTexture/dimension",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputexture-dimension",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -208,6 +223,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUTexture/format",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputexture-format",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -249,6 +267,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUTexture/height",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputexture-height",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -290,6 +311,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUTexture/label",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -331,6 +355,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUTexture/mipLevelCount",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputexture-miplevelcount",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -372,6 +399,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUTexture/sampleCount",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputexture-samplecount",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -413,6 +443,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUTexture/usage",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputexture-usage",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -454,6 +487,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUTexture/width",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gputexture-width",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUTextureView.json
+++ b/api/GPUTextureView.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUTextureView",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gputextureview",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -44,6 +47,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUTextureView/label",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuobjectbase-label",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUUncapturedErrorEvent.json
+++ b/api/GPUUncapturedErrorEvent.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUUncapturedErrorEvent",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpuuncapturederrorevent",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -45,6 +48,9 @@
           "description": "<code>GPUUncapturedErrorEvent()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUUncapturedErrorEvent/GPUUncapturedErrorEvent",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuuncapturederrorevent-gpuuncapturederrorevent",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",
@@ -86,6 +92,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUUncapturedErrorEvent/error",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuuncapturederroreventinit-error",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/GPUValidationError.json
+++ b/api/GPUValidationError.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUValidationError",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpuvalidationerror",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "113",
@@ -45,6 +48,9 @@
           "description": "<code>GPUValidationError()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUValidationError/GPUValidationError",
           "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpuvalidationerror-gpuvalidationerror",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -710,6 +710,9 @@
           "__compat": {
             "description": "<code>webgpu</code> context",
             "spec_url": "https://gpuweb.github.io/gpuweb/#canvas-getcontext",
+            "tags": [
+              "web-features:webgpu"
+            ],
             "support": {
               "chrome": {
                 "version_added": "113",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1473,6 +1473,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/gpu",
           "spec_url": "https://gpuweb.github.io/gpuweb/#navigator-gpu",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",

--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -377,6 +377,9 @@
           "__compat": {
             "description": "<code>webgpu</code> context",
             "spec_url": "https://gpuweb.github.io/gpuweb/#canvas-getcontext",
+            "tags": [
+              "web-features:webgpu"
+            ],
             "support": {
               "chrome": {
                 "version_added": "113",

--- a/api/WGSLLanguageFeatures.json
+++ b/api/WGSLLanguageFeatures.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WGSLLanguageFeatures",
         "spec_url": "https://gpuweb.github.io/gpuweb/#gpuwgsllanguagefeatures",
+        "tags": [
+          "web-features:webgpu"
+        ],
         "support": {
           "chrome": {
             "version_added": "115",
@@ -39,6 +42,9 @@
       "entries": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#gpuwgsllanguagefeatures",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"
@@ -74,6 +80,9 @@
       "forEach": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#gpuwgsllanguagefeatures",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"
@@ -109,6 +118,9 @@
       "has": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#gpuwgsllanguagefeatures",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"
@@ -144,6 +156,9 @@
       "keys": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#gpuwgsllanguagefeatures",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"
@@ -179,6 +194,9 @@
       "size": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#gpuwgsllanguagefeatures",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"
@@ -214,6 +232,9 @@
       "values": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#gpuwgsllanguagefeatures",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"
@@ -249,6 +270,9 @@
       "@@iterator": {
         "__compat": {
           "spec_url": "https://gpuweb.github.io/gpuweb/#gpuwgsllanguagefeatures",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "115"

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -288,6 +288,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerNavigator/gpu",
           "spec_url": "https://gpuweb.github.io/gpuweb/#navigator-gpu",
+          "tags": [
+            "web-features:webgpu"
+          ],
           "support": {
             "chrome": {
               "version_added": "113",


### PR DESCRIPTION
I'm tagging features which I think should belong into a group called "webgpu". cc @ddbeck 

I think the interesting part is what I didn't tag:

- api.GPU.requestAdapter.discrete_adapter_default_ac (non-critical behavioral sub feature)
- api.GPUAdapter.requestDevice.lost_device_on_duplicate (non-critical behavioral sub feature)
- api.GPUComputePassEncoder.writeTimestamp (non-standard feature)
- api.GPUDevice.importExternalTexture.videoframe_source (non-critical behavioral sub feature)
- api.GPUPipelineError.GPUPipelineError.message_optional (non-critical behavioral sub feature)
- api.GPUQueue.copyExternalImageToTexture.videoframe_source (non-critical behavioral sub feature)
- api.GPURenderBundleEncoder.setVertexBuffer.unset_vertex_buffer (non-critical behavioral sub feature)
- api.GPURenderPassEncoder.setVertexBuffer.unset_vertex_buffer (non-critical behavioral sub feature)
- api.GPURenderPassEncoder.writeTimestamp  (non-standard feature)

The following features are tagged with "web-features:webgpu": (verify the list with `npm run traverse -- -t web-features:webgpu` and also get the count of 242).

1. api.GPU
2. api.GPU.getPreferredCanvasFormat
3. api.GPU.requestAdapter
4. api.GPU.wgslLanguageFeatures
5. api.GPUAdapter
6. api.GPUAdapter.features
7. api.GPUAdapter.isFallbackAdapter
8. api.GPUAdapter.limits
9. api.GPUAdapter.requestAdapterInfo
10. api.GPUAdapter.requestDevice
11. api.GPUAdapterInfo
12. api.GPUAdapterInfo.architecture
13. api.GPUAdapterInfo.description
14. api.GPUAdapterInfo.device
15. api.GPUAdapterInfo.vendor
16. api.GPUBindGroup
17. api.GPUBindGroup.label
18. api.GPUBindGroupLayout
19. api.GPUBindGroupLayout.label
20. api.GPUBuffer
21. api.GPUBuffer.destroy
22. api.GPUBuffer.getMappedRange
23. api.GPUBuffer.label
24. api.GPUBuffer.mapAsync
25. api.GPUBuffer.mapState
26. api.GPUBuffer.size
27. api.GPUBuffer.unmap
28. api.GPUBuffer.usage
29. api.GPUCanvasContext
30. api.GPUCanvasContext.canvas
31. api.GPUCanvasContext.configure
32. api.GPUCanvasContext.getCurrentTexture
33. api.GPUCanvasContext.unconfigure
34. api.GPUCommandBuffer
35. api.GPUCommandBuffer.label
36. api.GPUCommandEncoder
37. api.GPUCommandEncoder.beginComputePass
38. api.GPUCommandEncoder.beginRenderPass
39. api.GPUCommandEncoder.clearBuffer
40. api.GPUCommandEncoder.copyBufferToBuffer
41. api.GPUCommandEncoder.copyBufferToTexture
42. api.GPUCommandEncoder.copyTextureToBuffer
43. api.GPUCommandEncoder.copyTextureToTexture
44. api.GPUCommandEncoder.finish
45. api.GPUCommandEncoder.insertDebugMarker
46. api.GPUCommandEncoder.label
47. api.GPUCommandEncoder.popDebugGroup
48. api.GPUCommandEncoder.pushDebugGroup
49. api.GPUCommandEncoder.resolveQuerySet
50. api.GPUCommandEncoder.writeTimestamp
51. api.GPUCompilationInfo
52. api.GPUCompilationInfo.messages
53. api.GPUCompilationMessage
54. api.GPUCompilationMessage.length
55. api.GPUCompilationMessage.lineNum
56. api.GPUCompilationMessage.linePos
57. api.GPUCompilationMessage.message
58. api.GPUCompilationMessage.offset
59. api.GPUCompilationMessage.type
60. api.GPUComputePassEncoder
61. api.GPUComputePassEncoder.dispatchWorkgroups
62. api.GPUComputePassEncoder.dispatchWorkgroupsIndirect
63. api.GPUComputePassEncoder.end
64. api.GPUComputePassEncoder.insertDebugMarker
65. api.GPUComputePassEncoder.label
66. api.GPUComputePassEncoder.popDebugGroup
67. api.GPUComputePassEncoder.pushDebugGroup
68. api.GPUComputePassEncoder.setBindGroup
69. api.GPUComputePassEncoder.setPipeline
70. api.GPUComputePipeline
71. api.GPUComputePipeline.getBindGroupLayout
72. api.GPUComputePipeline.label
73. api.GPUDevice
74. api.GPUDevice.createBindGroup
75. api.GPUDevice.createBindGroupLayout
76. api.GPUDevice.createBuffer
77. api.GPUDevice.createCommandEncoder
78. api.GPUDevice.createComputePipeline
79. api.GPUDevice.createComputePipelineAsync
80. api.GPUDevice.createPipelineLayout
81. api.GPUDevice.createQuerySet
82. api.GPUDevice.createRenderBundleEncoder
83. api.GPUDevice.createRenderPipeline
84. api.GPUDevice.createRenderPipelineAsync
85. api.GPUDevice.createSampler
86. api.GPUDevice.createShaderModule
87. api.GPUDevice.createTexture
88. api.GPUDevice.destroy
89. api.GPUDevice.features
90. api.GPUDevice.importExternalTexture
91. api.GPUDevice.label
92. api.GPUDevice.limits
93. api.GPUDevice.lost
94. api.GPUDevice.popErrorScope
95. api.GPUDevice.pushErrorScope
96. api.GPUDevice.queue
97. api.GPUDevice.uncapturederror_event
98. api.GPUDeviceLostInfo
99. api.GPUDeviceLostInfo.message
100. api.GPUDeviceLostInfo.reason
101. api.GPUError
102. api.GPUError.message
103. api.GPUExternalTexture
104. api.GPUExternalTexture.label
105. api.GPUInternalError
106. api.GPUInternalError.GPUInternalError
107. api.GPUOutOfMemoryError
108. api.GPUOutOfMemoryError.GPUOutOfMemoryError
109. api.GPUPipelineError
110. api.GPUPipelineError.GPUPipelineError
111. api.GPUPipelineError.reason
112. api.GPUPipelineLayout
113. api.GPUPipelineLayout.label
114. api.GPUQuerySet
115. api.GPUQuerySet.count
116. api.GPUQuerySet.destroy
117. api.GPUQuerySet.label
118. api.GPUQuerySet.type
119. api.GPUQueue
120. api.GPUQueue.copyExternalImageToTexture
121. api.GPUQueue.label
122. api.GPUQueue.onSubmittedWorkDone
123. api.GPUQueue.submit
124. api.GPUQueue.writeBuffer
125. api.GPUQueue.writeTexture
126. api.GPURenderBundle
127. api.GPURenderBundle.label
128. api.GPURenderBundleEncoder
129. api.GPURenderBundleEncoder.draw
130. api.GPURenderBundleEncoder.drawIndexed
131. api.GPURenderBundleEncoder.drawIndexedIndirect
132. api.GPURenderBundleEncoder.drawIndirect
133. api.GPURenderBundleEncoder.finish
134. api.GPURenderBundleEncoder.insertDebugMarker
135. api.GPURenderBundleEncoder.label
136. api.GPURenderBundleEncoder.popDebugGroup
137. api.GPURenderBundleEncoder.pushDebugGroup
138. api.GPURenderBundleEncoder.setBindGroup
139. api.GPURenderBundleEncoder.setIndexBuffer
140. api.GPURenderBundleEncoder.setPipeline
141. api.GPURenderBundleEncoder.setVertexBuffer
142. api.GPURenderPassEncoder
143. api.GPURenderPassEncoder.beginOcclusionQuery
144. api.GPURenderPassEncoder.draw
145. api.GPURenderPassEncoder.drawIndexed
146. api.GPURenderPassEncoder.drawIndexedIndirect
147. api.GPURenderPassEncoder.drawIndirect
148. api.GPURenderPassEncoder.end
149. api.GPURenderPassEncoder.endOcclusionQuery
150. api.GPURenderPassEncoder.executeBundles
151. api.GPURenderPassEncoder.insertDebugMarker
152. api.GPURenderPassEncoder.label
153. api.GPURenderPassEncoder.popDebugGroup
154. api.GPURenderPassEncoder.pushDebugGroup
155. api.GPURenderPassEncoder.setBindGroup
156. api.GPURenderPassEncoder.setBlendConstant
157. api.GPURenderPassEncoder.setIndexBuffer
158. api.GPURenderPassEncoder.setPipeline
159. api.GPURenderPassEncoder.setScissorRect
160. api.GPURenderPassEncoder.setStencilReference
161. api.GPURenderPassEncoder.setVertexBuffer
162. api.GPURenderPassEncoder.setViewport
163. api.GPURenderPipeline
164. api.GPURenderPipeline.getBindGroupLayout
165. api.GPURenderPipeline.label
166. api.GPUSampler
167. api.GPUSampler.label
168. api.GPUShaderModule
169. api.GPUShaderModule.getCompilationInfo
170. api.GPUShaderModule.label
171. api.GPUSupportedFeatures
172. api.GPUSupportedFeatures.entries
173. api.GPUSupportedFeatures.forEach
174. api.GPUSupportedFeatures.has
175. api.GPUSupportedFeatures.keys
176. api.GPUSupportedFeatures.size
177. api.GPUSupportedFeatures.values
178. api.GPUSupportedFeatures.@@iterator
179. api.GPUSupportedLimits
180. api.GPUSupportedLimits.maxBindGroups
181. api.GPUSupportedLimits.maxBindingsPerBindGroup
182. api.GPUSupportedLimits.maxBindGroupsPlusVertexBuffers
183. api.GPUSupportedLimits.maxBufferSize
184. api.GPUSupportedLimits.maxColorAttachmentBytesPerSample
185. api.GPUSupportedLimits.maxColorAttachments
186. api.GPUSupportedLimits.maxComputeInvocationsPerWorkgroup
187. api.GPUSupportedLimits.maxComputeWorkgroupSizeX
188. api.GPUSupportedLimits.maxComputeWorkgroupSizeY
189. api.GPUSupportedLimits.maxComputeWorkgroupSizeZ
190. api.GPUSupportedLimits.maxComputeWorkgroupsPerDimension
191. api.GPUSupportedLimits.maxComputeWorkgroupStorageSize
192. api.GPUSupportedLimits.maxDynamicStorageBuffersPerPipelineLayout
193. api.GPUSupportedLimits.maxDynamicUniformBuffersPerPipelineLayout
194. api.GPUSupportedLimits.maxInterStageShaderComponents
195. api.GPUSupportedLimits.maxInterStageShaderVariables
196. api.GPUSupportedLimits.maxSampledTexturesPerShaderStage
197. api.GPUSupportedLimits.maxSamplersPerShaderStage
198. api.GPUSupportedLimits.maxStorageBufferBindingSize
199. api.GPUSupportedLimits.maxStorageBuffersPerShaderStage
200. api.GPUSupportedLimits.maxStorageTexturesPerShaderStage
201. api.GPUSupportedLimits.maxTextureArrayLayers
202. api.GPUSupportedLimits.maxTextureDimension1D
203. api.GPUSupportedLimits.maxTextureDimension2D
204. api.GPUSupportedLimits.maxTextureDimension3D
205. api.GPUSupportedLimits.maxUniformBufferBindingSize
206. api.GPUSupportedLimits.maxUniformBuffersPerShaderStage
207. api.GPUSupportedLimits.maxVertexAttributes
208. api.GPUSupportedLimits.maxVertexBufferArrayStride
209. api.GPUSupportedLimits.maxVertexBuffers
210. api.GPUSupportedLimits.minStorageBufferOffsetAlignment
211. api.GPUSupportedLimits.minUniformBufferOffsetAlignment
212. api.GPUTexture
213. api.GPUTexture.createView
214. api.GPUTexture.depthOrArrayLayers
215. api.GPUTexture.destroy
216. api.GPUTexture.dimension
217. api.GPUTexture.format
218. api.GPUTexture.height
219. api.GPUTexture.label
220. api.GPUTexture.mipLevelCount
221. api.GPUTexture.sampleCount
222. api.GPUTexture.usage
223. api.GPUTexture.width
224. api.GPUTextureView
225. api.GPUTextureView.label
226. api.GPUUncapturedErrorEvent
227. api.GPUUncapturedErrorEvent.GPUUncapturedErrorEvent
228. api.GPUUncapturedErrorEvent.error
229. api.GPUValidationError
230. api.GPUValidationError.GPUValidationError
231. api.HTMLCanvasElement.getContext.webgpu_context
232. api.Navigator.gpu
233. api.OffscreenCanvas.getContext.webgpu_context
234. api.WGSLLanguageFeatures
235. api.WGSLLanguageFeatures.entries
236. api.WGSLLanguageFeatures.forEach
237. api.WGSLLanguageFeatures.has
238. api.WGSLLanguageFeatures.keys
239. api.WGSLLanguageFeatures.size
240. api.WGSLLanguageFeatures.values
241. api.WGSLLanguageFeatures.iterator
242. api.WorkerNavigator.gpu
