### PR TITLE
STP supports all of the text-wrap properties, except "pretty"

### DIFF
--- a/css/properties/text-wrap.json
+++ b/css/properties/text-wrap.json
@@ -26,7 +26,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -60,7 +60,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -95,7 +95,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -165,7 +165,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -200,7 +200,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
I updated the safari text-wrap css properties to "preview" because STP supports the text-wrap CSS properties as of STP 182 and STP 183.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ I updated the safari text-wrap css properties to "preview" because STP supports text-wrap CSS properties as of STP 182 and STP 183. -->

#### Test results and supporting details

<!-- 👩‍🔬 I created my own test case with each text-wrap property. All of them are supported in the web inspector of STP, except for pretty which says it's an unsupported property value.-->

<!-- 🔗STP Release Notes (under CSS New Features): https://developer.apple.com/documentation/safari-technology-preview-release-notes/stp-release-182
https://developer.apple.com/documentation/safari-technology-preview-release-notes/stp-release-183

Commits: https://github.com/WebKit/WebKit/commit/3322e6b61d68491df248d444fb09f3c990ad0414 https://github.com/WebKit/WebKit/commit/c07a3c339c79176f5c06ffc5a285a450f4db7f8a -->

#### Related issues

<!-- 🔨 Still need support of pretty in STP, it is not an issue in MDN. -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
