### PR TITLE
Add word-break: auto-phrase as of Chrome 119

### DIFF
--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -72,9 +72,7 @@
                 "version_added": false
               },
               "safari_ios": "mirror",
-              "samsunginternet_android": {
-                "version_added": false
-              },
+              "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {

--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -46,6 +46,44 @@
             "deprecated": false
           }
         },
+        "auto-phrase": {
+          "__compat": {
+            "description": "<code>auto-phrase</code>",
+            "support": {
+              "chrome": {
+                "version_added": "119",
+                "notes": "This value is only applicable if <code>lang=\"ja\"</code> is specified. This value has no effect on other locales."
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": {
+                "version_added": false
+              },
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": {
+                "version_added": false
+              },
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "break-word": {
           "__compat": {
             "description": "<code>break-word</code>",
@@ -111,30 +149,6 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "auto-phrase": {
-          "__compat": {
-            "description": "<code>auto-phrase</code>",
-            "support": {
-              "chrome": {
-                "version_added": "119",
-                "notes": "Only works if Japanese is declared with lang=\"ja\" and does not affect other languages."
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": true
-              },
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -63,9 +63,7 @@
               "ie": {
                 "version_added": false
               },
-              "oculus": {
-                "version_added": false
-              },
+              "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {

--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -115,6 +115,30 @@
               "deprecated": false
             }
           }
+        },
+        "auto-phrase": {
+          "__compat": {
+            "description": "<code>auto-phrase</code>",
+            "support": {
+              "chrome": {
+                "version_added": "119",
+                "notes": "Only works if Japanese is declared with lang=\"ja\" and does not affect other languages."
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": true
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
#### Summary

Chrome 119 supports ``word-break: auto-phrase`` for Japanese text.

#### Test results and supporting details

Announced on the Chrome developer blog here: https://developer.chrome.com/blog/css-i18n-features

#### Related issues

None