### PR TITLE
Add Device Posture API

### DIFF
--- a/api/DevicePosture.json
+++ b/api/DevicePosture.json
@@ -1,0 +1,119 @@
+{
+  "api": {
+    "DevicePosture": {
+      "__compat": {
+        "spec_url": "https://w3c.github.io/device-posture/#dom-deviceposture",
+        "tags": [
+          "web-features:device-posture"
+        ],
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": {
+            "version_added": "16.2"
+          },
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "change_event": {
+        "__compat": {
+          "description": "<code>change</code> event",
+          "spec_url": "https://w3c.github.io/device-posture/#dom-deviceposture-onchange",
+          "tags": [
+            "web-features:device-posture"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": {
+              "version_added": "16.2"
+            },
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "type": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/device-posture/#dom-deviceposture-type",
+          "tags": [
+            "web-features:device-posture"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": {
+              "version_added": "16.2"
+            },
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -902,6 +902,44 @@
           }
         }
       },
+      "devicePosture": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/device-posture/#dom-navigator-deviceposture",
+          "tags": [
+            "web-features:device-posture"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": {
+              "version_added": "16.2"
+            },
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "doNotTrack": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/doNotTrack",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -407,6 +407,45 @@
             }
           }
         },
+        "device-posture": {
+          "__compat": {
+            "description": "<code>device-posture</code> media feature",
+            "spec_url": "https://w3c.github.io/device-posture/#the-device-posture-media-feature",
+            "tags": [
+              "web-features:device-posture"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": {
+                "version_added": "16.2"
+              },
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "device-width": {
           "__compat": {
             "description": "<code>device-width</code> media feature",


### PR DESCRIPTION
This pull request adds the https://w3c.github.io/device-posture/ API to BCD. 
Found by the Open Web Docs BCD Collector v10.6.1.

Samsung Internet version 16.2 comes from https://developer.samsung.com/internet/blog/en/2022/03/03/samsung-internet-newsletter-march-2022 where it says: "We’ve shipped 16.2 stable! 🎉 16.2 improves dark mode and enables our Device Posture API for folding screens by default."

I've tagged the features with `device-posture`. cc @ddbeck 

- api.DevicePosture
- api.DevicePosture.change_event
- api.DevicePosture.type
- api.Navigator.devicePosture
- css.at-rules.media.device-posture