### PR TITLE
text-wrap: balance; supported in chrome version 114, not 117

### DIFF
--- a/css/properties/text-wrap.json
+++ b/css/properties/text-wrap.json
@@ -45,7 +45,7 @@
             "spec_url": "https://drafts.csswg.org/css-text-4/#valdef-text-wrap-balance",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "114"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
#### Summary

`text-wrap: balance` supported in chrome version 114, not 117.

#### Test results and supporting details

- https://caniuse.com/css-text-wrap-balance
- https://developer.chrome.com/blog/css-text-wrap-balance

#### Related issues

#21311