### PR TITLE
`web-features:flexbox`: correct tag group

### DIFF
--- a/css/properties/justify-items.json
+++ b/css/properties/justify-items.json
@@ -44,6 +44,9 @@
           "__compat": {
             "description": "Supported in Flex Layout",
             "spec_url": "https://drafts.csswg.org/css-align/#justify-items-property",
+            "tags": [
+              "web-features:flexbox"
+            ],
             "support": {
               "chrome": {
                 "version_added": "52"

--- a/css/properties/justify-self.json
+++ b/css/properties/justify-self.json
@@ -42,6 +42,9 @@
           "__compat": {
             "description": "Supported in Flex Layout",
             "spec_url": "https://drafts.csswg.org/css-align/#justify-self-property",
+            "tags": [
+              "web-features:flexbox"
+            ],
             "support": {
               "chrome": {
                 "version_added": "57"

--- a/css/properties/place-content.json
+++ b/css/properties/place-content.json
@@ -37,6 +37,9 @@
         "flex_context": {
           "__compat": {
             "description": "Supported in Flex Layout",
+            "tags": [
+              "web-features:flexbox"
+            ],
             "support": {
               "chrome": {
                 "version_added": "59"

--- a/css/properties/place-items.json
+++ b/css/properties/place-items.json
@@ -37,6 +37,9 @@
         "flex_context": {
           "__compat": {
             "description": "Supported in Flex Layout",
+            "tags": [
+              "web-features:flexbox"
+            ],
             "support": {
               "chrome": {
                 "version_added": "59"

--- a/css/properties/place-self.json
+++ b/css/properties/place-self.json
@@ -37,6 +37,9 @@
         "flex_context": {
           "__compat": {
             "description": "Supported in Flex Layout",
+            "tags": [
+              "web-features:flexbox"
+            ],
             "support": {
               "chrome": {
                 "version_added": "59"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Tag missing features as being part of flexbox:

- `css.properties.justfiy-items.flex_content`
- `css.properties.justfiy-self.flex_content`
- `css.properties.place-content.flex_content`
- `css.properties.place-items.flex_content`
- `css.properties.place-self.flex_content`

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

These are closely related. See the enclosed table to see how all of these features appeared in a relatively short time and are thus related as a group.

<details>
<summary>Baseline calculation for <code>flexbox</code></summary

## flexbox

| Key                                                                                                                | Baseline | Low since date | Versions                                                                                                                    |
| :----------------------------------------------------------------------------------------------------------------- | :------: | :------------- | --------------------------------------------------------------------------------------------------------------------------- |
| **flexbox**                                                                                                        |  ✅ High  | 2020-09-22     | Chrome 59<br>Chrome Android 59<br>Edge 79<br>Firefox 81 🔑💎<br>Firefox for Android 81<br>Safari 11<br>Safari on iOS 11     |
| [`css.properties.flex-direction`](https://developer.mozilla.org/docs/Web/CSS/flex-direction#browser_compatibility) |  ✅ High  | 2020-09-22     | Chrome 29<br>Chrome Android 29<br>Edge 12<br>Firefox 81 🔑💎<br>Firefox for Android 81<br>Safari 9<br>Safari on iOS 9       |
| `css.properties.align-content.flex_context.stretch`                                                                |  ✅ High  | 2020-01-15     | Chrome 57<br>Chrome Android 57<br>Edge 79 🔑💎<br>Firefox 52<br>Firefox for Android 52<br>Safari 9<br>Safari on iOS 9       |
| `css.properties.align-items.flex_context.baseline`                                                                 |  ✅ High  | 2020-01-15     | Chrome 21<br>Chrome Android 25<br>Edge 79 🔑💎<br>Firefox 28<br>Firefox for Android 28<br>Safari 7<br>Safari on iOS 7       |
| `css.properties.align-self.flex_context.baseline`                                                                  |  ✅ High  | 2020-01-15     | Chrome 21<br>Chrome Android 25<br>Edge 79 🔑💎<br>Firefox 28<br>Firefox for Android 28<br>Safari 7<br>Safari on iOS 7       |
| `css.properties.align-self.flex_context.stretch`                                                                   |  ✅ High  | 2020-01-15     | Chrome 57<br>Chrome Android 57<br>Edge 79 🔑💎<br>Firefox 52<br>Firefox for Android 52<br>Safari 9<br>Safari on iOS 9       |
| `css.properties.justify-content.flex_context.stretch`                                                              |  ✅ High  | 2020-01-15     | Chrome 57<br>Chrome Android 57<br>Edge 79 🔑💎<br>Firefox 52<br>Firefox for Android 52<br>Safari 9<br>Safari on iOS 9       |
| `css.properties.place-content.flex_context`                                                                        |  ✅ High  | 2020-01-15     | Chrome 59<br>Chrome Android 59<br>Edge 79 🔑💎<br>Firefox 45<br>Firefox for Android 45<br>Safari 9<br>Safari on iOS 9       |
| `css.properties.place-items.flex_context`                                                                          |  ✅ High  | 2020-01-15     | Chrome 59<br>Chrome Android 59<br>Edge 79 🔑💎<br>Firefox 45<br>Firefox for Android 45<br>Safari 11<br>Safari on iOS 11     |
| `css.properties.place-self.flex_context`                                                                           |  ✅ High  | 2020-01-15     | Chrome 59<br>Chrome Android 59<br>Edge 79 🔑💎<br>Firefox 45<br>Firefox for Android 45<br>Safari 11<br>Safari on iOS 11     |
| `css.properties.justify-self.flex_context`                                                                         |  ✅ High  | 2017-10-17     | Chrome 57<br>Chrome Android 57<br>Edge 16 🔑💎<br>Firefox 45<br>Firefox for Android 45<br>Safari 10.1<br>Safari on iOS 10.3 |
| [`css.properties.flex-wrap`](https://developer.mozilla.org/docs/Web/CSS/flex-wrap#browser_compatibility)           |  ✅ High  | 2017-03-07     | Chrome 29<br>Chrome Android 29<br>Edge 12<br>Firefox 28<br>Firefox for Android 52 🔑💎<br>Safari 9<br>Safari on iOS 9       |
| `css.properties.align-items.flex_context`                                                                          |  ✅ High  | 2016-07-27     | Chrome 52<br>Chrome Android 52 🔑💎<br>Edge 12<br>Firefox 20<br>Firefox for Android 20<br>Safari 7<br>Safari on iOS 7       |
| `css.properties.justify-content.flex_context`                                                                      |  ✅ High  | 2016-07-27     | Chrome 52<br>Chrome Android 52 🔑💎<br>Edge 12<br>Firefox 20<br>Firefox for Android 20<br>Safari 7<br>Safari on iOS 7       |
| `css.properties.justify-items.flex_context`                                                                        |  ✅ High  | 2016-07-27     | Chrome 52<br>Chrome Android 52 🔑💎<br>Edge 12<br>Firefox 20<br>Firefox for Android 20<br>Safari 9<br>Safari on iOS 9       |
| `css.properties.align-content.flex_context`                                                                        |  ✅ High  | 2015-09-30     | Chrome 21<br>Chrome Android 25<br>Edge 12<br>Firefox 28<br>Firefox for Android 28<br>Safari 9 🔑💎<br>Safari on iOS 9       |
| `css.properties.display.flex`                                                                                      |  ✅ High  | 2015-09-30     | Chrome 29<br>Chrome Android 29<br>Edge 12<br>Firefox 20<br>Firefox for Android 20<br>Safari 9 🔑💎<br>Safari on iOS 9       |
| `css.properties.display.inline-flex`                                                                               |  ✅ High  | 2015-09-30     | Chrome 29<br>Chrome Android 29<br>Edge 12<br>Firefox 20<br>Firefox for Android 20<br>Safari 9 🔑💎<br>Safari on iOS 9       |
| [`css.properties.flex`](https://developer.mozilla.org/docs/Web/CSS/flex#browser_compatibility)                     |  ✅ High  | 2015-09-30     | Chrome 29<br>Chrome Android 29<br>Edge 12<br>Firefox 20<br>Firefox for Android 20<br>Safari 9 🔑💎<br>Safari on iOS 9       |
| [`css.properties.flex-basis`](https://developer.mozilla.org/docs/Web/CSS/flex-basis#browser_compatibility)         |  ✅ High  | 2015-09-30     | Chrome 29<br>Chrome Android 29<br>Edge 12<br>Firefox 22<br>Firefox for Android 22<br>Safari 9 🔑💎<br>Safari on iOS 9       |
| `css.properties.flex-basis.auto`                                                                                   |  ✅ High  | 2015-09-30     | Chrome 22<br>Chrome Android 25<br>Edge 12<br>Firefox 22<br>Firefox for Android 22<br>Safari 9 🔑💎<br>Safari on iOS 9       |
| [`css.properties.flex-flow`](https://developer.mozilla.org/docs/Web/CSS/flex-flow#browser_compatibility)           |  ✅ High  | 2015-09-30     | Chrome 29<br>Chrome Android 29<br>Edge 12<br>Firefox 28<br>Firefox for Android 28<br>Safari 9 🔑💎<br>Safari on iOS 9       |
| [`css.properties.flex-grow`](https://developer.mozilla.org/docs/Web/CSS/flex-grow#browser_compatibility)           |  ✅ High  | 2015-09-30     | Chrome 29<br>Chrome Android 29<br>Edge 12<br>Firefox 20<br>Firefox for Android 20<br>Safari 9 🔑💎<br>Safari on iOS 9       |
| [`css.properties.flex-shrink`](https://developer.mozilla.org/docs/Web/CSS/flex-shrink#browser_compatibility)       |  ✅ High  | 2015-09-30     | Chrome 29<br>Chrome Android 29<br>Edge 12<br>Firefox 20<br>Firefox for Android 20<br>Safari 9 🔑💎<br>Safari on iOS 9       |
| [`css.properties.order`](https://developer.mozilla.org/docs/Web/CSS/order#browser_compatibility)                   |  ✅ High  | 2015-09-30     | Chrome 29<br>Chrome Android 29<br>Edge 12<br>Firefox 20<br>Firefox for Android 20<br>Safari 9 🔑💎<br>Safari on iOS 9       |
| `css.properties.align-self.flex_context`                                                                           |  ✅ High  | 2015-07-28     | Chrome 36<br>Chrome Android 36<br>Edge 12 🔑💎<br>Firefox 20<br>Firefox for Android 20<br>Safari 7<br>Safari on iOS 7       |

🔑💎 marks a release that contributes to the Baseline low date.<br>



</details>

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

Discovered by @Elchi3 in https://github.com/mdn/browser-compat-data/pull/21598.
