### PR TITLE
Update Safari data for api.Window.deviceorientation_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1104,7 +1104,7 @@
               "version_added": "12"
             },
             "safari": {
-              "version_added": false
+              "version_added": "17"
             },
             "safari_ios": {
               "version_added": "4.2"


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `deviceorientation_event` member of the `Window` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.3).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Window/deviceorientation_event
