### PR TITLE
Add missing non-standard -webkit-slider-* CSS selector feature

### DIFF
--- a/css/selectors/-webkit-slider-runnable-track.json
+++ b/css/selectors/-webkit-slider-runnable-track.json
@@ -1,0 +1,38 @@
+{
+  "css": {
+    "selectors": {
+      "-webkit-slider-runnable-track": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤83"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/-webkit-slider-thumb.json
+++ b/css/selectors/-webkit-slider-thumb.json
@@ -1,0 +1,38 @@
+{
+  "css": {
+    "selectors": {
+      "-webkit-slider-thumb": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "≤83"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds the missing `-webkit-slider-*` CSS selector. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.3).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used:
https://mdn-bcd-collector.gooborg.com/tests/css/selectors/-webkit-slider-runnable-track
https://mdn-bcd-collector.gooborg.com/tests/css/selectors/-webkit-slider-thumb
