### PR TITLE
Update all browsers data for text-wrap CSS property

### DIFF
--- a/css/properties/text-wrap.json
+++ b/css/properties/text-wrap.json
@@ -7,16 +7,12 @@
           "spec_url": "https://drafts.csswg.org/css-text-4/#text-wrap",
           "support": {
             "chrome": {
-              "version_added": "114",
-              "partial_implementation": true,
-              "notes": "The <code>stable</code> value is not supported."
+              "version_added": "114"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "121",
-              "partial_implementation": true,
-              "notes": "The <code>nowrap</code> and <code>pretty</code> values are not supported."
+              "version_added": "121"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `text-wrap` CSS property. This removes the notes and `partial_implementation` from the property, as the lack of support for specific values is documented in the subfeatures.
