### PR TITLE
Rename css.properties.hyphens.auto_value -> auto

### DIFF
--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -78,9 +78,9 @@
             "deprecated": false
           }
         },
-        "auto_value": {
+        "auto": {
           "__compat": {
-            "description": "Support for the <code>auto</code> value",
+            "description": "<code>auto</code> value",
             "support": {
               "chrome": [
                 {


### PR DESCRIPTION
This PR renames `css.properties.hyphens.auto_value` to `css.properties.hyphens.auto` to better follow our usual convention.
