### PR TITLE
Remove css.properties.font-variant.font-variant-emoji from BCD

### DIFF
--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -74,40 +74,6 @@
             }
           }
         },
-        "font-variant-emoji": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/font-variant-emoji",
-            "spec_url": "https://drafts.csswg.org/css-fonts/#font-variant-emoji-prop",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "108"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "greek_accented_characters": {
           "__compat": {
             "description": "Greek accented characters",


### PR DESCRIPTION
This PR removes the `font-variant-emoji` member of the `font-variant` CSS property from BCD. This is already tracked in a separate file, where it is supposed to be tracked since it is a separate CSS property.

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/font-variant/font-variant-emoji
