### PR TITLE
Revert "Update Safari data for VideoTrack API (#21193)"

### DIFF
--- a/api/VideoTrack.json
+++ b/api/VideoTrack.json
@@ -50,8 +50,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "7",
-            "version_removed": "17"
+            "version_added": "7"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -113,8 +112,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7",
-              "version_removed": "17"
+              "version_added": "7"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -177,8 +175,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7",
-              "version_removed": "17"
+              "version_added": "7"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -241,8 +238,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7",
-              "version_removed": "17"
+              "version_added": "7"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -305,8 +301,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7",
-              "version_removed": "17"
+              "version_added": "7"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -369,8 +364,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7",
-              "version_removed": "17"
+              "version_added": "7"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -426,12 +420,10 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7",
-              "version_removed": "17"
+              "version_added": "7"
             },
             "safari_ios": {
               "version_added": "13",
-              "version_removed": "17",
               "partial_implementation": true,
               "notes": "Exposed in Mobile Safari on iPad but not on iPhone."
             },


### PR DESCRIPTION
This reverts commit 78a3dc1f4b661806fdf70d61133a13ab404dea9a.

Running the mdn-bcd-collector (v10.6.3) manually, it is evident that this API is still fully supported in Safari.