### PR TITLE
Remove `lostpointercapture` event from `Document` interface

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4938,48 +4938,6 @@
           }
         }
       },
-      "lostpointercapture_event": {
-        "__compat": {
-          "description": "<code>lostpointercapture</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/lostpointercapture_event",
-          "spec_url": [
-            "https://w3c.github.io/pointerevents/#the-lostpointercapture-event",
-            "https://w3c.github.io/pointerevents/#dom-globaleventhandlers-onlostpointercapture"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "57"
-            },
-            "chrome_android": "mirror",
-            "edge": {
-              "version_added": "17"
-            },
-            "firefox": {
-              "version_added": "59"
-            },
-            "firefox_android": {
-              "version_added": "79"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "13"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "mozSetImageElement": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/mozSetImageElement",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

following https://github.com/mdn/browser-compat-data/pull/16650, which trys to move `lostpointercapture` and `gotpointercapture` events from `Document` interface and `HTMLElement` interface to `Element` interface, but it forgot to remove `lostpointercapture` event in `Document` interface

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
