### PR TITLE
Release change concurrency is not working as expected

### DIFF
--- a/scripts/release/changes.ts
+++ b/scripts/release/changes.ts
@@ -144,7 +144,7 @@ export const getChanges = async (date: string): Promise<Changes> => {
   const runner = new Listr(tasks, {
     exitOnError: false,
     renderer: 'verbose',
-    concurrent: 5,
+    concurrent: 1,
     rendererOptions: {
       collapseSkips: false,
       collapseErrors: false,


### PR DESCRIPTION
This PR sets the release change collection concurrency to 1, as it does not seem to be parallelizing well.
