### PR TITLE
Remove test for useChalk in pluralize lib

### DIFF
--- a/scripts/lib/pluralize.test.ts
+++ b/scripts/lib/pluralize.test.ts
@@ -15,9 +15,4 @@ describe('Pluralize', () => {
     const result = pluralize('apple', 2);
     assert.equal(result, '2 apples');
   });
-
-  it('should return formatted string with chalk when useChalk is true', () => {
-    const result = pluralize('apple', 2, true);
-    assert.equal(result, '\u001b[1m2\u001b[22m apples');
-  });
 });


### PR DESCRIPTION
This PR removes a test for chalk formatting within the pluralize lib.  It seems that at some point, chalk formatting no longer applied within GitHub Actions workflows, so [this broke the latest release](https://github.com/mdn/browser-compat-data/actions/runs/7221747578/job/19683149509).  (I can't find a commit that could have changed this in our codebase, so I have a feeling it was a change in GitHub Actions itself.)