### PR TITLE
Restore chalk formatting test for pluralize lib

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm test
+        env:
+          FORCE_COLOR: 3
       - run: npm run build
       - run: npm publish build/ --access public
         env:

--- a/scripts/lib/pluralize.test.ts
+++ b/scripts/lib/pluralize.test.ts
@@ -15,4 +15,9 @@ describe('Pluralize', () => {
     const result = pluralize('apple', 2);
     assert.equal(result, '2 apples');
   });
+
+  it('should return formatted string with chalk when useChalk is true', () => {
+    const result = pluralize('apple', 2, true);
+    assert.equal(result, '\u001b[1m2\u001b[22m apples');
+  });
 });


### PR DESCRIPTION
This PR restores the unittest that was removed in #21635.  This also ensures that the test will not fail when running unittests during the release process.
