### PR TITLE
Update NumberFormat.json

### DIFF
--- a/javascript/builtins/Intl/NumberFormat.json
+++ b/javascript/builtins/Intl/NumberFormat.json
@@ -955,7 +955,7 @@
                     "version_added": false
                   },
                   "nodejs": {
-                    "version_added": false
+                    "version_added": "19.0.0"
                   },
                   "opera": "mirror",
                   "opera_android": "mirror",


### PR DESCRIPTION
#### Summary

Correcting compatibility of `trailingZeroDisplay` option in Intl.NumberFormat in NodeJS.

Currently the compatibility table shows that that NodeJS supports `trailingZeroDisplay` when checking which options are in effect (see [resolvedOptions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/resolvedOptions)). In reality it's also supported as an input option.

#### Test results and supporting details
I've tested it in NodeJS v20.10.0:
```
Intl.NumberFormat('sk-SK', { style: 'currency', currency: 'EUR', trailingZeroDisplay: "stripIfInteger" }).format(123) -- returns 123 €
Intl.NumberFormat('sk-SK', { style: 'currency', currency: 'EUR', trailingZeroDisplay: "auto" }).format(123) -- returns 123,00 €
```

More importantly, it's confirmed in a NodeJS issue: https://github.com/nodejs/node/issues/41568