### PR TITLE
Remove `HTMLElement/beforematch_event` | duplicate with `Element/beforematch_event`

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -346,41 +346,6 @@
           }
         }
       },
-      "beforematch_event": {
-        "__compat": {
-          "description": "<code>beforematch</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/beforematch_event",
-          "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-beforematch",
-          "support": {
-            "chrome": {
-              "version_added": "102"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "beforetoggle_event": {
         "__compat": {
           "description": "<code>beforetoggle</code> event",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the two `Element/beforematch_event` and `HTMLElement/beforematch_event` are duplicate

according to spec https://html.spec.whatwg.org/multipage/indices.html#event-beforematch:

![image](https://github.com/mdn/browser-compat-data/assets/95597335/a0b6b1b8-f9b0-4919-a369-9e10f166af1c)

so remove `HTMLElement/beforematch_event` and keep `Element/beforematch_event`

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
