### PR TITLE
Bluetooth availabilitychanged event isn't supported anywhere

### DIFF
--- a/api/Bluetooth.json
+++ b/api/Bluetooth.json
@@ -70,46 +70,6 @@
           "deprecated": false
         }
       },
-      "availabilitychanged_event": {
-        "__compat": {
-          "description": "<code>availabilitychanged</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth/availabilitychanged_event",
-          "spec_url": [
-            "https://webbluetoothcg.github.io/web-bluetooth/#eventdef-bluetooth-availabilitychanged",
-            "https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-onavailabilitychanged"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "56"
-            },
-            "chrome_android": {
-              "version_added": false
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "getAvailability": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Bluetooth/getAvailability",


### PR DESCRIPTION
Found by the Open Web Docs BCD collector v10.6.3.

Not in Chromium, confirmed by https://bugs.chromium.org/p/chromium/issues/detail?id=707640