### PR TITLE
Safari iOS doesn't support DeviceOrientationEvent.absolute

### DIFF
--- a/api/DeviceOrientationEvent.json
+++ b/api/DeviceOrientationEvent.json
@@ -111,7 +111,9 @@
             "safari": {
               "version_added": "17"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
Found by the Open Web Docs BCD Collector v10.6.3.

See https://github.com/WebKit/WebKit/blob/7c7d82b66b438315b7182d3b460c795c18ba81d2/Source/WebCore/dom/DeviceOrientationEvent.idl#L38-L50 where it is conditionally disabled on the iOS family. 