### PR TITLE
 Remove the incorrect mdn_url of `<img>` element `loading` attribute

### DIFF
--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -424,7 +424,6 @@
         },
         "loading": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/Performance/Lazy_loading",
             "spec_url": "https://html.spec.whatwg.org/multipage/urls-and-fetching.html#lazy-loading-attributes",
             "support": {
               "chrome": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the incorrect mdn_url of `<img>` element `loading` attribute

normally, the attribute of html element will not specific a mdn_url, and it should not specific to a page of performance

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
