### PR TITLE
Update Edge support for CSS paint-order

### DIFF
--- a/css/properties/paint-order.json
+++ b/css/properties/paint-order.json
@@ -12,9 +12,7 @@
               "notes": "Does not affect stroked HTML text, see <a href='https://crbug.com/815111'>bug 815111</a>"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "17"
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": "60"
             },


### PR DESCRIPTION
Fix https://github.com/mdn/browser-compat-data/issues/21649 by setting Edge to "mirror" from Chrome.