### PR TITLE
Reinstate install from Git

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,11 @@
 .prettierrc
 .vscode
 build
+!/build/data.json
+!/build/import.d.mts
+!/build/legacynode.mjs
+!/build/require.d.ts
+!/build/types.d.ts
 docs
 test
 schemas

--- a/package.json
+++ b/package.json
@@ -4,6 +4,23 @@
   "description": "Browser compatibility data provided by MDN Web Docs",
   "main": "index.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./build/require.d.ts",
+        "default": "./build/data.json"
+      },
+      "import": {
+        "types": "./build/import.d.mts",
+        "default": "./build/data.json"
+      }
+    },
+    "./forLegacyNode": {
+      "types": "./build/import.d.mts",
+      "default": "./build/legacynode.mjs"
+    }
+  },
+  "types": "./build/require.d.ts",
   "engines": {
     "node": ">=18.0.0"
   },
@@ -75,7 +92,7 @@
     "yargs": "~17.7.0"
   },
   "scripts": {
-    "prepare": "husky install && npm run gentypes",
+    "prepare": "husky install && npm run gentypes && npm run build",
     "diff": "node --loader=ts-node/esm --no-warnings=ExperimentalWarning scripts/diff.ts",
     "unittest": "NODE_ENV=test c8 mocha index.test.ts --recursive \"{,!(node_modules)/**}/*.test.ts\"",
     "coverage": "c8 report -r lcov && open-cli coverage/lcov-report/index.html",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Reinstate the option to install BCD from Git. This is useful to, for example, run analysis against the data of a BCD PR, before it's merged and released. 

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

1. Run `npm install git+https://github.com/mdn/browser-compat-data.git` and attempt to `import` or `require` BCD. 😢 
2. Run `npm install git+https://github.com/ddbeck/browser-compat-data.git#installable-from-HEAD` and attempt to `import` or `require` BCD. 😄

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

~Regress originated at https://github.com/mdn/browser-compat-data/pull/16593.~

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
