### PR TITLE
Update webview support for XRWebGLBinding

### DIFF
--- a/api/XRWebGLBinding.json
+++ b/api/XRWebGLBinding.json
@@ -25,9 +25,7 @@
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": false
-          }
+          "webview_android": "mirror"
         },
         "status": {
           "experimental": true,
@@ -61,9 +59,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": true,


### PR DESCRIPTION
Found by the Open Web Docs BCD collector v10.6.3.

The interface and its constructor is in webview.
Some methods aren't exposed, though. See https://source.chromium.org/chromium/chromium/src/+/main:android_webview/tools/system_webview_shell/test/data/webexposed/not-webview-exposed.txt;l=183;bpv=0;bpt=0