### PR TITLE
Update webview support for VideoPlaybackQuality.totalFrameDelay

### DIFF
--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -194,9 +194,7 @@
               "version_added": false
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "4.4.3"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
Found by the Open Web Docs BCD collector v10.6.3.

This is not supported in Webview, thus setting to mirror.