### PR TITLE
Mark ::backdrop as supported in fullscreen since Chrome 69

### DIFF
--- a/css/selectors/backdrop.json
+++ b/css/selectors/backdrop.json
@@ -95,12 +95,11 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "69"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "12",
-                "version_removed": "79"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "47"


### PR DESCRIPTION
https://chromiumdash.appspot.com/commit/14eeb1d5b6369a4fefa57973bf6b646469f72e35

The tests that were added at the time show this is the relevant commit: https://chromium-review.googlesource.com/c/chromium/src/+/1066600