### PR TITLE
relnote(122): SVG use elements cannot use data URIs

### DIFF
--- a/svg/elements/use.json
+++ b/svg/elements/use.json
@@ -48,14 +48,16 @@
             "description": "Load from <code>data:</code> URI",
             "support": {
               "chrome": {
-                "version_added": "22"
+                "version_added": "22",
+                "version_removed": "120"
               },
               "chrome_android": "mirror",
               "edge": {
                 "version_added": "≤18"
               },
               "firefox": {
-                "version_added": "4"
+                "version_added": "4",
+                "version_removed": "122"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -69,7 +71,7 @@
                 "version_added": "11.5"
               },
               "safari": {
-                "version_added": "5.1"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
For security reasons, the following is no longer allowed:

```html
<svg>
  <use href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0i...#x" />
</svg>
```

In Firefox, this is now behind a pref only, and disabled by default.

#### Test results and supporting details

- **Fx:**
  - intent to unship: https://groups.google.com/a/mozilla.org/g/dev-platform/c/jOd-oh6NEhs/m/2E3pqE4wAQAJ
- **Chrome:**
  - blog: https://developer.chrome.com/blog/migrate-way-from-data-urls-in-svg-use
  - intent to unship: https://groups.google.com/a/chromium.org/g/blink-dev/c/Q9dLyBhtZTw/m/ceirsUk7AgAJ
  - https://chromestatus.com/feature/5128825141198848

__Safari:__

I can't find any evidence that Safari ever supported this.
Web search only shows bug reports of people struggling to get it to work.
I tested in Browserstack with Safari right back to the beginning of time, with no luck.

```html
<!DOCTYPE html>
<html>
  <title>Test use data uri</title>
  <meta charset="utf-8" />
  <body>
    <svg>
      <use
        href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGlkPSJ4Ij4gPGNpcmNsZSBjeD0iNSIgY3k9IjUiIHI9IjQiIHN0cm9rZT0iYmx1ZSI+PC9jaXJjbGU+IDwvc3ZnPg==#x"
      />
    </svg>
  </body>
</html>
```

#### Related issues and pull requests

- [ ] parent issue https://github.com/mdn/content/issues/31111
- [ ] Fx relnote https://github.com/mdn/content/pull/31124
- [x] reverts changes in https://github.com/mdn/browser-compat-data/pull/1419
