### PR TITLE
SVG viewTarget attribute is removed everywhere

### DIFF
--- a/svg/elements/view.json
+++ b/svg/elements/view.json
@@ -100,40 +100,6 @@
             }
           }
         },
-        "viewTarget": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/viewTarget",
-            "spec_url": "https://www.w3.org/TR/SVG11/linking.html#ViewElementViewTargetAttribute",
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "15"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "3"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
-            }
-          }
-        },
         "zoomAndPan": {
           "__compat": {
             "support": {


### PR DESCRIPTION
Found by the Open Web Docs BCD collector v10.6.3

Gone long enough everywhere so it can be [considered irrelevant](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features).

- Firefox 61: https://bugzilla.mozilla.org/show_bug.cgi?id=1455763
- Safari end of 2019: https://bugs.webkit.org/show_bug.cgi?id=203217
- Chrome end of 2016: https://bugs.chromium.org/p/chromium/issues/detail?id=633908&q=viewTarget&can=1