### PR TITLE
Update Nesting selector

### DIFF
--- a/css/selectors/nesting.json
+++ b/css/selectors/nesting.json
@@ -28,9 +28,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16.5",
-              "partial_implementation": true,
-              "notes": "Does not support nested rules that start with a type selector."
+              "version_added": "17.2"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/selectors/nesting.json
+++ b/css/selectors/nesting.json
@@ -10,11 +10,16 @@
             "web-features:nesting"
           ],
           "support": {
-            "chrome": {
-              "version_added": "112",
-              "partial_implementation": true,
-              "notes": "Does not support nested rules that start with a type selector."
-            },
+            "chrome": [
+              {
+                "version_added": "120",
+              },
+              {
+                "version_added": "112",
+                "partial_implementation": true,
+                "notes": "Does not support nested rules that start with a type selector."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/css/selectors/nesting.json
+++ b/css/selectors/nesting.json
@@ -27,9 +27,16 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "17.2"
-            },
+            "safari": [
+              {
+                "version_added": "17.2"
+              },
+              {
+                "version_added": "16.5",
+                "partial_implementation": true,
+                "notes": "Does not support nested rules that start with a type selector."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"

--- a/css/selectors/nesting.json
+++ b/css/selectors/nesting.json
@@ -12,7 +12,7 @@
           "support": {
             "chrome": [
               {
-                "version_added": "120",
+                "version_added": "120"
               },
               {
                 "version_added": "112",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

CSS Nesting Selectors are full supported in the 17.2 Safari: <https://developer.apple.com/documentation/safari-release-notes/safari-17_2-release-notes>.

Like this: <https://www.webkit.org/blog/14787/webkit-features-in-safari-17-2/>
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
