### PR TITLE
Remove SVG <switch> allowReorder

### DIFF
--- a/svg/elements/switch.json
+++ b/svg/elements/switch.json
@@ -41,39 +41,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "allowReorder": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "4",
-                "version_removed": "50"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": null
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "3.1"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
Found by the Open Web Docs BCD collector v10.6.4.

The allowReorder attribute has been dropped everywhere for a long time and the behavior it was setting is now the default for SVG [`<switch>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/switch) elements.