### PR TITLE
Correct Czechoslovak -> Slovak in hyphens.json

### DIFF
--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -584,39 +584,6 @@
             }
           }
         },
-        "language_czechoslovak": {
-          "__compat": {
-            "description": "Hyphenation dictionary for Czechoslovak (sk, sk-*)",
-            "support": {
-              "chrome": {
-                "version_added": "112"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "language_danish": {
           "__compat": {
             "description": "Hyphenation dictionary for Danish (da, da-*)",
@@ -1903,6 +1870,39 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "5.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "language_slovak": {
+          "__compat": {
+            "description": "Hyphenation dictionary for Slovak (sk, sk-*)",
+            "support": {
+              "chrome": {
+                "version_added": "112"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

In `hyphens.json`, I corrected the name of the language with language code `sk` from Czechoslovak (which is not even a language) to Slovak.

#### Test results and supporting details

You can check the [Wikidata entry](https://www.wikidata.org/wiki/Q9058) for the Slovak language.

#### Related issues

None.