### PR TITLE
Remove <filter> filterRes attribute

### DIFF
--- a/svg/elements/filter.json
+++ b/svg/elements/filter.json
@@ -32,48 +32,12 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": true
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "filterRes": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Attribute/filterRes",
-            "spec_url": "https://www.w3.org/TR/SVG11/filters.html#FilterElementFilterResAttribute",
-            "support": {
-              "chrome": {
-                "version_added": "5"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "3"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": null
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "6"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
-            }
           }
         },
         "filterUnits": {


### PR DESCRIPTION
Found by the Open Web Docs BCD collector v10.6.4.

The filterRes attribute is gone from browsers for a long time already:

- Safari in 2018: https://bugs.webkit.org/show_bug.cgi?id=129565
- Firefox in 2014: https://bugzilla.mozilla.org/show_bug.cgi?id=979472
- Chrome in 2015: https://bugs.chromium.org/p/chromium/issues/detail?id=353272

(Plus a drive-by edit to set webview_android to mirror for the `<filter>` element itself.)