### PR TITLE
Update scripting.json for updated Safari support

### DIFF
--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -157,7 +157,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "16.4"
                 },
                 "safari_ios": "mirror"
               }
@@ -196,8 +196,7 @@
                 "firefox_android": "mirror",
                 "opera": "mirror",
                 "safari": {
-                  "version_added": false,
-                  "notes": "Safari returns an array with the results, instead of an array of InjectionResults."
+                  "version_added": "17"
                 },
                 "safari_ios": "mirror"
               }
@@ -235,7 +234,7 @@
                   "firefox_android": "mirror",
                   "opera": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": "17"
                   },
                   "safari_ios": "mirror"
                 }
@@ -254,7 +253,7 @@
                   "firefox_android": "mirror",
                   "opera": "mirror",
                   "safari": {
-                    "version_added": false
+                    "version_added": "17"
                   },
                   "safari_ios": "mirror"
                 }


### PR DESCRIPTION
Update Safari's support for the `InjectionResult` for the `browser.scripting` API. Also, fix a mistake where the documentation states that Safari doesn't support the `world` property for `browser.scripting.RegisteredContentScripts`, when it added support in Safari 16.4.
