### PR TITLE
Update compat data for SVG <cursor>

### DIFF
--- a/api/SVGCursorElement.json
+++ b/api/SVGCursorElement.json
@@ -22,11 +22,10 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "3"
+            "version_added": "3",
+            "version_removed": "16.4"
           },
-          "safari_ios": {
-            "version_added": "1"
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "≤37",

--- a/svg/elements/cursor.json
+++ b/svg/elements/cursor.json
@@ -7,7 +7,8 @@
           "spec_url": "https://www.w3.org/TR/SVG11/interact.html#CursorElement",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "57"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -16,18 +17,20 @@
             },
             "firefox_android": "mirror",
             "ie": {
-              "version_added": null
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "16.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
-              "version_added": "4"
+              "version_added": "≤37",
+              "version_removed": "57"
             }
           },
           "status": {
@@ -40,7 +43,8 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "50"
+                "version_added": "1",
+                "version_removed": "57"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -49,17 +53,21 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "12.1"
+                "version_added": "3",
+                "version_removed": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤37",
+                "version_removed": "57"
+              }
             },
             "status": {
               "experimental": false,
@@ -72,7 +80,8 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "57"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -81,21 +90,21 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
-                "version_added": "3"
+                "version_added": "3",
+                "version_removed": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤37",
+                "version_removed": "57"
+              }
             },
             "status": {
               "experimental": false,
@@ -109,7 +118,8 @@
             "description": "<code>xlink:href</code>",
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "57"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -118,21 +128,21 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
-                "version_added": "3"
+                "version_added": "3",
+                "version_removed": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤37",
+                "version_removed": "57"
+              }
             },
             "status": {
               "experimental": false,
@@ -145,7 +155,8 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": "1",
+                "version_removed": "57"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -154,21 +165,21 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": null
+                "version_added": false
               },
               "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
+              "opera": "mirror",
+              "opera_android": "mirror",
               "safari": {
-                "version_added": "3"
+                "version_added": "3",
+                "version_removed": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
+              "webview_android": {
+                "version_added": "≤37",
+                "version_removed": "57"
+              }
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
Found by the Open Web Docs BCD collector v10.6.4.

The SVG cursor element is gone everywhere. The last removal was in Safari 16.4 which was released March 27, 2023. So not long enough ago to remove the feature altogether yet.