### PR TITLE
Update Firefox compat data for the ping attribute

### DIFF
--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -583,7 +583,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "partial_implementation": true,
+              "notes": "This property is exposed but has no effect if the <code>browser.send_pings</code> preference is not set to <code>true</code>. See <a href='https://bugzil.la/951104'>bug 951104</a>."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -467,7 +467,9 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "partial_implementation": true,
+              "notes": "This property is exposed but has no effect if the <code>browser.send_pings</code> preference is not set to <code>true</code>. See <a href='https://bugzil.la/951104'>bug 951104</a>."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -162,7 +162,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "61"
+              "version_added": "61",
+              "partial_implementation": true,
+              "notes": "This property is exposed but has no effect if the <code>browser.send_pings</code> preference is not set to <code>true</code>. See <a href='https://bugzil.la/951104'>bug 951104</a>."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -405,13 +405,8 @@
               },
               "firefox": {
                 "version_added": "1",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "browser.send_pings",
-                    "value_to_set": "true"
-                  }
-                ]
+                "partial_implementation": true,
+                "notes": "This property is exposed but has no effect if the <code>browser.send_pings</code> preference is not set to <code>true</code>. See <a href='https://bugzil.la/951104'>bug 951104</a>."
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -291,13 +291,8 @@
               },
               "firefox": {
                 "version_added": "1",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "browser.send_pings",
-                    "value_to_set": "true"
-                  }
-                ]
+                "partial_implementation": true,
+                "notes": "This property is exposed but has no effect if the <code>browser.send_pings</code> preference is not set to <code>true</code>. See <a href='https://bugzil.la/951104'>bug 951104</a>."
               },
               "firefox_android": "mirror",
               "ie": {

--- a/svg/elements/a.json
+++ b/svg/elements/a.json
@@ -151,13 +151,8 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "61",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "browser.send_pings",
-                    "value_to_set": "true"
-                  }
-                ]
+                "partial_implementation": true,
+                "notes": "This property is exposed but has no effect if the <code>browser.send_pings</code> preference is not set to <code>true</code>. See <a href='https://bugzil.la/951104'>bug 951104</a>."
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
Found by the Open Web Docs BCD collector v10.6.4.

The `ping` property is [exposed](https://searchfox.org/mozilla-central/source/dom/webidl/HTMLAnchorElement.webidl#24) but it has no effect. See https://bugzil.la/951104 which is about enabling this by default.