### PR TITLE
Safari supports <area> referrerpolicy attribute in version 14

### DIFF
--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -341,11 +341,9 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "11.1"
+                "version_added": "14"
               },
-              "safari_ios": {
-                "version_added": false
-              },
+              "safari_ios": "mirror",
               "samsunginternet_android": {
                 "version_added": "7.2"
               },


### PR DESCRIPTION
Found by the Open Web Docs BCD collector v10.6.4

See also referrerpolicy on other elements like https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#browser_compatibility which also have 14.