### PR TITLE
Fix(color.json): correct mdn_url for light-dark color function

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -664,7 +664,7 @@
         "light-dark": {
           "__compat": {
             "description": "<code>light-dark()</code>",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color/light-dark",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/color_value/light-dark",
             "spec_url": "https://drafts.csswg.org/css-color-5/#light-dark",
             "support": {
               "chrome": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Hi!
Fixed the broken mdn_url for the `light-dark` `<color>` function.
The correct url should be : [https://developer.mozilla.org/docs/Web/CSS/color_value/light-dark](https://developer.mozilla.org/docs/Web/CSS/color_value/light-dark)

#### Test results and supporting details
- Current: [https://developer.mozilla.org/en-US/docs/Web/CSS/color/light-dark](https://developer.mozilla.org/en-US/docs/Web/CSS/color/light-dark) leads to a 404 page.
- Corrected: [https://developer.mozilla.org/docs/Web/CSS/color_value/light-dark](https://developer.mozilla.org/docs/Web/CSS/color_value/light-dark) leads to the correct page.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
