### PR TITLE
Add @scope implementation in Safari

### DIFF
--- a/css/at-rules/scope.json
+++ b/css/at-rules/scope.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview",
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/at-rules/scope.json
+++ b/css/at-rules/scope.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview",
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Adds `@scope` implementation in Safari TP.

#### Test results and supporting details

- [Activate the CSS @scope feature in stable](https://github.com/WebKit/WebKit/pull/21435)
- [Release Notes for Safari Technology Preview 185](https://www.webkit.org/blog/14885/release-notes-for-safari-technology-preview-185/)