### PR TITLE
Update white-space-collapse.json to `preview` in safari

### DIFF
--- a/css/properties/white-space-collapse.json
+++ b/css/properties/white-space-collapse.json
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview",
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/white-space-collapse.json
+++ b/css/properties/white-space-collapse.json
@@ -24,7 +24,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview",
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
I am updating the safari version to `preview`, because it was added in STP 182. I also tested in STP and according to the web inspector, it is supported.
https://developer.apple.com/documentation/safari-technology-preview-release-notes/stp-release-182

Here is the link to the implementation:
https://github.com/WebKit/WebKit/commit/30f3214ab2d13ea5977cdba2f97ea230a4d5d5d9

I also checked the layout tests in WPT, they pass:
https://wpt.fyi/results/css/css-text/white-space/white-space-collapse-000.html?label=master&label=experimental&aligned https://wpt.fyi/results/css/css-text/white-space/white-space-collapse-001.html?label=master&label=experimental&aligned