### PR TITLE
Update overflow-anchor.json to `preview` in safari

### DIFF
--- a/css/properties/overflow-anchor.json
+++ b/css/properties/overflow-anchor.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": preview
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/overflow-anchor.json
+++ b/css/properties/overflow-anchor.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": preview
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
`overflow-anchor` is supported in STP 185. I also tested this in the web inspector of STP: 

Release:
https://developer.apple.com/documentation/safari-technology-preview-release-notes/stp-release-185

Commit:
https://github.com/WebKit/WebKit/commit/b19a8ecd83e6c20215a86dc28725fc62fd9ca976