### PR TITLE
Mark ::backdrop as supported in fullscreen since Safari 16.4

### DIFF
--- a/css/selectors/backdrop.json
+++ b/css/selectors/backdrop.json
@@ -112,7 +112,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This was determined via WebKit source history:
https://github.com/WebKit/WebKit/commit/c96dd4f574c01a761f875ce4222725c44693f2b1 https://github.com/WebKit/WebKit/blob/c96dd4f574c01a761f875ce4222725c44693f2b1/Configurations/Version.xcconfig

The Safari 16.4 release notes lend further support, as they say "Added support for the unprefixed Fullscreen API on macOS and iPadOS": https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes