### PR TITLE
Update HTMLInputElement.json safari adds support for `<input type="time">`

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2320,7 +2320,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "14.1"
+                "version_added": "16"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2320,7 +2320,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
+                "version_added": "14.1"
                 "impl_url": "https://webkit.org/b/234009"
               },
               "safari_ios": "mirror",

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2320,7 +2320,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "14.1"
+                "version_added": "14.1",
                 "impl_url": "https://webkit.org/b/234009"
               },
               "safari_ios": "mirror",

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2320,8 +2320,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "14.1",
-                "impl_url": "https://webkit.org/b/234009"
+                "version_added": "14.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
`<input type="time">` implemented in Safari 16. I updated the safari version to 16 and deleted the url.

release note:
https://developer.apple.com/documentation/safari-release-notes/safari-16-release-notes

commits:
https://github.com/WebKit/WebKit/commit/87edc399776c6661db62cc09c50e3aca274af941
https://github.com/WebKit/WebKit/commit/dddc5bb328a4b8636946a735281b09101f1d3161

WPT tests pass in safari 17.2.1 in the live browser:
https://wpt.fyi/results/html/semantics/forms/the-input-element/time.html?label=master&label=experimental&aligned&q=time
https://wpt.fyi/results/html/semantics/forms/the-input-element/time-2.html?label=master&label=experimental&aligned&q=time