### PR TITLE
FF122 HTMLVideoElement.disablePictureInPicture is now in WebIDL

### DIFF
--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -92,8 +92,8 @@
               "version_added": "116",
               "partial_implementation": true,
               "notes": [
-                "The property is undefined, but still has an effect if set to a value.",
-                "When this property is set to <code>true</code>, the overlay button to disable picture-in-picture (PiP) is hidden, but the user can still enable PiP."
+                "When this property is set to <code>true</code>, the overlay button to disable picture-in-picture (PiP) is hidden, but the user can still enable PiP.",
+                "Before version 122 the property is undefined, but still has an effect if set to a value."
               ]
             },
             "firefox_android": "mirror",


### PR DESCRIPTION
The `disablePictureInPicture` was not in WebIDL in FF116 so it basically worked, but wasn't detectable in the bcd collector or detectable to users. The "fix" was to add a note. 

In FF122 https://bugzilla.mozilla.org/show_bug.cgi?id=1863583 adds it to IDL. This updates the note to specify the version at which the problem ends. We could even remove the note altogether as it won't matter in several releases. Up to you.