### PR TITLE
FF122 Screen WakeLock API in Nightly

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4847,7 +4847,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/WakeLock.json
+++ b/api/WakeLock.json
@@ -11,7 +11,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -44,7 +44,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/WakeLockSentinel.json
+++ b/api/WakeLockSentinel.json
@@ -11,7 +11,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -44,7 +44,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -79,7 +79,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -113,7 +113,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -147,7 +147,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF122 adds support for the [Screen Wake Lock API](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API) in https://bugzilla.mozilla.org/show_bug.cgi?id=1589554 in Nightly. This adds the preview to the API features/subfeatures.

Related docs work can be tracked in https://github.com/mdn/content/issues/31112 