### PR TITLE
FF122 Intl.Segmenter supported in Nightly

### DIFF
--- a/javascript/builtins/Intl/Segmenter.json
+++ b/javascript/builtins/Intl/Segmenter.json
@@ -16,7 +16,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -56,7 +56,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "preview"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -96,7 +96,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "preview"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -136,7 +136,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "preview"
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -176,7 +176,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "preview"
                 },
                 "firefox_android": "mirror",
                 "ie": {


### PR DESCRIPTION
FF122 supports the [Intl/Segmenter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter) in nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=1423593.

The APIs all appear to show up correctly in BCD collector too. This just sets the version as preview.

Related docs work can be tracked in https://github.com/mdn/content/issues/31098