### PR TITLE
Update grammar-error.json to `preview` in Safari

### DIFF
--- a/css/selectors/grammar-error.json
+++ b/css/selectors/grammar-error.json
@@ -23,7 +23,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://webkit.org/b/175784"
             },
             "safari_ios": "mirror",

--- a/css/selectors/grammar-error.json
+++ b/css/selectors/grammar-error.json
@@ -23,8 +23,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview",
-              "impl_url": "https://webkit.org/b/175784"
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
As of STP 185 supports `::grammar-error`. I updated safari to `preview`.

the release notes:
https://developer.apple.com/documentation/safari-technology-preview-release-notes/stp-release-185

the commits:
https://github.com/WebKit/WebKit/commit/bdc9c3cf0a54ccd3e90bfae34b7e5ffbb22874cd https://github.com/WebKit/WebKit/pull/21340/commits/dea7937dec2bc7d25ea94641cb60bdf586f6526e