### PR TITLE
FF122 ArrayBuffer.transfer() et al

### DIFF
--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -248,14 +248,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.arraybuffer_transfer",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "122"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -275,7 +268,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -506,14 +499,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.arraybuffer_transfer",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "122"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -533,7 +519,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -553,14 +539,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.arraybuffer_transfer",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "122"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -580,7 +559,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
FF122 ships support for [`ArrayBuffer.prototype.transfer()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transfer), [`ArrayBuffer.prototype.transferToFixedLength()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transferToFixedLength),[`ArrayBuffer.prototype.detached`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/detached) in https://bugzilla.mozilla.org/show_bug.cgi?id=1865103

This adds a the version and changes the APIs to experimental "false"

Related docs work can be tracked in https://github.com/mdn/content/issues/31101