### PR TITLE
Ff122 Element.checkVisibily options

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2970,6 +2970,142 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "options_checkOpacity_parameter": {
+          "__compat": {
+            "description": "<code>options.checkOpacity</code> parameter is supported",
+            "spec_url": "https://drafts.csswg.org/cssom-view-1/#dictdef-checkvisibilityoptions",
+            "support": {
+              "chrome": {
+                "version_added": "105"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "106"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "options_checkVisibilityCSS_parameter": {
+          "__compat": {
+            "description": "<code>options.checkVisibilityCSS</code> parameter is supported",
+            "spec_url": "https://drafts.csswg.org/cssom-view-1/#dictdef-checkvisibilityoptions",
+            "support": {
+              "chrome": {
+                "version_added": "105"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "106"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "options_contentVisibilityAuto_parameter": {
+          "__compat": {
+            "description": "<code>options.contentVisibilityAuto</code> parameter is supported",
+            "spec_url": "https://drafts.csswg.org/cssom-view-1/#dictdef-checkvisibilityoptions",
+            "support": {
+              "chrome": {
+                "version_added": "121"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "preview"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "options_visibilityProperty_parameter": {
+          "__compat": {
+            "description": "<code>options.visibilityProperty</code> parameter is supported",
+            "spec_url": "https://drafts.csswg.org/cssom-view-1/#dictdef-checkvisibilityoptions",
+            "support": {
+              "chrome": {
+                "version_added": "121"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "preview"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "childElementCount": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -2941,6 +2941,7 @@
       },
       "checkVisibility": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/checkVisibility",
           "spec_url": "https://drafts.csswg.org/cssom-view-1/#dom-element-checkvisibility",
           "support": {
             "chrome": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -2974,7 +2974,7 @@
         },
         "options_checkOpacity_parameter": {
           "__compat": {
-            "description": "<code>options.checkOpacity</code> parameter is supported",
+            "description": "<code>options.checkOpacity</code> parameter",
             "spec_url": "https://drafts.csswg.org/cssom-view-1/#dictdef-checkvisibilityoptions",
             "support": {
               "chrome": {
@@ -3008,7 +3008,7 @@
         },
         "options_checkVisibilityCSS_parameter": {
           "__compat": {
-            "description": "<code>options.checkVisibilityCSS</code> parameter is supported",
+            "description": "<code>options.checkVisibilityCSS</code> parameter",
             "spec_url": "https://drafts.csswg.org/cssom-view-1/#dictdef-checkvisibilityoptions",
             "support": {
               "chrome": {
@@ -3042,7 +3042,7 @@
         },
         "options_contentVisibilityAuto_parameter": {
           "__compat": {
-            "description": "<code>options.contentVisibilityAuto</code> parameter is supported",
+            "description": "<code>options.contentVisibilityAuto</code> parameter",
             "spec_url": "https://drafts.csswg.org/cssom-view-1/#dictdef-checkvisibilityoptions",
             "support": {
               "chrome": {
@@ -3076,7 +3076,7 @@
         },
         "options_visibilityProperty_parameter": {
           "__compat": {
-            "description": "<code>options.visibilityProperty</code> parameter is supported",
+            "description": "<code>options.visibilityProperty</code> parameter",
             "spec_url": "https://drafts.csswg.org/cssom-view-1/#dictdef-checkvisibilityoptions",
             "support": {
               "chrome": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -2960,7 +2960,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2993,7 +2993,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -3027,7 +3027,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -3061,7 +3061,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -3095,7 +3095,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
`Element.checkVisibility` has an `options` object parameter. In the spec this has two options, `checkOpacity` and `checkVisibilityCSS`, both of which are implemented AFAIK in Chrome (105) and Firefox (106) on first release of the method.

The spec has an unmerged PR [csswg-drafts#9549](https://github.com/w3c/csswg-drafts/pull/9549) to add three more options.
- `opacityProperty` and `visibilityProperty` are aliases for the original names with a new naming convention. The old names are not yet "deprecated" in the spec.
- `contentVisibilityAuto` allows you to check if an element is being skipped for layout because it is not in the view.

Even though the spec change hasn't merged, Chrome has implemented the [change in 121](https://groups.google.com/a/chromium.org/g/blink-dev/c/ruNqbP3wDSY/m/JZUK92gsAwAJ) and Firefox has implemented it in nightly in FF122 (https://bugzilla.mozilla.org/show_bug.cgi?id=1859852).

- This adds all the options as subfeatures. For FF the new options are marked as preview. For Chrome as 121. 
- The new options are marked as experimental because FF is still in nightly
- The new options are marked as `standard` even though the spec change has not merged. You might argue that.
- The old options are included because at some point they are going to be deprecated. TO me it makes sense to include them here so that when it is time to remove them that becomes easy. 

Note that it is not entirely clear that the new options are preview in the web IDL, however you really can't test `contentVisibilityAuto` except in preview because the associated CSS is nightly only.
My gut feeling is that all the options are actually "released", because I think the result of `checkVisibility()` is correct whether or not you are in preview (because it defaults false, and the feature isn't enabled results in false). I'm asking on the issue, but would appreciate your opinion - in which case we'd set FF release on these to 122?

Other docs work for this can be tracked in https://github.com/mdn/content/issues/31107

@Elchi3 @queengooborg If you are around and able, review appreciated. Mostly because I'm around on and off over January.