### PR TITLE
Add screen-wake-lock tag; Firefox preview for Permission Policy

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4840,6 +4840,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/wakeLock",
           "spec_url": "https://w3c.github.io/screen-wake-lock/#extensions-to-the-navigator-interface",
+          "tags": [
+            "web-features:screen-wake-lock"
+          ],
           "support": {
             "chrome": {
               "version_added": "84"

--- a/api/WakeLock.json
+++ b/api/WakeLock.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WakeLock",
         "spec_url": "https://w3c.github.io/screen-wake-lock/#the-wakelock-interface",
+        "tags": [
+          "web-features:screen-wake-lock"
+        ],
         "support": {
           "chrome": {
             "version_added": "84"
@@ -37,6 +40,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WakeLock/request",
           "spec_url": "https://w3c.github.io/screen-wake-lock/#the-request-method",
+          "tags": [
+            "web-features:screen-wake-lock"
+          ],
           "support": {
             "chrome": {
               "version_added": "84"

--- a/api/WakeLockSentinel.json
+++ b/api/WakeLockSentinel.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WakeLockSentinel",
         "spec_url": "https://w3c.github.io/screen-wake-lock/#the-wakelocksentinel-interface",
+        "tags": [
+          "web-features:screen-wake-lock"
+        ],
         "support": {
           "chrome": {
             "version_added": "84"
@@ -37,6 +40,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WakeLockSentinel/release",
           "spec_url": "https://w3c.github.io/screen-wake-lock/#the-release-method",
+          "tags": [
+            "web-features:screen-wake-lock"
+          ],
           "support": {
             "chrome": {
               "version_added": "84"
@@ -72,6 +78,9 @@
           "description": "<code>release</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WakeLockSentinel/release_event",
           "spec_url": "https://w3c.github.io/screen-wake-lock/#the-onrelease-attribute",
+          "tags": [
+            "web-features:screen-wake-lock"
+          ],
           "support": {
             "chrome": {
               "version_added": "84"
@@ -106,6 +115,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WakeLockSentinel/released",
           "spec_url": "https://w3c.github.io/screen-wake-lock/#dom-wakelocksentinel-released",
+          "tags": [
+            "web-features:screen-wake-lock"
+          ],
           "support": {
             "chrome": {
               "version_added": "87"
@@ -140,6 +152,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WakeLockSentinel/type",
           "spec_url": "https://w3c.github.io/screen-wake-lock/#the-type-attribute",
+          "tags": [
+            "web-features:screen-wake-lock"
+          ],
           "support": {
             "chrome": {
               "version_added": "84"

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -1233,6 +1233,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/screen-wake-lock",
             "spec_url": "https://w3c.github.io/screen-wake-lock/#policy-control",
+            "tags": [
+              "web-features:screen-wake-lock"
+            ],
             "support": {
               "chrome": [
                 {
@@ -1246,7 +1249,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
Follow-up to https://github.com/mdn/browser-compat-data/pull/21710 in which we forgot the Permissions-Policy.
Introducing a group so we will not forget again :)