### PR TITLE
Add Login Status API and related FedCM additions

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -553,6 +553,39 @@
               }
             }
           },
+          "error_api": {
+            "__compat": {
+              "description": "Error API",
+              "support": {
+                "chrome": {
+                  "version_added": "120"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": false,
+                "deprecated": false
+              }
+            }
+          },
           "loginHint": {
             "__compat": {
               "description": "<code>identity.providers.loginHint</code>",

--- a/api/IdentityCredential.json
+++ b/api/IdentityCredential.json
@@ -33,6 +33,39 @@
           "deprecated": false
         }
       },
+      "isAutoSelected": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdentityCredential/isAutoSelected",
+          "support": {
+            "chrome": {
+              "version_added": "120"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "token": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdentityCredential/token",

--- a/api/IdentityProvider.json
+++ b/api/IdentityProvider.json
@@ -36,6 +36,7 @@
       "close_static": {
         "__compat": {
           "description": "<code>close()</code> static method",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdentityProvider/close_static",
           "spec_url": "https://fedidcg.github.io/FedCM/#dom-identityprovider-close",
           "support": {
             "chrome": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1875,6 +1875,7 @@
       },
       "login": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/login",
           "spec_url": "https://fedidcg.github.io/FedCM/#dom-navigator-login",
           "support": {
             "chrome": {

--- a/api/NavigatorLogin.json
+++ b/api/NavigatorLogin.json
@@ -2,6 +2,7 @@
   "api": {
     "NavigatorLogin": {
       "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorLogin",
         "spec_url": "https://fedidcg.github.io/FedCM/#navigatorlogin",
         "support": {
           "chrome": {
@@ -34,6 +35,7 @@
       },
       "setStatus": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NavigatorLogin/setStatus",
           "spec_url": "https://fedidcg.github.io/FedCM/#dom-navigatorlogin-setstatus",
           "support": {
             "chrome": {

--- a/http/headers/Set-Login.json
+++ b/http/headers/Set-Login.json
@@ -1,0 +1,40 @@
+{
+  "http": {
+    "headers": {
+      "Set-Login": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Login",
+          "spec_url": "https://fedidcg.github.io/FedCM/#login-status-http",
+          "support": {
+            "chrome": {
+              "version_added": "120"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 120 adds several new additions related to the [FedCM API](https://developer.mozilla.org/en-US/docs/Web/API/FedCM_API). This PR adds/completes data for those additions.

Specifically, it adds/modifies:

- The Login Status API (https://chromestatus.com/feature/5177628008382464):
  - `Navigator.login`
  - `NavigatorStatus.setStatus()`
  - The `Set-Login` HTTP header
- Related features added at the same time (https://chromestatus.com/feature/5384360374566912):
  - The Error API, which mainly manifests as useful properties of the return error object when a FedCM `get()` call rejects.
  - The Auto-Selected Flag, which mainly manifests as the `IdentityCredential.isAutoSelected` property.
- `IdentityProvider.close()`, which is not part of the above ChromeStatuses, but is related and not documented, so I decided to deal with it as part of this workstream.

See my [research document](https://docs.google.com/document/d/1znCl0Ry8T1qi7rZbhKVxQDzKhfUfy7EN1Ad8JnslMnc/edit) for more details about these additions.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
