### PR TITLE
Update AbortSignal.json Safari to `"preview"` for `any`

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -250,7 +250,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
STP 184 added support for `AbortSignal.any()`

Release note:
https://developer.apple.com/documentation/safari-technology-preview-release-notes/stp-release-184

Commits:
https://github.com/WebKit/WebKit/pull/13940/files
https://github.com/WebKit/WebKit/commit/fbea645d50ed3428db7cc9a692f1898107d1666c