### PR TITLE
Update ArrayBuffer.json Safari to `"preview"` for `detached`, `transfer`, and `transferToFixedLength`

### DIFF
--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -512,7 +512,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview",
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -261,7 +261,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -512,7 +512,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview",
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -552,7 +552,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
STP 184 added support for `ArrayBuffer.prototype.detached`, `ArrayBuffer.prototype.transfer`, and `ArrayBuffer.prototype.transferToFixedLength`

Release note:
https://developer.apple.com/documentation/safari-technology-preview-release-notes/stp-release-184

Commits:
https://github.com/WebKit/WebKit/commit/cbdbb78e64fdc212c8e2ed5d85003568f839783a https://github.com/WebKit/WebKit/commit/fe0aa79252484e5da584cf525ccc930e7698deef https://github.com/WebKit/WebKit/commit/1007b7a34ee9ad34c10f8032d13663567e7bdf4e