### PR TITLE
Update Element.json Safari to `"preview"` for `checkVisibility`

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2959,7 +2959,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
STP 184 supports `Element.checkvisibility()`. I updated Safari to `"preview"`.

Release note:
https://developer.apple.com/documentation/safari-technology-preview-release-notes/stp-release-184

Commits:
https://github.com/WebKit/WebKit/commit/a884b8e751c17ed1dd2e61b0cae011581c6110b8 https://github.com/WebKit/WebKit/pull/20043/files
https://github.com/WebKit/WebKit/pull/19321/files