### PR TITLE
Update basic-shape.json in Safari to `17.2` and `"experimental"` to `false` in `rect()`

### DIFF
--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -486,7 +486,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "17.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -486,7 +486,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -493,7 +493,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
Safari 17.2  adds support for `rect()`, I updated Safari to `17.2`and `experimental` to false.

release note:
https://developer.apple.com/documentation/safari-release-notes/safari-17_2-release-notes

commit:
https://github.com/WebKit/WebKit/commit/60c71caf6ae8f78fcf776c5441ebdcd14f8cc5bf

blobs:
https://github.com/WebKit/WebKit/blob/92e26bad7aef126178d279d5fd326ef7bec9852b/Source/WebCore/css/Rect.h#L23
https://github.com/WebKit/WebKit/blob/92e26bad7aef126178d279d5fd326ef7bec9852b/Source/WebCore/css/RectBase.h

passes the WPT subtests in live browser in Safari 17.2.1:
https://wpt.fyi/results/css/css-contain/content-visibility/content-visibility-svg-rect.html?label=master&label=experimental&aligned&q=%2Fcss%2Fcss-contain%2Fcontent-visibility%2Fcontent-visibility-svg-rect.html