### PR TITLE
Update content-visibility.json to `"preview"` in Safari for `content-visibility` and `@keyframe animation`

### DIFF
--- a/css/properties/content-visibility.json
+++ b/css/properties/content-visibility.json
@@ -37,7 +37,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -70,7 +70,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
STP 181 added support for `content-visibility` and `@keyframe animation. I updated Safari to `"preview"` for each.

Release note:
https://developer.apple.com/documentation/safari-technology-preview-release-notes/stp-release-181

Commits:
https://github.com/WebKit/WebKit/commit/fb9399777d6383007caed6983f544373fc55021b https://github.com/WebKit/WebKit/commit/6fb45947f4f465d513debb81ecbf1e95a519b60d

The WPT tests pass for content-visibility:
https://wpt.fyi/results/css/css-contain/content-visibility/animation-display-lock.html?label=experimental&label=master&aligned
https://wpt.fyi/results/css/css-contain/content-visibility/content-visibility-001.html?label=master&label=experimental&aligned
https://wpt.fyi/results/css/css-contain/content-visibility/content-visibility-002.html?label=experimental&label=master&aligned
https://wpt.fyi/results/css/css-contain/content-visibility/content-visibility-003.html?label=experimental&label=master&aligned