### PR TITLE
Update Promise.json `withResolvers` to `"preview"` in Safari

### DIFF
--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -538,7 +538,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
STP 181 added support for `Promise.withResolvers()`, I updated Safari to `"preview"`.

release note:
https://developer.apple.com/documentation/safari-technology-preview-release-notes/stp-release-181

commits:
https://github.com/WebKit/WebKit/commit/781be0233d6a2333b4673f44b5fbfa9878bfc8ce https://github.com/WebKit/WebKit/pull/15790/files
https://github.com/WebKit/WebKit/pull/15808/files

passes the WPT test:
https://wpt.fyi/results/fullscreen/api/promises-resolve.html?label=experimental&label=master&aligned