### PR TITLE
Update basic-shape.json update Safari to "17.2"  for `rect` and `xywh`

### DIFF
--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -486,14 +486,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -530,14 +530,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
Safari version 17.2 added support for `rect` and `xywh`, updating `experimental` to `false`.

Release note:
https://developer.apple.com/documentation/safari-release-notes/safari-17_2-release-notes

Commits:
https://github.com/WebKit/WebKit/commit/6dd9b4ce08d7fc1933952dfd57de080a21882127 https://github.com/WebKit/WebKit/commit/534a722e7081523b73c20634c2932ab927c499a9

WPT tests that are passing:
https://wpt.fyi/results/css/css-masking/clip-path/clip-path-xywh-001.html?label=master&label=experimental&aligned&q=%2Fcss%2Fcss-masking%2Fclip-path%2Fclip-path-xywh-001.html
https://wpt.fyi/results/css/css-masking/clip-path/clip-path-xywh-002.html?label=master&label=experimental&aligned&q=%2Fcss%2Fcss-masking%2Fclip-path%2Fclip-path-xywh-002.html
https://wpt.fyi/results/css/css-masking/clip-path/clip-path-xywh-003.html?label=master&label=experimental&aligned&q=%2Fcss%2Fcss-masking%2Fclip-path%2Fclip-path-xywh-003.html
https://wpt.fyi/results/css/css-masking/clip-path/clip-path-xywh-003.html?label=master&label=experimental&aligned&q=%2Fcss%2Fcss-masking%2Fclip-path%2Fclip-path-xywh-004.html
https://wpt.fyi/results/css/css-masking/clip-path/animations/clip-path-xywh-interpolation-001.html?label=experimental&label=master&aligned

WPT test pass including `rect` and `xywh` subtests and fails all of the `inset` subtests :
https://wpt.fyi/results/css/css-masking/animations/clip-path-interpolation-xywh-rect.html?label=experimental&label=master&aligned