### PR TITLE
add the `partitioned` option BCD data in `CookieChangeEvent` and `ExtendableCookieChangeEvent`

### DIFF
--- a/api/CookieChangeEvent.json
+++ b/api/CookieChangeEvent.json
@@ -100,6 +100,40 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "partitioned_property": {
+          "__compat": {
+            "description": "<code>partitioned</code> property",
+            "spec_url": "https://wicg.github.io/cookie-store/#dom-cookielistitem-partitioned",
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "deleted": {
@@ -133,6 +167,40 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "partitioned_property": {
+          "__compat": {
+            "description": "<code>partitioned</code> property",
+            "spec_url": "https://wicg.github.io/cookie-store/#dom-cookielistitem-partitioned",
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/api/ExtendableCookieChangeEvent.json
+++ b/api/ExtendableCookieChangeEvent.json
@@ -100,6 +100,40 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "partitioned_property": {
+          "__compat": {
+            "description": "<code>partitioned</code> property",
+            "spec_url": "https://wicg.github.io/cookie-store/#dom-cookielistitem-partitioned",
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "deleted": {
@@ -133,6 +167,40 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "partitioned_property": {
+          "__compat": {
+            "description": "<code>partitioned</code> property",
+            "spec_url": "https://wicg.github.io/cookie-store/#dom-cookielistitem-partitioned",
+            "support": {
+              "chrome": {
+                "version_added": "114"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the PR ues the same data from `CookieStore` interface

see https://github.com/mdn/content/pull/23495 and https://github.com/mdn/browser-compat-data/pull/18591, where the `partitioned` option was added to `CookieStore` interface, but forget to add the option to the two event types

reference to https://github.com/mdn/content/pull/31272 and https://github.com/mdn/content/pull/31273 and the spec https://wicg.github.io/cookie-store/

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
