### PR TITLE
add spec-url for `MerchantValidationEvent`

### DIFF
--- a/api/MerchantValidationEvent.json
+++ b/api/MerchantValidationEvent.json
@@ -3,6 +3,7 @@
     "MerchantValidationEvent": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MerchantValidationEvent",
+        "spec_url": "https://w3c.github.io/merchant-validation/#dom-merchantvalidationevent",
         "support": {
           "chrome": {
             "version_added": false
@@ -44,6 +45,7 @@
         "__compat": {
           "description": "<code>MerchantValidationEvent()</code> constructor",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MerchantValidationEvent/MerchantValidationEvent",
+          "spec_url": "https://w3c.github.io/merchant-validation/#dom-merchantvalidationevent-constructor",
           "support": {
             "chrome": {
               "version_added": false
@@ -86,6 +88,7 @@
         "__compat": {
           "description": "<code>complete()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MerchantValidationEvent/complete",
+          "spec_url": "https://w3c.github.io/merchant-validation/#dom-merchantvalidationevent-complete",
           "support": {
             "chrome": {
               "version_added": false
@@ -127,6 +130,7 @@
       "methodName": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MerchantValidationEvent/methodName",
+          "spec_url": "https://w3c.github.io/merchant-validation/#dom-merchantvalidationevent-methodname",
           "support": {
             "chrome": {
               "version_added": false
@@ -168,6 +172,7 @@
       "validationURL": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MerchantValidationEvent/validationURL",
+          "spec_url": "https://w3c.github.io/merchant-validation/#dom-merchantvalidationevent-validationurl",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/MerchantValidationEvent.json
+++ b/api/MerchantValidationEvent.json
@@ -3,6 +3,7 @@
     "MerchantValidationEvent": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MerchantValidationEvent",
+        "spec_url": "https://w3c.github.io/merchant-validation/#dom-merchantvalidationevent",
         "support": {
           "chrome": {
             "version_added": false

--- a/api/MerchantValidationEvent.json
+++ b/api/MerchantValidationEvent.json
@@ -3,7 +3,6 @@
     "MerchantValidationEvent": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/MerchantValidationEvent",
-        "spec_url": "https://w3c.github.io/merchant-validation/#dom-merchantvalidationevent",
         "support": {
           "chrome": {
             "version_added": false

--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -294,6 +294,7 @@
         "__compat": {
           "description": "<code>merchantvalidation</code> event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PaymentRequest/merchantvalidation_event",
+          "spec_url": ["https://w3c.github.io/merchant-validation/#dom-paymentrequest-onmerchantvalidation", "https://w3c.github.io/merchant-validation/#dfn-merchantvalidation"],
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the spec is at https://w3c.github.io/merchant-validation/, which is deprecated but not remove from standard

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
