### PR TITLE
mark `PaymentManager.instruments` as non-standard

### DIFF
--- a/api/PaymentManager.json
+++ b/api/PaymentManager.json
@@ -72,7 +72,6 @@
       },
       "instruments": {
         "__compat": {
-          "spec_url": "https://w3c.github.io/payment-handler/#dom-paymentmanager-instruments",
           "support": {
             "chrome": {
               "version_added": "70",
@@ -101,7 +100,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

`PaymentManager.instruments` has been removed from [spec](https://w3c.github.io/payment-handler/) in https://github.com/w3c/payment-handler/pull/409

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
