### PR TITLE
add spec_url for `SharedStorageWorkletGlobalScope.sharedStorage`

### DIFF
--- a/api/SharedStorageWorkletGlobalScope.json
+++ b/api/SharedStorageWorkletGlobalScope.json
@@ -70,6 +70,7 @@
       "sharedStorage": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedStorageWorkletGlobalScope/sharedStorage",
+          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorageworkletglobalscope-sharedstorage",
           "support": {
             "chrome": {
               "version_added": "117"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the `spec_url` of `SharedStorageWorkletGlobalScope.sharedStorage` seems to forget to add

see https://wicg.github.io/shared-storage/#dom-sharedstorageworkletglobalscope-sharedstorage

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
