### PR TITLE
Remove description for `ReadableStream[@@asyncIterator]`

### DIFF
--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -454,7 +454,6 @@
       },
       "@@asyncIterator": {
         "__compat": {
-          "description": "Async iterable (supports iteration using <a href='https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/for-await...of'><code>for await ... of</code></a>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator",
           "spec_url": "https://streams.spec.whatwg.org/#rs-asynciterator",
           "support": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

normally `@@asyncIterator` or `@@iterator` will not add a special `description` key (and the link in `description` key because the `mdn_url` is specified)

see also https://github.com/mdn/browser-compat-data/issues/6367

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
