### PR TITLE
Update Firefox data for api.HTMLVideoElement.disablePictureInPicture

### DIFF
--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -88,14 +88,17 @@
               "version_added": "105"
             },
             "edge": "mirror",
-            "firefox": {
-              "version_added": "116",
-              "partial_implementation": true,
-              "notes": [
-                "When this property is set to <code>true</code>, the overlay button to disable picture-in-picture (PiP) is hidden, but the user can still enable PiP.",
-                "Before version 122 the property is undefined, but still has an effect if set to a value."
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "122"
+              },
+              {
+                "version_added": "116",
+                "version_removed": "122",
+                "partial_implementation": true,
+                "notes": "When this property is set to <code>true</code>, the overlay button to disable picture-in-picture (PiP) is hidden, but the user can still enable PiP."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `disablePictureInPicture` member of the `HTMLVideoElement` API. This fixes the data to adhere to the proper schema.
