### PR TITLE
Add mdn_url for CustomElementRegistry built-in element support

### DIFF
--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -39,7 +39,7 @@
       "builtin_element_support": {
         "__compat": {
           "description": "Customized built-in element support",
-          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#defining_a_customized_built-in_element",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomElementRegistry/define#defining_a_customized_built-in_element",
           "tags": [
             "web-features:custom-elements"
           ],

--- a/api/CustomElementRegistry.json
+++ b/api/CustomElementRegistry.json
@@ -39,6 +39,7 @@
       "builtin_element_support": {
         "__compat": {
           "description": "Customized built-in element support",
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#defining_a_customized_built-in_element",
           "tags": [
             "web-features:custom-elements"
           ],


### PR DESCRIPTION
This adds an MDN URL for the built-in element support subfeature of the CustomElementRegistry API.  This will help explain what it means, as there is no explanation on the MDN page for `CustomElementRegistry` itself (only in the `define` method).
