### PR TITLE
Remove api.WebGLRenderingContext.canvas.OffscreenCanvas from BCD

### DIFF
--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -936,38 +936,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "OffscreenCanvas": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "105"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "checkFramebufferStatus": {

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -812,38 +812,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "OffscreenCanvas": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "69"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "105"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "checkFramebufferStatus": {


### PR DESCRIPTION
This PR removes the `canvas.OffscreenCanvas` member of the `WebGLRenderingContext` API from BCD. This feature seems redundant, and appears to be a mirror of the `OffscreenCanvas` data.

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/WebGLRenderingContext/canvas/OffscreenCanvas
