### PR TITLE
Remove api.MediaRecorder.warning_event from BCD

### DIFF
--- a/api/MediaRecorder.json
+++ b/api/MediaRecorder.json
@@ -807,43 +807,6 @@
             "deprecated": false
           }
         }
-      },
-      "warning_event": {
-        "__compat": {
-          "description": "<code>warning</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaRecorder/warning_event",
-          "support": {
-            "chrome": {
-              "version_added": "49"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "25",
-              "version_removed": "71"
-            },
-            "firefox_android": {
-              "version_added": "25"
-            },
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
This PR removes the `warning_event` member of the `MediaRecorder` API from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.4).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/MediaRecorder/warning_event
