### PR TITLE
Update Safari data for api.Window.orientationchange_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3564,7 +3564,7 @@
               "version_added": "≤14"
             },
             "safari": {
-              "version_added": "16.4"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "≤3"


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `orientationchange_event` member of the `Window` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Window/orientationchange_event

Additional Notes: This was previously updated from collector results, but I believe there was an issue with the results used; Safari on iPadOS reports itself as Desktop Safari.
