### PR TITLE
Update Chromium data for -webkit-mask-repeat-y CSS property

### DIFF
--- a/css/properties/-webkit-mask-repeat-y.json
+++ b/css/properties/-webkit-mask-repeat-y.json
@@ -6,7 +6,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-repeat-y",
           "support": {
             "chrome": {
-              "version_added": "3"
+              "version_added": "3",
+              "version_removed": "120"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `-webkit-mask-repeat-y` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/-webkit-mask-repeat-y
