### PR TITLE
Update Safari data for api.ServiceWorker.ecmascript_modules

### DIFF
--- a/api/ServiceWorker.json
+++ b/api/ServiceWorker.json
@@ -47,7 +47,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": false
+              "version_added": "114"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -57,14 +57,18 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "15",
+              "notes": [
+                "Nested workers support was introduced in Safari 15.5.",
+                "Script loading in nested workers was introduced in Safari 16.4."
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/ServiceWorker.json
+++ b/api/ServiceWorker.json
@@ -47,7 +47,7 @@
               "version_added": false
             },
             "firefox": {
-              "version_added": "114"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Safari for the `ecmascript_modules` member of the `ServiceWorker` API. This copies the support info from the Worker and SharedWorker APIs.

Test Code Used:

index.html
```html
<script type="module">
	const reg = await navigator.serviceWorker.register('./es-module-sw.js', { type: 'module' }).then(navigator.serviceWorker.ready);

	var messageChannel = new MessageChannel();

	/**
	* Handle the 'message' event from the message channel port.
	* @param {MessageEvent} event - The message event.
	*/
	messageChannel.port1.onmessage = (event) => {
		console.log(event.data);
	};

	reg.active.postMessage('foo', [messageChannel.port2]);
</script>
```

es-module-sw.js
```js
import { cacheName } from "./config.js";

self.addEventListener("install", (event) => {});

self.addEventListener("message", function (event) {
	event.ports[0].postMessage(cacheName);
});
```

config.js
```js
export const cacheName = "my-cache";
```