### PR TITLE
Add & fix spec_url for `href` attribute of SVG elements

### DIFF
--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -78,7 +78,7 @@
       },
       "href": {
         "__compat": {
-          "spec_url": "https://html.spec.whatwg.org/multipage/links.html#dom-hyperlink-href",
+          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGURIReference__href",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/api/SVGFilterElement.json
+++ b/api/SVGFilterElement.json
@@ -119,6 +119,7 @@
       },
       "href": {
         "__compat": {
+          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGURIReference__href",
           "support": {
             "chrome": {
               "version_added": "5"

--- a/api/SVGMPathElement.json
+++ b/api/SVGMPathElement.json
@@ -39,6 +39,7 @@
       },
       "href": {
         "__compat": {
+          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGURIReference__href",
           "support": {
             "chrome": {
               "version_added": "19"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

add & fix spec_url for `href` attribute of SVG elements

the `SVGAElement` `SVGFilterElement` `SVGMPathElement` both include the `SVGURIReference` mixin, which add `href` property to those interfaces

see https://svgwg.org/svg2-draft/types.htmltypes.html#InterfaceSVGURIReference and https://drafts.fxtf.org/filter-effects/#svgfilterelement https://svgwg.org/specs/animations/#InterfaceSVGMPathElement https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
