### PR TITLE
Update content-visibility.json Safari to `"preview"` for `content-visibility`

### DIFF
--- a/css/properties/content-visibility.json
+++ b/css/properties/content-visibility.json
@@ -37,7 +37,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
STP 181 added support for `content-visibility`. I updated Safari to `"preview"`.

Release Note:
https://developer.apple.com/documentation/safari-technology-preview-release-notes/stp-release-181

Commits:
WebKit/WebKit@fb93997
WebKit/WebKit@804d915
WebKit/WebKit@7a80f9c
WebKit/WebKit@eea0af3

Passes the WPT tests for `content-visibility`:
https://wpt.fyi/results/accessibility/crashtests?label=master&label=experimental&aligned&q=content-visibility https://wpt.fyi/results/html/semantics/embedded-content/the-embed-element?label=master&label=experimental&aligned&q=content-visibility https://wpt.fyi/results/css/css-contain/content-visibility?label=master&label=experimental&aligned&q=content-visibility
