### PR TITLE
Update HTMLCanvasElement.json Safari added support for `quality` in version 11

### DIFF
--- a/api/HTMLCanvasElement.json
+++ b/api/HTMLCanvasElement.json
@@ -1081,7 +1081,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "11"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
Update `quality` in Safari to "11".

I am addressing the following issue:
https://github.com/mdn/browser-compat-data/issues/21770

The commit which confirms implementation:
https://github.com/WebKit/WebKit/commit/d79600d2a2e805ab46022cfa1d550bc90067b01a