### PR TITLE
html.img: Remove phantom onerror deprecation

### DIFF
--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -553,7 +553,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": true
+              "deprecated": false
             }
           }
         },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR removes the deprecation annotation from the `onerror` attribute of the HTML `img` tag's browser compatibility data.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
* [mdn/sprints#4014](https://github.com/mdn/sprints/issues/4014) (including attempts to query @teoli2003, author of #388)
* [Stackoverflow discussion](https://stackoverflow.com/a/77278205/1204976)
* Changes made to update the `api.HtmlImageElement` reference regarding error-handling, in #4724

##### Original source of existing data

* #388


#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

#### Commit message body

The `onerror` attribute to the `img` element has been marked deprecated since the table data was introduced in 061483a. However, that deprecation was never sourced to any specs or references, and multiple inquiries since have failed to uncover any explanation for it. It appears to have been a simple error.
