### PR TITLE
fix spec_url of `WorkerNavigator.mediaCapabilities`

### DIFF
--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -496,7 +496,7 @@
       "mediaCapabilities": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerNavigator/mediaCapabilities",
-          "spec_url": "https://w3c.github.io/media-capabilities/#dom-navigator-mediacapabilities",
+          "spec_url": "https://w3c.github.io/media-capabilities/#dom-workernavigator-mediacapabilities",
           "support": {
             "chrome": {
               "version_added": "76"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the spec_url of `WorkerNavigator.mediaCapabilities` should link to the one of the `WorkerNavigator`, not the `Navigator`

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
