### PR TITLE
Fix typo in description (HTMLFieldSetElement)

### DIFF
--- a/api/HTMLFieldSetElement.json
+++ b/api/HTMLFieldSetElement.json
@@ -170,7 +170,7 @@
         },
         "type_HTMLCollection": {
           "__compat": {
-            "description": "Returns a <code>HTMLCollection</code>",
+            "description": "Returns an <code>HTMLCollection</code>",
             "support": {
               "chrome": {
                 "version_added": "57"


### PR DESCRIPTION
The _h_ is silent, so HTML starts with a vowel sound.