### PR TITLE
Update all browsers data for api.Element.focus*_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -4045,14 +4045,18 @@
           "spec_url": "https://w3c.github.io/uievents/#event-type-focusin",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "partial_implementation": true,
+              "notes": "The <code>onfocusin</code> event handler property is not supported. To listen to this event, use <code>element.addEventListener('focusin', () => {});</code>."
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "52"
+              "version_added": "52",
+              "partial_implementation": true,
+              "notes": "The <code>onfocusin</code> event handler property is not supported. To listen to this event, use <code>element.addEventListener('focusin', () => {});</code>."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4088,14 +4092,18 @@
           "spec_url": "https://w3c.github.io/uievents/#event-type-focusout",
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "partial_implementation": true,
+              "notes": "The <code>onfocusout</code> event handler property is not supported. To listen to this event, use <code>element.addEventListener('focusout', () => {});</code>."
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "52"
+              "version_added": "52",
+              "partial_implementation": true,
+              "notes": "The <code>onfocusout</code> event handler property is not supported. To listen to this event, use <code>element.addEventListener('focusout', () => {});</code>."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -4047,7 +4047,7 @@
             "chrome": {
               "version_added": "1",
               "partial_implementation": true,
-              "notes": "The <code>onfocusin</code> event handler property is not supported. To listen to this event, use <code>element.addEventListener('focusin', () => {});</code>."
+              "notes": "The <code>onfocusin</code> event handler property is not supported. To listen to this event, use <code>element.addEventListener('focusin', function() {});</code>."
             },
             "chrome_android": "mirror",
             "edge": {
@@ -4056,7 +4056,7 @@
             "firefox": {
               "version_added": "52",
               "partial_implementation": true,
-              "notes": "The <code>onfocusin</code> event handler property is not supported. To listen to this event, use <code>element.addEventListener('focusin', () => {});</code>."
+              "notes": "The <code>onfocusin</code> event handler property is not supported. To listen to this event, use <code>element.addEventListener('focusin', function() {});</code>."
             },
             "firefox_android": "mirror",
             "ie": {
@@ -4094,7 +4094,7 @@
             "chrome": {
               "version_added": "1",
               "partial_implementation": true,
-              "notes": "The <code>onfocusout</code> event handler property is not supported. To listen to this event, use <code>element.addEventListener('focusout', () => {});</code>."
+              "notes": "The <code>onfocusout</code> event handler property is not supported. To listen to this event, use <code>element.addEventListener('focusout', function() {});</code>."
             },
             "chrome_android": "mirror",
             "edge": {
@@ -4103,7 +4103,7 @@
             "firefox": {
               "version_added": "52",
               "partial_implementation": true,
-              "notes": "The <code>onfocusout</code> event handler property is not supported. To listen to this event, use <code>element.addEventListener('focusout', () => {});</code>."
+              "notes": "The <code>onfocusout</code> event handler property is not supported. To listen to this event, use <code>element.addEventListener('focusout', function() {});</code>."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `focus*_event` member of the `Element` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Additional Notes: The [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Element/focusin_event) doesn't mention an `onfocusin` or `onfocusout`, and in manual testing, this event handler property was defined neither on a generic Element or an HTMLElement.

Tests Used:
https://mdn-bcd-collector.gooborg.com/tests/api/Element/focusin_event
https://mdn-bcd-collector.gooborg.com/tests/api/Element/focusout_event
