### PR TITLE
Update Firefox data for api.RTCDtlsTransport.error_event

### DIFF
--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -49,7 +49,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "82"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `error_event` member of the `RTCDtlsTransport` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/RTCDtlsTransport/error_event

Additional Notes: This was updated in https://github.com/mdn/browser-compat-data/pull/19906, but the only hint about the event data was that it was guesstimated (the collector didn't update event data back then).  The bug linked in that PR doesn't have any mention of the error event either, so it's safe to assume this was incorrect data to begin with.
