### PR TITLE
Update Safari data for api.Element.gesture*_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -4369,7 +4369,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "9.1"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "2"
@@ -4405,7 +4405,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "9.1"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "2"
@@ -4441,7 +4441,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "9.1"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "2"


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `gesture*_event` member of the `Element` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Element/gesture*_event

Additional Notes: In https://github.com/WebKit/WebKit/commit/4b98457dae18e27afae7d48138b9ec1068eb8a0c#diff-5062a30a774512ad7d02525d4670935d55330194d9ba2d9f00bdf31b83e38002R181-R183, an "IOS_GESTURE_EVENTS" was added to the Element interface (and had been present on other interfaces).
