### PR TITLE
Update Chromium data for api.Worker.messageerror_event

### DIFF
--- a/api/Worker.json
+++ b/api/Worker.json
@@ -401,7 +401,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-messageerror",
           "support": {
             "chrome": {
-              "version_added": "60"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "deno": {


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `messageerror_event` member of the `Worker` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Worker/messageerror_event

Additional Notes: This data came from the wiki migration as the event handler data.  I have not been able to find any indication that it has been supported in Chrome when searching the source code.
