### PR TITLE
Update Safari data for api.WorkerGlobalScope.languagechange_event

### DIFF
--- a/api/WorkerGlobalScope.json
+++ b/api/WorkerGlobalScope.json
@@ -271,7 +271,7 @@
             },
             "opera_android": "mirror",
             "safari": {
-              "version_added": "4"
+              "version_added": false
             },
             "safari_ios": {
               "version_added": "5"


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `languagechange_event` member of the `WorkerGlobalScope` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.4).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/WorkerGlobalScope/languagechange_event

Additional Notes: This data came from the wiki migration as the event handler data, but I can't find any indication of support in Safari.
