### PR TITLE
Update overflow-block.json update Safari to "17" for `overflow-block`

### DIFF
--- a/css/properties/overflow-block.json
+++ b/css/properties/overflow-block.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
Safari 17 added support for `overflow-block`. 

Release note:
https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes

Commit:
https://github.com/WebKit/WebKit/commit/3f9d91e4ed1d08b947d964a91254b65e2046ab08
