### PR TITLE
Update notes for api.HTMLVideoElement.disablePictureInPicture

### DIFF
--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -90,13 +90,18 @@
             "edge": "mirror",
             "firefox": [
               {
-                "version_added": "122"
+                "version_added": "122",
+                "partial_implementation": true,
+                "notes": "When this property is set to <code>true</code>, the overlay button to disable picture-in-picture (PiP) is hidden, but the user can still enable PiP."
               },
               {
                 "version_added": "116",
                 "version_removed": "122",
                 "partial_implementation": true,
-                "notes": "When this property is set to <code>true</code>, the overlay button to disable picture-in-picture (PiP) is hidden, but the user can still enable PiP."
+                "notes": [
+                  "This property is undefined, but still has an effect if set to a value.",
+                  "When this property is set to <code>true</code>, the overlay button to disable picture-in-picture (PiP) is hidden, but the user can still enable PiP."
+                ]
               }
             ],
             "firefox_android": "mirror",


### PR DESCRIPTION
Quick follow-up for #21753, which brings back a note that wasn't meant to be removed.