### PR TITLE
Add shadowrootmode in Firefox preview

### DIFF
--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -81,7 +81,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "122"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -81,7 +81,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "122"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -54,7 +54,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "122"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -54,7 +54,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "122"
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
#### Summary

Declarative Shadow DOM support via the `shadowrootmode` attribute for the `<template>` element will be shipped in Firefox 122 behind the flag, disabled by default for now.

#### Test results and supporting details

- https://bugzilla.mozilla.org/show_bug.cgi?id=1712140