### PR TITLE
Update Chrome/Safari data for api.SVGStyleElement.disabled

### DIFF
--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -49,7 +49,7 @@
           "spec_url": "https://svgwg.org/svg2-draft/styling.html#__svg__SVGStyleElement__disabled",
           "support": {
             "chrome": {
-              "version_added": "≤80"
+              "version_added": "45"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -64,7 +64,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤13.1"
+              "version_added": "6"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -49,7 +49,7 @@
           "spec_url": "https://svgwg.org/svg2-draft/styling.html#__svg__SVGStyleElement__disabled",
           "support": {
             "chrome": {
-              "version_added": "102"
+              "version_added": "≤80"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -64,7 +64,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "≤13.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `disabled` member of the `SVGStyleElement` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.5).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/SVGStyleElement/disabled
