### PR TITLE
Update Safari data for css.properties.overflow.overlay

### DIFF
--- a/css/properties/overflow-x.json
+++ b/css/properties/overflow-x.json
@@ -116,7 +116,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "≤13.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": {

--- a/css/properties/overflow-y.json
+++ b/css/properties/overflow-y.json
@@ -116,7 +116,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "≤13.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": {

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -150,7 +150,7 @@
                 "version_added": false
               },
               "safari": {
-                "version_added": false
+                "version_added": "≤13.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": {


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `overlay` member of the `overflow` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.5).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/overflow/overlay
