### PR TITLE
Update Firefox data for html.elements.td.char

### DIFF
--- a/html/elements/td.json
+++ b/html/elements/td.json
@@ -192,7 +192,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": false,
+                "version_added": "≤72",
                 "impl_url": "https://bugzil.la/2212"
               },
               "firefox_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `char` member of the `td` HTML element. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.5).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/td/char
