### PR TITLE
Wake Lock API doesn't work in iOS Safari Home Screen Web Apps

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4862,7 +4862,11 @@
             "safari": {
               "version_added": "16.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "16.4",
+              "partial_implementation": true,
+              "notes": "Does not work in standalone Home Screen Web Apps. See <a href='https://webkit.org/b/254545#c32'>bug 254545</a>."
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/WakeLock.json
+++ b/api/WakeLock.json
@@ -26,7 +26,11 @@
           "safari": {
             "version_added": "16.4"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "16.4",
+            "partial_implementation": true,
+            "notes": "Does not work in standalone Home Screen Web Apps. See <a href='https://webkit.org/b/254545#c32'>bug 254545</a>."
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -62,7 +66,11 @@
             "safari": {
               "version_added": "16.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "16.4",
+              "partial_implementation": true,
+              "notes": "Does not work in standalone Home Screen Web Apps. See <a href='https://webkit.org/b/254545#c32'>bug 254545</a>."
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/WakeLockSentinel.json
+++ b/api/WakeLockSentinel.json
@@ -26,7 +26,11 @@
           "safari": {
             "version_added": "16.4"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "16.4",
+            "partial_implementation": true,
+            "notes": "Does not work in standalone Home Screen Web Apps. See <a href='https://webkit.org/b/254545#c32'>bug 254545</a>."
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -62,7 +66,11 @@
             "safari": {
               "version_added": "16.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "16.4",
+              "partial_implementation": true,
+              "notes": "Does not work in standalone Home Screen Web Apps. See <a href='https://webkit.org/b/254545#c32'>bug 254545</a>."
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -100,7 +108,11 @@
             "safari": {
               "version_added": "16.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "16.4",
+              "partial_implementation": true,
+              "notes": "Does not work in standalone Home Screen Web Apps. See <a href='https://webkit.org/b/254545#c32'>bug 254545</a>."
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -137,7 +149,11 @@
             "safari": {
               "version_added": "16.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "16.4",
+              "partial_implementation": true,
+              "notes": "Does not work in standalone Home Screen Web Apps. See <a href='https://webkit.org/b/254545#c32'>bug 254545</a>."
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -174,7 +190,11 @@
             "safari": {
               "version_added": "16.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "16.4",
+              "partial_implementation": true,
+              "notes": "Does not work in standalone Home Screen Web Apps. See <a href='https://webkit.org/b/254545#c32'>bug 254545</a>."
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
I was building a web app during my end of year holidays and the Wake Lock API doesn't work in standalone PWAs/Home Screen Web Apps in iOS Safari. See https://bugs.webkit.org/show_bug.cgi?id=254545#c32