### PR TITLE
Remove accept attribute from <form>

### DIFF
--- a/html/elements/form.json
+++ b/html/elements/form.json
@@ -36,40 +36,6 @@
             "deprecated": false
           }
         },
-        "accept": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": true
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "3"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
-            }
-          }
-        },
         "accept-charset": {
           "__compat": {
             "support": {


### PR DESCRIPTION
The Open Web Docs BCD collector v10.6.5 says that the `accept` attribute is not supported on `<form>` and I can't find evidence that it was supported before. You can have `accept` on `<input>` but not on `<form>`. 
Further there is no `accept` in the `HTMLFormElement` data and it is not in the HTML spec either.