### PR TITLE
Update Chrome/Safari data for svg.elements.feMergeNode.in

### DIFF
--- a/svg/elements/feMergeNode.json
+++ b/svg/elements/feMergeNode.json
@@ -44,7 +44,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": "≤80"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -65,7 +65,7 @@
                 "version_added": "10.1"
               },
               "safari": {
-                "version_added": null
+                "version_added": "≤13.1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/svg/elements/feMergeNode.json
+++ b/svg/elements/feMergeNode.json
@@ -44,7 +44,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "5"
               },
               "chrome_android": "mirror",
               "edge": {
@@ -65,7 +65,7 @@
                 "version_added": "10.1"
               },
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "6"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `in` member of the `feMergeNode` SVG element. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.5).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/svg/elements/feMergeNode/in
