### PR TITLE
Firefox 122: Update motion-related features

### DIFF
--- a/css/properties/offset-path.json
+++ b/css/properties/offset-path.json
@@ -78,14 +78,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "116",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.motion-path-basic-shapes.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "122"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -102,7 +95,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -118,14 +111,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "116",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.motion-path-coord-box.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "122"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -142,7 +128,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/types/ray.json
+++ b/css/types/ray.json
@@ -13,15 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "72",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.motion-path-ray.enabled",
-                  "value_to_set": "true"
-                }
-              ]
-            },
+              "version_added": "122",
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -30,14 +22,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "16"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -52,15 +44,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "116",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.motion-path-ray.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": "<code>&lt;at-position&gt;</code> is optional. If omitted, the <code>offset-position</code> of the element is used."
+                "version_added": "122"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -70,14 +54,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -92,30 +76,9 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "112",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.motion-path-ray.enabled",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "<code>&lt;size&gt;</code> is optional. If omitted, the value <code>closest-side</code> is used."
-                },
-                {
-                  "version_added": "72",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.motion-path-ray.enabled",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "notes": "<code>&lt;size&gt;</code> is required."
-                }
-              ],
+              "firefox": {
+                "version_added": "122"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -124,14 +87,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/types/ray.json
+++ b/css/types/ray.json
@@ -13,7 +13,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "122",
+              "version_added": "122"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

### Targets

**Target release**: Firefox 122
**Release date**: Jan 23, 2024

#### Summary

This PR proposes changes in addition to the ones in https://github.com/mdn/browser-compat-data/pull/21678.

1. Updates to `css/types/ray.json`, which corresponds to the BCD table on the [ray()](https://developer.mozilla.org/en-US/docs/Web/CSS/ray#browser_compatibility) page:

- For all the row entries, updated firefox to `122` and experimental to `false`.

- Additionally for those rows:
  - `ray()`: Updated safari to `16`
       Sources: https://bugs.webkit.org/show_bug.cgi?id=233344 and in [offset-path.json](https://github.com/mdn/browser-compat-data/blob/main/css/properties/offset-path.json#L226-L228)

  - `at <position>`: Updated safari to `17.2`
       Sources: https://bugs.webkit.org/show_bug.cgi?id=258113 and https://developer.apple.com/documentation/safari-release-notes/safari-17_2-release-notes

  - `size`: Updated safari to `17`
       Sources: https://bugs.webkit.org/show_bug.cgi?id=258110 and https://developer.apple.com/documentation/safari-release-notes/safari-17-release-notes

2. Updates to `css/properties/offset-path.json`:

- For `<basic-shape>` and `<coord-box>`, updated firefox to `122` and experimental to `false`.

#### Supporting details

- The Firefox bugs (listed in the next section) turn on the following preferences by default in FF122 (**_corresponding BCD updates in `offset-position` and `offset-path` are part of https://github.com/mdn/browser-compat-data/pull/21678 except two below)_**:
   - offset-position: `layout.css.motion-path-offset-position.enabled`
   - offset-path:
      - `layout.css.motion-path-ray.enabled`
      - `layout.css.motion-path-basic-shapes.enabled` - updated in this PR
      - `layout.css.motion-path-coord-box.enabled` - updated in this PR
      - `layout.css.motion-path-url.enabled`

- Updated preferences: https://hg.mozilla.org/integration/autoland/file/tip/modules/libpref/init/StaticPrefList.yaml

- WPT: https://wpt.fyi/results/css/motion?label=master&product=chrome%5Bstable%5D&product=firefox%5Bbeta%5D&product=safari%5Bstable%5D&aligned&view=interop&q=label%3Ainterop-2023-motion

- [Firefox 122 Beta Release Notes](https://www.mozilla.org/en-US/firefox/122.0beta/releasenotes/)

#### Related issues

- Doc issue: https://github.com/mdn/content/issues/31099
- Content PR: https://github.com/mdn/content/pull/31514
- Firefox bugs:
https://bugzilla.mozilla.org/show_bug.cgi?id=1598151
https://bugzilla.mozilla.org/show_bug.cgi?id=1598152
https://bugzilla.mozilla.org/show_bug.cgi?id=1598159
