### PR TITLE
permissions.request supported in Firefox for Android

### DIFF
--- a/webextensions/api/permissions.json
+++ b/webextensions/api/permissions.json
@@ -175,7 +175,7 @@
                 ]
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "120"
               },
               "opera": "mirror",
               "safari": {


### PR DESCRIPTION
#### Summary

Documents the support added in [Bug 1810047](https://bugzilla.mozilla.org/show_bug.cgi?id=1810047) Implement extension runtime permissions Dialog in AC

#### Related issues

Fixes #21704