### PR TITLE
storage.StorageArea methods support in Firefox for Android

### DIFF
--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -42,7 +42,7 @@
                 },
                 "firefox_android": {
                   "version_added": "48",
-                  "notes": "Only supports <code>local</code> and <code>session</code> storage area."
+                  "notes": "Doesn't support the <code>managed</code> storage area."
                 },
                 "opera": {
                   "version_added": "33"
@@ -71,7 +71,7 @@
                 },
                 "firefox_android": {
                   "version_added": "48",
-                  "notes": "Only supports <code>local</code> and <code>session</code> storage area."
+                  "notes": "Doesn't support the <code>managed</code> storage area."
                 },
                 "opera": {
                   "version_added": "33"
@@ -181,7 +181,7 @@
                 },
                 "firefox_android": {
                   "version_added": "48",
-                  "notes": "Only supports <code>local</code> and <code>session</code> storage area."
+                  "notes": "Doesn't support the <code>managed</code> storage area."
                 },
                 "opera": {
                   "version_added": "33"
@@ -237,7 +237,7 @@
                 },
                 "firefox_android": {
                   "version_added": "48",
-                  "notes": "Only supports <code>local</code> and <code>session</code> storage area."
+                  "notes": "Doesn't support the <code>managed</code> storage area."
                 },
                 "opera": {
                   "version_added": "33"
@@ -419,7 +419,8 @@
                 "notes": "Before version 79, storage quota limits are not enforced."
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": true,
+                "notes": "Data isn't synchronized with the user's Mozilla account. See <a href='https://bugzil.la/1316442'>bug 1316442</a>."
               },
               "opera": {
                 "version_added": false

--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -41,7 +41,8 @@
                   "version_added": "45"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "notes": "Only supports <code>local</code> and <code>session</code> storage area."
                 },
                 "opera": {
                   "version_added": "33"
@@ -69,7 +70,8 @@
                   "version_added": "45"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "notes": "Only supports <code>local</code> and <code>session</code> storage area."
                 },
                 "opera": {
                   "version_added": "33"
@@ -178,7 +180,8 @@
                   "version_added": "45"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "notes": "Only supports <code>local</code> and <code>session</code> storage area."
                 },
                 "opera": {
                   "version_added": "33"
@@ -233,7 +236,8 @@
                   "version_added": "45"
                 },
                 "firefox_android": {
-                  "version_added": "48"
+                  "version_added": "48",
+                  "notes": "Only supports <code>local</code> and <code>session</code> storage area."
                 },
                 "opera": {
                   "version_added": "33"

--- a/webextensions/api/storage.json
+++ b/webextensions/api/storage.json
@@ -420,7 +420,7 @@
               },
               "firefox_android": {
                 "version_added": true,
-                "notes": "Data isn't synchronized with the user's Mozilla account. See <a href='https://bugzil.la/1316442'>bug 1316442</a>."
+                "notes": "Data isn't synchronized with the user's Mozilla account. See <a href='https://bugzil.la/1625257'>bug 1625257</a>."
               },
               "opera": {
                 "version_added": false


### PR DESCRIPTION
#### Summary

Add a note that StorageArea.get(), set(), remove(), and clear() only support local and session storage in Firefox for Android.

#### Related issues

Fixes #21734
