### PR TITLE
Safari 17.2 supports priority in fetch and request apis

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -226,14 +226,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -248,14 +248,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17.2"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
#### Summary

Marked priority as being supported in fetch and request apis as of Safari 17.2.  Removed experimental flag from the features (automated test complained).

#### Test results and supporting details

Tested (in Safari 17.2) by going to https://www.google.com and opening the network tab.  In network tab make sure to display priority of the requests being made (right click on headers to choose the priority column).

In the console run and observe the request and the priority at which it was made:

`fetch('https://www.google.com/', { priority: 'low' })`

`fetch('https://www.google.com/', { priority: 'high' })`

`fetch(new Request('https://www.google.com/', {priority: 'low'}))`

`fetch(new Request('https://www.google.com/', {priority: 'high'}))`


##### Documentation

https://developer.apple.com/documentation/safari-release-notes/safari-17_2-release-notes

Safari 17.2 release notes:

> Added support for Fetch Priority. (106852027)

#### Related issues

Fixes #21838
