### PR TITLE
add missing mdn_url for HTMLLinkElement.hreflang

### DIFF
--- a/api/HTMLLinkElement.json
+++ b/api/HTMLLinkElement.json
@@ -320,6 +320,7 @@
       },
       "hreflang": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/hreflang",
           "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#dom-link-hreflang",
           "support": {
             "chrome": {


### PR DESCRIPTION
this PR is related to [#31517](https://github.com/mdn/content/pull/31517). Adding a new page for HTMLLinkElement.hreflang.
