### PR TITLE
html.elements.img.decoding update mdn_url & fix spec_url

### DIFF
--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -248,7 +248,7 @@
         },
         "decoding": {
           "__compat": {
-            "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-decoding",
+            "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-decoding",
             "support": {
               "chrome": {
                 "version_added": "65"

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -248,7 +248,6 @@
         },
         "decoding": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLImageElement/decoding",
             "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-decoding",
             "support": {
               "chrome": {

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -248,6 +248,7 @@
         },
         "decoding": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Element/img#decoding",
             "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-decoding",
             "support": {
               "chrome": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

~normally the attribute of html element do not add `mdn_url`~

also, the `spec_url` is not good, which should specific with a hash like attr-img-*

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

fix incorrect links added in https://github.com/mdn/browser-compat-data/pull/21323

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
