### PR TITLE
Add data for html.elements.iframe.csp

### DIFF
--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -269,6 +269,39 @@
             }
           }
         },
+        "csp": {
+          "__compat": {
+            "spec_url": "https://w3c.github.io/webappsec-cspee/#element-attrdef-iframe-csp",
+            "support": {
+              "chrome": {
+                "version_added": "61"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "external_protocol_urls_blocked": {
           "__compat": {
             "description": "External protocol URLs blocked",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

using the data from `api.HTMLIFrameElement.csp` and assume its data is correct

see https://github.com/mdn/browser-compat-data/pull/2017 and https://github.com/mdn/browser-compat-data/pull/1470, which add data for api.HTMLIFrameElement.csp

see also the spec https://w3c.github.io/webappsec-cspee/#csp-attribute

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes #21756 

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
