### PR TITLE
update buggy support for MediaStreamTrack.muted state

### DIFF
--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -558,9 +558,9 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "59"
+              "version_added": "59",
               "partial_implementation": true,
-              "notes": "Does not currently track the microphone's muted state from the operating system, see <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1739163'>bug 1739163</a>."
+              "notes": "Does not currently track the microphone's muted state from the operating system, see <a href='https://bugzil.la/1739163'>bug 1739163</a>."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -559,6 +559,8 @@
             },
             "firefox": {
               "version_added": "59"
+              "partial_implementation": true,
+              "notes": "Does not currently track the microphone's muted state from the operating system, see <a href='https://bugzilla.mozilla.org/show_bug.cgi?id=1739163'>bug 1739163</a>."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
#### Summary

Account for [current Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1739163) breaking support for [the `muted` property of a `MediaStreamTrack`](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/muted).

#### Test results and supporting details

See the associated [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1739163), including a test page, and results and [the original ticket](https://bugzilla.mozilla.org/show_bug.cgi?id=1208378), tracking implementation of the feature.

On Arch Linux (kernel 6.6.6-zen1) with Firefox (120.0.1), I visited a [small demo page](https://detect-mute.glitch.com) I created. I then toggled the muted state of the system's default microphone (by toggling "mute" on the PulseAudio source). The page shows that `mediaStream.getAudioTracks()[0].muted` is always false in Firefox. However, in Chromium (120.0.6099.109) on the same system, the same `muted` attribute changes according to the state of the microphone state. The following screen recording shows Chromium (right) responding to the change in microphone state while Firefox (left) does not.

![animated screen recording](https://github.com/mdn/browser-compat-data/assets/553637/1a51a429-285a-4f65-931f-a8aade509338)

#### Related issues

Fixes #21611.