### PR TITLE
Remove html.elements.button.autocomplete

### DIFF
--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -40,38 +40,6 @@
             "deprecated": false
           }
         },
-        "autocomplete": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "4"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": false
-            }
-          }
-        },
         "disabled": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Attributes/disabled",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

as the data added in #19949 , this attribute is not supported in Firefox 121 as I test; also no info that `<button>` html element has ever supported this attribute searched in Firefox release or bugs

content update https://github.com/mdn/content/pull/31605

autocomplete attribute spec https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete
form spec https://html.spec.whatwg.org/multipage/forms.html#the-form-element
input spec https://html.spec.whatwg.org/multipage/input.html#the-input-element
select spec https://html.spec.whatwg.org/multipage/form-elements.html#the-select-element
textarea spec https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element

this also relates with https://github.com/mdn/browser-compat-data/issues/21790

---

update later when doing content update:

in mdn docs for `<button>` element

![image](https://github.com/mdn/browser-compat-data/assets/95597335/b4d24676-1dc9-4273-9f59-06af5f39e9ba)

it suggest two links - https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing and https://bugzilla.mozilla.org/show_bug.cgi?id=654072, but they are discussing about `<input type="button" />`, not `<button>` element

so I guess this attribute is added incorrectly

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
