### PR TITLE
updated the version added for ff for rect() and xywh()

### DIFF
--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -469,14 +469,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "117",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.basic-shape-rect.enabled, layout.css.motion-path-basic-shapes.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "122"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -513,14 +506,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "117",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.basic-shape-xywh.enabled, layout.css.motion-path-basic-shapes.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "122"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
#### Summary

Updated the version added for ff for rect() and xywh()

#### Test results and supporting details

Tested in Firefox Beta & Nightly

#### Related issues

- [[CSS] Ship xywh() and rect() for basic-shape](https://github.com/mdn/content/issues/31103)