### PR TITLE
Add missing BufferedChangeEvent API feature

### DIFF
--- a/api/BufferedChangeEvent.json
+++ b/api/BufferedChangeEvent.json
@@ -2,6 +2,7 @@
   "api": {
     "BufferedChangeEvent": {
       "__compat": {
+        "spec_url": "https://w3c.github.io/media-source/#dom-bufferedchangeevent",
         "support": {
           "chrome": {
             "version_added": false
@@ -34,6 +35,7 @@
       "BufferedChangeEvent": {
         "__compat": {
           "description": "<code>BufferedChangeEvent()</code> constructor",
+          "spec_url": "https://w3c.github.io/media-source/#dom-bufferedchangeevent-constructor",
           "support": {
             "chrome": {
               "version_added": false
@@ -66,6 +68,7 @@
       },
       "addedRanges": {
         "__compat": {
+          "spec_url": "https://w3c.github.io/media-source/#dom-bufferedchangeevent-addedranges",
           "support": {
             "chrome": {
               "version_added": false
@@ -98,6 +101,7 @@
       },
       "removedRanges": {
         "__compat": {
+          "spec_url": "https://w3c.github.io/media-source/#dom-bufferedchangeevent-removedranges",
           "support": {
             "chrome": {
               "version_added": false

--- a/api/BufferedChangeEvent.json
+++ b/api/BufferedChangeEvent.json
@@ -22,7 +22,9 @@
           "safari": {
             "version_added": "17"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "17.1"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -55,7 +57,9 @@
             "safari": {
               "version_added": "17"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "17.1"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -88,7 +92,9 @@
             "safari": {
               "version_added": "17"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "17.1"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -121,7 +127,9 @@
             "safari": {
               "version_added": "17"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "17.1"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/BufferedChangeEvent.json
+++ b/api/BufferedChangeEvent.json
@@ -1,0 +1,133 @@
+{
+  "api": {
+    "BufferedChangeEvent": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": "17"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "BufferedChangeEvent": {
+        "__compat": {
+          "description": "<code>BufferedChangeEvent()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "17"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "addedRanges": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "17"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "removedRanges": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "17"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing `BufferedChangeEvent` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.5).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/BufferedChangeEvent
