### PR TITLE
Add missing ManagedMediaSource API feature

### DIFF
--- a/api/ManagedMediaSource.json
+++ b/api/ManagedMediaSource.json
@@ -1,0 +1,167 @@
+{
+  "api": {
+    "ManagedMediaSource": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": "17"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "ManagedMediaSource": {
+        "__compat": {
+          "description": "<code>ManagedMediaSource()</code> constructor",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "17"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "endstreaming_event": {
+        "__compat": {
+          "description": "<code>endstreaming</code> event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "17"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "startstreaming_event": {
+        "__compat": {
+          "description": "<code>startstreaming</code> event",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "17"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "streaming": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "17"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/ManagedMediaSource.json
+++ b/api/ManagedMediaSource.json
@@ -22,7 +22,9 @@
           "safari": {
             "version_added": "17"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "17.1"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -55,7 +57,9 @@
             "safari": {
               "version_added": "17"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "17.1"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -89,7 +93,9 @@
             "safari": {
               "version_added": "17"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "17.1"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -123,7 +129,9 @@
             "safari": {
               "version_added": "17"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "17.1"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -156,7 +164,9 @@
             "safari": {
               "version_added": "17"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "17.1"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/ManagedMediaSource.json
+++ b/api/ManagedMediaSource.json
@@ -2,6 +2,7 @@
   "api": {
     "ManagedMediaSource": {
       "__compat": {
+        "spec_url": "https://w3c.github.io/media-source/#dom-managedmediasource",
         "support": {
           "chrome": {
             "version_added": false
@@ -34,6 +35,7 @@
       "ManagedMediaSource": {
         "__compat": {
           "description": "<code>ManagedMediaSource()</code> constructor",
+          "spec_url": "https://w3c.github.io/media-source/#dom-managedmediasource-constructor",
           "support": {
             "chrome": {
               "version_added": false
@@ -67,6 +69,7 @@
       "endstreaming_event": {
         "__compat": {
           "description": "<code>endstreaming</code> event",
+          "spec_url": "https://w3c.github.io/media-source/#dfn-endstreaming",
           "support": {
             "chrome": {
               "version_added": false
@@ -100,6 +103,7 @@
       "startstreaming_event": {
         "__compat": {
           "description": "<code>startstreaming</code> event",
+          "spec_url": "https://w3c.github.io/media-source/#dfn-startstreaming",
           "support": {
             "chrome": {
               "version_added": false
@@ -132,6 +136,7 @@
       },
       "streaming": {
         "__compat": {
+          "spec_url": "https://w3c.github.io/media-source/#dom-managedmediasource-streaming",
           "support": {
             "chrome": {
               "version_added": false


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing `ManagedMediaSource` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.5).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/ManagedMediaSource
