### PR TITLE
Add missing ManagedSourceBuffer API feature

### DIFF
--- a/api/ManagedSourceBuffer.json
+++ b/api/ManagedSourceBuffer.json
@@ -1,0 +1,71 @@
+{
+  "api": {
+    "ManagedSourceBuffer": {
+      "__compat": {
+        "spec_url": "https://w3c.github.io/media-source/#dom-managedsourcebuffer",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "ie": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": "17"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "bufferedchange_event": {
+        "__compat": {
+          "description": "<code>bufferedchange</code> event",
+          "spec_url": "https://w3c.github.io/media-source/#dfn-bufferedchange",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "17"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/ManagedSourceBuffer.json
+++ b/api/ManagedSourceBuffer.json
@@ -22,7 +22,9 @@
           "safari": {
             "version_added": "17"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "17.1"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -55,7 +57,9 @@
             "safari": {
               "version_added": "17"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "17.1"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
This PR is a part of a project to add missing interfaces and interface features to BCD that are from an active spec (including WICG specs) and is supported in at least one browser. This particular PR adds the missing `ManagedSourceBuffer` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.5).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/ManagedSourceBuffer
