### PR TITLE
Update Safari data for api.RTCStatsReport.type_candidate-pair.priority

### DIFF
--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -758,7 +758,6 @@
         "priority": {
           "__compat": {
             "description": "<code>priority</code> in 'candidate-pair' stats",
-            "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcicecandidatepairstats-priority",
             "support": {
               "chrome": {
                 "version_added": "58"
@@ -791,7 +790,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": true
             }
           }

--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -782,7 +782,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "11"
+                "version_added": "11",
+                "version_removed": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `type_candidate-pair.priority` member of the `RTCStatsReport` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.5).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/RTCStatsReport/type_candidate-pair/priority

Additional Notes: Confirmed by https://github.com/WebKit/WebKit/commit/bc18af2122edaa89bbec6b93a6404c01ea626276.
