### PR TITLE
Update Safari data for api.RTCStatsReport.type_inbound-rtp.mid

### DIFF
--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -2989,6 +2989,7 @@
         },
         "mid": {
           "__compat": {
+            "description": "<code>mid</code> in 'inbound-rtp' stats",
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats-mid",
             "support": {
               "chrome": {
@@ -3007,14 +3008,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `type_inbound-rtp.mid` member of the `RTCStatsReport` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.5).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/RTCStatsReport/type_inbound-rtp/mid
