### PR TITLE
Move html.elements.a.href_sms to html.elements.a.href.href_sms

### DIFF
--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -219,6 +219,39 @@
               "deprecated": false
             }
           },
+          "href_sms": {
+            "__compat": {
+              "description": "<code>href = 'sms:'</code>",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "12"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "href_top": {
             "__compat": {
               "description": "<code>href = '#top'</code>",
@@ -252,39 +285,6 @@
                 "standard_track": true,
                 "deprecated": false
               }
-            }
-          }
-        },
-        "href_sms": {
-          "__compat": {
-            "description": "<code>href = 'sms:'</code>",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "12"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
             }
           }
         },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

![image](https://github.com/mdn/browser-compat-data/assets/95597335/caa7f70c-e654-4aea-8820-fb290cc5b045)

`href_sms` reflects the `sms` value of `href` attribute, put it under `href` attribute is better

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
