### PR TITLE
Mark api.HTMLMediaElement.seekToNextFrame as non-standard

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2704,7 +2704,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the method is a non-standard feature, which is added in https://github.com/mdn/browser-compat-data/pull/1166 and update firefox data in https://github.com/mdn/browser-compat-data/pull/7506, also reference to firefox release note v49 and v50

related implement links https://bugzilla.mozilla.org/show_bug.cgi?id=1336404 (added to firefox) https://bugs.chromium.org/p/chromium/issues/detail?id=1065675 (will not add to chromium)


<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
