### PR TITLE
Add data for html.elements.video.disablepictureinpicture

### DIFF
--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -79,7 +79,7 @@
       "disablePictureInPicture": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/disablePictureInPicture",
-          "spec_url": "https://w3c.github.io/picture-in-picture/#disable-pip",
+          "spec_url": "https://w3c.github.io/picture-in-picture/#dom-htmlvideoelement-disablepictureinpicture",
           "support": {
             "chrome": {
               "version_added": "69"

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -207,16 +207,13 @@
                 {
                   "version_added": "122",
                   "partial_implementation": true,
-                  "notes": "When this property is set to <code>true</code>, the overlay button to disable picture-in-picture (PiP) is hidden, but the user can still enable PiP."
+                  "notes": "When this attribute is set, the overlay button to disable picture-in-picture (PiP) is hidden, but the user can still enable PiP."
                 },
                 {
                   "version_added": "116",
                   "version_removed": "122",
                   "partial_implementation": true,
-                  "notes": [
-                    "This property is undefined, but still has an effect if set to a value.",
-                    "When this property is set to <code>true</code>, the overlay button to disable picture-in-picture (PiP) is hidden, but the user can still enable PiP."
-                  ]
+                  "notes": "When this attribute is set, the overlay button to disable picture-in-picture (PiP) is hidden, but the user can still enable PiP."
                 }
               ],
               "firefox_android": "mirror",

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -192,6 +192,56 @@
             }
           }
         },
+        "disablepictureinpicture": {
+          "__compat": {
+            "spec_url": "https://w3c.github.io/picture-in-picture/#dom-htmlvideoelement-disablepictureinpicture",
+            "support": {
+              "chrome": {
+                "version_added": "69"
+              },
+              "chrome_android": {
+                "version_added": "105"
+              },
+              "edge": "mirror",
+              "firefox": [
+                {
+                  "version_added": "122",
+                  "partial_implementation": true,
+                  "notes": "When this property is set to <code>true</code>, the overlay button to disable picture-in-picture (PiP) is hidden, but the user can still enable PiP."
+                },
+                {
+                  "version_added": "116",
+                  "version_removed": "122",
+                  "partial_implementation": true,
+                  "notes": [
+                    "This property is undefined, but still has an effect if set to a value.",
+                    "When this property is set to <code>true</code>, the overlay button to disable picture-in-picture (PiP) is hidden, but the user can still enable PiP."
+                  ]
+                }
+              ],
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "13.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": false
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "height": {
           "__compat": {
             "support": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

using data from api.HTMLVideoElement.disablePictureInPicture and assuming its data is correct

spec-url https://w3c.github.io/picture-in-picture/#dom-htmlvideoelement-disablepictureinpicture

chrome & safari data update #9438 

chrome android data update #17047 

firefox data update #21753 & #21812 

webview data update #18544 

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
