### PR TITLE
Update Firefox data for font-synthesis CSS property

### DIFF
--- a/css/properties/font-synthesis.json
+++ b/css/properties/font-synthesis.json
@@ -110,7 +110,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "111"
+                "version_added": "≤72"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -143,7 +143,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "111"
+                "version_added": "≤72"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `font-synthesis` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.5).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/font-synthesis

Additional Test Code Used:
```html
<style>
    p {
        font-synthesis: weight style;
    }
</style>
<p>This font does not support <strong>bold</strong> and <em>italic</em>.</p>
```
