### PR TITLE
Remove html.elements.dd.nowrap from BCD

### DIFF
--- a/html/elements/dd.json
+++ b/html/elements/dd.json
@@ -38,40 +38,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "nowrap": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": true
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "≤4"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
This PR removes the `nowrap` member of the `dd` HTML element from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.5).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/dd/nowrap

Additional Notes: I set a `<dd>` element to `<dd nowrap="yes">`, but it still wrapped the text; no rendering changed.
