### PR TITLE
Update all browsers data for html.elements.pre.wrap

### DIFF
--- a/html/elements/pre.json
+++ b/html/elements/pre.json
@@ -112,12 +112,12 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "16"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "1"
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `wrap` member of the `pre` HTML element. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.6.5).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/html/elements/pre/wrap

Additional Notes: I did some manual testing and found that there is no effect if the attribute is present.
