### PR TITLE
Remove api.File.type from BCD

### DIFF
--- a/api/File.json
+++ b/api/File.json
@@ -227,51 +227,6 @@
           }
         }
       },
-      "type": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/File/type",
-          "spec_url": "https://w3c.github.io/FileAPI/#dfn-type",
-          "support": {
-            "chrome": {
-              "version_added": "13"
-            },
-            "chrome_android": "mirror",
-            "deno": {
-              "version_added": "1.0"
-            },
-            "edge": {
-              "version_added": "12"
-            },
-            "firefox": {
-              "version_added": "3.6"
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": "10"
-            },
-            "oculus": "mirror",
-            "opera": {
-              "version_added": "≤15"
-            },
-            "opera_android": {
-              "version_added": "≤14"
-            },
-            "safari": {
-              "version_added": "8"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "webkitRelativePath": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/File/webkitRelativePath",


### PR DESCRIPTION
This PR removes the `type` member of the `File` API from BCD. This is duplicate data since the `type` property is defined on `Blob` which `File` inherits from.

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/File/type

Additional Notes: Fixes #21855.
