### PR TITLE
Update Safari data for Alt-Svc HTTP header

### DIFF
--- a/http/headers/Alt-Svc.json
+++ b/http/headers/Alt-Svc.json
@@ -32,7 +32,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "17",
+              "impl_url": "https://webkit.org/b/255017"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `Alt-Svc` HTTP header. The data comes from a commit in the browser's source code, mapped to a version number using available tooling or via the commit timestamp.

Commit: https://github.com/WebKit/WebKit/commit/2162ae8bd6047aced442b0d00edce9b270dec870

Additional Notes: Fixes #21845.
