### PR TITLE
add mdn_urls for *VideoFrameCallback methods

### DIFF
--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -45,6 +45,7 @@
       },
       "cancelVideoFrameCallback": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/cancelVideoFrameCallback",
           "spec_url": "https://wicg.github.io/video-rvfc/#dom-htmlvideoelement-cancelvideoframecallback",
           "support": {
             "chrome": {
@@ -607,6 +608,7 @@
       },
       "requestVideoFrameCallback": {
         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/requestVideoFrameCallback",
           "spec_url": "https://wicg.github.io/video-rvfc/#dom-htmlvideoelement-requestvideoframecallback",
           "support": {
             "chrome": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

I am going to document `HTMLVideoElement.requestVideoFrameCallback()` and `HTMLVideoElement.cancelVideoFrameCallback()`, but I noticed that the `mdn_url`s for these methods is missing. This PR adds those.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
