### PR TITLE
Update ruby-align.json STP supports `ruby-align` updating Safari to `preview`

### DIFF
--- a/css/properties/ruby-align.json
+++ b/css/properties/ruby-align.json
@@ -23,7 +23,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview",
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/ruby-align.json
+++ b/css/properties/ruby-align.json
@@ -23,7 +23,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview",
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
`ruby-align` supported by STP.

Commits:
WebKit/WebKit@5aefb40 WebKit/WebKit@9ef3ca6

Screenshot of implementation in STP:
<img width="1582" alt="ruby-align supported in STP" src="https://github.com/mdn/browser-compat-data/assets/113309999/d69b1de1-8b38-4754-b668-7764ea52a19b">