### PR TITLE
Firefox122: Add clonable attribute to ShadowRoot

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2624,6 +2624,40 @@
             "deprecated": false
           }
         },
+        "init_clonable_parameter": {
+          "__compat": {
+            "description": "<code>init.clonable</code> parameter",
+            "spec_url": "https://dom.spec.whatwg.org/#dom-shadowrootinit-clonable",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "preview"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "init_delegatesFocus_parameter": {
           "__compat": {
             "description": "<code>init.delegatesFocus</code> parameter",

--- a/api/Element.json
+++ b/api/Element.json
@@ -2645,7 +2645,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                 "alternative_name": "cloneable",
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -2645,7 +2645,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                 "alternative_name": "cloneable",
+                "alternative_name": "cloneable",
                 "version_added": "16.4"
               },
               "safari_ios": "mirror",

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -130,7 +130,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "alternative_name": "cloneable",
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -106,6 +106,43 @@
           }
         }
       },
+      "clonable": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/clonable",
+          "spec_url": "https://dom.spec.whatwg.org/#dom-shadowroot-clonable",
+          "tags": [
+            "web-features:shadow-dom"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "delegatesFocus": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/delegatesFocus",

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -130,7 +130,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Added new attachShadow `clonable` option and ShadowRoot `clonable` attribute per updated DOM spec:

- Available since Firefox Nightly 122
- Not available in Safari (it’s complicated, see below)
- Not available in Chrome Canary

#### Safari

⚠️ It is available in Safari but with a different spelling:

- Since Safari 16.4 as an option
- Since Safari TP 186 as an attribute

There’s a [mistype](https://bugs.webkit.org/show_bug.cgi?id=267634) in Safari’s implementation: it should be `clonable` [per spec](https://dom.spec.whatwg.org/#dom-shadowroot-clonable), not `cloneable`, in both cases. I made it `false` for now, and I will get back once it’s fixed.

WPT agrees: [clonable.window.html](https://wpt.fyi/results/shadow-dom/declarative/clonable.window.html?label=master&label=experimental&aligned&q=clonable)

#### Test results and supporting details

How I tested support in the DevTools console:

```js
const host = document.createElement('div');
const shadowRoot = host.attachShadow({mode: 'open', clonable: true});
shadowRoot.clonable;
```

- https://github.com/whatwg/dom/pull/1237
- [Bugzilla: Add ShadowRoot::clonable](https://bugzilla.mozilla.org/show_bug.cgi?id=1868428)
- [WebKit: Add ShadowRoot clonable attribute](https://bugs.webkit.org/show_bug.cgi?id=266227)
- [WebKit: ShadowRoot/Init's "cloneable" is different from the spec's "clonable"](https://bugs.webkit.org/show_bug.cgi?id=267634)
- [WPT: clonable.window.html](https://wpt.fyi/results/shadow-dom/declarative/clonable.window.html?label=master&label=experimental&aligned&q=clonable)

#### Related issues

- https://github.com/mdn/content/issues/31108