### PR TITLE
Fix Firefox version of NumberFormat signDisplay negative value

### DIFF
--- a/javascript/builtins/Intl/NumberFormat.json
+++ b/javascript/builtins/Intl/NumberFormat.json
@@ -865,7 +865,7 @@
                     },
                     "edge": "mirror",
                     "firefox": {
-                      "version_added": "93"
+                      "version_added": "116"
                     },
                     "firefox_android": "mirror",
                     "ie": {


### PR DESCRIPTION
#### Summary

Change the Firefox version from 93 to 116 for the `Intl.NumberFormat` constructor's `options.signDisplay` parameter `negative` value.

#### Test results and supporting details

Here is the [changeset](https://hg.mozilla.org/integration/autoland/rev/9f247edc6c08) where the support was added to Firefox.
I had originally filed this [issue](https://github.com/Fyrd/caniuse/issues/6940) to `caniuse`, but they pointed me here.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
