### PR TITLE
Remove `bgcolor` attribute of `<col>` element and `<colgroup>` element

### DIFF
--- a/html/elements/col.json
+++ b/html/elements/col.json
@@ -70,40 +70,6 @@
             }
           }
         },
-        "bgcolor": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": true
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "1"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
-            }
-          }
-        },
         "char": {
           "__compat": {
             "support": {

--- a/html/elements/colgroup.json
+++ b/html/elements/colgroup.json
@@ -71,40 +71,6 @@
             }
           }
         },
-        "bgcolor": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "1"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12"
-              },
-              "firefox": {
-                "version_added": "1"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": true
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "1"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": true
-            }
-          }
-        },
         "char": {
           "__compat": {
             "support": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

the `bgcolor` attribute of `<col>` element and `<colgroup>` element and not in standard (not included in https://html.spec.whatwg.org/multipage/obsolete.html), and tey take not effect in browsers

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

use the test based on the sample of https://codepen.io/queengooborg/pen/QWrYaXg, which indicates the property takes no effect both in chrome and firefox

```html
<body bgcolor="#C0A0F0">
  <table bgcolor="green">
    <colgroup bgcolor="yellow">
      <col>test</col>
      <col bgcolor="red">test</col>
    </colgroup>
 <thead bgcolor="red" align="char" char=".">
    <tr>
      <th>hello</th>
      <th bgcolor="green">farewell</th>
    </tr>
  </thead>
  <tbody bgcolor="yellow">
    <tr bgcolor="cyan">
      <td>0.456</td>
      <td>12439</td>
    </tr>    <tr>
      <td bgcolor="purple">456.0</td>
    <td>869.5</td>
    </tr>    <tr>
      <td>1</td>
    <td>5</td>
    </tr>    <tr>
      <td>4000000</td>
    <td>8000000</td>
    </tr>
    </tr>
  </tbody>
</table>
</body>
```

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Relates with #17478 

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
