### PR TITLE
Remove css.properties.outline.invert from BCD

### DIFF
--- a/css/properties/outline.json
+++ b/css/properties/outline.json
@@ -96,46 +96,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "invert": {
-          "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-ui/#valdef-outline-color-invert",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12",
-                "version_removed": "79"
-              },
-              "firefox": {
-                "version_added": "1",
-                "version_removed": "3"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "8"
-              },
-              "oculus": "mirror",
-              "opera": {
-                "version_added": "7",
-                "version_removed": "15"
-              },
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       }
     }


### PR DESCRIPTION
This PR removes the `invert` member of the `outline` CSS property from BCD. This is just a duplicate of `outline-color: invert`.

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/outline/invert
