### PR TITLE
`background-clip: text` supported in Chrome 120

### DIFF
--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -165,11 +165,16 @@
           "__compat": {
             "description": "<code>text</code>",
             "support": {
-              "chrome": {
-                "version_added": "3",
-                "partial_implementation": true,
-                "notes": "The <code>text</code> value is only supported by <code>-webkit-background-clip</code> (and not by <code>background-clip</code>; see <a href='https://crbug.com/1339290'>bug 1339290</a>)."
-              },
+              "chrome": [
+                {
+                  "version_added": "120"
+                },
+                {
+                  "version_added": "3",
+                  "partial_implementation": true,
+                  "notes": "The <code>text</code> value is only supported by <code>-webkit-background-clip</code> (and not by <code>background-clip</code>; see <a href='https://crbug.com/1339290'>bug 1339290</a>)."
+                }
+              ],
               "chrome_android": "mirror",
               "edge": [
                 {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome has shipped `background-clip: text` by [unprefixing `-webkit-background-clip` for text and making it an alias](https://chromestatus.com/feature/5125388091260928)

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
