### PR TITLE
docs: added `impl_url` URLs in Navigation.json & NavigateEvent.json

### DIFF
--- a/api/NavigateEvent.json
+++ b/api/NavigateEvent.json
@@ -11,7 +11,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": false,
+            "impl_url": "https://bugzil.la/1777171"
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/Navigation.json
+++ b/api/Navigation.json
@@ -318,7 +318,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1777171"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
#### Summary

Added `impl_url` to:
- https://github.com/mdn/browser-compat-data/blob/main/api/Navigation.json
- https://github.com/mdn/browser-compat-data/blob/main/api/NavigateEvent.json

#### Test results and supporting details

n/a

#### Related issues

Fixes #21952

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
