### PR TITLE
Update ShadowRoot.json adding `cloneable` attribute

### DIFF
--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -106,6 +106,40 @@
           }
         }
       },
+      "cloneable": {
+         "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/delegatesFocus",
+          "spec_url": "https://dom.spec.whatwg.org/#shadowroot-delegates-focus",
+          "support": {
+            "chrome": {
+              "version_added": "false"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "false"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "preview",
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "delegatesFocus": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/delegatesFocus",


### PR DESCRIPTION
Add `cloneable` attribute to ShadowRoot.json, it is experimental and supported in STP.

#### Summary

I am adding the `cloneable` attribute to ShadowRoot.json, it is an experimental property.

#### Test results and supporting details

It added supported in STP 186: [notes](https://webkit.org/blog/14916/release-notes-for-safari-technology-preview-186/)

#### Related issues

I am addressing issue [#518](https://github.com/mdn/mdn/issues/518), that I submitted.