### PR TITLE
commands.onCommand tab implementation link

### DIFF
--- a/webextensions/api/commands.json
+++ b/webextensions/api/commands.json
@@ -56,7 +56,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1843866"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",


### PR DESCRIPTION
#### Summary

Add a link to [Bug 1843866](https://bugzilla.mozilla.org/show_bug.cgi?id=1843866) Add tab parameter to commands.onCommand

#### Related issues

Fixes #20913