### PR TITLE
Updates for Firefox 123 beta

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2635,7 +2635,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "123"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -81,7 +81,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "123"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -120,7 +120,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "123"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/-moz-user-focus.json
+++ b/css/properties/-moz-user-focus.json
@@ -11,7 +11,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "version_removed": "123"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/-moz-user-focus.json
+++ b/css/properties/-moz-user-focus.json
@@ -12,7 +12,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "1",
-              "version_removed": "123"
+              "version_removed": "122"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -54,7 +54,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "123"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/http/status.json
+++ b/http/status.json
@@ -107,14 +107,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "102",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "network.early-hints.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "123"
               },
               "ie": {
                 "version_added": false
@@ -126,7 +119,7 @@
               }
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
The [Open Web Docs BCD collector](https://github.com/openwebdocs/mdn-bcd-collector) v10.7.0 found new features shipping in Firefox 123 beta which was released yesterday. Currently, the collector covers about 82% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following features as shipping in Firefox 123:

- `api.Element.attachShadow.init_clonable_parameter` ([Intent to ship: Declarative ShadowDOM](https://groups.google.com/a/mozilla.org/g/dev-platform/c/P-ZBI_7fEaE))
- `api.HTMLTemplateElement.shadowRootMode` ([Intent to ship: Declarative ShadowDOM](https://groups.google.com/a/mozilla.org/g/dev-platform/c/P-ZBI_7fEaE))
- `api.ShadowRoot.clonable` ([Intent to ship: Declarative ShadowDOM](https://groups.google.com/a/mozilla.org/g/dev-platform/c/P-ZBI_7fEaE))
- `css.properties.-moz-user-focus` (see [Intent to change: -moz-user-focus](https://groups.google.com/a/mozilla.org/g/dev-platform/c/BsgxAHsVVvU))
- `html.elements.template.shadowrootmode` ([Intent to ship: Declarative ShadowDOM](https://groups.google.com/a/mozilla.org/g/dev-platform/c/P-ZBI_7fEaE))
- `http.status.103.preload` (see https://bugzilla.mozilla.org/show_bug.cgi?id=1874445)
- `webextensions.api.contextualIdentities.move` (already submitted before this PR in https://github.com/mdn/browser-compat-data/pull/21702)

Again, I hope this auto-generated PR is useful to update BCD for the new Firefox 123 more easily and faster. If you have feedback, let me know! /cc @Rumyra @bsmth @pepelsbey 