### PR TITLE
Adding scripting to permissions manifest key

### DIFF
--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -795,6 +795,29 @@
             }
           }
         },
+        "scripting": {
+          "__compat": {
+            "description": "<code>scripting</code>",
+            "support": {
+              "chrome": {
+                "version_added": "88",
+                "notes": "Available for use in Manifest V3 or later."
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "102"
+              },
+              "firefox_android": "mirror",
+              "opera": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "search": {
           "__compat": {
             "description": "<code>search</code>",


### PR DESCRIPTION
#### Summary

The introduction of the scripting API also included the scripting permission. This change adds that scripting permission to the permissions manifest key.

#### Related issues

Fixes #20859