### PR TITLE
Adding scripting to optional_permissions manifest key

### DIFF
--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -643,6 +643,29 @@
             }
           }
         },
+        "scripting": {
+          "__compat": {
+            "description": "<code>scripting</code>",
+            "support": {
+              "chrome": {
+                "version_added": "88",
+                "notes": "Available for use in Manifest V3 or later."
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "102"
+              },
+              "firefox_android": "mirror",
+              "opera": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "sessions": {
           "__compat": {
             "description": "<code>sessions</code>",


### PR DESCRIPTION
Summary

The introduction of the scripting API also included the scripting optional permission. This change adds that scripting permission to the optional_permissions manifest key.

Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/20859