### PR TITLE
Update content.json- Safari `alt_text` to `"preview"`

### DIFF
--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -60,7 +60,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview",
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -60,7 +60,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview",
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

I am updating `alt-text` to preview, STP 187 adds support for `alt_text`.

#### Test results and supporting details

STP 187 release notes: https://webkit.org/blog/14931/release-notes-for-safari-technology-preview-187/
Commit: https://github.com/WebKit/WebKit/commit/1b3e497426196dd3289ad58811bdb12cbaa29379

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
