### PR TITLE
Updates for Chrome 122 beta

### DIFF
--- a/api/IdentityCredential.json
+++ b/api/IdentityCredential.json
@@ -35,7 +35,7 @@
       },
       "disconnect_static": {
         "__compat": {
-          "description": "<code>abort()</code> static method",
+          "description": "<code>disconnect()</code> static method",
           "spec_url": "https://fedidcg.github.io/FedCM/#dom-identitycredential-disconnect",
           "support": {
             "chrome": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4373,6 +4373,42 @@
           }
         }
       },
+      "storageBuckets": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/storage-buckets/#dom-navigatorstoragebuckets-storagebuckets",
+          "tags": [
+            "web-features:storage-buckets"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "taintEnabled": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/taintEnabled",

--- a/api/StorageBucket.json
+++ b/api/StorageBucket.json
@@ -1,17 +1,16 @@
 {
   "api": {
-    "URLPattern": {
+    "StorageBucket": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/URLPattern",
-        "spec_url": "https://urlpattern.spec.whatwg.org/#urlpattern",
+        "spec_url": "https://wicg.github.io/storage-buckets/#storagebucket",
+        "tags": [
+          "web-features:storage-buckets"
+        ],
         "support": {
           "chrome": {
-            "version_added": "95"
+            "version_added": "122"
           },
           "chrome_android": "mirror",
-          "deno": {
-            "version_added": "1.15"
-          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -36,158 +35,12 @@
           "deprecated": false
         }
       },
-      "URLPattern": {
+      "caches": {
         "__compat": {
-          "description": "<code>URLPattern()</code> constructor",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/URLPattern/URLPattern",
-          "spec_url": "https://urlpattern.spec.whatwg.org/#dom-urlpattern-urlpattern",
-          "support": {
-            "chrome": {
-              "version_added": "95"
-            },
-            "chrome_android": "mirror",
-            "deno": {
-              "version_added": "1.15"
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        },
-        "ignoreCase_option": {
-          "__compat": {
-            "description": "<code>ignoreCase</code> option",
-            "spec_url": "https://urlpattern.spec.whatwg.org/#dom-urlpatternoptions-ignorecase",
-            "support": {
-              "chrome": {
-                "version_added": "107"
-              },
-              "chrome_android": "mirror",
-              "deno": {
-                "version_added": false
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        }
-      },
-      "exec": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/URLPattern/exec",
-          "spec_url": "https://urlpattern.spec.whatwg.org/#dom-urlpattern-exec",
-          "support": {
-            "chrome": {
-              "version_added": "95"
-            },
-            "chrome_android": "mirror",
-            "deno": {
-              "version_added": "1.15"
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "hash": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/URLPattern/hash",
-          "spec_url": "https://urlpattern.spec.whatwg.org/#dom-urlpattern-hash",
-          "support": {
-            "chrome": {
-              "version_added": "95"
-            },
-            "chrome_android": "mirror",
-            "deno": {
-              "version_added": "1.15"
-            },
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "ie": {
-              "version_added": false
-            },
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
-      "hasRegExpGroups": {
-        "__compat": {
-          "spec_url": "https://urlpattern.spec.whatwg.org/#dom-urlpattern-hasregexpgroups",
+          "spec_url": "https://wicg.github.io/storage-buckets/#dom-storagebucket-caches",
+          "tags": [
+            "web-features:storage-buckets"
+          ],
           "support": {
             "chrome": {
               "version_added": "122"
@@ -218,18 +71,17 @@
           }
         }
       },
-      "hostname": {
+      "estimate": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/URLPattern/hostname",
-          "spec_url": "https://urlpattern.spec.whatwg.org/#dom-urlpattern-hostname",
+          "spec_url": "https://wicg.github.io/storage-buckets/#dom-storagebucket-caches",
+          "tags": [
+            "web-features:storage-buckets"
+          ],
           "support": {
             "chrome": {
-              "version_added": "95"
+              "version_added": "122"
             },
             "chrome_android": "mirror",
-            "deno": {
-              "version_added": "1.15"
-            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -255,18 +107,17 @@
           }
         }
       },
-      "password": {
+      "expires": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/URLPattern/password",
-          "spec_url": "https://urlpattern.spec.whatwg.org/#dom-urlpattern-password",
+          "spec_url": "https://wicg.github.io/storage-buckets/#dom-storagebucket-expires",
+          "tags": [
+            "web-features:storage-buckets"
+          ],
           "support": {
             "chrome": {
-              "version_added": "95"
+              "version_added": "122"
             },
             "chrome_android": "mirror",
-            "deno": {
-              "version_added": "1.15"
-            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -292,18 +143,17 @@
           }
         }
       },
-      "pathname": {
+      "getDirectory": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/URLPattern/pathname",
-          "spec_url": "https://urlpattern.spec.whatwg.org/#dom-urlpattern-pathname",
+          "spec_url": "https://wicg.github.io/storage-buckets/#dom-storagebucket-getdirectory",
+          "tags": [
+            "web-features:storage-buckets"
+          ],
           "support": {
             "chrome": {
-              "version_added": "95"
+              "version_added": "122"
             },
             "chrome_android": "mirror",
-            "deno": {
-              "version_added": "1.15"
-            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -329,18 +179,17 @@
           }
         }
       },
-      "port": {
+      "indexedDB": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/URLPattern/port",
-          "spec_url": "https://urlpattern.spec.whatwg.org/#dom-urlpattern-port",
+          "spec_url": "https://wicg.github.io/storage-buckets/#dom-storagebucket-indexeddb",
+          "tags": [
+            "web-features:storage-buckets"
+          ],
           "support": {
             "chrome": {
-              "version_added": "95"
+              "version_added": "122"
             },
             "chrome_android": "mirror",
-            "deno": {
-              "version_added": "1.15"
-            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -366,18 +215,17 @@
           }
         }
       },
-      "protocol": {
+      "name": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/URLPattern/protocol",
-          "spec_url": "https://urlpattern.spec.whatwg.org/#dom-urlpattern-protocol",
+          "spec_url": "https://wicg.github.io/storage-buckets/#dom-storagebucket-name",
+          "tags": [
+            "web-features:storage-buckets"
+          ],
           "support": {
             "chrome": {
-              "version_added": "95"
+              "version_added": "122"
             },
             "chrome_android": "mirror",
-            "deno": {
-              "version_added": "1.15"
-            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -403,18 +251,17 @@
           }
         }
       },
-      "search": {
+      "persist": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/URLPattern/search",
-          "spec_url": "https://urlpattern.spec.whatwg.org/#dom-urlpattern-search",
+          "spec_url": "https://wicg.github.io/storage-buckets/#dom-storagebucket-persist",
+          "tags": [
+            "web-features:storage-buckets"
+          ],
           "support": {
             "chrome": {
-              "version_added": "95"
+              "version_added": "122"
             },
             "chrome_android": "mirror",
-            "deno": {
-              "version_added": "1.15"
-            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -440,18 +287,17 @@
           }
         }
       },
-      "test": {
+      "persisted": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/URLPattern/test",
-          "spec_url": "https://urlpattern.spec.whatwg.org/#dom-urlpattern-test",
+          "spec_url": "https://wicg.github.io/storage-buckets/#dom-storagebucket-persisted",
+          "tags": [
+            "web-features:storage-buckets"
+          ],
           "support": {
             "chrome": {
-              "version_added": "95"
+              "version_added": "122"
             },
             "chrome_android": "mirror",
-            "deno": {
-              "version_added": "1.15"
-            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -477,18 +323,17 @@
           }
         }
       },
-      "username": {
+      "setExpires": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/URLPattern/username",
-          "spec_url": "https://urlpattern.spec.whatwg.org/#dom-urlpattern-username",
+          "spec_url": "https://wicg.github.io/storage-buckets/#dom-storagebucket-setexpires",
+          "tags": [
+            "web-features:storage-buckets"
+          ],
           "support": {
             "chrome": {
-              "version_added": "95"
+              "version_added": "122"
             },
             "chrome_android": "mirror",
-            "deno": {
-              "version_added": "1.15"
-            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/StorageBucketManager.json
+++ b/api/StorageBucketManager.json
@@ -1,12 +1,14 @@
 {
   "api": {
-    "IdentityCredential": {
+    "StorageBucketManager": {
       "__compat": {
-        "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdentityCredential",
-        "spec_url": "https://fedidcg.github.io/FedCM/#browser-api-identity-credential-interface",
+        "spec_url": "https://wicg.github.io/storage-buckets/#storagebucketmanager",
+        "tags": [
+          "web-features:storage-buckets"
+        ],
         "support": {
           "chrome": {
-            "version_added": "108"
+            "version_added": "122"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -33,10 +35,12 @@
           "deprecated": false
         }
       },
-      "disconnect_static": {
+      "delete": {
         "__compat": {
-          "description": "<code>abort()</code> static method",
-          "spec_url": "https://fedidcg.github.io/FedCM/#dom-identitycredential-disconnect",
+          "spec_url": "https://wicg.github.io/storage-buckets/#dom-storagebucketmanager-delete",
+          "tags": [
+            "web-features:storage-buckets"
+          ],
           "support": {
             "chrome": {
               "version_added": "122"
@@ -67,12 +71,15 @@
           }
         }
       },
-      "isAutoSelected": {
+      "keys": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdentityCredential/isAutoSelected",
+          "spec_url": "https://wicg.github.io/storage-buckets/#dom-storagebucketmanager-keys",
+          "tags": [
+            "web-features:storage-buckets"
+          ],
           "support": {
             "chrome": {
-              "version_added": "120"
+              "version_added": "122"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -95,18 +102,20 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }
       },
-      "token": {
+      "open": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/IdentityCredential/token",
-          "spec_url": "https://fedidcg.github.io/FedCM/#dom-identitycredential-token",
+          "spec_url": "https://wicg.github.io/storage-buckets/#dom-storagebucketmanager-open",
+          "tags": [
+            "web-features:storage-buckets"
+          ],
           "support": {
             "chrome": {
-              "version_added": "108"
+              "version_added": "122"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -3082,6 +3082,7 @@
       },
       "drawingBufferFormat": {
         "__compat": {
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.1",
           "support": {
             "chrome": {
               "version_added": "122"
@@ -3150,6 +3151,7 @@
       },
       "drawingBufferStorage": {
         "__compat": {
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/1.0/#2.2",
           "support": {
             "chrome": {
               "version_added": "122"

--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -3080,6 +3080,38 @@
           }
         }
       },
+      "drawingBufferFormat": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "122"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "drawingBufferHeight": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/drawingBufferHeight",
@@ -3111,6 +3143,38 @@
           },
           "status": {
             "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "drawingBufferStorage": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "122"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -2358,6 +2358,39 @@
           }
         }
       },
+      "drawingBufferFormat": {
+        "__compat": {
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.1",
+          "support": {
+            "chrome": {
+              "version_added": "122"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "drawingBufferHeight": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/drawingBufferHeight",
@@ -2399,6 +2432,39 @@
           },
           "status": {
             "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "drawingBufferStorage": {
+        "__compat": {
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/1.0/#2.2",
+          "support": {
+            "chrome": {
+              "version_added": "122"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -805,6 +805,42 @@
           }
         }
       },
+      "storageBuckets": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/storage-buckets/#dom-navigatorstoragebuckets-storagebuckets",
+          "tags": [
+            "web-features:storage-buckets"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "122"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "usb": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WorkerNavigator/usb",

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -49,7 +49,7 @@
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iterator-constructor",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "122"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -91,7 +91,7 @@
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.drop",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "122"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -133,7 +133,7 @@
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.every",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "122"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -175,7 +175,7 @@
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.filter",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "122"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -217,7 +217,7 @@
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.find",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "122"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -259,7 +259,7 @@
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.flatmap",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "122"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -301,7 +301,7 @@
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.foreach",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "122"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -343,7 +343,7 @@
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iterator.from",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "122"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -385,7 +385,7 @@
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.map",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "122"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -427,7 +427,7 @@
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.reduce",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "122"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -469,7 +469,7 @@
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.some",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "122"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -511,7 +511,7 @@
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.take",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "122"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -553,7 +553,7 @@
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.toarray",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": "122"
               },
               "chrome_android": "mirror",
               "deno": {

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -345,8 +345,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/v8/13556"
+                "version_added": "122"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -381,7 +380,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -522,8 +521,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/v8/13556"
+                "version_added": "122"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -558,7 +556,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -573,8 +571,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/v8/13556"
+                "version_added": "122"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -609,7 +606,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -624,8 +621,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/v8/13556"
+                "version_added": "122"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -660,7 +656,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -675,8 +671,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/v8/13556"
+                "version_added": "122"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -711,7 +706,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -852,8 +847,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/v8/13556"
+                "version_added": "122"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -888,7 +882,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -903,8 +897,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/v8/13556"
+                "version_added": "122"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -939,7 +932,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
The [Open Web Docs BCD collector](https://github.com/openwebdocs/mdn-bcd-collector) v10.7.1 found new features shipping in Chrome 122 beta which was released yesterday. Currently, the collector covers about 82% of BCD, so the following list might not be exhaustive. Also, if a feature is in Chrome Canary/behind origin trials/enrollment, it is not considered here.

With this PR, BCD considers the following 44 features as shipping in Chrome 122:

- api.IdentityCredential.disconnect_static
- api.Navigator.storageBuckets
- api.StorageBucket
- api.StorageBucket.caches
- api.StorageBucket.estimate
- api.StorageBucket.expires
- api.StorageBucket.getDirectory
- api.StorageBucket.indexedDB
- api.StorageBucket.name
- api.StorageBucket.persist
- api.StorageBucket.persisted
- api.StorageBucket.setExpires
- api.StorageBucketManager
- api.StorageBucketManager.delete
- api.StorageBucketManager.keys
- api.StorageBucketManager.open
- api.URLPattern.hasRegExpGroups
- api.WebGL2RenderingContext.drawingBufferFormat
- api.WebGL2RenderingContext.drawingBufferStorage
- api.WebGLRenderingContext.drawingBufferFormat
- api.WebGLRenderingContext.drawingBufferStorage
- api.WorkerNavigator.storageBuckets
- css.types.color.rgb.mixed_type_parameters (not in this PR but added to BCD manually previously)
- css.types.color.rgba.mixed_type_parameters (ditto)
- javascript.builtins.Iterator.Iterator
- javascript.builtins.Iterator.drop
- javascript.builtins.Iterator.every
- javascript.builtins.Iterator.filter
- javascript.builtins.Iterator.find
- javascript.builtins.Iterator.flatMap
- javascript.builtins.Iterator.forEach
- javascript.builtins.Iterator.from
- javascript.builtins.Iterator.map
- javascript.builtins.Iterator.reduce
- javascript.builtins.Iterator.some
- javascript.builtins.Iterator.take
- javascript.builtins.Iterator.toArray
- javascript.builtins.Set.difference
- javascript.builtins.Set.intersection
- javascript.builtins.Set.isDisjointFrom
- javascript.builtins.Set.isSubsetOf
- javascript.builtins.Set.isSupersetOf
- javascript.builtins.Set.symmetricDifference
- javascript.builtins.Set.union

I think all of this is in line with what https://chromestatus.com says currently.

Again, I hope this auto-generated PR is useful to update BCD for the new Chrome 122 more easily and faster. If you have feedback, let me know! /cc @chrisdavidmills 