### PR TITLE
Add Safari 17.4 support for date input showPicker function

### DIFF
--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -2172,7 +2172,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "17.4"
               },
               "safari_ios": {
                 "version_added": false,
@@ -2208,7 +2208,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "17.4"
               },
               "safari_ios": {
                 "version_added": false,

--- a/browsers/safari.json
+++ b/browsers/safari.json
@@ -296,6 +296,11 @@
           "status": "current",
           "engine": "WebKit",
           "engine_version": "617.2.4"
+        },
+        "17.4": {
+          "release_notes": "https://developer.apple.com/documentation/safari-release-notes/safari-17_4-release-notes",
+          "status": "beta",
+          "engine": "WebKit"
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add Safari 17.4 support for date showPicker function

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

https://developer.apple.com/documentation/safari-release-notes/safari-17_4-release-notes#:~:text=support%20for%20the-,showPicker,-()%20method%20for 

Release notes say type="date" but this also applies to datetime-local too.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
