### PR TITLE
FF123 -moz-user-focus default value

### DIFF
--- a/css/properties/-moz-user-focus.json
+++ b/css/properties/-moz-user-focus.json
@@ -12,7 +12,8 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "1",
-              "notes": "From version 123 the default value is <code>normal</code> (previously it was <code>none</code>), and <code>none</code> prevents the element accepting focus. See <a href='https://bugzil.la/1749806'>bug 1749806</a>."
+              "version_removed": "123",
+              "notes": "From version 123 this property is not available in web content (but can be used in browser code). The default value is now <code>normal</code> (previously it was <code>none</code>), and <code>none</code> correctly prevents the element accepting focus. See <a href='https://bugzil.la/1749806'>bug 1749806</a> and <a href='https://bugzil.la/1871745'>bug 1871745</a>."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/-moz-user-focus.json
+++ b/css/properties/-moz-user-focus.json
@@ -11,7 +11,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "From version 123 the default value is <code>normal</code> (previously it was <code>none</code>), and <code>none</code> prevents the element accepting focus. See <a href='https://bugzil.la/1749806'>bug 1749806</a>."
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/-moz-user-focus.json
+++ b/css/properties/-moz-user-focus.json
@@ -12,8 +12,8 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "1",
-              "version_removed": "123",
-              "notes": "From version 123 this property is not available in web content (but can be used in browser code). The default value is now <code>normal</code> (previously it was <code>none</code>), and <code>none</code> correctly prevents the element accepting focus. See <a href='https://bugzil.la/1749806'>bug 1749806</a> and <a href='https://bugzil.la/1871745'>bug 1871745</a>."
+              "version_removed": "122",
+              "notes": "From version 122 this property is not available in web content (but can be used in browser code). The default value also changed from <code>none</code> to <code>normal</code>), and <code>none</code> correctly prevents the element accepting focus. See <a href='https://bugzil.la/1749806'>bug 1749806</a> and <a href='https://bugzil.la/1871745'>bug 1871745</a>."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF122 changes the default value of CSS [`-moz-user-focus`](https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-user-focus) default from `none` to `normal` in https://bugzilla.mozilla.org/show_bug.cgi?id=1868552. It also fixed a bug that `none` didn't actually do what it was supposed to do.

But then https://bugzilla.mozilla.org/show_bug.cgi?id=1871745 appears to remove this whole value from content (i.e. only affects chrome). I'm asking about this in https://bugzilla.mozilla.org/show_bug.cgi?id=1871745#c13

Related docs work can be tracked in https://github.com/mdn/content/issues/31928