### PR TITLE
Update Edge data for CSSScopeRule API

### DIFF
--- a/api/CSSScopeRule.json
+++ b/api/CSSScopeRule.json
@@ -8,9 +8,7 @@
             "version_added": "118"
           },
           "chrome_android": "mirror",
-          "edge": {
-            "version_added": false
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": false
           },
@@ -42,9 +40,7 @@
               "version_added": "118"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -77,9 +73,7 @@
               "version_added": "118"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `CSSScopeRule` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/CSSScopeRule
