### PR TITLE
Update Edge data for api.Document.hasStorageAccess

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4462,7 +4462,9 @@
             "chrome_android": {
               "version_added": "120"
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "85"
+            },
             "firefox": {
               "version_added": "65"
             },
@@ -6123,7 +6125,9 @@
             "chrome_android": {
               "version_added": "120"
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "85"
+            },
             "firefox": {
               "version_added": "65"
             },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `hasStorageAccess` member of the `Document` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Document/hasStorageAccess
