### PR TITLE
Add missing api.Document.hasPrivateToken feature

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4418,6 +4418,39 @@
           }
         }
       },
+      "hasPrivateToken": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/trust-token-api/#dom-document-hasprivatetoken",
+          "support": {
+            "chrome": {
+              "version_added": "117"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "hasRedemptionRecord": {
         "__compat": {
           "spec_url": "https://wicg.github.io/trust-token-api/#dom-document-hasredemptionrecord",


### PR DESCRIPTION
This PR adds the missing `hasPrivateToken` member of the `Document` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Document/hasPrivateToken
