### PR TITLE
Update Edge data for api.Element.focus_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -4340,7 +4340,7 @@
             "edge": {
               "version_added": "12",
               "partial_implementation": true,
-              "notes": "The <code>onfocusin</code> event handler property is not supported. To listen to this event, use <code>element.addEventListener('focusin', function() {});</code>."
+              "notes": "The <code>onfocusout</code> event handler property is not supported. To listen to this event, use <code>element.addEventListener('focusin', function() {});</code>."
             },
             "firefox": {
               "version_added": "52",

--- a/api/Element.json
+++ b/api/Element.json
@@ -4289,7 +4289,9 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "partial_implementation": true,
+              "notes": "The <code>onfocusin</code> event handler property is not supported. To listen to this event, use <code>element.addEventListener('focusin', function() {});</code>."
             },
             "firefox": {
               "version_added": "52",
@@ -4336,7 +4338,9 @@
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12"
+              "version_added": "12",
+              "partial_implementation": true,
+              "notes": "The <code>onfocusin</code> event handler property is not supported. To listen to this event, use <code>element.addEventListener('focusin', function() {});</code>."
             },
             "firefox": {
               "version_added": "52",


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `focus_event` member of the `Element` API. This copies the notes from Chrome.
