### PR TITLE
Update Edge data for api.NavigateEvent.hasUAVisualTransition

### DIFF
--- a/api/NavigateEvent.json
+++ b/api/NavigateEvent.json
@@ -295,9 +295,7 @@
               "version_added": "118"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `hasUAVisualTransition` member of the `NavigateEvent` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/NavigateEvent/hasUAVisualTransition
