### PR TITLE
Update Edge data for api.PopStateEvent.hasUAVisualTransition

### DIFF
--- a/api/PopStateEvent.json
+++ b/api/PopStateEvent.json
@@ -84,9 +84,7 @@
               "version_added": "118"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `hasUAVisualTransition` member of the `PopStateEvent` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/PopStateEvent/hasUAVisualTransition
