### PR TITLE
Update Opera releases

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -796,9 +796,16 @@
           "engine_version": "119"
         },
         "106": {
-          "status": "beta",
+          "release_date": "2023-12-19",
+          "release_notes": "https://blogs.opera.com/desktop/2023/12/opera-106/",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "120"
+        },
+        "107": {
+          "status": "beta",
+          "engine": "Blink",
+          "engine_version": "121"
         }
       }
     }

--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -445,9 +445,15 @@
         },
         "79": {
           "release_date": "2023-12-06",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "119"
+        },
+        "80": {
+          "release_date": "2024-01-25",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "120"
         }
       }
     }


### PR DESCRIPTION
Release date for Opera Android comes from UpToDown.com.
