### PR TITLE
Update Edge data for api.Window.vrdisplaypresentchange_event

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -6847,7 +6847,8 @@
               ]
             },
             "edge": {
-              "version_added": "15"
+              "version_added": "15",
+              "version_removed": "79"
             },
             "firefox": [
               {


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `vrdisplaypresentchange_event` member of the `Window` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Window/vrdisplaypresentchange_event
