### PR TITLE
Update Edge data for api.Worker.messageerror_event

### DIFF
--- a/api/Worker.json
+++ b/api/Worker.json
@@ -408,7 +408,8 @@
               "version_added": "1.0"
             },
             "edge": {
-              "version_added": "18"
+              "version_added": "18",
+              "version_removed": "79"
             },
             "firefox": {
               "version_added": "57"


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `messageerror_event` member of the `Worker` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Worker/messageerror_event
