### PR TITLE
Update Edge data for transform-box CSS property

### DIFF
--- a/css/properties/transform-box.json
+++ b/css/properties/transform-box.json
@@ -41,9 +41,7 @@
                 "version_added": "118"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "≤72"
               },
@@ -75,9 +73,7 @@
                 "version_added": "118"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "preview"
               },
@@ -109,9 +105,7 @@
                 "version_added": "118"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": false
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "preview"
               },


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `transform-box` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/transform-box
