### PR TITLE
Update Chrome/Safari data for svg.elements.image.crossorigin

### DIFF
--- a/svg/elements/image.json
+++ b/svg/elements/image.json
@@ -48,7 +48,7 @@
             "spec_url": "https://svgwg.org/svg2-draft/embedded.html#ImageElementCrossoriginAttribute",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "118"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -63,7 +63,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `crossorigin` member of the `image` SVG element. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/svg/elements/image/crossorigin
