### PR TITLE
feat(api): Add Ed25519 sign/verify SubtleCrypto algo

### DIFF
--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -670,6 +670,52 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "ed25519": {
+          "__compat": {
+            "description": "<code>Ed25519</code> algorithm",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/sign",
+            "spec_url": "https://w3c.github.io/webcrypto/#SubtleCrypto-method-sign",
+            "support": {
+              "chrome": {
+                "version_added": "113",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.26.1"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "nodejs": {
+                "version_added": "16.17.0",
+                "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "generateKey": {
@@ -815,6 +861,52 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "ed25519": {
+          "__compat": {
+            "description": "<code>Ed25519</code> algorithm",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/sign",
+            "spec_url": "https://w3c.github.io/webcrypto/#SubtleCrypto-method-sign",
+            "support": {
+              "chrome": {
+                "version_added": "113",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.26.1"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "nodejs": {
+                "version_added": "16.17.0",
+                "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "sign": {
@@ -867,6 +959,52 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "ed25519": {
+          "__compat": {
+            "description": "<code>Ed25519</code> algorithm",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/sign",
+            "spec_url": "https://w3c.github.io/webcrypto/#SubtleCrypto-method-sign",
+            "support": {
+              "chrome": {
+                "version_added": "113",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.26.1"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "nodejs": {
+                "version_added": "16.17.0",
+                "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },
@@ -984,6 +1122,52 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "ed25519": {
+          "__compat": {
+            "description": "<code>Ed25519</code> algorithm",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/sign",
+            "spec_url": "https://w3c.github.io/webcrypto/#SubtleCrypto-method-sign",
+            "support": {
+              "chrome": {
+                "version_added": "113",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.26.1"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "nodejs": {
+                "version_added": "16.17.0",
+                "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -689,13 +689,16 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": "1.26.1"
+                "version_added": "1.26"
               },
               "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
               "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
               "nodejs": {
                 "version_added": "16.17.0",
                 "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)"
@@ -880,13 +883,16 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": "1.26.1"
+                "version_added": "1.26"
               },
               "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
               "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
               "nodejs": {
                 "version_added": "16.17.0",
                 "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)"
@@ -979,13 +985,16 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": "1.26.1"
+                "version_added": "1.26"
               },
               "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
               "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
               "nodejs": {
                 "version_added": "16.17.0",
                 "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)"
@@ -1142,13 +1151,16 @@
               },
               "chrome_android": "mirror",
               "deno": {
-                "version_added": "1.26.1"
+                "version_added": "1.26"
               },
               "edge": "mirror",
               "firefox": {
                 "version_added": false
               },
               "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
               "nodejs": {
                 "version_added": "16.17.0",
                 "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)"

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -674,8 +674,8 @@
         "ed25519": {
           "__compat": {
             "description": "<code>Ed25519</code> algorithm",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/sign",
-            "spec_url": "https://w3c.github.io/webcrypto/#SubtleCrypto-method-sign",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/exportKey",
+            "spec_url": "https://wicg.github.io/webcrypto-secure-curves/#ed25519",
             "support": {
               "chrome": {
                 "version_added": "113",
@@ -701,7 +701,7 @@
               },
               "nodejs": {
                 "version_added": "16.17.0",
-                "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)"
+                "notes": "Marked as <a href='https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs'>'Stability 1' - Experimental</a>."
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -788,6 +788,55 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "ed25519": {
+          "__compat": {
+            "description": "<code>Ed25519</code> algorithm",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/generateKey",
+            "spec_url": "https://wicg.github.io/webcrypto-secure-curves/#ed25519",
+            "support": {
+              "chrome": {
+                "version_added": "113",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": "1.26"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "nodejs": {
+                "version_added": "16.17.0",
+                "notes": "Marked as <a href='https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs'>'Stability 1' - Experimental</a>."
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "importKey": {
@@ -868,8 +917,8 @@
         "ed25519": {
           "__compat": {
             "description": "<code>Ed25519</code> algorithm",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/sign",
-            "spec_url": "https://w3c.github.io/webcrypto/#SubtleCrypto-method-sign",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/importKey",
+            "spec_url": "https://wicg.github.io/webcrypto-secure-curves/#ed25519",
             "support": {
               "chrome": {
                 "version_added": "113",
@@ -895,7 +944,7 @@
               },
               "nodejs": {
                 "version_added": "16.17.0",
-                "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)"
+                "notes": "Marked as <a href='https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs'>'Stability 1' - Experimental</a>."
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -971,7 +1020,7 @@
           "__compat": {
             "description": "<code>Ed25519</code> algorithm",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/sign",
-            "spec_url": "https://w3c.github.io/webcrypto/#SubtleCrypto-method-sign",
+            "spec_url": "https://wicg.github.io/webcrypto-secure-curves/#ed25519",
             "support": {
               "chrome": {
                 "version_added": "113",
@@ -997,7 +1046,7 @@
               },
               "nodejs": {
                 "version_added": "16.17.0",
-                "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)"
+                "notes": "Marked as <a href='https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs'>'Stability 1' - Experimental</a>."
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -1136,8 +1185,8 @@
         "ed25519": {
           "__compat": {
             "description": "<code>Ed25519</code> algorithm",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/sign",
-            "spec_url": "https://w3c.github.io/webcrypto/#SubtleCrypto-method-sign",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/SubtleCrypto/verify",
+            "spec_url": "https://wicg.github.io/webcrypto-secure-curves/#ed25519",
             "support": {
               "chrome": {
                 "version_added": "113",
@@ -1163,7 +1212,7 @@
               },
               "nodejs": {
                 "version_added": "16.17.0",
-                "notes": "Marked as ['Stability 1' - Experimental](https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs)"
+                "notes": "Marked as <a href='https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs'>'Stability 1' - Experimental</a>."
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
#### Summary

Currently [the spec states](https://w3c.github.io/webcrypto/#scope-algorithms):

>Because the underlying cryptographic implementations will vary between conforming user agents... this specification does not dictate a mandatory set of algorithms that MUST be implemented. Instead, it defines a common set of bindings that can be used in an algorithm-independent manner...

There are a list of recommendations for [implementers](https://www.w3.org/TR/WebCryptoAPI/#algorithm-recommendations-implementers):

>In order to promote interoperability for developers, this specification includes a list of suggested algorithms. These are considered to be the most widely used algorithms in practice at the time of writing, and therefore provide a good starting point for initial implementations of this specification. The suggested algorithms are:
>
>[HMAC](https://www.w3.org/TR/WebCryptoAPI/#hmac) using [SHA-1](https://www.w3.org/TR/WebCryptoAPI/#alg-sha-1)
[HMAC](https://www.w3.org/TR/WebCryptoAPI/#hmac) using [SHA-256](https://www.w3.org/TR/WebCryptoAPI/#alg-sha-256)
[RSASSA-PKCS1-v1_5](https://www.w3.org/TR/WebCryptoAPI/#rsassa-pkcs1) using [SHA-1](https://www.w3.org/TR/WebCryptoAPI/#alg-sha-256)
[RSA-PSS](https://www.w3.org/TR/WebCryptoAPI/#rsa-pss) using [SHA-256](https://www.w3.org/TR/WebCryptoAPI/#alg-sha-256) and MGF1 with [SHA-256](https://www.w3.org/TR/WebCryptoAPI/#alg-sha-256).
[RSA-OAEP](https://www.w3.org/TR/WebCryptoAPI/#rsa-oaep) using [SHA-256](https://www.w3.org/TR/WebCryptoAPI/#alg-sha-256) and MGF1 with [SHA-256](https://www.w3.org/TR/WebCryptoAPI/#alg-sha-256).
[ECDSA](https://www.w3.org/TR/WebCryptoAPI/#ecdsa) using [P-256](https://www.w3.org/TR/WebCryptoAPI/#dfn-NamedCurve-p256) curve and [SHA-256](https://www.w3.org/TR/WebCryptoAPI/#alg-sha-256)
[AES-CBC](https://www.w3.org/TR/WebCryptoAPI/#aes-cbc)


I've added a sub-feature for an algo which is not part of this recommendation, but is available in multiple engines.

Standardization status:

> There's a WICG draft for Curve25519 and Curve448 in [Web Crypto here](https://wicg.github.io/webcrypto-secure-curves/)

#### Test results and supporting details

* **Chrome:** 113 (behind flag)
   - Commit https://chromium-review.googlesource.com/c/chromium/src/+/4016576
   - Commit in find release tool: https://storage.googleapis.com/chromium-find-releases-static/2db.html#2db4c847d07e2811f9efff4387f20906d109dedf
   - Flag: `enable-experimental-web-platform-features` (chrome://flags/#enable-experimental-web-platform-features)

* **Safari:** Stable v17
  * Relnote https://webkit.org/blog/13839/release-notes-for-safari-technology-preview-163/
  * Commit https://github.com/WebKit/WebKit/commit/3abe0e45310ef3e846f8509e44b5514fb2099f76 

* **Node.js:** 16.17.0 (marked as experimental)
  * Docs - https://nodejs.org/dist/latest-v16.x/docs/api/webcrypto.html#ed25519ed448x25519x448-key-pairs  
  * Changelog https://github.com/nodejs/node/commit/5e5fb825fc4bc3cd3e51614aaad9af14342a5e6c

* **Deno:** 1.26.0 
  * Changelog https://github.com/denoland/deno/blob/main/Releases.md#1260--20220928

* No Fx support

* **WPT:** generateKey
  * https://wpt.live/WebCryptoAPI/generateKey/successes_Ed25519.https.any.html 
  * https://wpt.fyi/results/WebCryptoAPI/generateKey/successes_Ed25519.https.any.html?label=master&product=chrome%5Bexperimental%5D&product=deno%5Bexperimental%5D&product=firefox%5Bexperimental%5D&product=safari%5Bexperimental%5D&product=node.js%5Bexperimental%5D&product=chrome%5Bstable%5D&product=safari%5Bstable%5D&product=deno%5Bstable%5D&product=node.js%5Bstable%5D&aligned

Node repro:

```js
async function generateAndSignKey() {
  const algorithm = { name: "Ed25519" };
  const encoder = new TextEncoder();
  const cryptoKey = await crypto.subtle.generateKey(
    algorithm,
    true,
    ["sign", "verify"]
  );

  console.log(
    await crypto.subtle.sign(
      algorithm,
      cryptoKey.privateKey,
      new Uint8Array([255])
    )
  );
}

generateAndSignKey();
```

output:

```
(node:27247) ExperimentalWarning: The Ed25519 Web Crypto API algorithm is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
ArrayBuffer {
  [Uint8Contents]: <bd 47 7d 05...
//
node --version
v20.11.0
```

#### Related issues

* https://github.com/WICG/webcrypto-secure-curves/issues/20
* https://github.com/mdn/content/issues/30886
* https://github.com/mdn/dom-examples/pull/247