### PR TITLE
Chrome optional permissions update

### DIFF
--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -29,7 +29,7 @@
             "description": "<code>activeTab</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": true
               },
               "edge": "mirror",
               "firefox": {
@@ -43,6 +43,26 @@
               "safari_ios": {
                 "version_added": "15"
               }
+            }
+          }
+        },
+        "alarm": {
+          "__compat": {
+            "description": "<code>alarm</code>",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
             }
           }
         },
@@ -117,7 +137,7 @@
             "description": "<code>browsingData</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": true
               },
               "edge": "mirror",
               "firefox": {
@@ -255,7 +275,7 @@
             "description": "<code>debugger</code>",
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": false
               },
               "edge": {
                 "version_added": "79"
@@ -355,12 +375,32 @@
             }
           }
         },
+        "dns": {
+          "__compat": {
+            "description": "<code>dms</code>",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "downloads": {
           "__compat": {
             "description": "<code>downloads</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": true
               },
               "edge": "mirror",
               "firefox": {
@@ -380,7 +420,7 @@
             "description": "<code>downloads.open</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": true
               },
               "edge": "mirror",
               "firefox": {
@@ -461,6 +501,26 @@
             }
           }
         },
+        "identity": {
+          "__compat": {
+            "description": "<code>identity</code>",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "idle": {
           "__compat": {
             "description": "<code>idle</code>",
@@ -512,7 +572,7 @@
             "description": "<code>nativeMessaging</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": true
               },
               "edge": "mirror",
               "firefox": {
@@ -666,12 +726,32 @@
             }
           }
         },
+        "search": {
+          "__compat": {
+            "description": "<code>search</code>",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "sessions": {
           "__compat": {
             "description": "<code>sessions</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": true
               },
               "edge": "mirror",
               "firefox": {
@@ -680,6 +760,26 @@
               "firefox_android": {
                 "version_added": false
               },
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "storage": {
+          "__compat": {
+            "description": "<code>storage</code>",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
                 "version_added": false
@@ -746,6 +846,26 @@
               },
               "firefox": {
                 "version_added": "55"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "unlimitedStorage": {
+          "__compat": {
+            "description": "<code>unlimitedStorage</code>",
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
               },
               "firefox_android": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
#### Summary

This change aligns the compatibility information with the [optional permission details provided by Chrome](https://developer.chrome.com/docs/extensions/reference/api/permissions#step_2_declare_optional_permissions_in_the_manifest).

It only covers common permissions e.g., those shared between Firefox, Chrome, and Safari.

#### Related issues

Fixes  #20858
