### PR TITLE
Update Chrome/Safari data for DragEvent API

### DIFF
--- a/api/DragEvent.json
+++ b/api/DragEvent.json
@@ -8,9 +8,7 @@
           "chrome": {
             "version_added": "46"
           },
-          "chrome_android": {
-            "version_added": false
-          },
+          "chrome_android": "mirror",
           "edge": {
             "version_added": "12"
           },
@@ -30,9 +28,7 @@
           "safari": {
             "version_added": "14"
           },
-          "safari_ios": {
-            "version_added": false
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
@@ -51,9 +47,7 @@
             "chrome": {
               "version_added": "46"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
@@ -72,9 +66,7 @@
             "safari": {
               "version_added": "14"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -93,9 +85,7 @@
             "chrome": {
               "version_added": "46"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
@@ -114,9 +104,7 @@
             "safari": {
               "version_added": "14"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
This PR updates and corrects version values for Chrome and Safari for the `DragEvent` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/DragEvent

Additional Notes: These had been marked unsupported on mobile since the wiki era, so I don't trust the existing data much.
