### PR TITLE
Update Safari iOS data for api.Element.requestFullscreen.options_navigationUI_parameter

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -7862,7 +7862,9 @@
               "safari": {
                 "version_added": "16.4"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": false
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `requestFullscreen.options_navigationUI_parameter` member of the `Element` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Element/requestFullscreen/options_navigationUI_parameter

Additional Notes: Both iOS and iPadOS results were collected.
