### PR TITLE
Update Firefox Android data for api.File.webkitRelativePath

### DIFF
--- a/api/File.json
+++ b/api/File.json
@@ -245,7 +245,9 @@
             "firefox": {
               "version_added": "50"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox Android for the `webkitRelativePath` member of the `File` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/File/webkitRelativePath

Additional Notes: The original data seems to come from the wiki era.
