### PR TITLE
Chrome Android 109 adds FileSystemWritableFileStream API support

### DIFF
--- a/api/FileSystemWritableFileStream.json
+++ b/api/FileSystemWritableFileStream.json
@@ -8,9 +8,7 @@
           "chrome": {
             "version_added": "86"
           },
-          "chrome_android": {
-            "version_added": false
-          },
+          "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
             "version_added": "111"
@@ -43,9 +41,7 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": "111"
@@ -79,9 +75,7 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": "111"
@@ -115,9 +109,7 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": "111"

--- a/api/FileSystemWritableFileStream.json
+++ b/api/FileSystemWritableFileStream.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "86"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": "109"
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": "111"
@@ -41,7 +43,9 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": "109"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "111"
@@ -75,7 +79,9 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": "109"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "111"
@@ -109,7 +115,9 @@
             "chrome": {
               "version_added": "86"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": "109"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "111"


### PR DESCRIPTION
This PR updates and corrects version values for Chrome Android for the `FileSystemWritableFileStream` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/FileSystemWritableFileStream
