### PR TITLE
Update Firefox Android data for api.Gamepad.displayId

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -233,7 +233,8 @@
               }
             ],
             "firefox_android": {
-              "version_added": "55"
+              "version_added": "55",
+              "version_removed": "98"
             },
             "ie": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Firefox Android for the `displayId` member of the `Gamepad` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Gamepad/displayId

Additional Notes: Exact version number was mirrored from desktop.
