### PR TITLE
Update Chromium data for GeolocationPositionError API

### DIFF
--- a/api/GeolocationPositionError.json
+++ b/api/GeolocationPositionError.json
@@ -12,7 +12,7 @@
             {
               "alternative_name": "PositionError",
               "version_added": "5",
-              "version_removed": "78"
+              "version_removed": "79"
             }
           ],
           "chrome_android": "mirror",
@@ -42,14 +42,8 @@
             "version_added": "9"
           },
           "oculus": "mirror",
-          "opera": {
-            "alternative_name": "PositionError",
-            "version_added": "16"
-          },
-          "opera_android": {
-            "alternative_name": "PositionError",
-            "version_added": "16"
-          },
+          "opera": "mirror",
+          "opera_android": "mirror",
           "safari": [
             {
               "version_added": "13.1"
@@ -61,16 +55,7 @@
           ],
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
-          "webview_android": [
-            {
-              "version_added": "79"
-            },
-            {
-              "alternative_name": "PositionError",
-              "version_added": "≤37",
-              "version_removed": "78"
-            }
-          ]
+          "webview_android": "mirror"
         },
         "status": {
           "experimental": false,


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `GeolocationPositionError` API. Discrepancies from the collector results had helped me catch these issues, where downstream browsers weren't mirroring, and the `version_removed` was improperly set to the last version of support, not the version it was removed in.
