### PR TITLE
Update Chrome Android data for LaunchParams API

### DIFF
--- a/api/LaunchParams.json
+++ b/api/LaunchParams.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "102"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -41,7 +43,9 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -75,7 +79,9 @@
             "chrome": {
               "version_added": "110"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Chrome Android for the `LaunchParams` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/LaunchParams

Additional Notes: ChromeStatus doesn't mention an Android release: https://chromestatus.com/feature/5722383233056768
