### PR TITLE
Update Chrome Android data for LaunchQueue API

### DIFF
--- a/api/LaunchQueue.json
+++ b/api/LaunchQueue.json
@@ -8,7 +8,9 @@
           "chrome": {
             "version_added": "102"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -41,7 +43,9 @@
             "chrome": {
               "version_added": "102"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Chrome Android for the `LaunchQueue` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/LaunchQueue

Additional Notes: ChromeStatus doesn't mention an Android release: https://chromestatus.com/feature/5722383233056768
