### PR TITLE
Update Opera data for api.MediaDevices.devicechange_event

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -70,9 +70,7 @@
             "opera": {
               "version_added": "34"
             },
-            "opera_android": {
-              "version_added": "43"
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "11"
             },


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `devicechange_event` member of the `MediaDevices` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/MediaDevices/devicechange_event
