### PR TITLE
Update Firefox Android data for api.MediaStream.addTrack

### DIFF
--- a/api/MediaStream.json
+++ b/api/MediaStream.json
@@ -184,9 +184,7 @@
             "firefox": {
               "version_added": "44"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "ie": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Firefox Android for the `addTrack` member of the `MediaStream` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/MediaStream/addTrack
