### PR TITLE
Update Safari iOS data for api.PublicKeyCredential.isConditionalMediationAvailable_static

### DIFF
--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -160,9 +160,7 @@
             "safari": {
               "version_added": "16"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `isConditionalMediationAvailable` static method of the `PublicKeyCredential` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/PublicKeyCredential/isConditionalMediationAvailable_static
