### PR TITLE
Update Safari iOS data for api.RTCPeerConnection.signalingstatechange_event

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -2993,9 +2993,7 @@
             "safari": {
               "version_added": "11"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `signalingstatechange_event` member of the `RTCPeerConnection` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/RTCPeerConnection/signalingstatechange_event
