### PR TITLE
Update Chrome Android data for ScreenDetailed API

### DIFF
--- a/api/ScreenDetailed.json
+++ b/api/ScreenDetailed.json
@@ -8,9 +8,7 @@
           "chrome": {
             "version_added": "100"
           },
-          "chrome_android": {
-            "version_added": false
-          },
+          "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -43,9 +41,7 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -79,9 +75,7 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -115,9 +109,7 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -151,9 +143,7 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -187,9 +177,7 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -223,9 +211,7 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -259,9 +245,7 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -295,9 +279,7 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Chrome Android for the `ScreenDetailed` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/ScreenDetailed
