### PR TITLE
Update Chrome Android data for ScreenDetails API

### DIFF
--- a/api/ScreenDetails.json
+++ b/api/ScreenDetails.json
@@ -8,9 +8,7 @@
           "chrome": {
             "version_added": "100"
           },
-          "chrome_android": {
-            "version_added": false
-          },
+          "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -43,9 +41,7 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -83,9 +79,7 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -119,9 +113,7 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -159,9 +151,7 @@
             "chrome": {
               "version_added": "100"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Chrome Android for the `ScreenDetails` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/ScreenDetails

Additional Notes: api.ScreenDetails
