### PR TITLE
Update Opera data for SpeechGrammar API

### DIFF
--- a/api/SpeechGrammar.json
+++ b/api/SpeechGrammar.json
@@ -27,12 +27,8 @@
             "version_added": false
           },
           "oculus": "mirror",
-          "opera": {
-            "version_added": "27"
-          },
-          "opera_android": {
-            "version_added": false
-          },
+          "opera": "mirror",
+          "opera_android": "mirror",
           "safari": {
             "version_added": false
           },
@@ -75,12 +71,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "27"
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
@@ -123,12 +115,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "27"
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },
@@ -171,12 +159,8 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": "27"
-            },
-            "opera_android": {
-              "version_added": false
-            },
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": {
               "version_added": false
             },


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `SpeechGrammar` API. This sets Opera to mirror from Chrome, as a discrepancy was caught by the collector.
