### PR TITLE
Update Safari iOS data for VideoPlaybackQuality API

### DIFF
--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -26,9 +26,7 @@
           "safari": {
             "version_added": "8"
           },
-          "safari_ios": {
-            "version_added": false
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": {
             "version_added": "4.4.3"
@@ -69,9 +67,7 @@
             "safari": {
               "version_added": "8"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -108,9 +104,7 @@
             "safari": {
               "version_added": "8"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "4.4.3"
@@ -149,9 +143,7 @@
             "safari": {
               "version_added": "8"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "4.4.3"
@@ -190,9 +182,7 @@
             "safari": {
               "version_added": "8"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -229,9 +219,7 @@
             "safari": {
               "version_added": "8"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "4.4.3"


### PR DESCRIPTION
This PR updates and corrects version values for Safari iOS/iPadOS for the `VideoPlaybackQuality` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/VideoPlaybackQuality
