### PR TITLE
Update Opera data for api.Worker.messageerror_event

### DIFF
--- a/api/Worker.json
+++ b/api/Worker.json
@@ -423,9 +423,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": "47"
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "16.4",
               "impl_url": "https://webkit.org/b/171216"


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `messageerror_event` member of the `Worker` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Worker/messageerror_event
