### PR TITLE
Update Opera data for XR* API

### DIFF
--- a/api/XRCamera.json
+++ b/api/XRCamera.json
@@ -17,9 +17,7 @@
             "version_added": false
           },
           "oculus": "mirror",
-          "opera": {
-            "version_added": false
-          },
+          "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
             "version_added": false
@@ -53,9 +51,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false
@@ -90,9 +86,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false

--- a/api/XRSession.json
+++ b/api/XRSession.json
@@ -201,9 +201,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false

--- a/api/XRView.json
+++ b/api/XRView.json
@@ -54,9 +54,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false

--- a/api/XRWebGLBinding.json
+++ b/api/XRWebGLBinding.json
@@ -265,9 +265,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `XR*` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used:
https://mdn-bcd-collector.gooborg.com/tests/api/XRCamera
https://mdn-bcd-collector.gooborg.com/tests/api/XRSession
https://mdn-bcd-collector.gooborg.com/tests/api/XRView
https://mdn-bcd-collector.gooborg.com/tests/api/XRWebGLBinding
