### PR TITLE
Update WebView data for -webkit-mask-repeat-x CSS property

### DIFF
--- a/css/properties/-webkit-mask-repeat-x.json
+++ b/css/properties/-webkit-mask-repeat-x.json
@@ -30,9 +30,7 @@
               "version_removed": "15"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR updates and corrects version values for WebView Android for the `-webkit-mask-repeat-x` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/-webkit-mask-repeat-x
