### PR TITLE
Update Chromium data for -webkit-mask-repeat-y CSS property

### DIFF
--- a/css/properties/-webkit-mask-repeat-y.json
+++ b/css/properties/-webkit-mask-repeat-y.json
@@ -20,9 +20,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": {
-              "version_added": "15"
-            },
+            "opera_android": "mirror",
             "safari": {
               "version_added": "5",
               "version_removed": "15"
@@ -32,9 +30,7 @@
               "version_removed": "15"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,


### PR DESCRIPTION
This PR updates and corrects version values for Chromium (Chrome, Opera, Samsung Internet, WebView Android) for the `-webkit-mask-repeat-y` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.1).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/-webkit-mask-repeat-y
