### PR TITLE
FF122 URL() now parses host/hostname/port for unknown schemes

### DIFF
--- a/api/URL.json
+++ b/api/URL.json
@@ -88,7 +88,8 @@
               "notes": "Before Edge 79, query arguments in the base URL argument are removed when calling the <code>URL</code> constructor."
             },
             "firefox": {
-              "version_added": "26"
+              "version_added": "26",
+              "notes": "Before version 122, <code>host</code>, <code>hostname</code>, and <code>port</code> were not parsed for unknown protocols/schemes."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF122 started using a different URL parser in https://bugzilla.mozilla.org/show_bug.cgi?id=1603699. Previously if you passed in an URL with an unknown scheme/protocol in [URL()](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL), the host, hostname and port would be empty strings. Now these values are populated (as discussed in https://github.com/mdn/content/issues/31100#issuecomment-1907520020).

This adds a note about the change. Didn't seem worthwhile to add a completely new version for this (originally I thought this had no developer impact).

Related docs work can be tracked in https://github.com/mdn/content/issues/31100