### PR TITLE
Adding details for browserAction.getUserSettings

### DIFF
--- a/webextensions/api/pageAction.json
+++ b/webextensions/api/pageAction.json
@@ -82,6 +82,48 @@
             }
           }
         },
+        "getUserSettings": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/getUserSettings",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "116"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          },
+          "returns_userSettings_isOnToolbar_property": {
+            "__compat": {
+              "description": "<code>userSettings.isOnToolbar</code> in returned object",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "116"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          }
+        },
         "hide": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/hide",


### PR DESCRIPTION
#### Summary

Compatibility data for browserAction.getUserSetting which was added in [Bug 1814905](https://bugzilla.mozilla.org/show_bug.cgi?id=1814905) "Implement chrome.action.getUserSettings" but missed from the original documentation update.

