### PR TITLE
FF123 IDBObjectStore.createIndex() locale option deprecated

### DIFF
--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -285,6 +285,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "options_locale_parameter": {
+          "__compat": {
+            "description": "<code>options.locale</code> parameter",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "43"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
+            }
+          }
         }
       },
       "delete": {


### PR DESCRIPTION
The Firefox-only `options.locale` argument to [`IDBObjectStore.createIndex()`](https://developer.mozilla.org/en-US/docs/Web/API/IDBObjectStore/createIndex) is now deprecated by https://bugzilla.mozilla.org/show_bug.cgi?id=1872675 in FF123.

This adds the option as a subfeature and marks it deprecated. This is in preparation for expected removal at some point. Either way it is more correct than having this info in the docs.

Related docs work can be tracked in https://github.com/mdn/content/issues/31915