### PR TITLE
FF121 CSS :state() pseudo class

### DIFF
--- a/css/selectors/state.json
+++ b/css/selectors/state.json
@@ -9,7 +9,7 @@
           "support": {
             "chrome": {
               "version_added": false,
-              "notes": ""
+              "notes": "From version 90 Chromium supports custom state selection using a dashed-ident (such as <code>:--foo</code>) instead of <code>:state()</code>."
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/selectors/state.json
+++ b/css/selectors/state.json
@@ -1,0 +1,41 @@
+{
+  "css": {
+    "selectors": {
+      "state": {
+        "__compat": {
+          "description": "Custom state pseudo-class selector (<code>:state()</code>)",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/:state",
+          "spec_url": "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-custom",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "121"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/selectors/state.json
+++ b/css/selectors/state.json
@@ -8,12 +8,20 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/semantics-other.html#selector-custom",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": false,
+              "notes": ""
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "121"
+              "version_added": "121",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.element.customstateset.enabled",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/selectors/state.json
+++ b/css/selectors/state.json
@@ -31,7 +31,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview",
+              "flags": [
+                {
+                  "name": "CustomStateSet",
+                  "value_to_set": "true",
+                  "type": "preference"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
FF121 added support for a `:state()` pseudo selector in FF121 in https://bugzilla.mozilla.org/show_bug.cgi?id=1861466

This adds a feature for `:state()`.

Note, FF adds support for `:state()` after `::part()` in FF123 in https://bugzilla.mozilla.org/show_bug.cgi?id=1866351. However as this is all behind a preference currently not much point recording this change. Note that if we want to test this stuff for compatibility on other browsers the [docs have a live example](https://pr32000.content.dev.mdn.mozit.cloud/en-US/docs/Web/API/CustomStateSet#question_box_exposing_states_in_shadow_parts).

Related docs work can be tracked in https://github.com/mdn/content/issues/31971

