### PR TITLE
Fix identifiers for toLocaleString parameters

### DIFF
--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -215,8 +215,9 @@
               "deprecated": false
             }
           },
-          "locales": {
+          "locales_parameter": {
             "__compat": {
+              "description": "<code>locales</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": "76"
@@ -263,8 +264,9 @@
               }
             }
           },
-          "options": {
+          "options_parameter": {
             "__compat": {
+              "description": "<code>options</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": "76"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -2207,8 +2207,9 @@
               }
             }
           },
-          "locales": {
+          "locales_parameter": {
             "__compat": {
+              "description": "<code>locales</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -2264,8 +2265,9 @@
               }
             }
           },
-          "options": {
+          "options_parameter": {
             "__compat": {
+              "description": "<code>options</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -2398,8 +2400,9 @@
               }
             }
           },
-          "locales": {
+          "locales_parameter": {
             "__compat": {
+              "description": "<code>locales</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -2455,8 +2458,9 @@
               }
             }
           },
-          "options": {
+          "options_parameter": {
             "__compat": {
+              "description": "<code>options</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -2589,8 +2593,9 @@
               }
             }
           },
-          "locales": {
+          "locales_parameter": {
             "__compat": {
+              "description": "<code>locales</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -2646,8 +2651,9 @@
               }
             }
           },
-          "options": {
+          "options_parameter": {
             "__compat": {
+              "description": "<code>options</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": "24"

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -843,8 +843,9 @@
               "deprecated": false
             }
           },
-          "locales": {
+          "locales_parameter": {
             "__compat": {
+              "description": "<code>locales</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -902,8 +903,9 @@
               }
             }
           },
-          "options": {
+          "options_parameter": {
             "__compat": {
+              "description": "<code>options</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": "24"

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1139,8 +1139,9 @@
               "deprecated": false
             }
           },
-          "locales": {
+          "locales_parameter": {
             "__compat": {
+              "description": "<code>locales</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": "24"
@@ -1202,8 +1203,9 @@
               }
             }
           },
-          "options": {
+          "options_parameter": {
             "__compat": {
+              "description": "<code>options</code> parameter",
               "support": {
                 "chrome": {
                   "version_added": "24"


### PR DESCRIPTION
This PR renames a few subfeatures of the `toLocaleString` methods to reflect BCD conventions, by adding a `_parameter` suffix to them.
