### PR TITLE
Remove javascript.builtins.DataView.buffer.sharedarraybuffer_support from BCD

### DIFF
--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -227,46 +227,6 @@
               "standard_track": true,
               "deprecated": false
             }
-          },
-          "sharedarraybuffer_support": {
-            "__compat": {
-              "description": "<code>SharedArrayBuffer</code> accepted as buffer",
-              "support": {
-                "chrome": {
-                  "version_added": "60"
-                },
-                "chrome_android": "mirror",
-                "deno": {
-                  "version_added": "1.0"
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "79"
-                },
-                "firefox_android": "mirror",
-                "ie": {
-                  "version_added": false
-                },
-                "nodejs": {
-                  "version_added": "8.10.0"
-                },
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": "10.1",
-                  "version_removed": "11.1"
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror"
-              },
-              "status": {
-                "experimental": false,
-                "standard_track": true,
-                "deprecated": false
-              }
-            }
           }
         },
         "byteLength": {


### PR DESCRIPTION
This PR removes the `buffer.sharedarraybuffer_support` member of the `DataView` JavaScript builtin from BCD. This is basically a duplicate of javascript.builtins.DataView.DataView.sharedarraybuffer_support.

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/javascript/builtins/DataView/buffer/sharedarraybuffer_support
