### PR TITLE
Fix Safari releases script

### DIFF
--- a/scripts/update-browser-releases/safari.ts
+++ b/scripts/update-browser-releases/safari.ts
@@ -17,12 +17,13 @@ import { newBrowserEntry, updateBrowserEntry } from './utils.js';
  */
 const extractReleaseData = (str) => {
   // Note: \s is needed as some spaces in Apple source are non-breaking
-  const result = /Released\s(.*)\s.*\sVersion\s(.*?)\s(beta\s)?\((.*)\)/.exec(
-    str,
-  );
+  const result =
+    /Released\s+(.*)\s*—\s*(?:Version\s+)?(\d+(?:\.\d+)*)\s*(\s*beta)?\s*\((.*)\)/.exec(
+      str,
+    );
   if (!result) {
     console.warn(
-      chalk`{yellow A release string for Safari is not parsable (${str}'). Skipped.`,
+      chalk`{yellow A release string for Safari is not parsable (${str}'). Skipped.}`,
     );
     return null;
   }


### PR DESCRIPTION
Fixes https://github.com/mdn/browser-compat-data/actions/runs/7691213976/job/20956176989

- A closing bracket was missing 
- The regex doesn't work if "Version" is omitted in the string. This is the case for 17.4 beta.