### PR TITLE
Correct MDN URL for api.Animation.remove_filling_animation

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -729,7 +729,7 @@
       "remove_filling_animation": {
         "__compat": {
           "description": "Browsers automatically remove indefinite filling animations",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/Animation#Automatically_removing_filling_animations",
+          "mdn_url": "https://developer.mozilla.org/docs/web/api/web_animations_api/using_the_web_animations_api#automatically_removing_filling_animations",
           "support": {
             "chrome": {
               "version_added": "84"


### PR DESCRIPTION
The section was moved in https://github.com/mdn/content/pull/26716, so the MDN URL became broken.  This fixes the link to point to the right location.
