### PR TITLE
Rename api.EventSource.cors_support

### DIFF
--- a/api/EventSource.json
+++ b/api/EventSource.json
@@ -89,9 +89,9 @@
             "deprecated": false
           }
         },
-        "cors_support": {
+        "options_withCredentials_parameter": {
           "__compat": {
-            "description": "CORS support (<code>withCredentials</code>)",
+            "description": "<code>options.withCredentials</code> parameter",
             "support": {
               "chrome": {
                 "version_added": "26"


### PR DESCRIPTION
This PR renames the `cors_support` subfeature of the EventSource constructor to conform to our typical structure.
