### PR TITLE
Rename OfflineAudioContext "parameters_accepted_in_an_object"

### DIFF
--- a/api/OfflineAudioContext.json
+++ b/api/OfflineAudioContext.json
@@ -99,9 +99,9 @@
             "deprecated": false
           }
         },
-        "parameters_accepted_in_an_object": {
+        "options_parameter": {
           "__compat": {
-            "description": "Parameters accepted as a single object, as well as being passed in individually",
+            "description": "<code>options</code> parameter (accepts all parameters as a single dictionary)",
             "support": {
               "chrome": {
                 "version_added": "62"


### PR DESCRIPTION
This PR renames the `api.OfflineAudioContext.OfflineAudioContext.parameters_accepted_in_an_object` feature to `options_parameter` to conform to our typical conventions.
