### PR TITLE
Updates for Safari 17.4 beta

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -250,7 +250,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/CSSScopeRule.json
+++ b/api/CSSScopeRule.json
@@ -20,14 +20,14 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "17.4"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -52,14 +52,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -85,14 +85,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/DOMMatrixReadOnly.json
+++ b/api/DOMMatrixReadOnly.json
@@ -1364,7 +1364,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/Document.json
+++ b/api/Document.json
@@ -5114,6 +5114,40 @@
           }
         }
       },
+      "parseHTMLUnsafe_static": {
+        "__compat": {
+          "description": "<code>parseHTMLUnsafe()</code> static method",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-parsehtmlunsafe",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "123"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "17.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "pictureInPictureElement": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/pictureInPictureElement",

--- a/api/Element.json
+++ b/api/Element.json
@@ -9242,6 +9242,39 @@
           }
         }
       },
+      "setHTMLUnsafe": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-element-sethtmlunsafe",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "123"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "17.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "setPointerCapture": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/setPointerCapture",

--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -85,6 +85,39 @@
           }
         }
       },
+      "getClientCapabilities_static": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webauthn/#sctn-getClientCapabilities",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "17.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getClientExtensionResults": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PublicKeyCredential/getClientExtensionResults",

--- a/api/SVGFESpecularLightingElement.json
+++ b/api/SVGFESpecularLightingElement.json
@@ -139,7 +139,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -174,7 +174,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/SVGRenderingIntent.json
+++ b/api/SVGRenderingIntent.json
@@ -22,7 +22,8 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "3.1"
+            "version_added": "3.1",
+            "version_removed": "17.4"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -547,6 +547,39 @@
           }
         }
       },
+      "setHTMLUnsafe": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-shadowroot-sethtmlunsafe",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "123"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "17.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "slotAssignment": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ShadowRoot/slotAssignment",

--- a/css/at-rules/scope.json
+++ b/css/at-rules/scope.json
@@ -22,14 +22,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/content.json
+++ b/css/properties/content.json
@@ -60,7 +60,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "17.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/text-wrap-mode.json
+++ b/css/properties/text-wrap-mode.json
@@ -1,26 +1,17 @@
 {
   "css": {
     "properties": {
-      "text-decoration-thickness": {
+      "text-wrap-mode": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/text-decoration-thickness",
-          "spec_url": "https://drafts.csswg.org/css-text-decor-4/#text-decoration-width-property",
+          "spec_url": "https://drafts.csswg.org/css-text-4/#text-wrap-mode",
           "support": {
-            "chrome": [
-              {
-                "version_added": "89"
-              },
-              {
-                "version_added": "87",
-                "version_removed": "89",
-                "partial_implementation": true,
-                "notes": "The <code>text-decoration-thickness</code> property does not work unless either <code>text-underline-offset</code> is set to something other than <code>auto</code> or <code>text-decoration-color</code> is set to something other than <code>currentColor</code>. See <a href='https://crbug.com/1154537'>bug 1154537</a>."
-              }
-            ],
+            "chrome": {
+              "version_added": false
+            },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "70"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "ie": {
@@ -30,29 +21,28 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "12.1"
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
         },
-        "percentage": {
+        "nowrap": {
           "__compat": {
-            "description": "percentage values",
             "support": {
               "chrome": {
-                "version_added": "87"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "74"
+                "version_added": false
               },
               "firefox_android": "mirror",
               "ie": {
@@ -69,7 +59,39 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "wrap": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/text-wrap.json
+++ b/css/properties/text-wrap.json
@@ -22,7 +22,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -91,14 +91,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "17.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -196,14 +196,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "17.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/transition-behavior.json
+++ b/css/properties/transition-behavior.json
@@ -22,14 +22,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/white-space-collapse.json
+++ b/css/properties/white-space-collapse.json
@@ -24,14 +24,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/selectors/grammar-error.json
+++ b/css/selectors/grammar-error.json
@@ -23,14 +23,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/selectors/spelling-error.json
+++ b/css/selectors/spelling-error.json
@@ -23,14 +23,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -261,7 +261,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "17.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -512,7 +512,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "17.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -552,7 +552,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "17.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -449,12 +449,12 @@
               "opera_android": "mirror",
               "safari": [
                 {
-                  "version_added": "preview"
+                  "version_added": "17.4"
                 },
                 {
                   "alternative_name": "Array.prototype.groupToMap",
                   "version_added": "16.4",
-                  "version_removed": "preview"
+                  "version_removed": "17.4"
                 }
               ],
               "safari_ios": "mirror",

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -832,12 +832,12 @@
               "opera_android": "mirror",
               "safari": [
                 {
-                  "version_added": "preview"
+                  "version_added": "17.4"
                 },
                 {
                   "alternative_name": "Array.prototype.groupToMap",
                   "version_added": "16.4",
-                  "version_removed": "preview"
+                  "version_removed": "17.4"
                 }
               ],
               "safari_ios": "mirror",

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -538,7 +538,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": "17.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/svg/elements/feSpecularLighting.json
+++ b/svg/elements/feSpecularLighting.json
@@ -97,7 +97,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "17.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/webassembly/extended-constant-expressions.json
+++ b/webassembly/extended-constant-expressions.json
@@ -20,7 +20,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "17.4"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",


### PR DESCRIPTION
The [Open Web Docs BCD collector](https://github.com/openwebdocs/mdn-bcd-collector) v10.7.1 found new features shipping in Safari 17.4 beta (19618.1.11.11.3) which was released last week. Currently, the collector covers about 82% of BCD, so the following list might not be exhaustive. Also, if a feature is in Safari TP and/or behind flags, it is not considered here.

With this PR, BCD considers the following 35 features as shipping in Safari 17.4:

- api.AbortSignal.any_static
- api.CSSScopeRule
- api.CSSScopeRule.end
- api.CSSScopeRule.start
- api.DOMMatrixReadOnly.scaleNonUniform
- api.Document.parseHTMLUnsafe_static
- api.Element.setHTMLUnsafe
- api.HTMLInputElement.showPicker.date_input (submitted in a previous PR)
- api.HTMLInputElement.showPicker.datetime_local_input (submitted in a previous PR)
- api.PublicKeyCredential.getClientCapabilities_static
- api.SVGFESpecularLightingElement.kernelUnitLengthX
- api.SVGFESpecularLightingElement.kernelUnitLengthY
- api.SVGRenderingIntent (removal)
- api.ShadowRoot.setHTMLUnsafe
- css.at-rules.scope
- css.properties.content.alt_text
- css.properties.text-decoration-thickness.percentage
- css.properties.text-wrap-mode
- css.properties.text-wrap-mode.nowrap
- css.properties.text-wrap-mode.wrap
- css.properties.text-wrap
- css.properties.text-wrap.nowrap
- css.properties.text-wrap.wrap
- css.properties.transition-behavior
- css.properties.white-space-collapse
- css.selectors.grammar-error
- css.selectors.spelling-error
- javascript.builtins.ArrayBuffer.detached
- javascript.builtins.ArrayBuffer.transfer
- javascript.builtins.ArrayBuffer.transferToFixedLength
- javascript.builtins.Map.groupBy
- javascript.builtins.Object.groupBy
- javascript.builtins.Promise.withResolvers
- svg.elements.feSpecularLighting.kernelUnitLength
- webassembly.extended-constant-expressions

https://developer.apple.com/documentation/safari-release-notes/safari-17_4-release-notes can confirm most of the features above. Some aren't mentioned in the release notes, but maybe they should be added there:
- api.DOMMatrixReadOnly.scaleNonUniform
- api.SVGFESpecularLightingElement.kernelUnitLengthX
- api.SVGFESpecularLightingElement.kernelUnitLengthY
- api.SVGRenderingIntent (removal)
- svg.elements.feSpecularLighting.kernelUnitLength

I hope this auto-generated PR is useful to update BCD for the new Safari 17.4 more easily and faster. If you have feedback, let me know! /cc @jdatapple @francescorn  