### PR TITLE
CustomStateSet - spec links are wrong

### DIFF
--- a/api/CustomStateSet.json
+++ b/api/CustomStateSet.json
@@ -3,7 +3,7 @@
     "CustomStateSet": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomStateSet",
-        "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#customstateset",
+        "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#customstateset",
         "support": {
           "chrome": {
             "version_added": "90"
@@ -50,7 +50,7 @@
       "add": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomStateSet/add",
-          "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#dom-customstateset-add",
+          "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#custom-state-pseudo-class",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -98,7 +98,7 @@
       "clear": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomStateSet/clear",
-          "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#customstateset",
+          "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#custom-state-pseudo-class",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -146,7 +146,7 @@
       "delete": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomStateSet/delete",
-          "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#customstateset",
+          "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#custom-state-pseudo-class",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -194,7 +194,7 @@
       "entries": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomStateSet/entries",
-          "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#customstateset",
+          "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#custom-state-pseudo-class",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -242,7 +242,7 @@
       "forEach": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomStateSet/forEach",
-          "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#customstateset",
+          "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#custom-state-pseudo-class",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -290,7 +290,7 @@
       "has": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomStateSet/has",
-          "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#customstateset",
+          "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#custom-state-pseudo-class",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -338,7 +338,7 @@
       "keys": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomStateSet/keys",
-          "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#customstateset",
+          "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#custom-state-pseudo-class",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -386,7 +386,7 @@
       "size": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomStateSet/size",
-          "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#customstateset",
+          "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#custom-state-pseudo-class",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -434,7 +434,7 @@
       "values": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CustomStateSet/values",
-          "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#customstateset",
+          "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#custom-state-pseudo-class",
           "support": {
             "chrome": {
               "version_added": "90"
@@ -481,7 +481,7 @@
       },
       "@@iterator": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/custom-state-pseudo-class/#customstateset",
+          "spec_url": "https://html.spec.whatwg.org/multipage/custom-elements.html#custom-state-pseudo-class",
           "support": {
             "chrome": {
               "version_added": "90"


### PR DESCRIPTION
The custom state set links were all going to the draft spec https://wicg.github.io/custom-state-pseudo-class/#dom-customstateset-add

But this appears to all have migrated into the HTML living spec here: https://html.spec.whatwg.org/multipage/custom-elements.html#custom-state-pseudo-class

Certainly the live spec is what everyone is now targeting.

Related docs work in https://github.com/mdn/content/issues/31971