### PR TITLE
Update residentKey support data

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -446,7 +446,7 @@
                 }
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }

--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -424,9 +424,12 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "114"
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false,
+                  "notes": "See <a href='https://bugzil.la/1831137'>bug 1831137</a>."
+                },
                 "ie": {
                   "version_added": false
                 },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Firefox 114+ supports residentKey in WebAuthN L2. But this is desktop only, so mobile isn't  yet  .See https://bugzilla.mozilla.org/show_bug.cgi?id=1831137 for Firefox/Android.

#### Test results and supporting details
See https://bugzilla.mozilla.org/show_bug.cgi?id=1813282

#### Related issues
