### PR TITLE
Add a server-timing tag; Safari 16.4 supports Server-Timing header

### DIFF
--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -799,6 +799,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceResourceTiming/serverTiming",
           "spec_url": "https://w3c.github.io/server-timing/#servertiming-attribute",
+          "tags": [
+            "web-features:server-timing"
+          ],
           "support": {
             "chrome": {
               "version_added": "65"

--- a/api/PerformanceServerTiming.json
+++ b/api/PerformanceServerTiming.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceServerTiming",
         "spec_url": "https://w3c.github.io/server-timing/#the-performanceservertiming-interface",
+        "tags": [
+          "web-features:server-timing"
+        ],
         "support": {
           "chrome": {
             "version_added": "65"
@@ -37,6 +40,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceServerTiming/description",
           "spec_url": "https://w3c.github.io/server-timing/#dom-performanceservertiming-description",
+          "tags": [
+            "web-features:server-timing"
+          ],
           "support": {
             "chrome": {
               "version_added": "65"
@@ -71,6 +77,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceServerTiming/duration",
           "spec_url": "https://w3c.github.io/server-timing/#dom-performanceservertiming-duration",
+          "tags": [
+            "web-features:server-timing"
+          ],
           "support": {
             "chrome": {
               "version_added": "65"
@@ -105,6 +114,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceServerTiming/name",
           "spec_url": "https://w3c.github.io/server-timing/#dom-performanceservertiming-name",
+          "tags": [
+            "web-features:server-timing"
+          ],
           "support": {
             "chrome": {
               "version_added": "65"
@@ -139,6 +151,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceServerTiming/toJSON",
           "spec_url": "https://w3c.github.io/server-timing/#dom-performanceservertiming-tojson",
+          "tags": [
+            "web-features:server-timing"
+          ],
           "support": {
             "chrome": {
               "version_added": "65"

--- a/http/headers/Server-Timing.json
+++ b/http/headers/Server-Timing.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Headers/Server-Timing",
           "spec_url": "https://w3c.github.io/server-timing/#the-server-timing-header-field",
+          "tags": [
+            "web-features:server-timing"
+          ],
           "support": {
             "chrome": {
               "version_added": "65"
@@ -24,7 +27,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": null
+              "version_added": "16.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
 Output of `npm run traverse -- -t web-features:server-timing`:

- api.PerformanceResourceTiming.serverTiming
- api.PerformanceServerTiming
- api.PerformanceServerTiming.description
- api.PerformanceServerTiming.duration
- api.PerformanceServerTiming.name
- api.PerformanceServerTiming.toJSON
- http.headers.Server-Timing