### PR TITLE
Remove api.WebGL[2]RenderingContext.blendFuncSeparate.SharedArrayBuffer_as_param from BCD

### DIFF
--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -726,39 +726,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "SharedArrayBuffer_as_param": {
-          "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
-            "support": {
-              "chrome": {
-                "version_added": "60"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "79"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "blitFramebuffer": {

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -639,41 +639,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "SharedArrayBuffer_as_param": {
-          "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
-            "support": {
-              "chrome": {
-                "version_added": "60"
-              },
-              "chrome_android": "mirror",
-              "edge": {
-                "version_added": "≤79"
-              },
-              "firefox": {
-                "version_added": "79"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
         }
       },
       "bufferData": {


### PR DESCRIPTION
This PR removes the `blendFuncSeparate.SharedArrayBuffer_as_param` member of the `WebGLRenderingContext` APIs from BCD. This method doesn't accept an array buffer to begin with.