### PR TITLE
Update Chrome releases

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -852,6 +852,18 @@
           "status": "beta",
           "engine": "Blink",
           "engine_version": "122"
+        },
+        "123": {
+          "release_date": "2024-03-19",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "123"
+        },
+        "124": {
+          "release_date": "2024-04-16",
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "124"
         }
       }
     }


### PR DESCRIPTION
_(👋 Hi, Chrome DevRel here)_

This PR adds the Chrome 123 and Chrome 124 releases.

Source: https://chromiumdash.appspot.com/schedule