### PR TITLE
sync_event is experimental like SyncEvent and SyncManager

### DIFF
--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -1035,7 +1035,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/ServiceWorkerGlobalScope.json
+++ b/api/ServiceWorkerGlobalScope.json
@@ -1035,7 +1035,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/ServiceWorkerRegistration.json
+++ b/api/ServiceWorkerRegistration.json
@@ -791,7 +791,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/SyncEvent.json
+++ b/api/SyncEvent.json
@@ -28,7 +28,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -62,7 +62,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/SyncManager.json
+++ b/api/SyncManager.json
@@ -28,7 +28,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }


### PR DESCRIPTION
The docs say the ServiceWorkerGlobalScope ["sync" event](https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerGlobalScope/sync_event) is type [SyncEvent](https://developer.mozilla.org/en-US/docs/Web/API/SyncEvent) and depends on [SyncManager](https://developer.mozilla.org/en-US/docs/Web/API/SyncManager), and both of those are experimental technology, so the "sync" event must be experimental too.

NOTE: the script has been flipped and now `SyncEvent` and `SyncManager` are *not* experimental.  This PR reflects that change.