### PR TITLE
webextensions.api.permissions.request from Devtools

### DIFF
--- a/webextensions/api/permissions.json
+++ b/webextensions/api/permissions.json
@@ -169,7 +169,8 @@
               "firefox": {
                 "version_added": "55",
                 "notes": [
-                  "It's not possible to request permissions from a sidebar document (<a href='https://bugzil.la/1493396'>bug 1493396</a>).",
+                  "It's not possible to request permissions from within DevTools (<a href='https://bugzil.la/1796933'>bug 1796933</a>).",
+                  "Before version 101, permissions cannot be requested from a sidebar document (<a href='https://bugzil.la/1493396'>bug 1493396</a>).",
                   "Before version 75, permissions cannot be requested from popup panels (see <a href='https://bugzil.la/1432083'>bug 1432083</a>).",
                   "Before version 61, permissions cannot be requested from options pages embedded in <code>about:addons</code> (see <a href='https://bugzil.la/1382953'>bug 1382953</a>)."
                 ]


### PR DESCRIPTION
#### Summary

- adds a note about the inability to request permissions from devtools
- updates the note about requesting permissions from a sidebar document which was fixed in Firefox 101

#### Related issues

Fixes #20637
