### PR TITLE
webextensions.manifest.content_scripts.world support in Chrome

### DIFF
--- a/webextensions/manifest/content_scripts.json
+++ b/webextensions/manifest/content_scripts.json
@@ -230,6 +230,25 @@
               }
             }
           }
+        },
+        "world": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "95"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
#### Summary

Add details for support of `world ` in the `content_scripts` manifest key in Chrome.

#### Related issues

Fixes #20018
