### PR TITLE
Deprecated `usemap` attribute of `<object>` element and `useMap` property of `HTMLObjectElement` interface

### DIFF
--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -917,7 +917,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/html/elements/object.json
+++ b/html/elements/object.json
@@ -480,6 +480,7 @@
         },
         "usemap": {
           "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#attr-object-usemap",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -508,7 +509,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

these features are listed in the *Obsolete features* section

see spec https://html.spec.whatwg.org/multipage/obsolete.html#attr-object-usemap and https://html.spec.whatwg.org/multipage/obsolete.html#dom-object-usemap

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
