### PR TITLE
Removed unnecessary wrapper from webextensions.api.tabs.highlight.pop…

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -2241,26 +2241,24 @@
               "safari_ios": "mirror"
             }
           },
-          "highlightInfo": {
-            "populate": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": "mirror",
-                  "firefox": {
-                    "version_added": "63"
-                  },
-                  "firefox_android": {
-                    "version_added": false
-                  },
-                  "opera": "mirror",
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": "mirror"
-                }
+          "populate": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "63"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
               }
             }
           }


### PR DESCRIPTION
#### Summary
 
The additional `highlightInfo` is unnecessary and prevents the correct display of the BCD on MDN.

#### Related issues

Fixes #19017
