### PR TITLE
Chrome support for webextensions.action.openpopup

### DIFF
--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -445,14 +445,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/openPopup",
             "support": {
               "chrome": {
-                "version_added": "67",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#extension-apis",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "118"
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
 #### Summary

Adds details of Chrome support for webextensions.action.openpopup in 118

#### Test results and supporting details

Removed prior details as per test:
 ✖ webextensions.api.browserAction.openPopup - Error → Irrelevant flag data detected for chrome. Remove statement with #extension-apis flag
   ◆ Tip: Run npm run fix to fix this problem automatically

#### Related issues

Fixes #16442
