### PR TITLE
Chrome 122 added `support conditions` in `@import` statements

### DIFF
--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -85,7 +85,7 @@
             "spec_url": "https://drafts.csswg.org/css-cascade-5/#typedef-import-conditions",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "122"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -107,7 +107,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

`@import "foo.css" supports(display:block);` shipping in Chrome 122.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

I've been tracking `@import` in various browsers and bundling tools for a while with : https://github.com/romainmenke/css-import-tests


<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Chrome Status actually lists it as shipping in Chrome 121 but it doesn't work at all.
It started working in Chrome 122, so I asked for clarification : https://issues.chromium.org/issues/40244647#comment14

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
