### PR TITLE
Update `@import … supports()` support

### DIFF
--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -86,7 +86,7 @@
             "support": {
               "chrome": {
                 "version_added": "122",
-                "impl_url": "https://issues.chromium.org/40244647"
+                "impl_url": "https://crbug.com/40244647"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -101,7 +101,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -85,7 +85,8 @@
             "spec_url": "https://drafts.csswg.org/css-cascade-5/#typedef-import-conditions",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "122",
+                "impl_url": "https://issues.chromium.org/40244647"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/at-rules/import.json
+++ b/css/at-rules/import.json
@@ -108,7 +108,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
_👋 Hi, Chrome DevRel here_

`@import … supports()` shipped in Chrome 122.

Links:
- CrBug: https://issues.chromium.org/40244647
- ChromeStatus: https://chromestatus.com/feature/5899007704694784

Note that ChromeStatus mentions it shipping in 121 but that’s not the case. The flag only got flipped in commit `6ca8ac7e347b73c62609643164a444719f9d26f7`, which is only included in M122. See https://chromiumdash.appspot.com/commit/6ca8ac7e347b73c62609643164a444719f9d26f7 for details.