### PR TITLE
Add new Chromium Issue Tracker URLs format

### DIFF
--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -206,7 +206,7 @@
     "impl_url_value": {
       "type": "string",
       "format": "uri",
-      "pattern": "^https://(trac.webkit.org/changeset/|hg.mozilla.org/mozilla-central/rev/|crrev.com/|bugzil.la/|crbug.com/|webkit.org/b/)"
+      "pattern": "^https://(trac.webkit.org/changeset/|hg.mozilla.org/mozilla-central/rev/|crrev.com/|bugzil.la/|crbug.com/|issues.chromium.org/|webkit.org/b/)"
     },
 
     "compat_statement": {


### PR DESCRIPTION
_(👋 Hi, Chrome DevRel here!)_

Chromium moved to a new issue tracker [^1]. As a result, the URL format now used for Chromium bugs is `https://issues.chromium.org/issues/<id>`. 

In addition to that format there is also a redirect version in the form of `https://issues.chromium.org/<id>`. The `crbug.com` domain also still works, again redirecting to `issues.chromium.org`.

Example URLs:
- https://issues.chromium.org/40244647
- https://issues.chromium.org/issues/40244647
- https://crbug.com/40244647

This PRs adds support to allow URLs having that hostname as values for `impl_url`.

I chose not to include `issues/` in the pattern as the Chromium Tracker suggests the URL to share to not include `issues/`. You can try this out on an issue by hitting `i` and then `u` on your keyboard. That will copy a URL in the form of `https://issues.chromium.org/<id>` to your clipboard.

Technically speaking a URL like https://issuetracker.google.com/issues/40244647 also works but that shows a warning at the top to watch the issue in the Chromium Issue Tracker, linking to the `https://issues.chromium.org/` variant.

[^1]: The start of the migration was announced at https://blog.chromium.org/2024/02/chromium-issue-tracker-migration.html. The migration is finished by now, but the announcement post for that still needs to get published.