### PR TITLE
Function key support in command manifest key

### DIFF
--- a/webextensions/manifest/commands.json
+++ b/webextensions/manifest/commands.json
@@ -32,11 +32,9 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": true
+                "version_added": false
               },
-              "edge": {
-                "version_added": "79"
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": "53"
               },


### PR DESCRIPTION
#### Summary

The documentation for the [command manifest key](https://developer.chrome.com/docs/extensions/reference/api/commands) in Chrome doesn't include support for function keys.

### Related issues

Fixes #14809