### PR TITLE
FF123 FeaturePolicy: publickey-credentials-create supported

### DIFF
--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -1155,7 +1155,10 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "alternative_name": "Feature-Policy: publickey-credentials-create",
+                "version_added": "123",
+                "partial_implementation": true,
+                "notes": "Header not recognized but policy can be set through the <code>allow</code> attribute on <code>&lt;iframe&gt;</code> elements (see <a href='https://bugzil.la/1870863'>bug 1870863</a>)."
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
FF123 supports Feature policy [`publickey-credentials-create`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-create) in https://bugzilla.mozilla.org/show_bug.cgi?id=1870863

As per usual for FF, this can't be set on the header, but only via `allow` on the frame. That is recorded as a note.

Related docs work can be track in https://github.com/mdn/content/issues/31890