### PR TITLE
Add support data for vertical form controls via writing-mode

### DIFF
--- a/browsers/chrome.json
+++ b/browsers/chrome.json
@@ -852,6 +852,18 @@
           "status": "beta",
           "engine": "Blink",
           "engine_version": "122"
+        },
+        "123": {
+          "release_date": "2024-03-13",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "123"
+        },
+        "124": {
+          "release_date": "2024-04-10",
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "124"
         }
       }
     }

--- a/browsers/chrome_android.json
+++ b/browsers/chrome_android.json
@@ -688,6 +688,18 @@
           "status": "beta",
           "engine": "Blink",
           "engine_version": "122"
+        },
+        "123": {
+          "release_date": "2024-03-13",
+          "status": "nightly",
+          "engine": "Blink",
+          "engine_version": "123"
+        },
+        "124": {
+          "release_date": "2024-04-10",
+          "status": "planned",
+          "engine": "Blink",
+          "engine_version": "124"
         }
       }
     }

--- a/css/properties/direction.json
+++ b/css/properties/direction.json
@@ -39,6 +39,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "vertical_slider_direction": {
+          "__compat": {
+            "description": "Control direction of vertical range sliders, meters, and progress bars",
+            "support": {
+              "chrome": {
+                "version_added": "124"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -171,6 +171,54 @@
               "deprecated": true
             }
           }
+        },
+        "vertical_oriented_form_controls": {
+          "__compat": {
+            "description": "Vertically-oriented form control support via <code>writing-mode</code>",
+            "support": {
+              "chrome": [
+                {
+                  "version_added": "124",
+                  "notes": "Support for range sliders, meters, and progress bars"
+                },
+                {
+                  "version_added": "121",
+                  "partial_implementation": true,
+                  "notes": "Support for text inputs and textareas"
+                },
+                {
+                  "version_added": "119",
+                  "partial_implementation": true,
+                  "notes": "Support for selects and buttons"
+                }
+              ],
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "120"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "14",
+                "partial_implementation": true,
+                "notes": "Support for range sliders, text inputs, and textareas only"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/html/elements/button.json
+++ b/html/elements/button.json
@@ -491,6 +491,41 @@
               "deprecated": false
             }
           }
+        },
+        "vertical_orientation": {
+          "__compat": {
+            "description": "Vertically-oriented button support",
+            "support": {
+              "chrome": {
+                "version_added": "119",
+                "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": true,
+                "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/html/elements/input/button.json
+++ b/html/elements/input/button.json
@@ -37,6 +37,41 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "vertical_orientation": {
+            "__compat": {
+              "description": "Vertically-oriented button support",
+              "support": {
+                "chrome": {
+                  "version_added": "119",
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/html/elements/input/color.json
+++ b/html/elements/input/color.json
@@ -119,6 +119,42 @@
                 "deprecated": false
               }
             }
+          },
+          "vertical_orientation": {
+            "__compat": {
+              "description": "Vertically-oriented color input support",
+              "support": {
+                "chrome": {
+                  "version_added": "121",
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/html/elements/input/datetime-local.json
+++ b/html/elements/input/datetime-local.json
@@ -47,6 +47,42 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "vertical_orientation": {
+            "__compat": {
+              "description": "Vertically-oriented datetime-local support",
+              "support": {
+                "chrome": {
+                  "version_added": "121",
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/html/elements/input/email.json
+++ b/html/elements/input/email.json
@@ -48,6 +48,42 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "vertical_orientation": {
+            "__compat": {
+              "description": "Vertically-oriented email input support",
+              "support": {
+                "chrome": {
+                  "version_added": "121",
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/html/elements/input/file.json
+++ b/html/elements/input/file.json
@@ -44,6 +44,41 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "vertical_orientation": {
+            "__compat": {
+              "description": "Vertically-oriented file input support",
+              "support": {
+                "chrome": {
+                  "version_added": "121",
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/html/elements/input/image.json
+++ b/html/elements/input/image.json
@@ -37,6 +37,41 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "vertical_orientation": {
+            "__compat": {
+              "description": "Vertically-oriented image input support",
+              "support": {
+                "chrome": {
+                  "version_added": "121",
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/html/elements/input/number.json
+++ b/html/elements/input/number.json
@@ -37,6 +37,42 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "vertical_orientation": {
+            "__compat": {
+              "description": "Vertically-oriented number input support",
+              "support": {
+                "chrome": {
+                  "version_added": "121",
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/html/elements/input/password.json
+++ b/html/elements/input/password.json
@@ -72,6 +72,42 @@
                 "deprecated": false
               }
             }
+          },
+          "vertical_orientation": {
+            "__compat": {
+              "description": "Vertically-oriented password input support",
+              "support": {
+                "chrome": {
+                  "version_added": "121",
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/html/elements/input/range.json
+++ b/html/elements/input/range.json
@@ -95,38 +95,58 @@
           },
           "vertical_orientation": {
             "__compat": {
-              "description": "Vertically-oriented slider support",
+              "description": "Vertically-oriented range slider support",
               "support": {
-                "chrome": {
-                  "version_added": true,
-                  "notes": "The slider can be oriented vertically by setting the non-standard <code>-webkit-appearance: slider-vertical</code> style on the <code>input</code> element. You shouldn't use this, since it's proprietary, unless you include appropriate fallbacks for users of other browsers."
-                },
+                "chrome": [
+                  {
+                    "version_added": "124",
+                    "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                  },
+                  {
+                    "version_added": true,
+                    "partial_implementation": true,
+                    "notes": "Vertical orientation available by setting the non-standard <code>-webkit-appearance: slider-vertical</code> style on the <code>input</code> element. You shouldn't use this, since it's proprietary, unless you include appropriate fallbacks for users of other browsers."
+                  }
+                ],
                 "chrome_android": "mirror",
                 "edge": {
                   "version_added": "12",
-                  "notes": "The slider can be oriented vertically by setting the <code>writing-mode: bt-lr</code> style on the <code>input</code> element."
+                  "notes": "Vertical orientation available by setting the <code>writing-mode: bt-lr</code> style on the <code>input</code> element."
                 },
-                "firefox": {
-                  "version_added": "≤72",
-                  "impl_url": [
-                    "https://bugzil.la/840820",
-                    "https://bugzil.la/981916"
-                  ],
-                  "partial_implementation": true,
-                  "notes": "Supported using the non-standard <code>orient=\"vertical\"</code> attribute."
-                },
+                "firefox": [
+                  {
+                    "version_added": true,
+                    "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                  },
+                  {
+                    "version_added": "≤72",
+                    "impl_url": [
+                      "https://bugzil.la/840820",
+                      "https://bugzil.la/981916"
+                    ],
+                    "partial_implementation": true,
+                    "notes": "Supported using the non-standard <code>orient=\"vertical\"</code> attribute."
+                  }
+                ],
                 "firefox_android": "mirror",
                 "ie": {
                   "version_added": "10",
-                  "notes": "The slider can be oriented vertically by setting the <code>writing-mode: bt-lr</code> style on the <code>input</code> element."
+                  "notes": "Vertical orientation available by setting the <code>writing-mode: bt-lr</code> style on the <code>input</code> element."
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
                 "opera_android": "mirror",
-                "safari": {
-                  "version_added": true,
-                  "notes": "The slider can be oriented vertically by setting the non-standard <code>-webkit-appearance: slider-vertical</code> style on the <code>input</code> element. You shouldn't use this, since it's proprietary, unless you include appropriate fallbacks for users of other browsers."
-                },
+                "safari": [
+                  {
+                    "version_added": true,
+                    "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                  },
+                  {
+                    "version_added": true,
+                    "partial_implementation": true,
+                    "notes": "Vertical orientation available by setting the non-standard <code>-webkit-appearance: slider-vertical</code> style on the <code>input</code> element. You shouldn't use this, since it's proprietary, unless you include appropriate fallbacks for users of other browsers."
+                  }
+                ],
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror"

--- a/html/elements/input/reset.json
+++ b/html/elements/input/reset.json
@@ -38,6 +38,41 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "vertical_orientation": {
+            "__compat": {
+              "description": "Vertically-oriented reset button support",
+              "support": {
+                "chrome": {
+                  "version_added": "119",
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/html/elements/input/search.json
+++ b/html/elements/input/search.json
@@ -39,6 +39,41 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "vertical_orientation": {
+            "__compat": {
+              "description": "Vertically-oriented search input support",
+              "support": {
+                "chrome": {
+                  "version_added": "121",
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/html/elements/input/submit.json
+++ b/html/elements/input/submit.json
@@ -38,6 +38,41 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "vertical_orientation": {
+            "__compat": {
+              "description": "Vertically-oriented submit button support",
+              "support": {
+                "chrome": {
+                  "version_added": "119",
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/html/elements/input/tel.json
+++ b/html/elements/input/tel.json
@@ -49,6 +49,42 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "vertical_orientation": {
+            "__compat": {
+              "description": "Vertically-oriented tel input support",
+              "support": {
+                "chrome": {
+                  "version_added": "121",
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/html/elements/input/text.json
+++ b/html/elements/input/text.json
@@ -37,6 +37,42 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "vertical_orientation": {
+            "__compat": {
+              "description": "Vertically-oriented text input support",
+              "support": {
+                "chrome": {
+                  "version_added": "121",
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/html/elements/input/time.json
+++ b/html/elements/input/time.json
@@ -43,6 +43,42 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "vertical_orientation": {
+            "__compat": {
+              "description": "Vertically-oriented time input support",
+              "support": {
+                "chrome": {
+                  "version_added": "121",
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/html/elements/input/url.json
+++ b/html/elements/input/url.json
@@ -39,6 +39,42 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "vertical_orientation": {
+            "__compat": {
+              "description": "Vertically-oriented url input support",
+              "support": {
+                "chrome": {
+                  "version_added": "121",
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": true,
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/html/elements/input/week.json
+++ b/html/elements/input/week.json
@@ -43,6 +43,40 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "vertical_orientation": {
+            "__compat": {
+              "description": "Vertically-oriented week input support",
+              "support": {
+                "chrome": {
+                  "version_added": "121",
+                  "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       }

--- a/html/elements/meter.json
+++ b/html/elements/meter.json
@@ -341,6 +341,41 @@
               "deprecated": false
             }
           }
+        },
+        "vertical_orientation": {
+          "__compat": {
+            "description": "Vertically-oriented meter support",
+            "support": {
+              "chrome": {
+                "version_added": "124",
+                "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": true,
+                "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/html/elements/progress.json
+++ b/html/elements/progress.json
@@ -128,6 +128,41 @@
               "deprecated": false
             }
           }
+        },
+        "vertical_orientation": {
+          "__compat": {
+            "description": "Vertically-oriented progress bar support",
+            "support": {
+              "chrome": {
+                "version_added": "124",
+                "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": true,
+                "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/html/elements/select.json
+++ b/html/elements/select.json
@@ -315,6 +315,42 @@
               "deprecated": false
             }
           }
+        },
+        "vertical_orientation": {
+          "__compat": {
+            "description": "Vertically-oriented <code>&lt;select&gt;</code> support",
+            "support": {
+              "chrome": {
+                "version_added": "119",
+                "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": true,
+                "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false,
+                "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/html/elements/textarea.json
+++ b/html/elements/textarea.json
@@ -585,6 +585,42 @@
             }
           }
         },
+        "vertical_orientation": {
+          "__compat": {
+            "description": "Vertically-oriented textarea support",
+            "support": {
+              "chrome": {
+                "version_added": "121",
+                "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": true,
+                "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": true,
+                "notes": "Vertical orientation available via the <code>writing-mode</code> property (see <a href='https://developer.mozilla.org/docs/Web/CSS/CSS_writing_modes/Vertical_controls'>Creating vertical controls</a>)."
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "wrap": {
           "__compat": {
             "support": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome has added support for vertical form controls; see https://developer.chrome.com/blog/vertical-form-controls for some more details. Specifically: 

- Vertical Selects/buttons released in 119
- Vertical textareas/text-based inputs in 121
- Vertical progress/meter/input type range in 123?

This is done by setting `writing-mode` to `vertical-lr` or `vertical-rl`

The blog post only talks about `<input type="text">`, but I also went through every other text-based input type and tested them all.

I also tested them all in Fx and Safari, and found that many of them work in those browsers too. I found it difficult to pinpoint exactly what browser versions include support for those, so:

- I reported to just saying `true` for Fx/Saf support in HTML elements
- I filled in arbitrary values for Fx/Saf support in CSS properties, as you're not allowed to put `true` for CSS ;-)

Any advice on tracking down more specific values for those would be appreciated. I have already reached out to folks at Fx that I know.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
