### PR TITLE
Bump web-specs from v2.41.0 to v3.0.0 and adjust test accordingly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "sinon": "^17.0.0",
         "ts-node": "~10.9.1",
         "typescript": "~5.3.2",
-        "web-specs": "^2.41.0",
+        "web-specs": "^3.0.0",
         "yargs": "~17.7.0"
       },
       "engines": {
@@ -8692,9 +8692,9 @@
       }
     },
     "node_modules/web-specs": {
-      "version": "2.79.0",
-      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-2.79.0.tgz",
-      "integrity": "sha512-364IxMgYLUjWDeTPrfNtO/+zZxIJ2ZzV4STzbOdVn6DANptLBo3aNTEJ0SS2Qe2P331apSfnU0b4K6wxl6cuew==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/web-specs/-/web-specs-3.0.0.tgz",
+      "integrity": "sha512-iFIqX1Zu13dJ9slgPlnxs0ndb1v/oB3WilmTAQRIm/RxyuAdjghoxWWnG6ypYOKdr+zv9lX+q/p9JLMZ1gi1GQ==",
       "dev": true
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "sinon": "^17.0.0",
     "ts-node": "~10.9.1",
     "typescript": "~5.3.2",
-    "web-specs": "^2.41.0",
+    "web-specs": "^3.0.0",
     "yargs": "~17.7.0"
   },
   "scripts": {

--- a/test/linter/test-spec-urls.ts
+++ b/test/linter/test-spec-urls.ts
@@ -23,10 +23,6 @@ const specsExceptions = [
   // Remove if it is in the main ECMA spec
   'https://github.com/tc39/proposal-regexp-legacy-features/',
 
-  // For the 'shared' flag in WebAssembly.Memory
-  // Remove if this spec will be merged with the main WebAssembly spec
-  'https://webassembly.github.io/threads/js-api/',
-
   // See https://github.com/w3c/browser-specs/issues/305
   // Features with this URL need to be checked after some time
   // if they have been integrated into a real spec
@@ -47,11 +43,12 @@ const allowedSpecURLs = [
     .filter((spec) => spec.standing == 'good')
     .map((spec) => [
       spec.url,
-      spec.nightly.url,
-      ...spec.nightly.alternateUrls,
+      spec.nightly?.url,
+      ...(spec.nightly ? spec.nightly.alternateUrls : []),
       spec.series.nightlyUrl,
     ])
-    .flat(),
+    .flat()
+    .filter((url) => !!url),
   ...specsExceptions,
 ];
 


### PR DESCRIPTION
#### Summary

A new major of web-specs was released. Breaking change is that the presence of a `nightly` property is no longer guaranteed. This happens for specs that do not have a public URL, such as ISO specs. The test that checks spec URLs needed to be adjusted accordingly.

Also, note the new version includes the Threading proposal for the WASM JS API, which could thus be dropped from the list of exceptions.
