### PR TITLE
Speculation Rules add `urls` and `where` keys

### DIFF
--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -864,6 +864,74 @@
                   }
                 }
               }
+            },
+            "urls": {
+              "__compat": {
+                "description": "<code>urls</code> key",
+                "support": {
+                  "chrome": {
+                    "version_added": "109"
+                  },
+                  "chrome_android": {
+                    "version_added": "103"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            },
+            "where": {
+              "__compat": {
+                "description": "<code>where</code> key",
+                "support": {
+                  "chrome": {
+                    "version_added": "121"
+                  },
+                  "chrome_android": "mirror",
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": "mirror",
+                  "ie": {
+                    "version_added": false
+                  },
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Chrome 121 added support for "document rules" to the Speculation Rules API. This is differentiated between the `urls` key and `where` key.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

Tested locally. Working on documenting this on the developer.chrome.com as we speak which is when I noticed it needed adding here.

Test case: https://speculative-rules.glitch.me/common-fruits.html

Screenshot from DevTools->Application->Speculative loads->Rules (open DevTools before loading above page, or reload after opening DevTools):

<img width="521" alt="image" src="https://github.com/mdn/browser-compat-data/assets/10931297/0784e2e8-f882-4b81-92aa-f37128547527">

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://developer.chrome.com/blog/new-in-chrome-121#speculation-rules-api

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
