### PR TITLE
FF123 - CredentialContainer.get .create support cross-origin calls

### DIFF
--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -453,9 +453,9 @@
             }
           }
         },
-        "supports_cross-origin": {
+        "cross-origin_iframes": {
           "__compat": {
-            "description": "Supported for Web Authentication API in cross-origin <code>&lt;iframes&gt;</code> via <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-create'><code>publickey-credentials-create</code></a>",
+            "description": "Callable in a cross-origin <code>&lt;iframe&gt;</code> via <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-create'><code>publickey-credentials-create</code></a>",
             "support": {
               "chrome": {
                 "version_added": "84"
@@ -855,9 +855,9 @@
             }
           }
         },
-        "supports_cross-origin": {
+        "cross-origin_iframes": {
           "__compat": {
-            "description": "Supported for Web Authentication API in cross-origin <code>&lt;iframes&gt;</code> via <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-get'><code>publickey-credentials-get</code></a>",
+            "description": "Callable in a cross-origin <code>&lt;iframe&gt;</code> via <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-get'><code>publickey-credentials-get</code></a>",
             "support": {
               "chrome": {
                 "version_added": "84"

--- a/api/CredentialsContainer.json
+++ b/api/CredentialsContainer.json
@@ -452,6 +452,43 @@
               }
             }
           }
+        },
+        "supports_cross-origin": {
+          "__compat": {
+            "description": "Supported for Web Authentication API in cross-origin <code>&lt;iframes&gt;</code> via <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-create'><code>publickey-credentials-create</code></a>",
+            "support": {
+              "chrome": {
+                "version_added": "84"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "123"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "get": {
@@ -815,6 +852,43 @@
                   "deprecated": false
                 }
               }
+            }
+          }
+        },
+        "supports_cross-origin": {
+          "__compat": {
+            "description": "Supported for Web Authentication API in cross-origin <code>&lt;iframes&gt;</code> via <a href='https://developer.mozilla.org/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-get'><code>publickey-credentials-get</code></a>",
+            "support": {
+              "chrome": {
+                "version_added": "84"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "118"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }


### PR DESCRIPTION
FF123 supports Feature policy [`publickey-credentials-create`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy/publickey-credentials-create) in https://bugzilla.mozilla.org/show_bug.cgi?id=1870863
That is updated in #22172

But the reason we add this is to enable calling `navigator.credentials.create({publicKey})` (for the Web Authentication API) in a cross-origin iframes.
So what this PR does is note that support in the `create()` method where you are likely to see it. The version uses is the earliest version of `publickey-credentials-create` (ignoring particular policy used to implement it).

Similarly in 118 we added support for the `get()` call with the `publickey-credentials-get` feature. So I added that too.

I did this separate to #22172 because I think this should be here, and done in this way, but I didn't want to block the unambiguously correct entry.

Related docs work can be tracked in https://github.com/mdn/content/issues/31890