### PR TITLE
Add runtime.onPerformanceWarning

### DIFF
--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -971,6 +971,26 @@
             }
           }
         },
+        "onPerformanceWarning": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onPerformanceWarning",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "124"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "onRestartRequired": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onRestartRequired",


### PR DESCRIPTION
### Description

Adds compatibility details for the `runtime.on performance` event introduced by [Bug 1861445](https://bugzilla.mozilla.org/show_bug.cgi?id=1861445) Add new hang warning event API for WebExtensionswarning.

See https://github.com/mdn/content/pull/32222 for the MDN content update.
