### PR TITLE
Add missing api.WebGL2RenderingContext.bufferData.SharedArrayBuffer_as_param feature

### DIFF
--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -831,6 +831,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "SharedArrayBuffer_as_param": {
+          "__compat": {
+            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "support": {
+              "chrome": {
+                "version_added": "60"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "79"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "bufferSubData": {


### PR DESCRIPTION
This PR adds the missing `bufferData.SharedArrayBuffer_as_param` member of the `WebGL2RenderingContext` API. This feature was copied from bufferSubData().
