### PR TITLE
Rename WebGL "SharedArrayBuffer_as_param" subfeatures

### DIFF
--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -831,6 +831,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "srcData_param_accepts_SharedArrayBuffer": {
+          "__compat": {
+            "description": "<code>srcData</code> parameter accepts <code>SharedArrayBuffer</code> type",
+            "support": {
+              "chrome": {
+                "version_added": "60"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "79"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "bufferSubData": {
@@ -868,9 +901,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "srcData_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>srcData</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -1084,9 +1117,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "values_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>values</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -1153,9 +1186,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "values_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>values</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -1222,9 +1255,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "values_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>values</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -1507,9 +1540,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "pixels_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>pixels</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -1576,9 +1609,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "pixels_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>pixels</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -1645,9 +1678,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "srcData_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>srcData</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -4012,9 +4045,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "dstData_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>dstData</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -5946,9 +5979,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "pixels_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>pixels</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -6561,9 +6594,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "srcData_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>srcData</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -6819,9 +6852,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "srcData_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>srcData</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -7824,9 +7857,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "value_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>value</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -7893,9 +7926,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "data_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>data</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -7962,9 +7995,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "data_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>data</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -8031,9 +8064,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "value_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>value</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -8100,9 +8133,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "data_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>data</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -8169,9 +8202,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "data_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>data</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -8238,9 +8271,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "value_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>value</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -8307,9 +8340,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "data_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>data</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -8376,9 +8409,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "data_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>data</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -8586,9 +8619,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "value_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>value</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -8691,9 +8724,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "value_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>value</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -8796,9 +8829,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "value_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>value</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -8901,9 +8934,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "value_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>value</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -9042,9 +9075,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "value_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>value</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -9147,9 +9180,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "value_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>value</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -1184,9 +1184,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "pixels_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>pixels</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -6409,9 +6409,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "value_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>value</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -6536,9 +6536,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "value_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>value</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -6663,9 +6663,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "value_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>value</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"
@@ -6790,9 +6790,9 @@
             "deprecated": false
           }
         },
-        "SharedArrayBuffer_as_param": {
+        "value_param_accepts_SharedArrayBuffer": {
           "__compat": {
-            "description": "<code>SharedArrayBuffer</code> as a parameter",
+            "description": "<code>value</code> parameter accepts <code>SharedArrayBuffer</code> type",
             "support": {
               "chrome": {
                 "version_added": "60"


### PR DESCRIPTION
This PR renames all of the `SharedArrayBuffer_as_param` subfeatures of the WebGL rendering contexts to conform to our conventions.
