### PR TITLE
Remove api.Window.open.outerwidth_outerheight from BCD

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -3380,42 +3380,6 @@
             }
           }
         },
-        "outerwidth_outerheight": {
-          "__compat": {
-            "description": "<code>outerHeight</code> and <code>outerWidth</code> features",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "1",
-                "version_removed": "80"
-              },
-              "firefox_android": {
-                "version_added": "4"
-              },
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
-        },
         "relative-multi-screen": {
           "__compat": {
             "description": "Opened relative to the <a href='https://developer.mozilla.org/docs/Web/API/Window_Management_API/Multi-screen_origin'>Multi-screen origin</a>",


### PR DESCRIPTION
This PR removes the `open.outerwidth_outerheight` member of the `Window` API from BCD. Per the [data guidelines](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/index.md#removal-of-irrelevant-features), this feature can be considered irrelevant and may be removed from BCD accordingly. Even if the current data suggests that the feature is supported, lack of support has been confirmed by the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.7.2).

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/Window/open/outerwidth_outerheight
