### PR TITLE
Chrome 123 will have full support for CSS paint-order

### DIFF
--- a/css/properties/paint-order.json
+++ b/css/properties/paint-order.json
@@ -6,11 +6,16 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/paint-order",
           "spec_url": "https://svgwg.org/svg2-draft/painting.html#PaintOrder",
           "support": {
-            "chrome": {
-              "version_added": "35",
-              "partial_implementation": true,
-              "notes": "Does not affect stroked HTML text, see <a href='https://crbug.com/815111'>bug 815111</a>"
-            },
+            "chrome": [
+              {
+                "version_added": "123"
+              },
+              {
+                "version_added": "35",
+                "partial_implementation": true,
+                "notes": "Does not affect stroked HTML text, see <a href='https://crbug.com/41372165'>bug 41372165</a>"
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
Following recent updates in https://issues.chromium.org/issues/41372165 support for applying the CSS paint-order property to HTML text has been implemented in Blink in version 123 (current nightly).

I've updated the information link to the new issue tracker, which has more up to date and complete information, using the crbug.com redirector per discussion on #22165