### PR TITLE
Tag javascript.* tree with snapshots

### DIFF
--- a/javascript/builtins/AggregateError.json
+++ b/javascript/builtins/AggregateError.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AggregateError",
           "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-aggregate-error-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-2021"
+          ],
           "support": {
             "chrome": {
               "version_added": "85"
@@ -45,6 +48,9 @@
             "description": "<code>AggregateError()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AggregateError/AggregateError",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-aggregate-error-constructor",
+            "tags": [
+              "web-features:snapshot:ecmascript-2021"
+            ],
             "support": {
               "chrome": {
                 "version_added": "85"
@@ -86,6 +92,9 @@
             "description": "<code>errors</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AggregateError/errors",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-aggregate-error",
+            "tags": [
+              "web-features:snapshot:ecmascript-2021"
+            ],
             "support": {
               "chrome": {
                 "version_added": "85"

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -6,7 +6,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array-objects",
           "tags": [
-            "web-features:array"
+            "web-features:array",
+            "web-features:snapshot:ecmascript-1"
           ],
           "support": {
             "chrome": {
@@ -57,7 +58,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array-constructor",
             "tags": [
-              "web-features:array"
+              "web-features:array",
+              "web-features:snapshot:ecmascript-1"
             ],
             "support": {
               "chrome": {
@@ -108,7 +110,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/at",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.at",
             "tags": [
-              "web-features:array-at"
+              "web-features:array-at",
+              "web-features:snapshot:ecmascript-2022"
             ],
             "support": {
               "chrome": {
@@ -151,7 +154,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/concat",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.concat",
             "tags": [
-              "web-features:array"
+              "web-features:array",
+              "web-features:snapshot:ecmascript-3"
             ],
             "support": {
               "chrome": {
@@ -200,7 +204,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.copywithin",
             "tags": [
-              "web-features:array-copywithin"
+              "web-features:array-copywithin",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -245,7 +250,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/entries",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.entries",
             "tags": [
-              "web-features:array-iterators"
+              "web-features:array-iterators",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -290,7 +296,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/every",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.every",
             "tags": [
-              "web-features:array-iteration-methods"
+              "web-features:array-iteration-methods",
+              "web-features:snapshot:ecmascript-5"
             ],
             "support": {
               "chrome": {
@@ -343,7 +350,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/fill",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.fill",
             "tags": [
-              "web-features:array-fill"
+              "web-features:array-fill",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -388,7 +396,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/filter",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.filter",
             "tags": [
-              "web-features:array-iteration-methods"
+              "web-features:array-iteration-methods",
+              "web-features:snapshot:ecmascript-5"
             ],
             "support": {
               "chrome": {
@@ -441,7 +450,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/find",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.find",
             "tags": [
-              "web-features:array-find"
+              "web-features:array-find",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -488,7 +498,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.findindex",
             "tags": [
-              "web-features:array-find"
+              "web-features:array-find",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -535,7 +546,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/findLast",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.findlast",
             "tags": [
-              "web-features:array-findlast"
+              "web-features:array-findlast",
+              "web-features:snapshot:ecmascript-2023"
             ],
             "support": {
               "chrome": {
@@ -578,7 +590,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/findLastIndex",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.findlastindex",
             "tags": [
-              "web-features:array-findlast"
+              "web-features:array-findlast",
+              "web-features:snapshot:ecmascript-2023"
             ],
             "support": {
               "chrome": {
@@ -621,7 +634,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flat",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.flat",
             "tags": [
-              "web-features:array-flat"
+              "web-features:array-flat",
+              "web-features:snapshot:ecmascript-2019"
             ],
             "support": {
               "chrome": {
@@ -664,7 +678,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.flatmap",
             "tags": [
-              "web-features:array-flat"
+              "web-features:array-flat",
+              "web-features:snapshot:ecmascript-2019"
             ],
             "support": {
               "chrome": {
@@ -707,7 +722,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.foreach",
             "tags": [
-              "web-features:array-iteration-methods"
+              "web-features:array-iteration-methods",
+              "web-features:snapshot:ecmascript-5"
             ],
             "support": {
               "chrome": {
@@ -760,7 +776,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/from",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.from",
             "tags": [
-              "web-features:array-from"
+              "web-features:array-from",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -848,7 +865,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/includes",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.includes",
             "tags": [
-              "web-features:array-includes"
+              "web-features:array-includes",
+              "web-features:snapshot:ecmascript-2016"
             ],
             "support": {
               "chrome": {
@@ -893,7 +911,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.indexof",
             "tags": [
-              "web-features:array-iteration-methods"
+              "web-features:array-iteration-methods",
+              "web-features:snapshot:ecmascript-5"
             ],
             "support": {
               "chrome": {
@@ -946,7 +965,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.isarray",
             "tags": [
-              "web-features:array-isarray"
+              "web-features:array-isarray",
+              "web-features:snapshot:ecmascript-5"
             ],
             "support": {
               "chrome": {
@@ -995,7 +1015,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/join",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.join",
             "tags": [
-              "web-features:array"
+              "web-features:array",
+              "web-features:snapshot:ecmascript-1"
             ],
             "support": {
               "chrome": {
@@ -1044,7 +1065,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/keys",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.keys",
             "tags": [
-              "web-features:array-iterators"
+              "web-features:array-iterators",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1089,7 +1111,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/lastIndexOf",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.lastindexof",
             "tags": [
-              "web-features:array-iteration-methods"
+              "web-features:array-iteration-methods",
+              "web-features:snapshot:ecmascript-5"
             ],
             "support": {
               "chrome": {
@@ -1142,7 +1165,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/length",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-properties-of-array-instances-length",
             "tags": [
-              "web-features:array"
+              "web-features:array",
+              "web-features:snapshot:ecmascript-1"
             ],
             "support": {
               "chrome": {
@@ -1193,7 +1217,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/map",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.map",
             "tags": [
-              "web-features:array-iteration-methods"
+              "web-features:array-iteration-methods",
+              "web-features:snapshot:ecmascript-5"
             ],
             "support": {
               "chrome": {
@@ -1246,7 +1271,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/of",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.of",
             "tags": [
-              "web-features:array-of"
+              "web-features:array-of",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1295,7 +1321,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/pop",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.pop",
             "tags": [
-              "web-features:array"
+              "web-features:array",
+              "web-features:snapshot:ecmascript-3"
             ],
             "support": {
               "chrome": {
@@ -1344,7 +1371,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/push",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.push",
             "tags": [
-              "web-features:array"
+              "web-features:array",
+              "web-features:snapshot:ecmascript-3"
             ],
             "support": {
               "chrome": {
@@ -1393,7 +1421,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.reduce",
             "tags": [
-              "web-features:array-iteration-methods"
+              "web-features:array-iteration-methods",
+              "web-features:snapshot:ecmascript-5"
             ],
             "support": {
               "chrome": {
@@ -1442,7 +1471,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/reduceRight",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.reduceright",
             "tags": [
-              "web-features:array-iteration-methods"
+              "web-features:array-iteration-methods",
+              "web-features:snapshot:ecmascript-5"
             ],
             "support": {
               "chrome": {
@@ -1491,7 +1521,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.reverse",
             "tags": [
-              "web-features:array"
+              "web-features:array",
+              "web-features:snapshot:ecmascript-1"
             ],
             "support": {
               "chrome": {
@@ -1540,7 +1571,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/shift",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.shift",
             "tags": [
-              "web-features:array"
+              "web-features:array",
+              "web-features:snapshot:ecmascript-3"
             ],
             "support": {
               "chrome": {
@@ -1589,7 +1621,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/slice",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.slice",
             "tags": [
-              "web-features:array"
+              "web-features:array",
+              "web-features:snapshot:ecmascript-3"
             ],
             "support": {
               "chrome": {
@@ -1638,7 +1671,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/some",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.some",
             "tags": [
-              "web-features:array-iteration-methods"
+              "web-features:array-iteration-methods",
+              "web-features:snapshot:ecmascript-5"
             ],
             "support": {
               "chrome": {
@@ -1691,7 +1725,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/sort",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.sort",
             "tags": [
-              "web-features:array"
+              "web-features:array",
+              "web-features:snapshot:ecmascript-1"
             ],
             "support": {
               "chrome": {
@@ -1738,7 +1773,8 @@
             "__compat": {
               "description": "Stable sorting",
               "tags": [
-                "web-features:stable-array-sort"
+                "web-features:stable-array-sort",
+                "web-features:snapshot:ecmascript-2019"
               ],
               "support": {
                 "chrome": {
@@ -1782,7 +1818,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/splice",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.splice",
             "tags": [
-              "web-features:array-splice"
+              "web-features:array-splice",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1835,7 +1872,8 @@
               "https://tc39.es/ecma402/#sup-array.prototype.tolocalestring"
             ],
             "tags": [
-              "web-features:array"
+              "web-features:array",
+              "web-features:snapshot:ecmascript-3"
             ],
             "support": {
               "chrome": {
@@ -1987,7 +2025,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/toReversed",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.toreversed",
             "tags": [
-              "web-features:array-by-copy"
+              "web-features:array-by-copy",
+              "web-features:snapshot:ecmascript-2023"
             ],
             "support": {
               "chrome": {
@@ -2030,7 +2069,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.tosorted",
             "tags": [
-              "web-features:array-by-copy"
+              "web-features:array-by-copy",
+              "web-features:snapshot:ecmascript-2023"
             ],
             "support": {
               "chrome": {
@@ -2073,7 +2113,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/toSpliced",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.tospliced",
             "tags": [
-              "web-features:array-by-copy"
+              "web-features:array-by-copy",
+              "web-features:snapshot:ecmascript-2023"
             ],
             "support": {
               "chrome": {
@@ -2116,7 +2157,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/toString",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.tostring",
             "tags": [
-              "web-features:array"
+              "web-features:array",
+              "web-features:snapshot:ecmascript-1"
             ],
             "support": {
               "chrome": {
@@ -2167,7 +2209,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/unshift",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.unshift",
             "tags": [
-              "web-features:array"
+              "web-features:array",
+              "web-features:snapshot:ecmascript-3"
             ],
             "support": {
               "chrome": {
@@ -2216,7 +2259,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/values",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.values",
             "tags": [
-              "web-features:array-iterators"
+              "web-features:array-iterators",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -2267,7 +2311,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/with",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.with",
             "tags": [
-              "web-features:array-by-copy"
+              "web-features:array-by-copy",
+              "web-features:snapshot:ecmascript-2023"
             ],
             "support": {
               "chrome": {
@@ -2310,7 +2355,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/@@iterator",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype-@@iterator",
             "tags": [
-              "web-features:array-iterators"
+              "web-features:array-iterators",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -2368,6 +2414,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/@@species",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-array-@@species",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "51"
@@ -2408,6 +2457,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/@@unscopables",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype-@@unscopables",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer",
           "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-arraybuffer-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "7"
@@ -55,6 +58,9 @@
             "description": "<code>ArrayBuffer()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/ArrayBuffer",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-arraybuffer-constructor",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -104,6 +110,9 @@
             "__compat": {
               "description": "<code>maxByteLength</code> option",
               "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-arraybuffer-constructor",
+              "tags": [
+                "web-features:snapshot:ecmascript-2024"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "111"
@@ -152,6 +161,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/byteLength",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-arraybuffer.prototype.bytelength",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -202,6 +214,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/detached",
             "spec_url": "https://tc39.es/proposal-arraybuffer-transfer/#sec-get-arraybuffer.prototype.detached",
+            "tags": [
+              "web-features:arraybuffer-transfer"
+            ],
             "support": {
               "chrome": {
                 "version_added": "114"
@@ -242,6 +257,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/isView",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-arraybuffer.isview",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "32"
@@ -284,6 +302,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/maxByteLength",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-arraybuffer.prototype.maxbytelength",
+            "tags": [
+              "web-features:snapshot:ecmascript-2024"
+            ],
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -331,6 +352,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/resizable",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-arraybuffer.prototype.resizable",
+            "tags": [
+              "web-features:snapshot:ecmascript-2024"
+            ],
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -378,6 +402,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/resize",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-arraybuffer.prototype.resize",
+            "tags": [
+              "web-features:snapshot:ecmascript-2024"
+            ],
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -425,6 +452,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/slice",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-arraybuffer.prototype.slice",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "17"
@@ -474,6 +504,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transfer",
             "spec_url": "https://tc39.es/proposal-arraybuffer-transfer/#sec-arraybuffer.prototype.transfer",
+            "tags": [
+              "web-features:arraybuffer-transfer"
+            ],
             "support": {
               "chrome": {
                 "version_added": "114"
@@ -514,6 +547,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/transferToFixedLength",
             "spec_url": "https://tc39.es/proposal-arraybuffer-transfer/#sec-arraybuffer.prototype.transfertofixedlength",
+            "tags": [
+              "web-features:arraybuffer-transfer"
+            ],
             "support": {
               "chrome": {
                 "version_added": "114"
@@ -554,6 +590,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/@@species",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-arraybuffer-@@species",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "51"

--- a/javascript/builtins/AsyncFunction.json
+++ b/javascript/builtins/AsyncFunction.json
@@ -6,7 +6,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncFunction",
           "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-async-function-objects",
           "tags": [
-            "web-features:async-await"
+            "web-features:async-await",
+            "web-features:snapshot:ecmascript-2017"
           ],
           "support": {
             "chrome": {
@@ -51,7 +52,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncFunction/AsyncFunction",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-async-function-constructor",
             "tags": [
-              "web-features:async-await"
+              "web-features:async-await",
+              "web-features:snapshot:ecmascript-2017"
             ],
             "support": {
               "chrome": {

--- a/javascript/builtins/AsyncGenerator.json
+++ b/javascript/builtins/AsyncGenerator.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator",
           "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asyncgenerator-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-2017"
+          ],
           "support": {
             "chrome": {
               "version_added": "63"
@@ -44,6 +47,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator/next",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asyncgenerator-prototype-next",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "63"
@@ -84,6 +90,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator/return",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asyncgenerator-prototype-return",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "63"
@@ -124,6 +133,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator/throw",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asyncgenerator-prototype-throw",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "63"

--- a/javascript/builtins/AsyncGeneratorFunction.json
+++ b/javascript/builtins/AsyncGeneratorFunction.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncGeneratorFunction",
           "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asyncgeneratorfunction-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-2017"
+          ],
           "support": {
             "chrome": {
               "version_added": "63"
@@ -45,6 +48,9 @@
             "description": "<code>AsyncGeneratorFunction()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncGeneratorFunction/AsyncGeneratorFunction",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asyncgeneratorfunction-constructor",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "63"

--- a/javascript/builtins/AsyncIterator.json
+++ b/javascript/builtins/AsyncIterator.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator",
           "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asynciteratorprototype",
+          "tags": [
+            "web-features:snapshot:ecmascript-2018"
+          ],
           "support": {
             "chrome": {
               "version_added": "63"
@@ -44,6 +47,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator/@@asyncIterator",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-asynciteratorprototype-asynciterator",
+            "tags": [
+              "web-features:snapshot:ecmascript-2018"
+            ],
             "support": {
               "chrome": {
                 "version_added": "63"

--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics",
           "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics-object",
+          "tags": [
+            "web-features:snapshot:ecmascript-2017"
+          ],
           "support": {
             "chrome": {
               "version_added": "68"
@@ -46,6 +49,9 @@
         "Atomic_operations_on_non_shared_buffers": {
           "__compat": {
             "description": "Atomic operations on non-shared <code>ArrayBuffer</code> objects",
+            "tags": [
+              "web-features:snapshot:ecmascript-2021"
+            ],
             "support": {
               "chrome": {
                 "version_added": false
@@ -86,6 +92,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/add",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.add",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "68"
@@ -128,6 +137,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/and",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.and",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "68"
@@ -170,6 +182,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/compareExchange",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.compareexchange",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "68"
@@ -212,6 +227,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/exchange",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.exchange",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "68"
@@ -254,6 +272,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/isLockFree",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.islockfree",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "68"
@@ -296,6 +317,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/load",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.load",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "68"
@@ -338,6 +362,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/notify",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.notify",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "68"
@@ -380,6 +407,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/or",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.or",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "68"
@@ -422,6 +452,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/store",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.store",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "68"
@@ -464,6 +497,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/sub",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.sub",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "68"
@@ -506,6 +542,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.wait",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "68"
@@ -548,6 +587,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/waitAsync",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.waitasync",
+            "tags": [
+              "web-features:snapshot:ecmascript-2024"
+            ],
             "support": {
               "chrome": {
                 "version_added": "87"
@@ -592,6 +634,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Atomics/xor",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-atomics.xor",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "68"

--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -6,6 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt",
           "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint-objects",
           "tags": [
+            "web-features:snapshot:ecmascript-2020",
             "web-features:bigint"
           ],
           "support": {
@@ -49,6 +50,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/BigInt",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint-constructor",
             "tags": [
+              "web-features:snapshot:ecmascript-2020",
               "web-features:bigint"
             ],
             "support": {
@@ -92,6 +94,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asIntN",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint.asintn",
             "tags": [
+              "web-features:snapshot:ecmascript-2020",
               "web-features:bigint"
             ],
             "support": {
@@ -135,6 +138,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asUintN",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint.asuintn",
             "tags": [
+              "web-features:snapshot:ecmascript-2020",
               "web-features:bigint"
             ],
             "support": {
@@ -178,6 +182,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toLocaleString",
             "spec_url": "https://tc39.es/ecma402/#sup-bigint.prototype.tolocalestring",
             "tags": [
+              "web-features:snapshot:ecmascript-2020",
               "web-features:bigint"
             ],
             "support": {
@@ -308,6 +313,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toString",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint.prototype.tostring",
             "tags": [
+              "web-features:snapshot:ecmascript-2020",
               "web-features:bigint"
             ],
             "support": {
@@ -351,6 +357,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt/valueOf",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-bigint.prototype.valueof",
             "tags": [
+              "web-features:snapshot:ecmascript-2020",
               "web-features:bigint"
             ],
             "support": {

--- a/javascript/builtins/BigInt64Array.json
+++ b/javascript/builtins/BigInt64Array.json
@@ -5,6 +5,10 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt64Array",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-2020",
+            "web-features:bigint"
+          ],
           "support": {
             "chrome": {
               "version_added": "67"
@@ -45,6 +49,10 @@
             "description": "<code>BigInt64Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigInt64Array/BigInt64Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
+            "tags": [
+              "web-features:snapshot:ecmascript-2020",
+              "web-features:bigint"
+            ],
             "support": {
               "chrome": {
                 "version_added": "67"

--- a/javascript/builtins/BigUint64Array.json
+++ b/javascript/builtins/BigUint64Array.json
@@ -5,6 +5,10 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigUint64Array",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-2020",
+            "web-features:bigint"
+          ],
           "support": {
             "chrome": {
               "version_added": "67"
@@ -45,6 +49,10 @@
             "description": "<code>BigUint64Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/BigUint64Array/BigUint64Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
+            "tags": [
+              "web-features:snapshot:ecmascript-2020",
+              "web-features:bigint"
+            ],
             "support": {
               "chrome": {
                 "version_added": "67"

--- a/javascript/builtins/Boolean.json
+++ b/javascript/builtins/Boolean.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean",
           "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-boolean-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -51,6 +54,9 @@
             "description": "<code>Boolean()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean/Boolean",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-boolean-constructor",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -97,6 +103,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean/toString",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-boolean.prototype.tostring",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -143,6 +152,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Boolean/valueOf",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-boolean.prototype.valueof",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView",
           "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "9"
@@ -53,6 +56,9 @@
             "description": "<code>DataView()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/DataView",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview-constructor",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -99,6 +105,9 @@
           "sharedarraybuffer_support": {
             "__compat": {
               "description": "<code>SharedArrayBuffer</code> accepted as buffer",
+              "tags": [
+                "web-features:snapshot:ecmascript-2017"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "68"
@@ -142,6 +151,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/buffer",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-dataview.prototype.buffer",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -190,6 +202,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/byteLength",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-dataview.prototype.bytelength",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -238,6 +253,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/byteOffset",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-dataview.prototype.byteoffset",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -286,6 +304,10 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getBigInt64",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getbigint64",
+            "tags": [
+              "web-features:snapshot:ecmascript-2020",
+              "web-features:bigint"
+            ],
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -326,6 +348,10 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getBigUint64",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getbiguint64",
+            "tags": [
+              "web-features:snapshot:ecmascript-2020",
+              "web-features:bigint"
+            ],
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -366,6 +392,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getFloat32",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getfloat32",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -414,6 +443,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getFloat64",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getfloat64",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -462,6 +494,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getInt16",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getint16",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -510,6 +545,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getInt32",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getint32",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -558,6 +596,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getInt8",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getint8",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -606,6 +647,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getUint16",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getuint16",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -654,6 +698,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getUint32",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getuint32",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -702,6 +749,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/getUint8",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.getuint8",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -750,6 +800,10 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setBigInt64",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setbigint64",
+            "tags": [
+              "web-features:snapshot:ecmascript-2020",
+              "web-features:bigint"
+            ],
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -790,6 +844,10 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setBigUint64",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setbiguint64",
+            "tags": [
+              "web-features:snapshot:ecmascript-2020",
+              "web-features:bigint"
+            ],
             "support": {
               "chrome": {
                 "version_added": "67"
@@ -830,6 +888,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setFloat32",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setfloat32",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -878,6 +939,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setFloat64",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setfloat64",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -926,6 +990,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setInt16",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setint16",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -974,6 +1041,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setInt32",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setint32",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1022,6 +1092,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setInt8",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setint8",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1070,6 +1143,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setUint16",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setuint16",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1118,6 +1194,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setUint32",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setuint32",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "9"
@@ -1166,6 +1245,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/DataView/setUint8",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-dataview.prototype.setuint8",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "9"

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date",
           "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -52,6 +55,9 @@
             "description": "<code>Date()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/Date",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date-constructor",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -98,6 +104,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/UTC",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.utc",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -142,6 +151,9 @@
           "optional_monthIndex": {
             "__compat": {
               "description": "<code>monthIndex</code> defaults to 0",
+              "tags": [
+                "web-features:snapshot:ecmascript-2017"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "57"
@@ -183,6 +195,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getDate",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getdate",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -229,6 +244,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getDay",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getday",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -275,6 +293,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getFullYear",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getfullyear",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -321,6 +342,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getHours",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.gethours",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -367,6 +391,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getMilliseconds",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getmilliseconds",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -413,6 +440,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getMinutes",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getminutes",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -459,6 +489,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getmonth",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -505,6 +538,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getSeconds",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getseconds",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -551,6 +587,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.gettime",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -597,6 +636,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.gettimezoneoffset",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -643,6 +685,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCDate",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getutcdate",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -689,6 +734,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCDay",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getutcday",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -735,6 +783,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCFullYear",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getutcfullyear",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -781,6 +832,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCHours",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getutchours",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -827,6 +881,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMilliseconds",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getutcmilliseconds",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -873,6 +930,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMinutes",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getutcminutes",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -919,6 +979,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMonth",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getutcmonth",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -965,6 +1028,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCSeconds",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.getutcseconds",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1011,6 +1077,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/getYear",
             "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-date.prototype.getyear",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1057,6 +1126,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/now",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.now",
+            "tags": [
+              "web-features:snapshot:ecmascript-5"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1103,6 +1175,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/parse",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.parse",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1147,6 +1222,9 @@
           "iso_8601": {
             "__compat": {
               "description": "ISO 8601 format",
+              "tags": [
+                "web-features:snapshot:ecmascript-5"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "6"
@@ -1196,6 +1274,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setDate",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setdate",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1242,6 +1323,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setFullYear",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setfullyear",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1288,6 +1372,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setHours",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.sethours",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1334,6 +1421,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setMilliseconds",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setmilliseconds",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1380,6 +1470,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setMinutes",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setminutes",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1426,6 +1519,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setMonth",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setmonth",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1472,6 +1568,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setSeconds",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setseconds",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1518,6 +1617,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setTime",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.settime",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1564,6 +1666,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCDate",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setutcdate",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1610,6 +1715,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCFullYear",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setutcfullyear",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1656,6 +1764,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCHours",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setutchours",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1702,6 +1813,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCMilliseconds",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setutcmilliseconds",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1748,6 +1862,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCMinutes",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setutcminutes",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1794,6 +1911,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCMonth",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setutcmonth",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1840,6 +1960,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCSeconds",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.setutcseconds",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1886,6 +2009,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/setYear",
             "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-date.prototype.setyear",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1932,6 +2058,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toDateString",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.todatestring",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1978,6 +2107,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toGMTString",
             "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-date.prototype.togmtstring",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2024,6 +2156,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.toisostring",
+            "tags": [
+              "web-features:snapshot:ecmascript-5"
+            ],
             "support": {
               "chrome": {
                 "version_added": "3"
@@ -2072,6 +2207,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.tojson",
+            "tags": [
+              "web-features:snapshot:ecmascript-5"
+            ],
             "support": {
               "chrome": {
                 "version_added": "3"
@@ -2122,6 +2260,9 @@
             "spec_url": [
               "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.tolocaledatestring",
               "https://tc39.es/ecma402/#sup-date.prototype.tolocaledatestring"
+            ],
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
             ],
             "support": {
               "chrome": {
@@ -2316,6 +2457,9 @@
               "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.tolocalestring",
               "https://tc39.es/ecma402/#sup-date.prototype.tolocalestring"
             ],
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2509,6 +2653,9 @@
               "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.tolocaletimestring",
               "https://tc39.es/ecma402/#sup-date.prototype.tolocaletimestring"
             ],
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2699,6 +2846,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toString",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.tostring",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2745,6 +2895,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toTimeString",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.totimestring",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2791,6 +2944,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/toUTCString",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.toutcstring",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2837,6 +2993,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/valueOf",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.valueof",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2883,6 +3042,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Date/@@toPrimitive",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype-@@toprimitive",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "47"

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error",
           "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-error-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -51,6 +54,9 @@
             "description": "<code>Error()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/Error",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-error-constructor",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -174,6 +180,9 @@
             "__compat": {
               "description": "<code>options.cause</code> parameter",
               "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-installerrorcause",
+              "tags": [
+                "web-features:snapshot:ecmascript-2022"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "93"
@@ -214,6 +223,9 @@
         "cause": {
           "__compat": {
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-installerrorcause",
+            "tags": [
+              "web-features:snapshot:ecmascript-2022"
+            ],
             "support": {
               "chrome": {
                 "version_added": "93"
@@ -411,6 +423,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/message",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-error.prototype.message",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -457,6 +472,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/name",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-error.prototype.name",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -596,6 +614,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Error/toString",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-error.prototype.tostring",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/EvalError.json
+++ b/javascript/builtins/EvalError.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/EvalError",
           "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-native-error-types-used-in-this-standard-evalerror",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -51,6 +54,9 @@
             "description": "<code>EvalError()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/EvalError/EvalError",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-nativeerror-constructors",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/FinalizationRegistry.json
+++ b/javascript/builtins/FinalizationRegistry.json
@@ -5,6 +5,10 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry",
           "spec_url": "https://tc39.es/ecma262/multipage/managing-memory.html#sec-finalization-registry-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-2021",
+            "web-features:weak-references"
+          ],
           "support": {
             "chrome": {
               "version_added": "84"
@@ -45,6 +49,10 @@
             "description": "<code>FinalizationRegistry()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry/FinalizationRegistry",
             "spec_url": "https://tc39.es/ecma262/multipage/managing-memory.html#sec-finalization-registry-constructor",
+            "tags": [
+              "web-features:snapshot:ecmascript-2021",
+              "web-features:weak-references"
+            ],
             "support": {
               "chrome": {
                 "version_added": "84"
@@ -85,6 +93,10 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry/register",
             "spec_url": "https://tc39.es/ecma262/multipage/managing-memory.html#sec-finalization-registry.prototype.register",
+            "tags": [
+              "web-features:snapshot:ecmascript-2021",
+              "web-features:weak-references"
+            ],
             "support": {
               "chrome": {
                 "version_added": "84"
@@ -124,6 +136,10 @@
         "symbol_as_target": {
           "__compat": {
             "description": "Non-registered symbol as target",
+            "tags": [
+              "web-features:snapshot:ecmascript-2023",
+              "web-features:weak-references"
+            ],
             "support": {
               "chrome": {
                 "version_added": "108"
@@ -164,6 +180,10 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry/unregister",
             "spec_url": "https://tc39.es/ecma262/multipage/managing-memory.html#sec-finalization-registry.prototype.unregister",
+            "tags": [
+              "web-features:snapshot:ecmascript-2021",
+              "web-features:weak-references"
+            ],
             "support": {
               "chrome": {
                 "version_added": "84"

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -6,7 +6,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float32Array",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
           "tags": [
-            "web-features:typed-arrays"
+            "web-features:typed-arrays",
+            "web-features:snapshot:ecmascript-2015"
           ],
           "support": {
             "chrome": {
@@ -59,7 +60,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float32Array/Float32Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -110,7 +112,8 @@
             "__compat": {
               "description": "Constructor without parameters",
               "tags": [
-                "web-features:typed-arrays"
+                "web-features:typed-arrays",
+                "web-features:snapshot:ecmascript-2015"
               ],
               "support": {
                 "chrome": {
@@ -160,7 +163,8 @@
             "__compat": {
               "description": "<code>new Float32Array(iterable)</code>",
               "tags": [
-                "web-features:typed-arrays"
+                "web-features:typed-arrays",
+                "web-features:snapshot:ecmascript-2015"
               ],
               "support": {
                 "chrome": {

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -6,7 +6,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float64Array",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
           "tags": [
-            "web-features:typed-arrays"
+            "web-features:typed-arrays",
+            "web-features:snapshot:ecmascript-2015"
           ],
           "support": {
             "chrome": {
@@ -59,7 +60,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float64Array/Float64Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -110,7 +112,8 @@
             "__compat": {
               "description": "Constructor without parameters",
               "tags": [
-                "web-features:typed-arrays"
+                "web-features:typed-arrays",
+                "web-features:snapshot:ecmascript-2015"
               ],
               "support": {
                 "chrome": {
@@ -160,7 +163,8 @@
             "__compat": {
               "description": "<code>new Float64Array(iterable)</code>",
               "tags": [
-                "web-features:typed-arrays"
+                "web-features:typed-arrays",
+                "web-features:snapshot:ecmascript-2015"
               ],
               "support": {
                 "chrome": {

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function",
           "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -53,6 +56,9 @@
             "description": "<code>Function()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/Function",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function-constructor",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -99,6 +105,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/apply",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function.prototype.apply",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -143,6 +152,9 @@
           "generic_arrays_as_arguments": {
             "__compat": {
               "description": "ES 5.1: generic array-like object as <code>arguments</code>",
+              "tags": [
+                "web-features:snapshot:ecmascript-5"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "17"
@@ -237,6 +249,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/bind",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function.prototype.bind",
+            "tags": [
+              "web-features:snapshot:ecmascript-5"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -287,6 +302,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/call",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function.prototype.call",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -420,6 +438,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/length",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function-instances-length",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -464,6 +485,9 @@
           "configurable_true": {
             "__compat": {
               "description": "Configurable: true",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "43"
@@ -507,6 +531,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/name",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function-instances-name",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "15"
@@ -551,6 +578,9 @@
           "configurable_true": {
             "__compat": {
               "description": "Configurable: true",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "43"
@@ -592,6 +622,9 @@
           "inferred_names": {
             "__compat": {
               "description": "Inferred names on anonymous functions",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "51"
@@ -643,6 +676,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/toString",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function.prototype.tostring",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -687,6 +723,9 @@
           "toString_revision": {
             "__compat": {
               "description": "Implements <code>Function.prototype.toString</code> revision",
+              "tags": [
+                "web-features:snapshot:ecmascript-2019"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "66"
@@ -728,6 +767,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Function/@@hasInstance",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-function.prototype-@@hasinstance",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "50"

--- a/javascript/builtins/Generator.json
+++ b/javascript/builtins/Generator.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Generator",
           "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-generator-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "39"
@@ -46,6 +49,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Generator/next",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-generator.prototype.next",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "39"
@@ -88,6 +94,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Generator/return",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-generator.prototype.return",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -130,6 +139,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Generator/throw",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-generator.prototype.throw",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "39"

--- a/javascript/builtins/GeneratorFunction.json
+++ b/javascript/builtins/GeneratorFunction.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/GeneratorFunction",
           "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-generatorfunction-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "39"
@@ -47,6 +50,9 @@
             "description": "<code>GeneratorFunction()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/GeneratorFunction/GeneratorFunction",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-generatorfunction-constructor",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "39"

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -6,7 +6,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int16Array",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
           "tags": [
-            "web-features:typed-arrays"
+            "web-features:typed-arrays",
+            "web-features:snapshot:ecmascript-2015"
           ],
           "support": {
             "chrome": {
@@ -59,7 +60,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int16Array/Int16Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -110,7 +112,8 @@
             "__compat": {
               "description": "Constructor without parameters",
               "tags": [
-                "web-features:typed-arrays"
+                "web-features:typed-arrays",
+                "web-features:snapshot:ecmascript-2015"
               ],
               "support": {
                 "chrome": {
@@ -159,6 +162,9 @@
           "iterable_allowed": {
             "__compat": {
               "description": "<code>new Int16Array(iterable)</code>",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "39"

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -6,7 +6,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int32Array",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
           "tags": [
-            "web-features:typed-arrays"
+            "web-features:typed-arrays",
+            "web-features:snapshot:ecmascript-2015"
           ],
           "support": {
             "chrome": {
@@ -59,7 +60,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int32Array/Int32Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -110,7 +112,8 @@
             "__compat": {
               "description": "Constructor without parameters",
               "tags": [
-                "web-features:typed-arrays"
+                "web-features:typed-arrays",
+                "web-features:snapshot:ecmascript-2015"
               ],
               "support": {
                 "chrome": {
@@ -160,7 +163,8 @@
             "__compat": {
               "description": "<code>new Int32Array(iterable)</code>",
               "tags": [
-                "web-features:typed-arrays"
+                "web-features:typed-arrays",
+                "web-features:snapshot:ecmascript-2015"
               ],
               "support": {
                 "chrome": {

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -6,7 +6,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int8Array",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
           "tags": [
-            "web-features:typed-arrays"
+            "web-features:typed-arrays",
+            "web-features:snapshot:ecmascript-2015"
           ],
           "support": {
             "chrome": {
@@ -59,7 +60,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Int8Array/Int8Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -110,7 +112,8 @@
             "__compat": {
               "description": "Constructor without parameters",
               "tags": [
-                "web-features:typed-arrays"
+                "web-features:typed-arrays",
+                "web-features:snapshot:ecmascript-2015"
               ],
               "support": {
                 "chrome": {
@@ -160,7 +163,8 @@
             "__compat": {
               "description": "<code>new Int8Array(iterable)</code>",
               "tags": [
-                "web-features:typed-arrays"
+                "web-features:typed-arrays",
+                "web-features:snapshot:ecmascript-2015"
               ],
               "support": {
                 "chrome": {

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator",
           "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-%iteratorprototype%-object",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "38"
@@ -47,6 +50,9 @@
             "description": "<code>Iterator()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/Iterator",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iterator-constructor",
+            "tags": [
+              "web-features:iterator-helpers"
+            ],
             "support": {
               "chrome": {
                 "version_added": "122"
@@ -89,6 +95,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/drop",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.drop",
+            "tags": [
+              "web-features:iterator-helpers"
+            ],
             "support": {
               "chrome": [
                 {
@@ -137,6 +146,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/every",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.every",
+            "tags": [
+              "web-features:iterator-helpers"
+            ],
             "support": {
               "chrome": [
                 {
@@ -185,6 +197,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/filter",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.filter",
+            "tags": [
+              "web-features:iterator-helpers"
+            ],
             "support": {
               "chrome": [
                 {
@@ -233,6 +248,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/find",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.find",
+            "tags": [
+              "web-features:iterator-helpers"
+            ],
             "support": {
               "chrome": [
                 {
@@ -281,6 +299,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/flatMap",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.flatmap",
+            "tags": [
+              "web-features:iterator-helpers"
+            ],
             "support": {
               "chrome": [
                 {
@@ -329,6 +350,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/forEach",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.foreach",
+            "tags": [
+              "web-features:iterator-helpers"
+            ],
             "support": {
               "chrome": [
                 {
@@ -377,6 +401,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/from",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iterator.from",
+            "tags": [
+              "web-features:iterator-helpers"
+            ],
             "support": {
               "chrome": [
                 {
@@ -425,6 +452,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/map",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.map",
+            "tags": [
+              "web-features:iterator-helpers"
+            ],
             "support": {
               "chrome": [
                 {
@@ -473,6 +503,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/reduce",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.reduce",
+            "tags": [
+              "web-features:iterator-helpers"
+            ],
             "support": {
               "chrome": [
                 {
@@ -521,6 +554,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/some",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.some",
+            "tags": [
+              "web-features:iterator-helpers"
+            ],
             "support": {
               "chrome": [
                 {
@@ -569,6 +605,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/take",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.take",
+            "tags": [
+              "web-features:iterator-helpers"
+            ],
             "support": {
               "chrome": [
                 {
@@ -617,6 +656,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/toArray",
             "spec_url": "https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.toarray",
+            "tags": [
+              "web-features:iterator-helpers"
+            ],
             "support": {
               "chrome": [
                 {
@@ -665,6 +707,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/@@iterator",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-%iteratorprototype%-@@iterator",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"

--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON",
           "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-json-object",
+          "tags": [
+            "web-features:snapshot:ecmascript-5"
+          ],
           "support": {
             "chrome": {
               "version_added": "3"
@@ -94,6 +97,9 @@
           "__compat": {
             "description": "JavaScript is a superset of JSON",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON#JavaScript_and_JSON_differences",
+            "tags": [
+              "web-features:snapshot:ecmascript-2019"
+            ],
             "support": {
               "chrome": {
                 "version_added": "66"
@@ -134,6 +140,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-json.parse",
+            "tags": [
+              "web-features:snapshot:ecmascript-5"
+            ],
             "support": {
               "chrome": {
                 "version_added": "3"
@@ -224,6 +233,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-json.stringify",
+            "tags": [
+              "web-features:snapshot:ecmascript-5"
+            ],
             "support": {
               "chrome": {
                 "version_added": "3"
@@ -272,6 +284,9 @@
           "well_formed_stringify": {
             "__compat": {
               "description": "Strings are escaped to well-formed UTF-8",
+              "tags": [
+                "web-features:snapshot:ecmascript-2019"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "72"

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -6,7 +6,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map",
           "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map-objects",
           "tags": [
-            "web-features:map"
+            "web-features:map",
+            "web-features:snapshot:ecmascript-2015"
           ],
           "support": {
             "chrome": {
@@ -51,7 +52,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/Map",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map-constructor",
             "tags": [
-              "web-features:map"
+              "web-features:map",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -94,7 +96,8 @@
             "__compat": {
               "description": "<code>new Map(iterable)</code>",
               "tags": [
-                "web-features:map"
+                "web-features:map",
+                "web-features:snapshot:ecmascript-2015"
               ],
               "support": {
                 "chrome": {
@@ -138,7 +141,8 @@
             "__compat": {
               "description": "<code>new Map(null)</code>",
               "tags": [
-                "web-features:map"
+                "web-features:map",
+                "web-features:snapshot:ecmascript-2015"
               ],
               "support": {
                 "chrome": {
@@ -184,7 +188,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/clear",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.clear",
             "tags": [
-              "web-features:map"
+              "web-features:map",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -229,7 +234,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/delete",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.delete",
             "tags": [
-              "web-features:map"
+              "web-features:map",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -274,7 +280,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/entries",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.entries",
             "tags": [
-              "web-features:map"
+              "web-features:map",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -319,7 +326,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/forEach",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.foreach",
             "tags": [
-              "web-features:map"
+              "web-features:map",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -364,7 +372,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/get",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.get",
             "tags": [
-              "web-features:map"
+              "web-features:map",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -459,7 +468,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/has",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.has",
             "tags": [
-              "web-features:map"
+              "web-features:map",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -503,7 +513,8 @@
           "__compat": {
             "description": "Key equality for -0 and 0",
             "tags": [
-              "web-features:map"
+              "web-features:map",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -548,7 +559,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/keys",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.keys",
             "tags": [
-              "web-features:map"
+              "web-features:map",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -593,7 +605,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/set",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.set",
             "tags": [
-              "web-features:map"
+              "web-features:map",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -640,7 +653,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/size",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-get-map.prototype.size",
             "tags": [
-              "web-features:map"
+              "web-features:map",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -686,7 +700,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/values",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype.values",
             "tags": [
-              "web-features:map"
+              "web-features:map",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -731,7 +746,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/@@iterator",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-map.prototype-@@iterator",
             "tags": [
-              "web-features:map"
+              "web-features:map",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -790,7 +806,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/@@species",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-get-map-@@species",
             "tags": [
-              "web-features:map"
+              "web-features:map",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math",
           "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math-object",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -50,6 +53,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/E",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.e",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -96,6 +102,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/LN10",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.ln10",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -142,6 +151,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/LN2",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.ln2",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -188,6 +200,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/LOG10E",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.log10e",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -234,6 +249,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/LOG2E",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.log2e",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -280,6 +298,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/PI",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.pi",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -326,6 +347,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/SQRT1_2",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.sqrt1_2",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -372,6 +396,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/SQRT2",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.sqrt2",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -418,6 +445,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/abs",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.abs",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -464,6 +494,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/acos",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.acos",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -510,6 +543,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/acosh",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.acosh",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -552,6 +588,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/asin",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.asin",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -598,6 +637,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/asinh",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.asinh",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -640,6 +682,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/atan",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.atan",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -686,6 +731,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/atan2",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.atan2",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -732,6 +780,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/atanh",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.atanh",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -774,6 +825,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/cbrt",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.cbrt",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -816,6 +870,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/ceil",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.ceil",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -862,6 +919,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/clz32",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.clz32",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -904,6 +964,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/cos",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.cos",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -950,6 +1013,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/cosh",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.cosh",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -992,6 +1058,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/exp",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.exp",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1038,6 +1107,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/expm1",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.expm1",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1080,6 +1152,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/floor",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.floor",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1126,6 +1201,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/fround",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.fround",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1168,6 +1246,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/hypot",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.hypot",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1210,6 +1291,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/imul",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.imul",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "28"
@@ -1254,6 +1338,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/log",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.log",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1300,6 +1387,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/log10",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.log10",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1342,6 +1432,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/log1p",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.log1p",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1384,6 +1477,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/log2",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.log2",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1426,6 +1522,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/max",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.max",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1472,6 +1571,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/min",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.min",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1518,6 +1620,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/pow",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.pow",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1564,6 +1669,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/random",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.random",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1610,6 +1718,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/round",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.round",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1656,6 +1767,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/sign",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.sign",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1698,6 +1812,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/sin",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.sin",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1744,6 +1861,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/sinh",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.sinh",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1786,6 +1906,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/sqrt",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.sqrt",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1832,6 +1955,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/tan",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.tan",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1878,6 +2004,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/tanh",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.tanh",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -1920,6 +2049,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.trunc",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number",
           "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -50,6 +53,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/EPSILON",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.epsilon",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -92,6 +98,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.max_safe_integer",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -134,6 +143,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_VALUE",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.max_value",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -180,6 +192,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_SAFE_INTEGER",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.min_safe_integer",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -222,6 +237,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_VALUE",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.min_value",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -268,6 +286,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.nan",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -314,6 +335,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/NEGATIVE_INFINITY",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.negative_infinity",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -361,6 +385,9 @@
             "description": "<code>Number()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/Number",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number-constructor",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -407,6 +434,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/POSITIVE_INFINITY",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.positive_infinity",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -453,6 +483,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.isfinite",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "19"
@@ -495,6 +528,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.isinteger",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -537,6 +573,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.isnan",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "25"
@@ -579,6 +618,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.issafeinteger",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -621,6 +663,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/parseFloat",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.parsefloat",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -663,6 +708,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/parseInt",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.parseint",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -705,6 +753,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.prototype.toexponential",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -751,6 +802,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.prototype.tofixed",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -799,6 +853,9 @@
             "spec_url": [
               "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.prototype.tolocalestring",
               "https://tc39.es/ecma402/#sup-number.prototype.tolocalestring"
+            ],
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
             ],
             "support": {
               "chrome": {
@@ -953,6 +1010,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.prototype.toprecision",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -999,6 +1059,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/toString",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.prototype.tostring",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1045,6 +1108,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number/valueOf",
             "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.prototype.valueof",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object",
           "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -51,6 +54,9 @@
             "description": "<code>Object()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/Object",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object-constructor",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -97,6 +103,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/assign",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.assign",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "45"
@@ -185,6 +194,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/create",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.create",
+            "tags": [
+              "web-features:snapshot:ecmascript-5"
+            ],
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -285,6 +297,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.defineproperties",
+            "tags": [
+              "web-features:snapshot:ecmascript-5"
+            ],
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -333,6 +348,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.defineproperty",
+            "tags": [
+              "web-features:snapshot:ecmascript-5"
+            ],
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -442,6 +460,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/entries",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.entries",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "54"
@@ -484,6 +505,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.freeze",
+            "tags": [
+              "web-features:snapshot:ecmascript-5"
+            ],
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -530,6 +554,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.fromentries",
+            "tags": [
+              "web-features:snapshot:ecmascript-2019"
+            ],
             "support": {
               "chrome": {
                 "version_added": "73"
@@ -570,6 +597,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.getownpropertydescriptor",
+            "tags": [
+              "web-features:snapshot:ecmascript-5"
+            ],
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -625,6 +655,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptors",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.getownpropertydescriptors",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "54"
@@ -667,6 +700,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.getownpropertynames",
+            "tags": [
+              "web-features:snapshot:ecmascript-5"
+            ],
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -715,6 +751,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.getownpropertysymbols",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -757,6 +796,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.getprototypeof",
+            "tags": [
+              "web-features:snapshot:ecmascript-5"
+            ],
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -855,6 +897,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.hasown",
+            "tags": [
+              "web-features:snapshot:ecmascript-2022"
+            ],
             "support": {
               "chrome": {
                 "version_added": "93"
@@ -895,6 +940,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.prototype.hasownproperty",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -943,6 +991,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/is",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.is",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "19"
@@ -985,6 +1036,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.isextensible",
+            "tags": [
+              "web-features:snapshot:ecmascript-5"
+            ],
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -1031,6 +1085,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/isFrozen",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.isfrozen",
+            "tags": [
+              "web-features:snapshot:ecmascript-5"
+            ],
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -1077,6 +1134,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/isPrototypeOf",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.prototype.isprototypeof",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1125,6 +1185,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/isSealed",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.issealed",
+            "tags": [
+              "web-features:snapshot:ecmascript-5"
+            ],
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -1171,6 +1234,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/keys",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.keys",
+            "tags": [
+              "web-features:snapshot:ecmascript-5"
+            ],
             "support": {
               "chrome": {
                 "version_added": "5"
@@ -1317,6 +1383,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.preventextensions",
+            "tags": [
+              "web-features:snapshot:ecmascript-5"
+            ],
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -1361,6 +1430,9 @@
           "ES2015_behavior": {
             "__compat": {
               "description": "ES2015 behavior for non-object argument",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "44"
@@ -1404,6 +1476,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.prototype.propertyisenumerable",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1453,6 +1528,9 @@
             "description": "<code>__proto__</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/proto",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.prototype.__proto__",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1501,6 +1579,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/seal",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.seal",
+            "tags": [
+              "web-features:snapshot:ecmascript-5"
+            ],
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -1547,6 +1628,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.setprototypeof",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -1589,6 +1673,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/toLocaleString",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.prototype.tolocalestring",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1636,6 +1723,9 @@
             "description": "<code>toString()</code>",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/toString",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.prototype.tostring",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1682,6 +1772,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/valueOf",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.prototype.valueof",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1728,6 +1821,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object/values",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object.values",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "54"

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -6,7 +6,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise",
           "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise-objects",
           "tags": [
-            "web-features:promise"
+            "web-features:promise",
+            "web-features:snapshot:ecmascript-2015"
           ],
           "support": {
             "chrome": {
@@ -51,7 +52,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/Promise",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise-constructor",
             "tags": [
-              "web-features:promise"
+              "web-features:promise",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -100,7 +102,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/all",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.all",
             "tags": [
-              "web-features:promise"
+              "web-features:promise",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -146,7 +149,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.allsettled",
             "tags": [
-              "web-features:promise-allsettled"
+              "web-features:promise-allsettled",
+              "web-features:snapshot:ecmascript-2020"
             ],
             "support": {
               "chrome": {
@@ -189,7 +193,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/any",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.any",
             "tags": [
-              "web-features:promise-any"
+              "web-features:promise-any",
+              "web-features:snapshot:ecmascript-2021"
             ],
             "support": {
               "chrome": {
@@ -233,7 +238,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.prototype.catch",
             "tags": [
-              "web-features:promise"
+              "web-features:promise",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -279,7 +285,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.prototype.finally",
             "tags": [
-              "web-features:promise-finally"
+              "web-features:promise-finally",
+              "web-features:snapshot:ecmascript-2018"
             ],
             "support": {
               "chrome": {
@@ -366,7 +373,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/race",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.race",
             "tags": [
-              "web-features:promise"
+              "web-features:promise",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -412,7 +420,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.reject",
             "tags": [
-              "web-features:promise"
+              "web-features:promise",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -458,7 +467,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.resolve",
             "tags": [
-              "web-features:promise"
+              "web-features:promise",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -504,7 +514,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/then",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promise.prototype.then",
             "tags": [
-              "web-features:promise"
+              "web-features:promise",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -592,7 +603,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise/@@species",
             "spec_url": "https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-get-promise-@@species",
             "tags": [
-              "web-features:promise"
+              "web-features:promise",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {

--- a/javascript/builtins/Proxy.json
+++ b/javascript/builtins/Proxy.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy",
           "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-proxy-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "49"
@@ -47,6 +50,9 @@
             "description": "<code>Proxy()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy",
             "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-proxy-constructor",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -90,6 +96,9 @@
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/apply",
               "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-call-thisargument-argumentslist",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -132,6 +141,9 @@
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/construct",
               "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-construct-argumentslist-newtarget",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -174,6 +186,9 @@
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/defineProperty",
               "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -216,6 +231,9 @@
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/deleteProperty",
               "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-delete-p",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -258,6 +276,9 @@
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/get",
               "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -300,6 +321,9 @@
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/getOwnPropertyDescriptor",
               "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -342,6 +366,9 @@
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/getPrototypeOf",
               "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -382,6 +409,9 @@
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/has",
               "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-hasproperty-p",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -424,6 +454,9 @@
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/isExtensible",
               "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-isextensible",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -466,6 +499,9 @@
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/ownKeys",
               "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -509,6 +545,9 @@
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/preventExtensions",
               "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-preventextensions",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -551,6 +590,9 @@
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/set",
               "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -593,6 +635,9 @@
             "__compat": {
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/setPrototypeOf",
               "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-proxy-object-internal-methods-and-internal-slots-setprototypeof-v",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "49"
@@ -636,6 +681,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Proxy/revocable",
             "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-proxy.revocable",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "63"

--- a/javascript/builtins/RangeError.json
+++ b/javascript/builtins/RangeError.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RangeError",
           "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-native-error-types-used-in-this-standard-rangeerror",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -51,6 +54,9 @@
             "description": "<code>RangeError()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RangeError/RangeError",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-nativeerror-constructors",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/ReferenceError.json
+++ b/javascript/builtins/ReferenceError.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError",
           "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-native-error-types-used-in-this-standard-referenceerror",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -51,6 +54,9 @@
             "description": "<code>ReferenceError()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError/ReferenceError",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-nativeerror-constructors",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/Reflect.json
+++ b/javascript/builtins/Reflect.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect",
           "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect-object",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "49"
@@ -46,6 +49,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/apply",
             "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.apply",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -88,6 +94,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/construct",
             "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.construct",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -130,6 +139,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/defineProperty",
             "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.defineproperty",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -172,6 +184,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/deleteProperty",
             "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.deleteproperty",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -214,6 +229,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/get",
             "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.get",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -256,6 +274,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/getOwnPropertyDescriptor",
             "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.getownpropertydescriptor",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -298,6 +319,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/getPrototypeOf",
             "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.getprototypeof",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -340,6 +364,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/has",
             "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.has",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -382,6 +409,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/isExtensible",
             "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.isextensible",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -424,6 +454,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/ownKeys",
             "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.ownkeys",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -466,6 +499,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/preventExtensions",
             "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.preventextensions",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -508,6 +544,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/set",
             "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.set",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -550,6 +589,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Reflect/setPrototypeOf",
             "spec_url": "https://tc39.es/ecma262/multipage/reflection.html#sec-reflect.setprototypeof",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp",
           "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp-regular-expression-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -51,6 +54,9 @@
             "description": "<code>RegExp()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/RegExp",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp-constructor",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -97,6 +103,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/compile",
             "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-regexp.prototype.compile",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -143,6 +152,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp.prototype.dotAll",
+            "tags": [
+              "web-features:snapshot:ecmascript-2018"
+            ],
             "support": {
               "chrome": {
                 "version_added": "62"
@@ -183,6 +195,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype.exec",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -229,6 +244,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/flags",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp.prototype.flags",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -273,6 +291,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/global",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp.prototype.global",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -360,6 +381,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/hasIndices",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp.prototype.hasIndices",
+            "tags": [
+              "web-features:snapshot:ecmascript-2022"
+            ],
             "support": {
               "chrome": {
                 "version_added": "90"
@@ -400,6 +424,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/ignoreCase",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp.prototype.ignorecase",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -532,6 +559,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-properties-of-regexp-instances",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -725,6 +755,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/multiline",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp.prototype.multiline",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -908,6 +941,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/source",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp.prototype.source",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1203,6 +1239,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype.test",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1249,6 +1288,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/toString",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype.tostring",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1420,6 +1462,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@match",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-@@match",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -1504,6 +1549,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-@@replace",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -1544,6 +1592,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@search",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-@@search",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -1586,6 +1637,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@species",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-get-regexp-@@species",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -1628,6 +1682,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@split",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-regexp.prototype-@@split",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "50"

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -6,7 +6,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set",
           "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set-objects",
           "tags": [
-            "web-features:set"
+            "web-features:set",
+            "web-features:snapshot:ecmascript-2015"
           ],
           "support": {
             "chrome": {
@@ -51,7 +52,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/Set",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set-constructor",
             "tags": [
-              "web-features:set"
+              "web-features:set",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -94,7 +96,8 @@
             "__compat": {
               "description": "<code>new Set(iterable)</code>",
               "tags": [
-                "web-features:set"
+                "web-features:set",
+                "web-features:snapshot:ecmascript-2015"
               ],
               "support": {
                 "chrome": {
@@ -138,7 +141,8 @@
             "__compat": {
               "description": "<code>new Set(null)</code>",
               "tags": [
-                "web-features:set"
+                "web-features:set",
+                "web-features:snapshot:ecmascript-2015"
               ],
               "support": {
                 "chrome": {
@@ -184,7 +188,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/add",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.add",
             "tags": [
-              "web-features:set"
+              "web-features:set",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -231,7 +236,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/clear",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.clear",
             "tags": [
-              "web-features:set"
+              "web-features:set",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -276,7 +282,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/delete",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.delete",
             "tags": [
-              "web-features:set"
+              "web-features:set",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -371,7 +378,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/entries",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.entries",
             "tags": [
-              "web-features:set"
+              "web-features:set",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -416,7 +424,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/forEach",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.foreach",
             "tags": [
-              "web-features:set"
+              "web-features:set",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -461,7 +470,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/has",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.has",
             "tags": [
-              "web-features:set"
+              "web-features:set",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -705,7 +715,8 @@
           "__compat": {
             "description": "Key equality for -0 and 0",
             "tags": [
-              "web-features:set"
+              "web-features:set",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -750,7 +761,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/keys",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.keys",
             "tags": [
-              "web-features:set"
+              "web-features:set",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -795,7 +807,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/size",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-get-set.prototype.size",
             "tags": [
-              "web-features:set"
+              "web-features:set",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -941,7 +954,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/values",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype.values",
             "tags": [
-              "web-features:set"
+              "web-features:set",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -986,7 +1000,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/@@iterator",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-set.prototype-@@iterator",
             "tags": [
-              "web-features:set"
+              "web-features:set",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1045,7 +1060,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Set/@@species",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-get-set-@@species",
             "tags": [
-              "web-features:set"
+              "web-features:set",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer",
           "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-sharedarraybuffer-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-2017"
+          ],
           "support": {
             "chrome": {
               "version_added": "68"
@@ -49,6 +52,9 @@
             "description": "<code>SharedArrayBuffer()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/SharedArrayBuffer",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-sharedarraybuffer-constructor",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "68"
@@ -92,6 +98,9 @@
             "__compat": {
               "description": "<code>maxByteLength</code> option",
               "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-sharedarraybuffer-constructor",
+              "tags": [
+                "web-features:snapshot:ecmascript-2024"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "111"
@@ -142,6 +151,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/byteLength",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-sharedarraybuffer.prototype.bytelength",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "68"
@@ -186,6 +198,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/grow",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-sharedarraybuffer.prototype.grow",
+            "tags": [
+              "web-features:snapshot:ecmascript-2024"
+            ],
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -235,6 +250,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/growable",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-sharedarraybuffer.prototype.growable",
+            "tags": [
+              "web-features:snapshot:ecmascript-2024"
+            ],
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -284,6 +302,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/maxByteLength",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-get-sharedarraybuffer.prototype.maxbytelength",
+            "tags": [
+              "web-features:snapshot:ecmascript-2024"
+            ],
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -333,6 +354,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/slice",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-sharedarraybuffer.prototype.slice",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "68"
@@ -377,6 +401,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer/@@species",
             "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-sharedarraybuffer-@@species",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "68"

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String",
           "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -51,6 +54,9 @@
             "description": "<code>String()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/String",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string-constructor",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -97,6 +103,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/anchor",
             "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.anchor",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -146,6 +155,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/at",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.at",
+            "tags": [
+              "web-features:snapshot:ecmascript-2022"
+            ],
             "support": {
               "chrome": {
                 "version_added": "92"
@@ -186,6 +198,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/big",
             "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.big",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -232,6 +247,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/blink",
             "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.blink",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -278,6 +296,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/bold",
             "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.bold",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -324,6 +345,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/charAt",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.charat",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -370,6 +394,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.charcodeat",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -416,6 +443,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/codePointAt",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.codepointat",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -458,6 +488,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/concat",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.concat",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -504,6 +537,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.endswith",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -548,6 +584,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/fixed",
             "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.fixed",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -594,6 +633,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/fontcolor",
             "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.fontcolor",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -640,6 +682,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/fontsize",
             "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.fontsize",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -686,6 +731,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/fromCharCode",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.fromcharcode",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -732,6 +780,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/fromCodePoint",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.fromcodepoint",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -774,6 +825,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/includes",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.includes",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -823,6 +877,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.indexof",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -909,6 +966,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/italics",
             "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.italics",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -955,6 +1015,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/lastIndexOf",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.lastindexof",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1001,6 +1064,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/length",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-properties-of-string-instances-length",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1047,6 +1113,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/link",
             "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.link",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1095,6 +1164,9 @@
             "spec_url": [
               "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.localecompare",
               "https://tc39.es/ecma402/#sup-String.prototype.localeCompare"
+            ],
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
             ],
             "support": {
               "chrome": {
@@ -1257,6 +1329,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/match",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.match",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1303,6 +1378,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.matchall",
+            "tags": [
+              "web-features:snapshot:ecmascript-2020"
+            ],
             "support": {
               "chrome": {
                 "version_added": "73"
@@ -1343,6 +1421,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/normalize",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.normalize",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "34"
@@ -1385,6 +1466,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.padend",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -1427,6 +1511,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/padStart",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.padstart",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "57"
@@ -1469,6 +1556,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/raw",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.raw",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -1511,6 +1601,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/repeat",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.repeat",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -1559,6 +1652,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/replace",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.replace",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1613,6 +1709,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/replaceAll",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.replaceall",
+            "tags": [
+              "web-features:snapshot:ecmascript-2021"
+            ],
             "support": {
               "chrome": {
                 "version_added": "85"
@@ -1653,6 +1752,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/search",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.search",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1699,6 +1801,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/slice",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.slice",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1745,6 +1850,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/small",
             "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.small",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1791,6 +1899,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/split",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.split",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1837,6 +1948,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.startswith",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "41"
@@ -1881,6 +1995,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/strike",
             "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.strike",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1927,6 +2044,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/sub",
             "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.sub",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -1973,6 +2093,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/substr",
             "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.substr",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2019,6 +2142,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/substring",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.substring",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2065,6 +2191,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/sup",
             "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-string.prototype.sup",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2113,6 +2242,9 @@
             "spec_url": [
               "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.tolocalelowercase",
               "https://tc39.es/ecma402/#sup-string.prototype.tolocalelowercase"
+            ],
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
             ],
             "support": {
               "chrome": {
@@ -2218,6 +2350,9 @@
               "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.tolocaleuppercase",
               "https://tc39.es/ecma402/#sup-string.prototype.tolocaleuppercase"
             ],
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2321,6 +2456,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toLowerCase",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.tolowercase",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2367,6 +2505,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toString",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.tostring",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2413,6 +2554,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toUpperCase",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.touppercase",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2459,6 +2603,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/toWellFormed",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.towellformed",
+            "tags": [
+              "web-features:snapshot:ecmascript-2024"
+            ],
             "support": {
               "chrome": {
                 "version_added": "111"
@@ -2499,6 +2646,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/trim",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.trim",
+            "tags": [
+              "web-features:snapshot:ecmascript-5"
+            ],
             "support": {
               "chrome": {
                 "version_added": "4"
@@ -2549,6 +2699,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.trimend",
+            "tags": [
+              "web-features:snapshot:ecmascript-2019"
+            ],
             "support": {
               "chrome": [
                 {
@@ -2629,6 +2782,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/trimStart",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.trimstart",
+            "tags": [
+              "web-features:snapshot:ecmascript-2019"
+            ],
             "support": {
               "chrome": [
                 {
@@ -2754,6 +2910,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/valueOf",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype.valueof",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -2800,6 +2959,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String/@@iterator",
             "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#sec-string.prototype-@@iterator",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol",
           "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "38"
@@ -48,6 +51,9 @@
             "description": "<code>Symbol()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/Symbol",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol-constructor",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -90,6 +96,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.asynciterator",
+            "tags": [
+              "web-features:snapshot:ecmascript-2018"
+            ],
             "support": {
               "chrome": {
                 "version_added": "63"
@@ -130,6 +139,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/description",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.prototype.description",
+            "tags": [
+              "web-features:snapshot:ecmascript-2019"
+            ],
             "support": {
               "chrome": {
                 "version_added": "70"
@@ -177,6 +189,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/for",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.for",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "40"
@@ -219,6 +234,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/hasInstance",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.hasinstance",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -261,6 +279,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/isConcatSpreadable",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.isconcatspreadable",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "48"
@@ -303,6 +324,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/iterator",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.iterator",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "43"
@@ -345,6 +369,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/keyFor",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.keyfor",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "40"
@@ -387,6 +414,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/match",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.match",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -427,6 +457,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/matchAll",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.matchall",
+            "tags": [
+              "web-features:snapshot:ecmascript-2020"
+            ],
             "support": {
               "chrome": {
                 "version_added": "73"
@@ -467,6 +500,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/replace",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.replace",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -507,6 +543,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/search",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.search",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -547,6 +586,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/species",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.species",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "51"
@@ -589,6 +631,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/split",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.split",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -629,6 +674,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toPrimitive",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.toprimitive",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "47"
@@ -671,6 +719,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toString",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.prototype.tostring",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -713,6 +764,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.tostringtag",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -754,6 +808,9 @@
             "__compat": {
               "description": "<code>toStringTag</code> available on all DOM prototype objects",
               "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toStringTag#toStringTag_available_on_all_DOM_prototype_objects",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "50"
@@ -795,6 +852,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/unscopables",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.unscopables",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -837,6 +897,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/valueOf",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.prototype.valueof",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "38"
@@ -879,6 +942,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/@@toPrimitive",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-symbol.prototype-@@toprimitive",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "47"

--- a/javascript/builtins/SyntaxError.json
+++ b/javascript/builtins/SyntaxError.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError",
           "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-native-error-types-used-in-this-standard-syntaxerror",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -51,6 +54,9 @@
             "description": "<code>SyntaxError()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError/SyntaxError",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-nativeerror-constructors",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/TypeError.json
+++ b/javascript/builtins/TypeError.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypeError",
           "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-native-error-types-used-in-this-standard-typeerror",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -51,6 +54,9 @@
             "description": "<code>TypeError()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypeError/TypeError",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-nativeerror-constructors",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -6,7 +6,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-objects",
           "tags": [
-            "web-features:typed-arrays"
+            "web-features:typed-arrays",
+            "web-features:snapshot:ecmascript-2015"
           ],
           "support": {
             "chrome": {
@@ -58,7 +59,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/BYTES_PER_ELEMENT",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray.bytes_per_element",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -111,7 +113,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/at",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.at",
             "tags": [
-              "web-features:array-at"
+              "web-features:array-at",
+              "web-features:snapshot:ecmascript-2022"
             ],
             "support": {
               "chrome": {
@@ -154,7 +157,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/buffer",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-%typedarray%.prototype.buffer",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -207,7 +211,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/byteLength",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-%typedarray%.prototype.bytelength",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -260,7 +265,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/byteOffset",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-%typedarray%.prototype.byteoffset",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -312,7 +318,8 @@
           "__compat": {
             "description": "Constructor without parameters",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -363,7 +370,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.copywithin",
             "tags": [
-              "web-features:array-copywithin"
+              "web-features:array-copywithin",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -408,7 +416,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/entries",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.entries",
             "tags": [
-              "web-features:typed-array-iterators"
+              "web-features:typed-array-iterators",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -453,7 +462,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/every",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.every",
             "tags": [
-              "web-features:typed-array-iteration-methods"
+              "web-features:typed-array-iteration-methods",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -498,7 +508,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/fill",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.fill",
             "tags": [
-              "web-features:array-fill"
+              "web-features:array-fill",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -543,7 +554,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/filter",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.filter",
             "tags": [
-              "web-features:typed-array-iteration-methods"
+              "web-features:typed-array-iteration-methods",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -588,7 +600,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/find",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.find",
             "tags": [
-              "web-features:array-find"
+              "web-features:array-find",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -633,7 +646,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/findIndex",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.findindex",
             "tags": [
-              "web-features:array-find"
+              "web-features:array-find",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -678,7 +692,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/findLast",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.findlast",
             "tags": [
-              "web-features:array-findlast"
+              "web-features:array-findlast",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -721,7 +736,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/findLastIndex",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.findlastindex",
             "tags": [
-              "web-features:array-findlast"
+              "web-features:array-findlast",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -764,7 +780,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/forEach",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.foreach",
             "tags": [
-              "web-features:typed-array-iteration-methods"
+              "web-features:typed-array-iteration-methods",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -809,7 +826,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.from",
             "tags": [
-              "web-features:array-from"
+              "web-features:array-from",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -854,7 +872,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/includes",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.includes",
             "tags": [
-              "web-features:array-includes"
+              "web-features:array-includes",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -897,6 +916,9 @@
         "index_properties_not_consulting_prototype": {
           "__compat": {
             "description": "Indexed properties not consulting prototype",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7",
@@ -955,7 +977,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/indexOf",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.indexof",
             "tags": [
-              "web-features:typed-array-iteration-methods"
+              "web-features:typed-array-iteration-methods",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -999,6 +1022,9 @@
         "iterable_in_constructor": {
           "__compat": {
             "description": "Iterable in constructor",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "39"
@@ -1042,7 +1068,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/join",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.join",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1087,7 +1114,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/keys",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.keys",
             "tags": [
-              "web-features:typed-array-iterators"
+              "web-features:typed-array-iterators",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1132,7 +1160,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/lastIndexOf",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.lastindexof",
             "tags": [
-              "web-features:typed-array-iteration-methods"
+              "web-features:typed-array-iteration-methods",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1178,7 +1207,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/length",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-%typedarray%.prototype.length",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1231,7 +1261,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/map",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.map",
             "tags": [
-              "web-features:typed-array-iteration-methods"
+              "web-features:typed-array-iteration-methods",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1276,7 +1307,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/name",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-properties-of-the-typedarray-constructors",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1328,7 +1360,8 @@
           "__compat": {
             "description": "Named properties",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1379,7 +1412,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/of",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.of",
             "tags": [
-              "web-features:array-of"
+              "web-features:array-of",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1424,7 +1458,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/reduce",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.reduce",
             "tags": [
-              "web-features:typed-array-iteration-methods"
+              "web-features:typed-array-iteration-methods",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1469,7 +1504,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/reduceRight",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.reduceright",
             "tags": [
-              "web-features:typed-array-iteration-methods"
+              "web-features:typed-array-iteration-methods",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1514,7 +1550,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/reverse",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.reverse",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1559,7 +1596,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/set",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.set",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1612,7 +1650,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/slice",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.slice",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1657,7 +1696,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/some",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.some",
             "tags": [
-              "web-features:typed-array-iteration-methods"
+              "web-features:typed-array-iteration-methods",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1702,7 +1742,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/sort",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.sort",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1747,7 +1788,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/subarray",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.subarray",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1800,7 +1842,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toLocaleString",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.tolocalestring",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1851,7 +1894,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toReversed",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.toreversed",
             "tags": [
-              "web-features:array-by-copy"
+              "web-features:array-by-copy",
+              "web-features:snapshot:ecmascript-2023"
             ],
             "support": {
               "chrome": {
@@ -1894,7 +1938,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toSorted",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.tosorted",
             "tags": [
-              "web-features:array-by-copy"
+              "web-features:array-by-copy",
+              "web-features:snapshot:ecmascript-2023"
             ],
             "support": {
               "chrome": {
@@ -1937,7 +1982,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/toString",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.tostring",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -1988,7 +2034,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/values",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.values",
             "tags": [
-              "web-features:typed-array-iterators"
+              "web-features:typed-array-iterators",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -2033,7 +2080,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/with",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype.with",
             "tags": [
-              "web-features:array-by-copy"
+              "web-features:array-by-copy",
+              "web-features:snapshot:ecmascript-2023"
             ],
             "support": {
               "chrome": {
@@ -2076,7 +2124,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/@@iterator",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-%typedarray%.prototype-@@iterator",
             "tags": [
-              "web-features:typed-array-iterators"
+              "web-features:typed-array-iterators",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -2134,6 +2183,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/@@species",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-get-%typedarray%-@@species",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "51"

--- a/javascript/builtins/URIError.json
+++ b/javascript/builtins/URIError.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/URIError",
           "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-native-error-types-used-in-this-standard-urierror",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -51,6 +54,9 @@
             "description": "<code>URIError()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/URIError/URIError",
             "spec_url": "https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-nativeerror-constructors",
+            "tags": [
+              "web-features:snapshot:ecmascript-3"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -6,7 +6,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
           "tags": [
-            "web-features:typed-arrays"
+            "web-features:typed-arrays",
+            "web-features:snapshot:ecmascript-2015"
           ],
           "support": {
             "chrome": {
@@ -59,7 +60,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array/Uint16Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -110,7 +112,8 @@
             "__compat": {
               "description": "Constructor without parameters",
               "tags": [
-                "web-features:typed-arrays"
+                "web-features:typed-arrays",
+                "web-features:snapshot:ecmascript-2015"
               ],
               "support": {
                 "chrome": {
@@ -160,7 +163,8 @@
             "__compat": {
               "description": "<code>new Uint16Array(iterable)</code>",
               "tags": [
-                "web-features:typed-arrays"
+                "web-features:typed-arrays",
+                "web-features:snapshot:ecmascript-2015"
               ],
               "support": {
                 "chrome": {

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "7"
@@ -55,6 +58,9 @@
             "description": "<code>Uint32Array()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array/Uint32Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "7"
@@ -103,6 +109,9 @@
           "constructor_without_parameters": {
             "__compat": {
               "description": "Constructor without parameters",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "7"
@@ -150,6 +159,9 @@
           "iterable_allowed": {
             "__compat": {
               "description": "<code>new Uint32Array(iterable)</code>",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "39"

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -6,7 +6,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
           "tags": [
-            "web-features:typed-arrays"
+            "web-features:typed-arrays",
+            "web-features:snapshot:ecmascript-2015"
           ],
           "support": {
             "chrome": {
@@ -59,7 +60,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/Uint8Array",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -110,7 +112,8 @@
             "__compat": {
               "description": "Constructor without parameters",
               "tags": [
-                "web-features:typed-arrays"
+                "web-features:typed-arrays",
+                "web-features:snapshot:ecmascript-2015"
               ],
               "support": {
                 "chrome": {
@@ -160,7 +163,8 @@
             "__compat": {
               "description": "<code>new Uint8Array(iterable)</code>",
               "tags": [
-                "web-features:typed-arrays"
+                "web-features:typed-arrays",
+                "web-features:snapshot:ecmascript-2015"
               ],
               "support": {
                 "chrome": {

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -6,7 +6,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray",
           "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#table-49",
           "tags": [
-            "web-features:typed-arrays"
+            "web-features:typed-arrays",
+            "web-features:snapshot:ecmascript-2015"
           ],
           "support": {
             "chrome": {
@@ -59,7 +60,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8ClampedArray/Uint8ClampedArray",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-typedarray-constructors",
             "tags": [
-              "web-features:typed-arrays"
+              "web-features:typed-arrays",
+              "web-features:snapshot:ecmascript-2015"
             ],
             "support": {
               "chrome": {
@@ -109,6 +111,9 @@
           "constructor_without_parameters": {
             "__compat": {
               "description": "Constructor without parameters",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "7"
@@ -157,7 +162,8 @@
             "__compat": {
               "description": "<code>new Uint8ClampedArray(iterable)</code>",
               "tags": [
-                "web-features:typed-arrays"
+                "web-features:typed-arrays",
+                "web-features:snapshot:ecmascript-2015"
               ],
               "support": {
                 "chrome": {

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap",
           "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakmap-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "36"
@@ -47,6 +50,9 @@
             "description": "<code>WeakMap()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/WeakMap",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakmap-constructor",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -87,6 +93,9 @@
           "iterable_allowed": {
             "__compat": {
               "description": "<code>new WeakMap(iterable)</code>",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "38"
@@ -128,6 +137,9 @@
           "null_allowed": {
             "__compat": {
               "description": "<code>new WeakMap(null)</code>",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "36"
@@ -171,6 +183,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/delete",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakmap.prototype.delete",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -214,6 +229,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/get",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakmap.prototype.get",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -257,6 +275,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/has",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakmap.prototype.has",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -300,6 +321,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakMap/set",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakmap.prototype.set",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -344,6 +368,9 @@
         "symbol_as_keys": {
           "__compat": {
             "description": "Non-registered symbols as keys",
+            "tags": [
+              "web-features:snapshot:ecmascript-2023"
+            ],
             "support": {
               "chrome": {
                 "version_added": "108"

--- a/javascript/builtins/WeakRef.json
+++ b/javascript/builtins/WeakRef.json
@@ -5,6 +5,10 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakRef",
           "spec_url": "https://tc39.es/ecma262/multipage/managing-memory.html#sec-weak-ref-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-2021",
+            "web-features:weak-references"
+          ],
           "support": {
             "chrome": {
               "version_added": "84"
@@ -45,6 +49,10 @@
             "description": "<code>WeakRef()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakRef/WeakRef",
             "spec_url": "https://tc39.es/ecma262/multipage/managing-memory.html#sec-weak-ref-constructor",
+            "tags": [
+              "web-features:snapshot:ecmascript-2021",
+              "web-features:weak-references"
+            ],
             "support": {
               "chrome": {
                 "version_added": "84"
@@ -85,6 +93,10 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakRef/deref",
             "spec_url": "https://tc39.es/ecma262/multipage/managing-memory.html#sec-weak-ref.prototype.deref",
+            "tags": [
+              "web-features:snapshot:ecmascript-2021",
+              "web-features:weak-references"
+            ],
             "support": {
               "chrome": {
                 "version_added": "84"
@@ -124,6 +136,9 @@
         "symbol_as_target": {
           "__compat": {
             "description": "Non-registered symbol as target",
+            "tags": [
+              "web-features:snapshot:ecmascript-2023"
+            ],
             "support": {
               "chrome": {
                 "version_added": "108"

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet",
           "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakset-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "36"
@@ -47,6 +50,9 @@
             "description": "<code>WeakSet()</code> constructor",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/WeakSet",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakset-constructor",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -87,6 +93,9 @@
           "iterable_allowed": {
             "__compat": {
               "description": "<code>new WeakSet(iterable)</code>",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "38"
@@ -128,6 +137,9 @@
           "null_allowed": {
             "__compat": {
               "description": "<code>new WeakSet(null)</code>",
+              "tags": [
+                "web-features:snapshot:ecmascript-2015"
+              ],
               "support": {
                 "chrome": {
                   "version_added": "36"
@@ -171,6 +183,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/add",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakset.prototype.add",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -213,6 +228,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/delete",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakset.prototype.delete",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -255,6 +273,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/WeakSet/has",
             "spec_url": "https://tc39.es/ecma262/multipage/keyed-collections.html#sec-weakset.prototype.has",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "36"
@@ -296,6 +317,9 @@
         "symbol_as_keys": {
           "__compat": {
             "description": "Non-registered symbols as keys",
+            "tags": [
+              "web-features:snapshot:ecmascript-2023"
+            ],
             "support": {
               "chrome": {
                 "version_added": "108"

--- a/javascript/builtins/globals.json
+++ b/javascript/builtins/globals.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Infinity",
           "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-value-properties-of-the-global-object-infinity",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -51,6 +54,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/NaN",
           "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-value-properties-of-the-global-object-nan",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -97,6 +103,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/decodeURI",
           "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-decodeuri-encodeduri",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -143,6 +152,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent",
           "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-decodeuricomponent-encodeduricomponent",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -189,6 +201,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/encodeURI",
           "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-encodeuri-uri",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -235,6 +250,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent",
           "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-encodeuricomponent-uricomponent",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -281,6 +299,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/escape",
           "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-escape-string",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -327,6 +348,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/eval",
           "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-eval-x",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -373,6 +397,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/globalThis",
           "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-globalthis",
+          "tags": [
+            "web-features:snapshot:ecmascript-2020"
+          ],
           "support": {
             "chrome": {
               "version_added": "71"
@@ -413,6 +440,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/isFinite",
           "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-isfinite-number",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -459,6 +489,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/isNaN",
           "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-isnan-number",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -505,6 +538,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/parseFloat",
           "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-parsefloat-string",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -551,6 +587,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/parseInt",
           "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-parseint-string-radix",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -638,6 +677,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined",
           "spec_url": "https://tc39.es/ecma262/multipage/global-object.html#sec-undefined",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -684,6 +726,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/unescape",
           "spec_url": "https://tc39.es/ecma262/multipage/additional-ecmascript-features-for-web-browsers.html#sec-unescape-string",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/classes.json
+++ b/javascript/classes.json
@@ -5,7 +5,8 @@
         "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes",
         "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-class-definitions",
         "tags": [
-          "web-features:class-syntax"
+          "web-features:class-syntax",
+          "web-features:snapshot:ecmascript-2015"
         ],
         "support": {
           "chrome": [
@@ -56,7 +57,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/constructor",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-static-semantics-constructormethod",
           "tags": [
-            "web-features:class-syntax"
+            "web-features:class-syntax",
+            "web-features:snapshot:ecmascript-2015"
           ],
           "support": {
             "chrome": [
@@ -108,7 +110,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/extends",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-class-definitions",
           "tags": [
-            "web-features:class-syntax"
+            "web-features:class-syntax",
+            "web-features:snapshot:ecmascript-2015"
           ],
           "support": {
             "chrome": [
@@ -332,7 +335,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Classes/static",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-class-definitions",
           "tags": [
-            "web-features:class-syntax"
+            "web-features:class-syntax",
+            "web-features:snapshot:ecmascript-2015"
           ],
           "support": {
             "chrome": [

--- a/javascript/functions.json
+++ b/javascript/functions.json
@@ -4,6 +4,9 @@
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions",
         "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-function-definitions",
+        "tags": [
+          "web-features:snapshot:ecmascript-1"
+        ],
         "support": {
           "chrome": {
             "version_added": "1"
@@ -49,6 +52,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/arguments",
           "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-arguments-exotic-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -94,6 +100,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/arguments/callee",
             "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-arguments-exotic-objects",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -140,6 +149,9 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/arguments/length",
             "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-arguments-exotic-objects",
+            "tags": [
+              "web-features:snapshot:ecmascript-1"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -189,6 +201,9 @@
               "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-createunmappedargumentsobject",
               "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-createmappedargumentsobject"
             ],
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "52"
@@ -233,6 +248,9 @@
           "description": "Arrow functions",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/Arrow_functions",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-arrow-function-definitions",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "45"
@@ -277,6 +295,9 @@
         "trailing_comma": {
           "__compat": {
             "description": "Trailing comma in parameters",
+            "tags": [
+              "web-features:snapshot:ecmascript-2017"
+            ],
             "support": {
               "chrome": {
                 "version_added": "58"
@@ -319,6 +340,9 @@
       "block_level_functions": {
         "__compat": {
           "description": "Block-level functions",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "49"
@@ -362,6 +386,9 @@
           "description": "Default parameters",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/Default_parameters",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-function-definitions",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "49"
@@ -402,6 +429,9 @@
         "destructured_parameter_with_default_value_assignment": {
           "__compat": {
             "description": "Destructured parameter with default value assignment",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -443,6 +473,9 @@
         "parameters_without_defaults_after_default_parameters": {
           "__compat": {
             "description": "Parameters without defaults after default parameters",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -486,6 +519,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/get",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-method-definitions",
+          "tags": [
+            "web-features:snapshot:ecmascript-5"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -530,6 +566,9 @@
         "computed_property_names": {
           "__compat": {
             "description": "Computed property names",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "46"
@@ -576,6 +615,9 @@
           "description": "Method definitions",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/Method_definitions",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-method-definitions",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "39"
@@ -740,6 +782,9 @@
           "description": "Rest parameters",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/rest_parameters",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-function-definitions",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "47"
@@ -780,6 +825,9 @@
         "destructuring": {
           "__compat": {
             "description": "Destructuring rest parameters",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -821,6 +869,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Functions/set",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-method-definitions",
+          "tags": [
+            "web-features:snapshot:ecmascript-5"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -865,6 +916,9 @@
         "computed_property_names": {
           "__compat": {
             "description": "Computed property names",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "46"

--- a/javascript/grammar.json
+++ b/javascript/grammar.json
@@ -7,7 +7,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Array_literals",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-array-initializer",
           "tags": [
-            "web-features:array"
+            "web-features:array",
+            "web-features:snapshot:ecmascript-1"
           ],
           "support": {
             "chrome": {
@@ -56,6 +57,9 @@
           "description": "Binary numeric literals (<code>0b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Binary",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-BinaryIntegerLiteral",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "41"
@@ -99,6 +103,9 @@
           "description": "Boolean literals (<code>true</code>/<code>false</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Boolean_literal",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-boolean-literals",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -146,6 +153,9 @@
           "description": "Decimal numeric literals (<code>1234567890</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Decimal",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-DecimalLiteral",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -193,6 +203,9 @@
           "description": "Hashbang (<code>#!</code>) comment syntax",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Hashbang_comments",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-hashbang",
+          "tags": [
+            "web-features:snapshot:ecmascript-2023"
+          ],
           "support": {
             "chrome": {
               "version_added": "74"
@@ -281,6 +294,9 @@
           "description": "Hexadecimal numeric literals (<code>0xAF</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Hexadecimal",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-HexIntegerLiteral",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -328,6 +344,9 @@
           "description": "Null literal (<code>null</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Null_literal",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-null-literals",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -418,6 +437,9 @@
           "description": "Octal numeric literals (<code>0o</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Octal",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-OctalIntegerLiteral",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "41"
@@ -461,6 +483,9 @@
           "description": "Regular expression literals (<code>/ab+c/g</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Regular_expression_literals",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-literals-regular-expression-literals",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -508,6 +533,9 @@
           "description": "String literals (<code>'Hello world'</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#String_literals",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#sec-literals-string-literals",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -555,6 +583,9 @@
           "description": "Unicode escape sequences (<code>'\\u00A9'</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Unicode_escape_sequences",
           "spec_url": "https://tc39.es/ecma262/multipage/structured-data.html#sec-unicodeescape",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -602,6 +633,9 @@
           "description": "Unicode point escapes (<code>\\u{}</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Lexical_grammar#Unicode_code_point_escapes",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-UnicodeEscapeSequence",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "44"
@@ -643,6 +677,9 @@
       "shorthand_object_literals": {
         "__compat": {
           "description": "Shorthand notation for object literals",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "43"
@@ -686,6 +723,9 @@
           "description": "Template literals",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Template_literals",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-template-literals",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "41"
@@ -726,6 +766,9 @@
         "template_literal_revision": {
           "__compat": {
             "description": "Escape sequences allowed in tagged template literals",
+            "tags": [
+              "web-features:snapshot:ecmascript-2018"
+            ],
             "support": {
               "chrome": {
                 "version_added": "62"

--- a/javascript/operators/addition.json
+++ b/javascript/operators/addition.json
@@ -6,6 +6,9 @@
           "description": "Addition (<code>+</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Addition",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-addition-operator-plus",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/addition_assignment.json
+++ b/javascript/operators/addition_assignment.json
@@ -6,6 +6,9 @@
           "description": "Addition assignment (<code>x += y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Addition_assignment",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/assignment.json
+++ b/javascript/operators/assignment.json
@@ -6,6 +6,9 @@
           "description": "Assignment (<code>x = y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Assignment",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/bitwise_and.json
+++ b/javascript/operators/bitwise_and.json
@@ -6,6 +6,9 @@
           "description": "Bitwise AND (<code>a &amp; b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Bitwise_AND",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-BitwiseANDExpression",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/bitwise_and_assignment.json
+++ b/javascript/operators/bitwise_and_assignment.json
@@ -6,6 +6,9 @@
           "description": "Bitwise AND assignment (<code>x &amp;= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Bitwise_AND_assignment",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/bitwise_not.json
+++ b/javascript/operators/bitwise_not.json
@@ -6,6 +6,9 @@
           "description": "Bitwise NOT (<code>~a</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Bitwise_NOT",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-bitwise-not-operator",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/bitwise_or.json
+++ b/javascript/operators/bitwise_or.json
@@ -6,6 +6,9 @@
           "description": "Bitwise OR (<code>a | b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Bitwise_OR",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-BitwiseORExpression",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/bitwise_or_assignment.json
+++ b/javascript/operators/bitwise_or_assignment.json
@@ -6,6 +6,9 @@
           "description": "Bitwise OR assignment (<code>x |= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Bitwise_OR_assignment",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/bitwise_xor.json
+++ b/javascript/operators/bitwise_xor.json
@@ -6,6 +6,9 @@
           "description": "Bitwise XOR (<code>a ^ b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Bitwise_XOR",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-BitwiseXORExpression",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/bitwise_xor_assignment.json
+++ b/javascript/operators/bitwise_xor_assignment.json
@@ -6,6 +6,9 @@
           "description": "Bitwise XOR assignment (<code>x ^= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Bitwise_XOR_assignment",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/class.json
+++ b/javascript/operators/class.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/class",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-class-definitions",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "42"

--- a/javascript/operators/comma.json
+++ b/javascript/operators/comma.json
@@ -6,6 +6,9 @@
           "description": "Comma operator",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Comma_operator",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-comma-operator",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/conditional.json
+++ b/javascript/operators/conditional.json
@@ -6,6 +6,9 @@
           "description": "Conditional operator (<code>c ? t : f</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Conditional_Operator",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-conditional-operator",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/decrement.json
+++ b/javascript/operators/decrement.json
@@ -6,6 +6,9 @@
           "description": "Decrement (<code>--</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Decrement",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-postfix-decrement-operator",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "2"

--- a/javascript/operators/delete.json
+++ b/javascript/operators/delete.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/delete",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-delete-operator",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/destructuring.json
+++ b/javascript/operators/destructuring.json
@@ -9,6 +9,9 @@
             "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-destructuring-assignment",
             "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-destructuring-binding-patterns"
           ],
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "49"
@@ -50,6 +53,9 @@
         "computed_property_names": {
           "__compat": {
             "description": "Computed property names",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -91,6 +97,9 @@
         "rest_in_arrays": {
           "__compat": {
             "description": "Rest in arrays",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -132,6 +141,9 @@
         "rest_in_objects": {
           "__compat": {
             "description": "Rest in objects",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "60"

--- a/javascript/operators/division.json
+++ b/javascript/operators/division.json
@@ -6,6 +6,9 @@
           "description": "Division (<code>/</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Division",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-multiplicative-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/division_assignment.json
+++ b/javascript/operators/division_assignment.json
@@ -6,6 +6,9 @@
           "description": "Division assignment (<code>x /= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Division_assignment",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/equality.json
+++ b/javascript/operators/equality.json
@@ -6,6 +6,9 @@
           "description": "Equality (<code>a == b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Equality",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-equality-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/exponentiation.json
+++ b/javascript/operators/exponentiation.json
@@ -6,6 +6,9 @@
           "description": "Exponentiation (<code>**</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Exponentiation",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-exp-operator",
+          "tags": [
+            "web-features:snapshot:ecmascript-2016"
+          ],
           "support": {
             "chrome": {
               "version_added": "52"

--- a/javascript/operators/exponentiation_assignment.json
+++ b/javascript/operators/exponentiation_assignment.json
@@ -6,6 +6,9 @@
           "description": "Exponentiation assignment (<code>x **= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Exponentiation_assignment",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-2016"
+          ],
           "support": {
             "chrome": {
               "version_added": "52"

--- a/javascript/operators/function.json
+++ b/javascript/operators/function.json
@@ -6,6 +6,9 @@
           "description": "<code>function</code> expression",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/function",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-function-definitions",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/generator_function.json
+++ b/javascript/operators/generator_function.json
@@ -6,6 +6,9 @@
           "description": "<code>function*</code> expression",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/function*",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-generator-function-definitions",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "49"

--- a/javascript/operators/greater_than.json
+++ b/javascript/operators/greater_than.json
@@ -6,6 +6,9 @@
           "description": "Greater than (<code>a &gt; b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Greater_than",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-relational-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/greater_than_or_equal.json
+++ b/javascript/operators/greater_than_or_equal.json
@@ -6,6 +6,9 @@
           "description": "Greater than or equal (<code>a &gt;= b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-relational-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/grouping.json
+++ b/javascript/operators/grouping.json
@@ -6,6 +6,9 @@
           "description": "Grouping operator <code>()</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Grouping",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-grouping-operator",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/in.json
+++ b/javascript/operators/in.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/in",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-relational-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/increment.json
+++ b/javascript/operators/increment.json
@@ -6,6 +6,9 @@
           "description": "Increment (<code>++</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Increment",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-postfix-increment-operator",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "2"

--- a/javascript/operators/inequality.json
+++ b/javascript/operators/inequality.json
@@ -6,6 +6,9 @@
           "description": "Inequality (<code>a != b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Inequality",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-equality-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/left_shift.json
+++ b/javascript/operators/left_shift.json
@@ -6,6 +6,9 @@
           "description": "Bitwise left shift (<code>a &lt;&lt; b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Left_shift",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-left-shift-operator",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/left_shift_assignment.json
+++ b/javascript/operators/left_shift_assignment.json
@@ -6,6 +6,9 @@
           "description": "Left shift assignment (<code>x &lt;&lt;= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Left_shift_assignment",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/less_than.json
+++ b/javascript/operators/less_than.json
@@ -6,6 +6,9 @@
           "description": "Less than (<code>a &lt; b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Less_than",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-relational-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/less_than_or_equal.json
+++ b/javascript/operators/less_than_or_equal.json
@@ -6,6 +6,9 @@
           "description": "Less than or equal (<code>a &lt;= b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-relational-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/logical_and.json
+++ b/javascript/operators/logical_and.json
@@ -6,6 +6,9 @@
           "description": "Logical AND (<code>&amp;&amp;</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Logical_AND",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-LogicalANDExpression",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/logical_not.json
+++ b/javascript/operators/logical_not.json
@@ -6,6 +6,9 @@
           "description": "Logical NOT (<code>!</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Logical_NOT",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-logical-not-operator",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/logical_or.json
+++ b/javascript/operators/logical_or.json
@@ -6,6 +6,9 @@
           "description": "Logical OR (<code>||</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Logical_OR",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-LogicalORExpression",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/multiplication.json
+++ b/javascript/operators/multiplication.json
@@ -6,6 +6,9 @@
           "description": "Multiplication (<code>*</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Multiplication",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-multiplicative-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/multiplication_assignment.json
+++ b/javascript/operators/multiplication_assignment.json
@@ -6,6 +6,9 @@
           "description": "Multiplication assignment (<code>x *= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Multiplication_assignment",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/new.json
+++ b/javascript/operators/new.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/new",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-new-operator",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/new_target.json
+++ b/javascript/operators/new_target.json
@@ -6,6 +6,9 @@
           "description": "<code>new.target</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/new.target",
           "spec_url": "https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-built-in-function-objects",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "46"

--- a/javascript/operators/null.json
+++ b/javascript/operators/null.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/null",
           "spec_url": "https://tc39.es/ecma262/multipage/overview.html#sec-null-value",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/nullish_coalescing.json
+++ b/javascript/operators/nullish_coalescing.json
@@ -6,6 +6,9 @@
           "description": "Nullish coalescing operator (<code>??</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-CoalesceExpression",
+          "tags": [
+            "web-features:snapshot:ecmascript-2020"
+          ],
           "support": {
             "chrome": {
               "version_added": "80"

--- a/javascript/operators/nullish_coalescing_assignment.json
+++ b/javascript/operators/nullish_coalescing_assignment.json
@@ -6,6 +6,9 @@
           "description": "Nullish coalescing assignment (<code>x ??= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Logical_nullish_assignment",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-2020"
+          ],
           "support": {
             "chrome": {
               "version_added": "85"

--- a/javascript/operators/object_initializer.json
+++ b/javascript/operators/object_initializer.json
@@ -50,6 +50,9 @@
         "computed_property_names": {
           "__compat": {
             "description": "Computed property names",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "47"
@@ -88,6 +91,9 @@
         "shorthand_method_names": {
           "__compat": {
             "description": "Shorthand method names",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "47"
@@ -126,6 +132,9 @@
         "shorthand_property_names": {
           "__compat": {
             "description": "Shorthand property names",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "47"

--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -6,6 +6,9 @@
           "description": "Optional chaining operator (<code>?.</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Optional_chaining",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-OptionalExpression",
+          "tags": [
+            "web-features:snapshot:ecmascript-2020"
+          ],
           "support": {
             "chrome": {
               "version_added": "80"

--- a/javascript/operators/property_accessors.json
+++ b/javascript/operators/property_accessors.json
@@ -6,6 +6,9 @@
           "description": "Property accessors",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Property_Accessors",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-property-accessors",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/remainder.json
+++ b/javascript/operators/remainder.json
@@ -6,6 +6,9 @@
           "description": "Remainder (<code>%</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Remainder",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-multiplicative-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/remainder_assignment.json
+++ b/javascript/operators/remainder_assignment.json
@@ -6,6 +6,9 @@
           "description": "Remainder assignment (<code>x %= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Remainder_assignment",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/right_shift.json
+++ b/javascript/operators/right_shift.json
@@ -6,6 +6,9 @@
           "description": "Bitwise right shift (<code>a &gt;&gt; b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Right_shift",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-signed-right-shift-operator",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/right_shift_assignment.json
+++ b/javascript/operators/right_shift_assignment.json
@@ -6,6 +6,9 @@
           "description": "Right shift assignment (<code>x &gt;&gt;= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Right_shift_assignment",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/spread.json
+++ b/javascript/operators/spread.json
@@ -10,6 +10,9 @@
             "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-ArgumentList",
             "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-PropertyDefinition"
           ],
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "46"
@@ -56,6 +59,9 @@
             "description": "Spread in array literals",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_array_literals",
             "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-SpreadElement",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "46"
@@ -103,6 +109,9 @@
             "description": "Spread in function calls",
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_function_calls",
             "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-ArgumentList",
+            "tags": [
+              "web-features:snapshot:ecmascript-2015"
+            ],
             "support": {
               "chrome": {
                 "version_added": "46"

--- a/javascript/operators/subtraction.json
+++ b/javascript/operators/subtraction.json
@@ -6,6 +6,9 @@
           "description": "Subtraction (<code>-</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Subtraction",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-subtraction-operator-minus",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/subtraction_assignment.json
+++ b/javascript/operators/subtraction_assignment.json
@@ -6,6 +6,9 @@
           "description": "Subtraction assignment (<code>x -= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Subtraction_assignment",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/super.json
+++ b/javascript/operators/super.json
@@ -6,7 +6,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/super",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-super-keyword",
           "tags": [
-            "web-features:class-syntax"
+            "web-features:class-syntax",
+            "web-features:snapshot:ecmascript-2015"
           ],
           "support": {
             "chrome": {

--- a/javascript/operators/this.json
+++ b/javascript/operators/this.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/this",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-this-keyword",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/typeof.json
+++ b/javascript/operators/typeof.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/typeof",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-typeof-operator",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/unary_negation.json
+++ b/javascript/operators/unary_negation.json
@@ -6,6 +6,9 @@
           "description": "Unary negation (<code>-</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Unary_negation",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-unary-minus-operator",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/unary_plus.json
+++ b/javascript/operators/unary_plus.json
@@ -6,6 +6,9 @@
           "description": "Unary plus (<code>+</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Unary_plus",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-unary-plus-operator",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/unsigned_right_shift.json
+++ b/javascript/operators/unsigned_right_shift.json
@@ -6,6 +6,9 @@
           "description": "Bitwise unsigned right shift (<code>a &gt;&gt;&gt; b</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-unsigned-right-shift-operator",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/unsigned_right_shift_assignment.json
+++ b/javascript/operators/unsigned_right_shift_assignment.json
@@ -6,6 +6,9 @@
           "description": "Unsigned right shift assignment (<code>x &gt;&gt;&gt;= y</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift_assignment",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-assignment-operators",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/void.json
+++ b/javascript/operators/void.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/void",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-void-operator",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/operators/yield.json
+++ b/javascript/operators/yield.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/yield",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#prod-YieldExpression",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "39"

--- a/javascript/operators/yield_star.json
+++ b/javascript/operators/yield_star.json
@@ -6,6 +6,9 @@
           "description": "<code>yield*</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/yield*",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-generator-function-definitions-runtime-semantics-evaluation",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "39"

--- a/javascript/regular_expressions.json
+++ b/javascript/regular_expressions.json
@@ -6,6 +6,9 @@
           "description": "Backreference: <code>\\1</code>, <code>\\2</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Backreference",
           "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#prod-DecimalEscape",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -53,6 +56,9 @@
           "description": "Capturing group: <code>(...)</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Capturing_group",
           "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#prod-Atom",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -100,6 +106,9 @@
           "description": "Character class: <code>[...]</code>, <code>[^...]</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Character_class",
           "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#prod-CharacterClass",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -147,6 +156,9 @@
           "description": "Character class escape: <code>\\d</code>, <code>\\D</code>, <code>\\w</code>, <code>\\W</code>, <code>\\s</code>, <code>\\S</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Character_class_escape",
           "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#prod-CharacterClassEscape",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -194,6 +206,9 @@
           "description": "Character escape: <code>\\n</code>, <code>\\x</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Character_escape",
           "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#prod-CharacterEscape",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -282,6 +297,9 @@
           "description": "Disjunction: <code>|</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Disjunction",
           "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#prod-Disjunction",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -329,6 +347,9 @@
           "description": "Input boundary assertion: <code>^</code>, <code>$</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Input_boundary_assertion",
           "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#prod-Assertion",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -376,6 +397,9 @@
           "description": "Literal character: <code>a</code>, <code>b</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Literal_character",
           "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#prod-PatternCharacter",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -423,6 +447,9 @@
           "description": "Lookahead assertion: <code>(?=...)</code>, <code>(?!...)</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Lookahead_assertion",
           "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#prod-Assertion",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -634,6 +661,9 @@
           "description": "Non-capturing group: <code>(?:...)</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Non-capturing_group",
           "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#prod-Atom",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -681,6 +711,9 @@
           "description": "Quantifier: <code>*</code>, <code>+</code>, <code>?</code>, <code>{n}</code>, <code>{n,}</code>, <code>{n,m}</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Quantifier",
           "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#prod-Quantifier",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -769,6 +802,9 @@
           "description": "Wildcard: <code>.</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Wildcard",
           "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#prod-Atom",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -816,6 +852,9 @@
           "description": "Word boundary assertion: <code>\\b</code>, <code>\\B</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Regular_expressions/Word_boundary_assertion",
           "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#prod-Assertion",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -92,6 +92,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/block",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-block",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -138,6 +141,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/break",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-break-statement",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -185,7 +191,8 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/class",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-class-definitions",
           "tags": [
-            "web-features:class-syntax"
+            "web-features:class-syntax",
+            "web-features:snapshot:ecmascript-2015"
           ],
           "support": {
             "chrome": [
@@ -236,6 +243,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/const",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-let-and-const-declarations",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "21"
@@ -286,6 +296,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/continue",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-continue-statement",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -379,6 +392,9 @@
           "description": "<code>do...while</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/do...while",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-do-while-statement",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -426,6 +442,9 @@
           "description": "Empty statement (<code>;</code>)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/Empty",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-empty-statement",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "3"
@@ -607,6 +626,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/for",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-for-statement",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -654,6 +676,9 @@
           "description": "<code>for await...of</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/for-await...of",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-for-in-and-for-of-statements",
+          "tags": [
+            "web-features:snapshot:ecmascript-2018"
+          ],
           "support": {
             "chrome": {
               "version_added": "63"
@@ -695,6 +720,9 @@
           "description": "<code>for...in</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/for...in",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-for-in-and-for-of-statements",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -742,6 +770,9 @@
           "description": "<code>for...of</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/for...of",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-for-in-and-for-of-statements",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "38"
@@ -783,6 +814,9 @@
         "async_iterators": {
           "__compat": {
             "description": "async iterators",
+            "tags": [
+              "web-features:snapshot:ecmascript-2018"
+            ],
             "support": {
               "chrome": {
                 "version_added": "63"
@@ -868,6 +902,9 @@
           "description": "<code>function</code> statement",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-function-definitions",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -956,6 +993,9 @@
           "description": "<code>function*</code> statement",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/function*",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-generator-function-definitions",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": {
               "version_added": "39"
@@ -996,6 +1036,9 @@
         "IteratorResult_object": {
           "__compat": {
             "description": "<code>IteratorResult</code> object instead of throwing",
+            "tags": [
+              "web-features:snapshot:ecmascript-2016"
+            ],
             "support": {
               "chrome": {
                 "version_added": "49"
@@ -1037,6 +1080,9 @@
         "not_constructable_with_new": {
           "__compat": {
             "description": "Not constructable with <code>new</code> (ES2016)",
+            "tags": [
+              "web-features:snapshot:ecmascript-2016"
+            ],
             "support": {
               "chrome": {
                 "version_added": "50"
@@ -1122,6 +1168,9 @@
           "description": "<code>if...else</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/if...else",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-if-statement",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -1592,6 +1641,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/label",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-labelled-statements",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -1638,6 +1690,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/let",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-let-and-const-declarations",
+          "tags": [
+            "web-features:snapshot:ecmascript-2015"
+          ],
           "support": {
             "chrome": [
               {
@@ -1707,6 +1762,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/return",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-return-statement",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -1799,6 +1857,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/throw",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-throw-statement",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -1846,6 +1907,9 @@
           "description": "<code>try...catch</code>",
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/try...catch",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-try-statement",
+          "tags": [
+            "web-features:snapshot:ecmascript-3"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -1931,6 +1995,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/var",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-variable-statement",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -1977,6 +2044,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/while",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-while-statement",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"
@@ -2023,6 +2093,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/with",
           "spec_url": "https://tc39.es/ecma262/multipage/ecmascript-language-statements-and-declarations.html#sec-with-statement",
+          "tags": [
+            "web-features:snapshot:ecmascript-1"
+          ],
           "support": {
             "chrome": {
               "version_added": "1"


### PR DESCRIPTION
This is a PR for https://github.com/web-platform-dx/web-features/issues/579

- It tags the `javascript/` folder with ECMAScript snapshots. The snapshots have been determined manually by reading (old) ECMAScript specifications.
- The idea of higher-level capability groups has been implemented in web-features instead. Features can be associated with a group in a web-feature yaml file.
- "Bundles" are just features now and over the last few weeks I already submitted features for array, typed-arrays, maps, sets, promises, and more, so they are not part of this PR anymore.

Interesting queries to look at or to review this PR:

Snapshots:
- npm run traverse -- -t web-features:snapshot:ecmascript-1
- npm run traverse -- -t web-features:snapshot:ecmascript-3
- npm run traverse -- -t web-features:snapshot:ecmascript-5
- npm run traverse -- -t web-features:snapshot:ecmascript-2015
- npm run traverse -- -t web-features:snapshot:ecmascript-2016
- ... and more years
 
Features: 
- npm run traverse -- -t web-features:arrays
- npm run traverse -- -t web-features:typed-arrays
- npm run traverse -- -t web-features:array-at
- npm run traverse -- -t web-features:array-copywithin
- npm run traverse -- -t web-features:array-fill
- npm run traverse -- -t web-features:array-find
- npm run traverse -- -t web-features:array-findlast
- npm run traverse -- -t web-features:array-flattening
- npm run traverse -- -t web-features:array-iteration-methods
- npm run traverse -- -t web-features:array-iterators
- npm run traverse -- -t web-features:array-from
- npm run traverse -- -t web-features:array-fromasync
- npm run traverse -- -t web-features:array-includes
- npm run traverse -- -t web-features:array-isarray
- npm run traverse -- -t web-features:array-of
- npm run traverse -- -t web-features:stable-array-sort
- npm run traverse -- -t web-features:array-by-copy