### PR TITLE
Update-browser-release: New Chrome release notes

### DIFF
--- a/scripts/update-browser-releases/chrome.ts
+++ b/scripts/update-browser-releases/chrome.ts
@@ -23,23 +23,38 @@ const getReleaseNotesURL = async (version, date, core, status) => {
   if (status !== 'stable') {
     return '';
   }
-  const dateObj = new Date(date);
-  const year = dateObj.getUTCFullYear();
-  const month = `0${dateObj.getUTCMonth() + 1}`.slice(-2);
-  const day = `0${dateObj.getUTCDate()}`.slice(-2);
 
-  // First possibility
-  let url = `https://chromereleases.googleblog.com/${year}/${month}/${core}_${day}.html`;
-  let releaseNote = await fetch(url);
+  let url;
 
-  if (releaseNote.status == 200) {
-    return url;
+  // Before release 54, we guess the release note
+  if (version < 54) {
+    const dateObj = new Date(date);
+    const year = dateObj.getUTCFullYear();
+    const month = `0${dateObj.getUTCMonth() + 1}`.slice(-2);
+    const day = `0${dateObj.getUTCDate()}`.slice(-2);
+
+    // First possibility
+    url = `https://chromereleases.googleblog.com/${year}/${month}/${core}_${day}.html`;
+    let releaseNote = await fetch(url);
+
+    if (releaseNote.status == 200) {
+      return url;
+    }
+
+    // Second possibility (less reliable)
+    url = `https://chromereleases.googleblog.com/${year}/${month}/${core}.html`;
+
+    releaseNote = await fetch(url);
+
+    if (releaseNote.status !== 200) {
+      throw chalk`{red \nRelease note not found for ${version}}.`;
+    }
   }
 
-  // Second possibility (less reliable)
-  url = `https://chromereleases.googleblog.com/${year}/${month}/${core}.html`;
+  // After release 54, we have an easier release note
+  url = `https://developer.chrome.com/blog/new-in-chrome-${version}`;
 
-  releaseNote = await fetch(url);
+  const releaseNote = await fetch(url);
 
   if (releaseNote.status !== 200) {
     throw chalk`{red \nRelease note not found for ${version}}.`;


### PR DESCRIPTION
This PR fixes the script to use new Chrome release notes URL.

It doesn't update old values, we will do it in a follow-up, if all is good here.

I tested it locally.