### PR TITLE
Add ::backdrop inheritance change info

### DIFF
--- a/css/selectors/backdrop.json
+++ b/css/selectors/backdrop.json
@@ -147,7 +147,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview",
+                "version_added": "17.4",
                 "impl_url": "https://bugzil.la/263834"
               },
               "safari_ios": "mirror",

--- a/css/selectors/backdrop.json
+++ b/css/selectors/backdrop.json
@@ -125,6 +125,42 @@
             }
           }
         },
+        "inherit_from_originating_element": {
+          "__compat": {
+            "description": "Backdrop elements inherit their values from its originating element",
+            "support": {
+              "chrome": {
+                "version_added": "122",
+                "impl_url": "https://crbug.com/40569411"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "120",
+                "impl_url": "https://bugzil.la/1855668"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview",
+                "impl_url": "https://bugzil.la/263834"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "popover": {
           "__compat": {
             "description": "Support on popovers",


### PR DESCRIPTION
_(👋 Hi, Chrome DevRel here)_

When `::backdrop` was moved from the fullscreen spec to css-position-4, it was made tree-abiding, inheriting from its originating element.

CSSWG Resolution: https://github.com/w3c/csswg-drafts/issues/7845#issuecomment-1789844429

This PR adds this information.

This feature is available in all major engines. _(I’m not sure on Safari’s specifics so I’ve marked it as preview)_