### PR TITLE
Add CSS Highlight Inheritance

### DIFF
--- a/css/selectors/grammar-error.json
+++ b/css/selectors/grammar-error.json
@@ -34,6 +34,42 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "inheritance": {
+          "__compat": {
+            "description": "Highlight pseudos inherit from from the corresponding highlight pseudo-element of its originating element’s parent element",
+            "support": {
+              "chrome": {
+                "version_added": "123",
+                "impl_url": "https://crbug.com/40107329"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1703961"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/220325"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/selectors/selection.json
+++ b/css/selectors/selection.json
@@ -49,6 +49,42 @@
             "deprecated": false
           }
         },
+        "inheritance": {
+          "__compat": {
+            "description": "Highlight pseudos inherit from from the corresponding highlight pseudo-element of its originating element’s parent element",
+            "support": {
+              "chrome": {
+                "version_added": "123",
+                "impl_url": "https://crbug.com/40107329"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1703961"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/220325"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "text-decoration": {
           "__compat": {
             "description": "Supports the <code>text-decoration</code> property",

--- a/css/selectors/spelling-error.json
+++ b/css/selectors/spelling-error.json
@@ -34,6 +34,42 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "inheritance": {
+          "__compat": {
+            "description": "Highlight pseudos inherit from from the corresponding highlight pseudo-element of its originating element’s parent element",
+            "support": {
+              "chrome": {
+                "version_added": "123",
+                "impl_url": "https://crbug.com/40107329"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1703961"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/220325"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/selectors/target-text.json
+++ b/css/selectors/target-text.json
@@ -34,6 +34,42 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "inheritance": {
+          "__compat": {
+            "description": "Highlight pseudos inherit from from the corresponding highlight pseudo-element of its originating element’s parent element",
+            "support": {
+              "chrome": {
+                "version_added": "123",
+                "impl_url": "https://crbug.com/40107329"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1703961"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/220325"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
_(👋 Hi, Chrome DevRel here)_

With CSS Highlight Inheritance, the CSS Highlight pseudo classes inherit their properties through the pseudo highlight chain, rather than the element chain.

This applies to all [Highlight Pseudo Elements](https://drafts.csswg.org/css-pseudo-4/#highlight-pseudo-element): `::selection`, `::target-text`, `::spelling-error`, and `::grammar-error`.

Spec: https://drafts.csswg.org/css-pseudo-4/#highlight-cascade
CSSWG Resolution: https://github.com/w3c/csswg-drafts/issues/2474#issuecomment-380369965

This PR adds this information as a separate block, because in Chrome this wasn’t always the case.