### PR TITLE
Update Safari support for ongamepadconnected + ongamepaddisconnected

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1793,14 +1793,18 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "10.1",
-              "partial_implementation": true,
-              "notes": "The <code>ongamepadconnected</code> event handler property is not supported. See <a href='https://webkit.org/b/223860'>bug 223860</a>."
-            },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari": [
+              {
+                "version_added": "16"
+              },
+              {
+                "version_added": "10.1",
+                "version_removed": "16",
+                "partial_implementation": true,
+                "notes": "The <code>ongamepadconnected</code> event handler property is not supported. See <a href='https://webkit.org/b/223860'>bug 223860</a>."
+              }
+            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
@@ -1860,14 +1864,18 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "10.1",
-              "partial_implementation": true,
-              "notes": "The <code>ongamepaddisconnected</code> event handler property is not supported. See <a href='https://webkit.org/b/223860'>bug 223860</a>."
-            },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari": [
+              {
+                "version_added": "16"
+              },
+              {
+                "version_added": "10.1",
+                "version_removed": "16",
+                "partial_implementation": true,
+                "notes": "The <code>ongamepaddisconnected</code> event handler property is not supported. See <a href='https://webkit.org/b/223860'>bug 223860</a>."
+              }
+            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
The linked bug https://webkit.org/b/223860 was fixed in WebKit 614.1.20:
https://github.com/WebKit/WebKit/commit/57f8b6aa692023a6ee9e78c9d6fe73e9c571e75b
https://github.com/WebKit/WebKit/blob/57f8b6aa692023a6ee9e78c9d6fe73e9c571e75b/Source/WebCore/Configurations/Version.xcconfig

That maps to Safari 16 using WebKit 614.1.25.

The presence of the two properties on window has also been confirmed
manually in Safari 17.3 on macOS and iOS 17.2.