### PR TITLE
Mirror iOS support for client.ancestorOrigins

### DIFF
--- a/api/WindowClient.json
+++ b/api/WindowClient.json
@@ -57,9 +57,7 @@
             "safari": {
               "version_added": "16"
             },
-            "safari_ios": {
-              "version_added": false
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
Support in iOS 17.2 confirmed manually with this test: https://mdn-bcd-collector.gooborg.com/tests/api/WindowClient/ancestorOrigins

Support was not guarded by any kind of flag when landed in WebKit: https://github.com/WebKit/WebKit/commit/5b0f2dd5f9d48d507a63f148bdc715d876d1b3a3