### PR TITLE
Update iOS support for video.getVideoPlaybackQuality()

### DIFF
--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -196,7 +196,9 @@
             "safari": {
               "version_added": "8"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "12.2"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/api/VideoPlaybackQuality.json
+++ b/api/VideoPlaybackQuality.json
@@ -27,7 +27,7 @@
             "version_added": "8"
           },
           "safari_ios": {
-            "version_added": false
+            "version_added": "12.2"
           },
           "samsunginternet_android": "mirror",
           "webview_android": {
@@ -70,7 +70,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -109,7 +109,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -150,7 +150,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {
@@ -191,7 +191,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
@@ -230,7 +230,7 @@
               "version_added": "8"
             },
             "safari_ios": {
-              "version_added": false
+              "version_added": "12.2"
             },
             "samsunginternet_android": "mirror",
             "webview_android": {


### PR DESCRIPTION
This API was originally implemented behind a `MEDIA_SOURCE` compile-time
flag:
https://github.com/WebKit/WebKit/commit/27dee3c249271155975bc4ac8ab21b1e7d8e00d5

The flag was removed in WebKit 607.1.10:
https://github.com/WebKit/WebKit/commit/b4c26716c070bb88c5e11809689836841cbd7c49
https://github.com/WebKit/WebKit/blob/b4c26716c070bb88c5e11809689836841cbd7c49/Source/WebCore/Configurations/Version.xcconfig

That maps to iOS 12.2. That specific version isn't available on
BrowserStack, but 12 and 13 were tested to all-but-confirm this:
https://mdn-bcd-collector.gooborg.com/tests/api/VideoPlaybackQuality

Fixes https://github.com/mdn/browser-compat-data/issues/22221.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
