### PR TITLE
Mark SharedWorkerGlobalScope as not supported on Android

### DIFF
--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -10,7 +10,7 @@
           },
           "chrome_android": {
             "version_added": false,
-            "impl_url": "https://crbug.com/154571"
+            "impl_url": "https://crbug.com/40290702"
           },
           "edge": "mirror",
           "firefox": {

--- a/api/SharedWorkerGlobalScope.json
+++ b/api/SharedWorkerGlobalScope.json
@@ -8,7 +8,10 @@
           "chrome": {
             "version_added": "4"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false,
+            "impl_url": "https://crbug.com/40290702"
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": "29"
@@ -61,7 +64,10 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false,
+              "impl_url": "https://crbug.com/40290702"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "29"
@@ -117,7 +123,10 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false,
+              "impl_url": "https://crbug.com/40290702"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "29",
@@ -172,7 +181,10 @@
             "chrome": {
               "version_added": "4"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false,
+              "impl_url": "https://crbug.com/40290702"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "29"


### PR DESCRIPTION
Confirmed in Chrome Android 120 with this test:
https://mdn-bcd-collector.gooborg.com/tests/api/SharedWorkerGlobalScope

Update the bug link to the redirected bug number.