### PR TITLE
Change identifier for transition-behavior value of transition CSS property

### DIFF
--- a/css/properties/transition.json
+++ b/css/properties/transition.json
@@ -146,7 +146,7 @@
             }
           }
         },
-        "transition_behavior_value": {
+        "transition-behavior": {
           "__compat": {
             "description": "<code>transition-behavior</code> value",
             "support": {


### PR DESCRIPTION
This PR fixes the identifier for the `transition-behavior` value of the `transition` CSS property to conform to our typical conventions.