### PR TITLE
tabs.Tab properties update

### DIFF
--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -736,27 +736,6 @@
               }
             }
           },
-          "groupId": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "88"
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": {
-                  "version_added": "54"
-                },
-                "opera": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror"
-              }
-            }
-          },
           "height": {
             "__compat": {
               "support": {
@@ -1016,7 +995,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1620774"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -3156,6 +3156,30 @@
             }
           },
           "queryInfo": {
+            "__compat": {
+              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/query",
+              "support": {
+                "chrome": {
+                  "version_added": true
+                },
+                "edge": {
+                  "version_added": "14"
+                },
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "54"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            },
             "active": {
               "__compat": {
                 "support": {

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -3215,8 +3215,7 @@
                     "version_added": "63"
                   },
                   "firefox_android": {
-                    "version_added": "63",
-                    "notes": "While present, always returns <code>false</code>."
+                    "version_added": false
                   },
                   "opera": "mirror",
                   "safari": {

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -615,9 +615,12 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": true
+                  "version_added": "63"
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": "63",
+                  "notes": "While present, always returns <code>false</code>."
+                },
                 "opera": "mirror",
                 "safari": {
                   "version_added": false
@@ -3175,6 +3178,28 @@
                   "safari_ios": {
                     "version_added": "15"
                   }
+                }
+              }
+            },
+            "attention": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "63"
+                  },
+                  "firefox_android": {
+                    "version_added": "63",
+                    "notes": "While present, always returns <code>false</code>."
+                  },
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror"
                 }
               }
             },

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -3157,7 +3157,6 @@
           },
           "queryInfo": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/tabs/query",
               "support": {
                 "chrome": {
                   "version_added": true

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -607,6 +607,25 @@
               }
             }
           },
+          "attention": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": true
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "audible": {
             "__compat": {
               "support": {
@@ -708,6 +727,27 @@
                 },
                 "firefox_android": {
                   "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "groupId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "88"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": {
+                  "version_added": "54"
                 },
                 "opera": "mirror",
                 "safari": {
@@ -905,7 +945,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "121"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -965,6 +1005,25 @@
                 "safari_ios": {
                   "version_added": "15"
                 }
+              }
+            }
+          },
+          "pendingUrl": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "79"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
               }
             }
           },


### PR DESCRIPTION
#### Summary

Update to tabs.Tab properties including:

- addition of `attention` - missing property supported in Firefox (could trace support back to Firefox 65 but was clearly implemented earlier, blame was failing to backtrack on show earliest version with this line.)
- addition of groupId and pendingUrl - missing properties supported in Chrome
- update to `lastAccessed` – now supported in Chrome as of 121

#### Related issues

Fixes https://github.com/mdn/content/issues/22275
Related mdn documentation updates in https://github.com/mdn/content/pull/32279
