### PR TITLE
[font-face] COLRv1 support in FF went stable in 107

### DIFF
--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -134,7 +134,7 @@
                       "value_to_set": "true"
                     }
                   ]
-                },
+                }
               ],
               "firefox_android": "mirror",
               "ie": {

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -123,7 +123,7 @@
               "edge": "mirror",
               "firefox": [
                 { 
-                  "version_added": "107", 
+                  "version_added": "107"
                 },
                 {
                   "version_added": "105",

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -121,7 +121,7 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": { 
+              "firefox": {
                 "version_added": "107"
               },
               "firefox_android": "mirror",

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -121,21 +121,9 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                { 
-                  "version_added": "107"
-                },
-                {
-                  "version_added": "105",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "gfx.font_rendering.colr_v1.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": { 
+                "version_added": "107"
+              },
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -122,14 +122,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "105",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "gfx.font_rendering.colr_v1.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "107",
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/at-rules/font-face.json
+++ b/css/at-rules/font-face.json
@@ -121,9 +121,21 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "107",
-              },
+              "firefox": [
+                { 
+                  "version_added": "107", 
+                },
+                {
+                  "version_added": "105",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "gfx.font_rendering.colr_v1.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false


### PR DESCRIPTION
COLRv1 support is shipped in FireFox since version 107. 

Source: https://bugzilla.mozilla.org/show_bug.cgi?id=1791558
See also: See also https://caniuse.com/colr-v1