### PR TITLE
Add scrollend event to VisualViewport

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6436,7 +6436,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/201556"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -8412,7 +8412,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/201556"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/VisualViewport.json
+++ b/api/VisualViewport.json
@@ -347,6 +347,45 @@
           }
         }
       },
+      "scrollend_event": {
+        "__compat": {
+          "description": "<code>scrollend</code> event",
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/VisualViewport/scrollend_event",
+          "spec_url": "https://drafts.csswg.org/cssom-view/#eventdef-document-scrollend",
+          "support": {
+            "chrome": {
+              "version_added": "114",
+              "partial_implementation": true,
+              "notes": "The <code>onscrollend</code> event handler property is not supported. See <a href='https://crbug.com/325307785'>bug 325307785</a>."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1801658"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false,
+              "impl_url": "https://webkit.org/b/201556"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/VisualViewport/width",


### PR DESCRIPTION
This was shipped in Chrome together with the general support for the
event, but the event handler property was missed.

Not supported in Firefox or Safari, bugs were linked.