### PR TITLE
Chrome releases script: Convert version number to string

### DIFF
--- a/scripts/update-browser-releases/chrome.ts
+++ b/scripts/update-browser-releases/chrome.ts
@@ -106,7 +106,7 @@ export const updateChromiumReleases = async (options) => {
     const versionData = versions[value];
     if (versionData) {
       data[value] = {};
-      data[value].version = versionData.version;
+      data[value].version = versionData.version.toString();
       data[value].releaseDate = versionData.stable_date.substring(0, 10); // Remove the time part;
 
       // Update the JSON in memory


### PR DESCRIPTION
Fixes the failure in https://github.com/mdn/browser-compat-data/pull/22230