### PR TITLE
Mark `NetworkInformation.typechange` event as non-standard

### DIFF
--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -382,8 +382,6 @@
       "typechange_event": {
         "__compat": {
           "description": "<code>typechange</code> event",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/NetworkInformation/typechange_event",
-          "spec_url": "https://wicg.github.io/netinfo/#dom-networkinformation-onchange",
           "support": {
             "chrome": {
               "version_added": false
@@ -418,7 +416,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

mark `NetworkInformation.typechange` event as non-standard, since it is not in the spec https://wicg.github.io/netinfo/

also remove the incorrect spec_url

also remove the mdn_url since the documentation does not existed

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
