### PR TITLE
Add palette-mix() function as subfeature of font-palette

### DIFF
--- a/css/properties/font-palette.json
+++ b/css/properties/font-palette.json
@@ -33,6 +33,40 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "palette-mix_function": {
+          "__compat": {
+            "description": "<code>palette-mix()</code>",
+            "spec_url": "https://drafts.csswg.org/css-fonts/#typedef-font-palette-palette-mix",
+            "support": {
+              "chrome": {
+                "version_added": "121"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This entry effectively represents the ability to animate font-palette.
The Chrome version is from this chromestatus entry:
https://chromestatus.com/feature/5177171439517696

BCD currently represents functions both under css.types and under
specific properties that accept those functions are values.

Since palette-mix() can so far only be used for font-palette, put it
there.

The spec URL is not ideal:
https://github.com/w3c/csswg-drafts/issues/9969