### PR TITLE
Mark unprefixed background-clip:text supported in Edge

### DIFF
--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -178,6 +178,9 @@
               "chrome_android": "mirror",
               "edge": [
                 {
+                  "version_added": "120"
+                },
+                {
                   "version_added": "79",
                   "partial_implementation": true,
                   "notes": "The <code>text</code> value is only supported by <code>-webkit-background-clip</code> (and not by <code>background-clip</code>; see <a href='https://crbug.com/1339290'>bug 1339290</a>)."


### PR DESCRIPTION
This cannot be mirrored because of the pre-Chromium history.