### PR TITLE
Update CSS exponential functions support in Chrome 120

### DIFF
--- a/css/types/exp.json
+++ b/css/types/exp.json
@@ -8,8 +8,7 @@
           "spec_url": "https://drafts.csswg.org/css-values/#exponent-funcs",
           "support": {
             "chrome": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/1407474"
+              "version_added": "120"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/types/hypot.json
+++ b/css/types/hypot.json
@@ -8,8 +8,7 @@
           "spec_url": "https://drafts.csswg.org/css-values/#exponent-funcs",
           "support": {
             "chrome": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/1407474"
+              "version_added": "120"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/types/log.json
+++ b/css/types/log.json
@@ -8,8 +8,7 @@
           "spec_url": "https://drafts.csswg.org/css-values/#exponent-funcs",
           "support": {
             "chrome": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/1407474"
+              "version_added": "120"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/types/pow.json
+++ b/css/types/pow.json
@@ -8,8 +8,7 @@
           "spec_url": "https://drafts.csswg.org/css-values/#exponent-funcs",
           "support": {
             "chrome": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/1407474"
+              "version_added": "120"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/types/sqrt.json
+++ b/css/types/sqrt.json
@@ -8,8 +8,7 @@
           "spec_url": "https://drafts.csswg.org/css-values/#exponent-funcs",
           "support": {
             "chrome": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/1407474"
+              "version_added": "120"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

`pow()`, `sqrt()`, `hypot()`, `log()`, `exp()` are shipped in Chromium 120.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

https://developer.mozilla.org/en-US/docs/Web/CSS/pow
https://developer.mozilla.org/en-US/docs/Web/CSS/sqrt
https://developer.mozilla.org/en-US/docs/Web/CSS/hypot
https://developer.mozilla.org/en-US/docs/Web/CSS/log
https://developer.mozilla.org/en-US/docs/Web/CSS/exp

https://wpt.fyi/results/css/css-values/hypot-pow-sqrt-computed.html?label=master&label=experimental&aligned&q=hypot
https://wpt.fyi/results/css/css-values/hypot-pow-sqrt-invalid.html?label=master&label=experimental&aligned&q=hypot
https://wpt.fyi/results/css/css-values/hypot-pow-sqrt-serialize.html?label=master&label=experimental&aligned&q=hypot
https://wpt.fyi/results/css/css-values/exp-log-compute.html?label=master&label=experimental&aligned&q=log
https://wpt.fyi/results/css/css-values/exp-log-invalid.html?label=master&label=experimental&aligned&q=log
https://wpt.fyi/results/css/css-values/exp-log-serialize.html?label=master&label=experimental&aligned&q=log

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://chromestatus.com/feature/5118715069202432
https://issues.chromium.org/issues/40253180
https://groups.google.com/a/chromium.org/g/blink-dev/c/oAu01pBscs8

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
