### PR TITLE
FF124 Screen Wakelock API shipped

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -4902,7 +4902,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "124"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -637,6 +637,45 @@
           }
         }
       },
+      "permission_screen-wake-lock": {
+        "__compat": {
+          "description": "<code>screen-wake-lock</code> permission",
+          "spec_url": "https://w3c.github.io/screen-wake-lock/#the-screen-wake-lock-powerful-feature",
+          "tags": [
+            "web-features:screen-wake-lock"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "84"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "124"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            }
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "permission_storage-access": {
         "__compat": {
           "description": "<code>storage-access</code> permission",

--- a/api/WakeLock.json
+++ b/api/WakeLock.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "124"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -54,7 +54,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "124"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/WakeLockSentinel.json
+++ b/api/WakeLockSentinel.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "124"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -54,7 +54,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "124"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -96,7 +96,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "124"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -137,7 +137,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "124"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -178,7 +178,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "124"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -1269,7 +1269,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -1252,7 +1252,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "124"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -1269,7 +1269,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -1262,14 +1262,14 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
FF124 supports the [Screen Wake Lock API](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API) by default in https://bugzilla.mozilla.org/show_bug.cgi?id=1874849

This updates from preview to 124 for all things tagged with `web-features:screen-wake-lock`

Related docs work can be tracked in https://github.com/mdn/content/issues/32338