### PR TITLE
Update WeakMap.json NodeJS symbol_as_keys

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -475,6 +475,13 @@
           "engine": "V8",
           "engine_version": "11.3"
         },
+        "20.1.0": {
+          "release_date": "2023-05-03",
+          "release_notes": "https://nodejs.org/en/blog/release/v20.1.0",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "11.3"
+        },
         "20.2.0": {
           "release_date": "2023-05-16",
           "release_notes": "https://nodejs.org/en/blog/release/v20.2.0",

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -402,7 +402,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "20.2.0"
+                "version_added": "20.1.0"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -402,7 +402,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": false
+                "version_added": "20.1.0"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -402,7 +402,7 @@
                 "version_added": false
               },
               "nodejs": {
-                "version_added": "20.1.0"
+                "version_added": "20.2.0"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Node 20.1.0 and later supports WeakMap with non-registered symbols as keys. 

#### Test results and supporting details

[issue #49135](https://github.com/nodejs/node/issues/49135)

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
