### PR TITLE
Updates opera browser to version 107

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -791,7 +791,7 @@
         "105": {
           "release_date": "2023-11-14",
           "release_notes": "https://blogs.opera.com/desktop/2023/11/opera-105-stable/",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "119"
         },
@@ -803,9 +803,16 @@
           "engine_version": "120"
         },
         "107": {
-          "status": "beta",
+          "release_date": "2024-02-07",
+          "release_notes": "https://blogs.opera.com/desktop/2024/02/opera-107/",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "121"
+        },
+        "108": {
+          "status": "beta",
+          "engine": "Blink",
+          "engine_version": "122"
         }
       }
     }


### PR DESCRIPTION
Hello everyone! 👋

Updating Opera to version 107, according to this [release note](https://blogs.opera.com/desktop/2024/02/opera-107/).