### PR TITLE
FF124 AbortSignal.any() static method supported

### DIFF
--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -231,7 +231,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "124"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
FF124 supports [AbortSignal.any()](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/any_static) in https://bugzilla.mozilla.org/show_bug.cgi?id=1830781 . This updates the record

Related docs work can be tracked in https://github.com/mdn/content/issues/32342