### PR TITLE
FF124 growable SharedArrayBuffer and resizeable ArrayBuffer behind prefs

### DIFF
--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -114,7 +114,14 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "124",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.experimental.arraybuffer_resizable",
+                      "value_to_set": "true"
+                    }
+                  ]
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -330,7 +337,14 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "124",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.experimental.arraybuffer_resizable",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "ie": {
@@ -370,7 +384,14 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "124",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.experimental.arraybuffer_resizable",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "ie": {
@@ -410,7 +431,14 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "124",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.experimental.arraybuffer_resizable",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "ie": {

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -102,7 +102,14 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "124",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.experimental.sharedarraybuffer_growable",
+                      "value_to_set": "true"
+                    }
+                  ]
                 },
                 "firefox_android": "mirror",
                 "ie": {
@@ -189,7 +196,14 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "124",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.experimental.sharedarraybuffer_growable",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "ie": {
@@ -231,7 +245,14 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "124",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.experimental.sharedarraybuffer_growable",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "ie": {
@@ -273,7 +294,14 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "124",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.experimental.sharedarraybuffer_growable",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
FF124 adds support for growable [`SharedArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer)behind pref `javascript.options.experimental.sharedarraybuffer_growable`, and resizable [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) behind pref 
`javascript.options.experimental.arraybuffer_resizable` in https://bugzilla.mozilla.org/show_bug.cgi?id=1842773

This PR updates the data appropriately.

Note I had to restart FF to get the BCD collector tests to work - such as https://mdn-bcd-collector.gooborg.com/tests/javascript/builtins/ArrayBuffer

Related docs work can be tracked in https://github.com/mdn/content/issues/32337