### PR TITLE
Chrome support for webextensions.action.openpopup correction

### DIFF
--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -425,14 +425,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/openPopup",
             "support": {
               "chrome": {
-                "version_added": "88",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#extension-apis",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": "118"
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -425,7 +425,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/openPopup",
             "support": {
               "chrome": {
-                "version_added": "118"
+                "version_added": "118",
+                "notes": "Is only available to policy installed extensions and dev builds (e.g., Canary)."
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -445,7 +445,14 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/openPopup",
             "support": {
               "chrome": {
-                "version_added": "118"
+                "version_added": "67",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#extension-apis",
+                    "value_to_set": "Enabled"
+                  }
+                ]
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
#### Summary

This fixes an error made in #22148, which updated `browserAction` not `action` compatibility data. Fixes #16442

