### PR TITLE
Updates for Firefox 124 beta

### DIFF
--- a/api/ContentVisibilityAutoStateChangeEvent.json
+++ b/api/ContentVisibilityAutoStateChangeEvent.json
@@ -14,14 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "110",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "layout.css.content-visibility.enabled",
-                "value_to_set": "true"
-              }
-            ]
+            "version_added": "124"
           },
           "firefox_android": "mirror",
           "ie": {
@@ -38,7 +31,7 @@
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -58,14 +51,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "110",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.content-visibility.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "124"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -102,14 +88,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "110",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.content-visibility.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "124"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/api/Element.json
+++ b/api/Element.json
@@ -3894,14 +3894,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "110",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.content-visibility.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "124"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -3918,7 +3911,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/text-wrap-mode.json
+++ b/css/properties/text-wrap-mode.json
@@ -11,7 +11,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "124"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -28,7 +28,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -42,7 +42,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "124"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -59,7 +59,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -74,7 +74,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "124"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -91,7 +91,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/text-wrap-style.json
+++ b/css/properties/text-wrap-style.json
@@ -1,16 +1,12 @@
 {
   "css": {
     "properties": {
-      "content-visibility": {
+      "text-wrap-style": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/content-visibility",
-          "spec_url": "https://drafts.csswg.org/css-contain/#content-visibility",
-          "tags": [
-            "web-features:content-visibility"
-          ],
+          "spec_url": "https://drafts.csswg.org/css-text-4/#propdef-text-wrap-style",
           "support": {
             "chrome": {
-              "version_added": "85"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -25,30 +21,28 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
         },
-        "keyframe_animatable": {
+        "auto": {
           "__compat": {
-            "description": "<code>@keyframe</code> animatable",
-            "spec_url": "https://drafts.csswg.org/css-contain-3/#content-visibility-animation",
             "support": {
               "chrome": {
-                "version_added": "116"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "124"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -58,7 +52,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -71,18 +65,48 @@
             }
           }
         },
-        "transitionable": {
+        "balance": {
           "__compat": {
-            "description": "Transitionable when setting <code>transition-behavior: allow-discrete</code>",
-            "spec_url": "https://drafts.csswg.org/css-display-4/#display-animation",
             "support": {
               "chrome": {
-                "version_added": "117"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
+                "version_added": "124"
+              },
+              "firefox_android": "mirror",
+              "ie": {
                 "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "stable": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "124"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/text-wrap.json
+++ b/css/properties/text-wrap.json
@@ -81,7 +81,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "124"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -186,7 +186,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "124"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
The [Open Web Docs BCD collector](https://github.com/openwebdocs/mdn-bcd-collector) v10.8.0 found new features shipping in Firefox 124 beta which was released yesterday. Currently, the collector covers about 88% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following features as shipping in Firefox 124:

- api.AbortSignal.any_static
- api.ContentVisibilityAutoStateChangeEvent
- api.ContentVisibilityAutoStateChangeEvent.ContentVisibilityAutoStateChangeEvent
- api.ContentVisibilityAutoStateChangeEvent.skipped
- api.Element.contentvisibilityautostatechange_event
- api.Navigator.wakeLock
- api.Permissions.permission_screen-wake-lock
- api.WakeLock
- api.WakeLock.request
- api.WakeLockSentinel
- api.WakeLockSentinel.release
- api.WakeLockSentinel.release_event
- api.WakeLockSentinel.released
- api.WakeLockSentinel.type
- css.properties.content-visibility
- css.properties.text-wrap-mode
- css.properties.text-wrap-mode.nowrap
- css.properties.text-wrap-mode.wrap
- css.properties.text-wrap-style
- css.properties.text-wrap-style.auto
- css.properties.text-wrap-style.balance
- css.properties.text-wrap-style.stable
- css.properties.text-wrap.nowrap
- css.properties.text-wrap.wrap
- http.headers.Permissions-Policy.screen-wake-lock
- javascript.builtins.ArrayBuffer.ArrayBuffer.maxByteLength_option
- javascript.builtins.ArrayBuffer.maxByteLength
- javascript.builtins.ArrayBuffer.resizable
- javascript.builtins.ArrayBuffer.resize
- javascript.builtins.SharedArrayBuffer.SharedArrayBuffer.maxByteLength_option
- javascript.builtins.SharedArrayBuffer.grow
- javascript.builtins.SharedArrayBuffer.growable
- javascript.builtins.SharedArrayBuffer.maxByteLength

Again, I hope this auto-generated PR is useful to update BCD for the new Firefox 124 more easily and faster. If you have feedback, let me know! 

See also https://github.com/mdn/mdn/issues/526