### PR TITLE
Update for Safari 17.4 beta (19618.1.15)

### DIFF
--- a/api/CustomStateSet.json
+++ b/api/CustomStateSet.json
@@ -28,21 +28,14 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "preview",
-            "flags": [
-              {
-                "name": "CustomStateSet",
-                "value_to_set": "true",
-                "type": "preference"
-              }
-            ]
+            "version_added": "17.4"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -75,21 +68,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "CustomStateSet",
-                  "value_to_set": "true",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -123,21 +109,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "CustomStateSet",
-                  "value_to_set": "true",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -171,21 +150,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "CustomStateSet",
-                  "value_to_set": "true",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -219,21 +191,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "CustomStateSet",
-                  "value_to_set": "true",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -267,21 +232,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "CustomStateSet",
-                  "value_to_set": "true",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -315,21 +273,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "CustomStateSet",
-                  "value_to_set": "true",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -363,21 +314,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "CustomStateSet",
-                  "value_to_set": "true",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -411,21 +355,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "CustomStateSet",
-                  "value_to_set": "true",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -459,21 +396,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "CustomStateSet",
-                  "value_to_set": "true",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -506,21 +436,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "CustomStateSet",
-                  "value_to_set": "true",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Element.json
+++ b/api/Element.json
@@ -1324,7 +1324,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -2644,10 +2644,15 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": {
-                "alternative_name": "cloneable",
-                "version_added": "16.4"
-              },
+              "safari": [
+                {
+                  "version_added": "17.4"
+                },
+                {
+                  "alternative_name": "cloneable",
+                  "version_added": "16.4"
+                }
+              ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
@@ -3061,7 +3066,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview"
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -2065,21 +2065,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "CustomStateSet",
-                  "value_to_set": "true",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -130,8 +130,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "alternative_name": "cloneable",
-              "version_added": "preview"
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/selectors/state.json
+++ b/css/selectors/state.json
@@ -31,14 +31,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "CustomStateSet",
-                  "value_to_set": "true",
-                  "type": "preference"
-                }
-              ]
+              "version_added": "17.4"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
The [Open Web Docs BCD collector](https://github.com/openwebdocs/mdn-bcd-collector) v10.8 found new features shipping in Safari 17.4 beta (19618.1.15) which was released yesterday. Currently, the collector covers about 88% of BCD, so the following list might not be exhaustive. Also, if a feature is in Safari TP and/or behind flags, it is not considered here.

I ran the collector previously for Safari 17.4 beta (19618.1.11.11.3). Here's the PR: https://github.com/mdn/browser-compat-data/pull/22101. This PR is about 19618.1.15 and new features from the previous beta release were found:

- api.CustomStateSet
- api.CustomStateSet.add
- api.CustomStateSet.clear
- api.CustomStateSet.delete
- api.CustomStateSet.entries
- api.CustomStateSet.forEach
- api.CustomStateSet.has
- api.CustomStateSet.keys
- api.CustomStateSet.size
- api.CustomStateSet.values
- api.CustomStateSet.@@iterator
- api.Element.ariaDescription
- api.Element.attachShadow.init_clonable_parameter
- api.Element.checkVisibility
- api.ElementInternals.states
- api.ShadowRoot.clonable
- css.selectors.state

https://developer.apple.com/documentation/safari-release-notes/safari-17_4-release-notes confirms these features.


<details><summary>Full list of features that BCD considers shipping in Safari 17.4 (taking into account the previous PR)</summary>
<p>

- api.AbortSignal.any_static
- api.CSSScopeRule
- api.CSSScopeRule.end
- api.CSSScopeRule.start
- api.CustomStateSet
- api.CustomStateSet.add
- api.CustomStateSet.clear
- api.CustomStateSet.delete
- api.CustomStateSet.entries
- api.CustomStateSet.forEach
- api.CustomStateSet.has
- api.CustomStateSet.keys
- api.CustomStateSet.size
- api.CustomStateSet.values
- api.CustomStateSet.@@iterator
- api.DOMMatrixReadOnly.scaleNonUniform
- api.Document.parseHTMLUnsafe_static
- api.Element.ariaDescription
- api.Element.attachShadow.init_clonable_parameter
- api.Element.checkVisibility
- api.Element.setHTMLUnsafe
- api.ElementInternals.states
- api.HTMLInputElement.showPicker.date_input
- api.HTMLInputElement.showPicker.datetime_local_input
- api.PublicKeyCredential.getClientCapabilities_static
- api.SVGFESpecularLightingElement.kernelUnitLengthX
- api.SVGFESpecularLightingElement.kernelUnitLengthY
- api.SVGRenderingIntent (removal)
- api.ShadowRoot.clonable
- api.ShadowRoot.setHTMLUnsafe
- css.at-rules.scope
- css.properties.content.alt_text
- css.properties.text-decoration-thickness.percentage
- css.properties.text-wrap-mode
- css.properties.text-wrap-mode.nowrap
- css.properties.text-wrap-mode.wrap
- css.properties.text-wrap
- css.properties.text-wrap.nowrap
- css.properties.text-wrap.wrap
- css.properties.transition-behavior
- css.properties.white-space-collapse
- css.selectors.grammar-error
- css.selectors.spelling-error
- css.selectors.state
- javascript.builtins.ArrayBuffer.detached
- javascript.builtins.ArrayBuffer.transfer
- javascript.builtins.ArrayBuffer.transferToFixedLength
- javascript.builtins.Map.groupBy
- javascript.builtins.Map.groupBy
- javascript.builtins.Object.groupBy
- javascript.builtins.Object.groupBy
- javascript.builtins.Promise.withResolvers
- svg.elements.feSpecularLighting.kernelUnitLength
- webassembly.extended-constant-expressions

</p>
</details> 


cc @jdatapple 