### PR TITLE
fix(browsers): add release dates for Opera Android 75-78

### DIFF
--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -424,7 +424,7 @@
           "engine_version": "110"
         },
         "75": {
-          "release_date": "2023-05-26",
+          "release_date": "2023-05-17",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "112"

--- a/browsers/opera_android.json
+++ b/browsers/opera_android.json
@@ -424,21 +424,25 @@
           "engine_version": "110"
         },
         "75": {
+          "release_date": "2023-05-26",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "112"
         },
         "76": {
+          "release_date": "2023-06-26",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "114"
         },
         "77": {
+          "release_date": "2023-08-31",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "115"
         },
         "78": {
+          "release_date": "2023-10-23",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "117"


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds missing release dates for Opera Android 75 to 78.

#### Test results and supporting details

Sources (assuming release date = announcement date):
- https://forums.opera.com/topic/62482/opera-for-android-75
- https://forums.opera.com/topic/63567/opera-for-android-76
- https://forums.opera.com/topic/65830/opera-for-android-77
- https://forums.opera.com/topic/67255/opera-for-android-78

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/22274.