### PR TITLE
Remove -webkit prefix from Firefox and Edge in flex-direction.json

### DIFF
--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -22,19 +22,11 @@
             "edge": [
               {
                 "version_added": "12"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "12"
               }
             ],
             "firefox": [
               {
                 "version_added": "81"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "49"
               },
               {
                 "version_added": "20",

--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -19,11 +19,9 @@
               }
             ],
             "chrome_android": "mirror",
-            "edge": [
-              {
-                "version_added": "12"
-              }
-            ],
+            "edge": {
+              "version_added": "12"
+            },
             "firefox": [
               {
                 "version_added": "81"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox from 49 to 80 does not need `-webkit` prefix on [flex-direction](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction). Moreover, this was inconsistent with [flex-flow](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-flow) which was never prefixed on Firefox 28 and later.
Edge 12 also does not have this prefix, but this edit will not have any effect as it was not displayed in compat data table.

#### Test results and supporting details

Tested today on Firefox 56.0.2

![image](https://github.com/mdn/browser-compat-data/assets/16428197/2d7fb210-05d0-41e3-9e9d-c52fea08d1d8)

#### Related issues

Fixes #16327 
