### PR TITLE
Update Edge 12 release date

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -9,7 +9,7 @@
       "accepts_webextensions": true,
       "releases": {
         "12": {
-          "release_date": "2015-07-28",
+          "release_date": "2015-07-29",
           "release_notes": "https://learn.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-12",
           "status": "retired",
           "engine": "EdgeHTML",

--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -10,7 +10,7 @@
       "releases": {
         "12": {
           "release_date": "2015-07-29",
-          "release_notes": "https://learn.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-12",
+          "release_notes": "https://learn.microsoft.com/en-us/archive/microsoft-edge/legacy/developer/dev-guide/whats-new/edgehtml-12",
           "status": "retired",
           "engine": "EdgeHTML",
           "engine_version": "12"


### PR DESCRIPTION
This date has a special significance for Baseline: https://github.com/web-platform-dx/web-features/issues/623

July 29 is claimed as the release date by Wikipedia: https://en.wikipedia.org/wiki/Microsoft_Edge