### PR TITLE
Safari 17.4 has complete support for forms in vertical writing modes

### DIFF
--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -403,11 +403,16 @@
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": {
-                "version_added": "14",
-                "partial_implementation": true,
-                "notes": "Support for range sliders, textual inputs, and textareas only"
-              },
+              "safari": [
+                {
+                  "version_added": "17.4"
+                },
+                {
+                  "version_added": "14",
+                  "partial_implementation": true,
+                  "notes": "Support for range sliders, textual inputs, and textareas only"
+                },
+              ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -411,7 +411,7 @@
                   "version_added": "14",
                   "partial_implementation": true,
                   "notes": "Support for range sliders, textual inputs, and textareas only"
-                },
+                }
               ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Safari 17.4 has complete support for forms in vertical writing modes.

#### Test results and supporting details

Release notes: https://developer.apple.com/documentation/safari-release-notes/safari-17_4-release-notes

Demo: https://codepen.io/jensimmons/pen/gOEVZbw?editors=1100
 
<img width="1146" alt="Screenshot 2024-02-26 at 9 26 28 PM" src="https://github.com/mdn/browser-compat-data/assets/108474/84fe49a4-1a34-4edc-9563-26ab5f81b166">

Tests: https://wpt.fyi/results/css/css-writing-modes/forms?label=master&label=experimental&product=chrome&product=firefox&product=safari&aligned&view=interop&q=label%3Ainterop-2022-forms%20or%20label%3Ainterop-2023-forms

Safari passes 40/40 tests, 100%.