### PR TITLE
Add missing api.WebTransportSendStream.getWriter feature

### DIFF
--- a/api/WebTransportSendStream.json
+++ b/api/WebTransportSendStream.json
@@ -65,6 +65,39 @@
           }
         }
       },
+      "getWriter": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportsendstream-getwriter",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "114"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "sendOrder": {
         "__compat": {
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportsendstream-sendorder",


### PR DESCRIPTION
This PR adds the missing `getWriter` member of the `WebTransportSendStream` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.8.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/WebTransportSendStream/getWriter