### PR TITLE
Update Firefox support for vertical from control direction

### DIFF
--- a/css/properties/direction.json
+++ b/css/properties/direction.json
@@ -50,7 +50,9 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "120",
+                "partial_implementation": true,
+                "notes": "Only supported for vertical range sliders."
               },
               "firefox_android": "mirror",
               "ie": {
@@ -67,7 +69,7 @@
               "webview_android": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This was originally updated in https://github.com/mdn/browser-compat-data/pull/22179, but testing showed that Firefox only seems to support changing direction of vertical range sliders via `direction`, as per https://github.com/mdn/content/pull/32142#issuecomment-1961833182.

This PR provides an update.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
