### PR TITLE
Add missing features for align-self CSS property

### DIFF
--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -74,13 +74,15 @@
                 "version_added": "21"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
                 "version_added": "28"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "10"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -71,12 +71,12 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "21"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "28"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -86,7 +86,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "7"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/align-self.json
+++ b/css/properties/align-self.json
@@ -67,6 +67,38 @@
             "deprecated": false
           }
         },
+        "auto": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "≤83"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "≤13.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "flex_context": {
           "__compat": {
             "description": "Supported in Flex Layout",
@@ -390,6 +422,70 @@
               "webview_android": {
                 "version_added": "57"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "normal": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "≤83"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "≤13.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "stretch": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "≤83"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "≤13.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
This PR adds the missing features of the `align-self` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.8.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/align-self