### PR TITLE
Add missing css.properties.animation-name.none feature

### DIFF
--- a/css/properties/animation-name.json
+++ b/css/properties/animation-name.json
@@ -105,6 +105,38 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "none": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "≤83"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "≤13.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/animation-name.json
+++ b/css/properties/animation-name.json
@@ -110,12 +110,12 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "3"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "≤16"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -125,7 +125,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/animation-name.json
+++ b/css/properties/animation-name.json
@@ -113,13 +113,15 @@
                 "version_added": "3"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
                 "version_added": "≤16"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "10"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
This PR adds the missing `none` member of the `animation-name` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.8.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/animation-name/none