### PR TITLE
Add missing css.properties.background-attachment.scroll feature

### DIFF
--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -235,7 +235,9 @@
               "safari": {
                 "version_added": "1"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": "3.2"
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -213,6 +213,38 @@
               "deprecated": false
             }
           }
+        },
+        "scroll": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "≤83"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "≤72"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "≤13.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -221,13 +221,15 @@
                 "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
                 "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "4"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -218,12 +218,12 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "≤83"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -233,7 +233,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR adds the missing `scroll` member of the `background-attachment` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.8.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/background-attachment/scroll