### PR TITLE
Update Edge release notes

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -332,7 +332,7 @@
         },
         "119": {
           "release_date": "2023-11-02",
-          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1190215144-november-2-2023",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-archive-stable-channel#version-1190215144-november-2-2023",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "119"
@@ -346,13 +346,15 @@
         },
         "121": {
           "release_date": "2024-01-26",
-          "status": "current",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1210227783-january-25-2024",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "121"
         },
         "122": {
-          "release_date": "2024-02-22",
-          "status": "beta",
+          "release_date": "2024-02-23",
+          "release_notes": "https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel#version-1220236552-february-23-2024",
+          "status": "current",
           "engine": "Blink",
           "engine_version": "122"
         },


### PR DESCRIPTION
Not sure why the script fails https://github.com/mdn/browser-compat-data/actions/runs/8059665676
Updating the release notes manually will repair it.