### PR TITLE
Update Chrome data now it supports relative rgb() colors properly

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -1232,11 +1232,16 @@
               "description": "Relative RGB colors",
               "spec_url": "https://drafts.csswg.org/css-color-5/#relative-RGB",
               "support": {
-                "chrome": {
-                  "version_added": "119",
-                  "partial_implementation": true,
-                  "notes": "Channel values incorrectly resolve to numbers between 0-1 rather than 0-255. As a result, channel value calculations require values to be specified as decimal percentage equivalents (e.g. 0.3 for 30%, which would be equivalent to a 76.5 <code>&lt;number&gt;</code> value)."
-                },
+                "chrome": [
+                  {
+                    "version_added": "122"
+                  },
+                  {
+                    "version_added": "119",
+                    "partial_implementation": true,
+                    "notes": "Channel values incorrectly resolve to numbers between 0-1 rather than 0-255. As a result, channel value calculations require values to be specified as decimal percentage equivalents (e.g. 0.3 for 30%, which would be equivalent to a 76.5 <code>&lt;number&gt;</code> value)."
+                  }
+                ],
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

From recent testing during reviews of the related content, it is evident that Chrome 122+ supports relative `rgb()` colors correctly as per spec. This PR updates the data to suit.

See https://pr32004.content.dev.mdn.mozit.cloud/en-US/docs/Web/CSS/color_value/rgb#using_relative_colors_with_rgb for a test case

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
