### PR TITLE
Add zstd content-encoding and mark Brotli as standard

### DIFF
--- a/http/headers/Content-Encoding.json
+++ b/http/headers/Content-Encoding.json
@@ -75,7 +75,40 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "zstd": {
+          "__compat": {
+            "description": "<code>zstd</code>",
+            "support": {
+              "chrome": {
+                "version_added": "123"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
               "deprecated": false
             }
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Adds `zstd` Content-Encoding due to ship in Chrome 123

This also sets Brotli as a Standard since it's well supported in all major browsers so not sure why it was still marked as experimental.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://wpt.fyi/results/fetch/content-encoding/zstd?label=experimental&label=master&aligned
https://chromestatus.com/feature/6186023867908096

#### Related issues

Content PR here: https://github.com/mdn/content/pull/32465

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->


