### PR TITLE
Add data for display-mode picture-in-picture value

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -540,7 +540,9 @@
                 "chrome": {
                   "version_added": "123"
                 },
-                "chrome_android": "mirror",
+                "chrome_android": {
+                  "version_added": false
+                },
                 "edge": "mirror",
                 "firefox": {
                   "version_added": false

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -531,6 +531,40 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "picture-in-picture": {
+            "__compat": {
+              "description": "<code>picture-in-picture</code> value",
+              "spec_url": "https://drafts.csswg.org/mediaqueries-5/#display-mode-picture-in-picture",
+              "support": {
+                "chrome": {
+                  "version_added": "123"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "dynamic-range": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 123 adds support for the [`@media` `display-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/display-mode) `picture-in-picture` value. This PR adds compat data for it.

- ChromeStatus: https://chromestatus.com/feature/5198101675769856
- Spec: https://drafts.csswg.org/mediaqueries-5/#display-mode-picture-in-picture
- Demo: https://document-picture-in-picture-api.glitch.me/display-mode.html

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
