### PR TITLE
Add missing css.properties.background-image.none feature

### DIFF
--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -264,13 +264,15 @@
                 "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
                 "version_added": "≤16"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "4"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -257,6 +257,38 @@
             }
           }
         },
+        "none": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "≤16"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "svg_images": {
           "__compat": {
             "description": "SVG images",


### PR DESCRIPTION
This PR adds the missing `none` member of the `background-image` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.9.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/background-image/none