### PR TITLE
Add missing features for background-origin CSS property

### DIFF
--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -115,6 +115,38 @@
             "deprecated": false
           }
         },
+        "border-box": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "≤15"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "3"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "content-box": {
           "__compat": {
             "description": "<code>content-box</code>",
@@ -153,6 +185,38 @@
               "webview_android": {
                 "version_added": "4"
               }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "padding-box": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "≤15"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "3"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -122,13 +122,15 @@
                 "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
                 "version_added": "≤15"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "9"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -200,13 +202,15 @@
                 "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
                 "version_added": "≤15"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "9"
               },
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
This PR adds the missing features of the `background-origin` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.9.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/background-origin