### PR TITLE
Fix incorrect webextension compat info

### DIFF
--- a/webextensions/api/alarms.json
+++ b/webextensions/api/alarms.json
@@ -90,26 +90,12 @@
               "edge": {
                 "version_added": "79"
               },
-              "firefox": [
-                {
-                  "version_added": "45"
-                },
-                {
-                  "version_added": "45",
-                  "version_removed": "64",
-                  "notes": "Alarms scheduled for a time in the past never fire."
-                }
-              ],
-              "firefox_android": [
-                {
-                  "version_added": "48"
-                },
-                {
-                  "version_added": "48",
-                  "version_removed": "64",
-                  "notes": "Alarms scheduled for a time in the past never fire."
-                }
-              ],
+              "firefox": {
+                "version_added": "45"
+              },
+              "firefox_android": {
+                "version_added": "48"
+              },
               "opera": "mirror",
               "safari": {
                 "version_added": "14"

--- a/webextensions/api/clipboard.json
+++ b/webextensions/api/clipboard.json
@@ -13,7 +13,10 @@
               "firefox": {
                 "version_added": "57"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false,
+                "notes": "Method is defined but always rejects with an error."
+              },
               "opera": "mirror",
               "safari": {
                 "version_added": false

--- a/webextensions/api/commands.json
+++ b/webextensions/api/commands.json
@@ -59,7 +59,9 @@
                   "version_added": false,
                   "impl_url": "https://bugzil.la/1843866"
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false
+                },
                 "opera": "mirror",
                 "safari": {
                   "version_added": false
@@ -177,7 +179,9 @@
                   "version_added": false,
                   "impl_url": "https://bugzil.la/1843866"
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false
+                },
                 "opera": "mirror",
                 "safari": {
                   "version_added": false

--- a/webextensions/api/contextualIdentities.json
+++ b/webextensions/api/contextualIdentities.json
@@ -13,7 +13,11 @@
                 "firefox": {
                   "version_added": "53"
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1638878",
+                  "notes": "<code>contextualIdentities</code> is defined but not functional in Firefox for Android."
+                },
                 "opera": "mirror",
                 "safari": {
                   "version_added": false
@@ -32,7 +36,11 @@
                 "firefox": {
                   "version_added": "53"
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1638878",
+                  "notes": "<code>contextualIdentities</code> is defined but not functional in Firefox for Android."
+                },
                 "opera": "mirror",
                 "safari": {
                   "version_added": false
@@ -51,7 +59,11 @@
                 "firefox": {
                   "version_added": "57"
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1638878",
+                  "notes": "<code>contextualIdentities</code> is defined but not functional in Firefox for Android."
+                },
                 "opera": "mirror",
                 "safari": {
                   "version_added": false
@@ -70,7 +82,11 @@
                 "firefox": {
                   "version_added": "53"
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1638878",
+                  "notes": "<code>contextualIdentities</code> is defined but not functional in Firefox for Android."
+                },
                 "opera": "mirror",
                 "safari": {
                   "version_added": false
@@ -89,7 +105,11 @@
                 "firefox": {
                   "version_added": "57"
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1638878",
+                  "notes": "<code>contextualIdentities</code> is defined but not functional in Firefox for Android."
+                },
                 "opera": "mirror",
                 "safari": {
                   "version_added": false
@@ -108,7 +128,11 @@
                 "firefox": {
                   "version_added": "53"
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1638878",
+                  "notes": "<code>contextualIdentities</code> is defined but not functional in Firefox for Android."
+                },
                 "opera": "mirror",
                 "safari": {
                   "version_added": false
@@ -130,7 +154,11 @@
                 "version_added": "53",
                 "notes": "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled."
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1638878",
+                "notes": "<code>contextualIdentities</code> is defined but not functional in Firefox for Android."
+              },
               "opera": "mirror",
               "safari": {
                 "version_added": false
@@ -154,7 +182,11 @@
                   "Before version 57, this method resolves its promise with <code>null</code> if the given identity was not found."
                 ]
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1638878",
+                "notes": "<code>contextualIdentities</code> is defined but not functional in Firefox for Android."
+              },
               "opera": "mirror",
               "safari": {
                 "version_added": false
@@ -174,7 +206,11 @@
               "firefox": {
                 "version_added": "57"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1638878",
+                "notes": "<code>contextualIdentities</code> is defined but not functional in Firefox for Android."
+              },
               "opera": "mirror",
               "safari": {
                 "version_added": false
@@ -194,7 +230,11 @@
               "firefox": {
                 "version_added": "57"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1638878",
+                "notes": "<code>contextualIdentities</code> is defined but not functional in Firefox for Android."
+              },
               "opera": "mirror",
               "safari": {
                 "version_added": false
@@ -214,7 +254,11 @@
               "firefox": {
                 "version_added": "57"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1638878",
+                "notes": "<code>contextualIdentities</code> is defined but not functional in Firefox for Android."
+              },
               "opera": "mirror",
               "safari": {
                 "version_added": false
@@ -234,7 +278,11 @@
               "firefox": {
                 "version_added": "123"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1638878",
+                "notes": "<code>contextualIdentities</code> is defined but not functional in Firefox for Android."
+              },
               "opera": "mirror",
               "safari": {
                 "version_added": false
@@ -255,7 +303,11 @@
                 "version_added": "53",
                 "notes": "Before version 57, this method resolves its promise with <code>false</code> if the contextual identities feature is disabled."
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1638878",
+                "notes": "<code>contextualIdentities</code> is defined but not functional in Firefox for Android."
+              },
               "opera": "mirror",
               "safari": {
                 "version_added": false
@@ -279,7 +331,11 @@
                   "Before version 57, this method resolves its promise with <code>null</code> if the given identity was not found."
                 ]
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1638878",
+                "notes": "<code>contextualIdentities</code> is defined but not functional in Firefox for Android."
+              },
               "opera": "mirror",
               "safari": {
                 "version_added": false
@@ -303,7 +359,11 @@
                   "Before version 57, this method resolves its promise with <code>null</code> if the given identity was not found."
                 ]
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1638878",
+                "notes": "<code>contextualIdentities</code> is defined but not functional in Firefox for Android."
+              },
               "opera": "mirror",
               "safari": {
                 "version_added": false

--- a/webextensions/api/cookies.json
+++ b/webextensions/api/cookies.json
@@ -48,7 +48,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "119"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -248,7 +248,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "119"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -322,7 +322,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "119"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -390,7 +390,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "119"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -454,7 +454,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "119"
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -629,7 +629,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "119"
                 },
                 "edge": "mirror",
                 "firefox": {

--- a/webextensions/api/dns.json
+++ b/webextensions/api/dns.json
@@ -2,12 +2,32 @@
   "webextensions": {
     "api": {
       "dns": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/dns",
+          "support": {
+            "chrome": {
+              "version_added": "preview",
+              "notes": "The required <code>dns</code> permission is only supported in Chrome Dev."
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "60"
+            },
+            "firefox_android": "mirror",
+            "opera": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror"
+          }
+        },
         "resolve": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/dns/resolve",
             "support": {
               "chrome": {
-                "version_added": "18"
+                "version_added": "preview",
+                "notes": "The required <code>dns</code> permission is only supported in Chrome Dev."
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/api/dom.json
+++ b/webextensions/api/dom.json
@@ -2,6 +2,24 @@
   "webextensions": {
     "api": {
       "dom": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/dom",
+          "support": {
+            "chrome": {
+              "version_added": "88"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "opera": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror"
+          }
+        },
         "openOrClosedShadowRoot": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/dom/openOrClosedShadowRoot",

--- a/webextensions/api/events.json
+++ b/webextensions/api/events.json
@@ -13,7 +13,7 @@
                 "version_added": "14"
               },
               "firefox": {
-                "version_added": false
+                "version_added": true
               },
               "firefox_android": "mirror",
               "opera": "mirror",
@@ -27,7 +27,6 @@
           },
           "addListener": {
             "__compat": {
-              "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/events/Event/addListener",
               "support": {
                 "chrome": {
                   "version_added": true
@@ -36,7 +35,7 @@
                   "version_added": "14"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": true
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -101,7 +100,7 @@
                   "version_added": "14"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": true
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -145,7 +144,7 @@
                   "version_added": "14"
                 },
                 "firefox": {
-                  "version_added": false
+                  "version_added": true
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",

--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -400,7 +400,9 @@
                 "notes": "From version 88, the <code>ftp</code> setting has no effect because FTP is no longer supported (see <a href='https://bugzil.la/1626365'>bug 1626365</a>)."
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1725981",
+                "notes": "The object is defined but any attempt to read or modify the setting throws an exception."
               },
               "opera": "mirror",
               "safari": {

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -119,7 +119,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1787379"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",

--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -67,7 +67,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1736575"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1781,7 +1781,7 @@
                 "version_added": "45"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "118"
               },
               "opera": "mirror",
               "safari": {

--- a/webextensions/manifest/action.json
+++ b/webextensions/manifest/action.json
@@ -47,7 +47,7 @@
           "__compat": {
             "support": {
               "chrome": {
-                "version_added": "88"
+                "version_added": false
               },
               "edge": "mirror",
               "firefox": {
@@ -82,9 +82,7 @@
               "firefox": {
                 "version_added": "109"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
                 "version_added": "15.4",

--- a/webextensions/manifest/background.json
+++ b/webextensions/manifest/background.json
@@ -67,6 +67,7 @@
               "firefox": {
                 "version_added": "48",
                 "notes": [
+                  "Available for use in Manifest V2 only.",
                   "From Firefox 106, persistent and non-persistent pages are supported for Manifest V2.",
                   "To Firefox 105, only persistent pages are supported.",
                   "Before version 66, Firefox would log a warning even if the value was set to <code>true</code>."
@@ -77,7 +78,7 @@
               "safari": [
                 {
                   "version_added": "14.1",
-                  "notes": "Since Safari 15.4, ignored if <code>service_worker</code> is used."
+                  "notes": "Non-persistent pages are supported, through <code>persistent: false</code>."
                 },
                 {
                   "version_added": "14",

--- a/webextensions/manifest/browser_action.json
+++ b/webextensions/manifest/browser_action.json
@@ -102,7 +102,7 @@
                 "version_added": "48"
               },
               "firefox_android": {
-                "version_added": false
+                "version_added": "79"
               },
               "opera": "mirror",
               "safari": {

--- a/webextensions/manifest/commands.json
+++ b/webextensions/manifest/commands.json
@@ -206,6 +206,70 @@
             }
           }
         },
+        "_execute_action": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "88"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": true
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "_execute_browser_action": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "52"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "_execute_page_action": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": true,
+                "notes": "Available for use in Manifest V2 only."
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "48"
+              },
+              "firefox_android": {
+                "version_added": false
+              },
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "_execute_sidebar_action": {
           "__compat": {
             "support": {

--- a/webextensions/manifest/content_scripts.json
+++ b/webextensions/manifest/content_scripts.json
@@ -183,6 +183,25 @@
             }
           }
         },
+        "match_origin_as_fallback": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "99"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "matches": {
           "__compat": {
             "support": {

--- a/webextensions/manifest/content_security_policy.json
+++ b/webextensions/manifest/content_security_policy.json
@@ -58,26 +58,6 @@
             }
           }
         },
-        "isolated_world": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy#isolated_world",
-            "support": {
-              "chrome": {
-                "version_added": "88"
-              },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "opera": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror"
-            }
-          }
-        },
         "sandbox": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy#sandbox",

--- a/webextensions/manifest/permissions.json
+++ b/webextensions/manifest/permissions.json
@@ -440,7 +440,8 @@
             "description": "<code>dns</code>",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "preview",
+                "notes": "The <code>dns</code> API is only available in Chrome Dev."
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Fix incorrect BCD support info, and added impl_url to some entries that have a bug tracking their implementation.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

alarms: drop confusing compat info about past timers. The version_added/version_removed ranges are hard to interpret. The affected versions are ancient and the use of past timers is very unusual. Hence, the simplest way to resolve the ambiguity is to drop the note. Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1478694

clipboard API disabled in Firefox for Android:
https://searchfox.org/mozilla-central/rev/0e7394a77cdbe1df5e04a1d4171d6da67b57fa17/toolkit/components/extensions/parent/ext-clipboard.js#25-31

contextualIdentities not functional in Firefox for Android: https://bugzilla.mozilla.org/show_bug.cgi?id=1638878

cookies: partitionKey supported in Chrome 119+: crbug.com/1225444 https://chromium.googlesource.com/chromium/src/+/45052d18b0f8dd0eb1a7492dc92acb8ba96aff64

dns: API restricted to Chrome dev
https://chromium.googlesource.com/chromium/src/+/603f4f94bc1d9bc363483bca56d31db492912d1a/extensions/common/api/_permission_features.json#231 "This API is only available in Chrome Dev. There are no foreseeable
 plans to move this API from the dev channel into Chrome stable."
https://developer.chrome.com/docs/extensions/reference/api/dns#availability

events: although it is more of an abstract interface, the methods are supported in Firefox, e.g. as seen at:
https://searchfox.org/mozilla-central/rev/0e7394a77cdbe1df5e04a1d4171d6da67b57fa17/toolkit/components/extensions/schemas/events.json#45

tabs: tabs.detectLanguage supported in Firefox for Android 118+: https://bugzilla.mozilla.org/show_bug.cgi?id=1817779

manifest/commands: _execute_browser_action introduced in: https://bugzilla.mozilla.org/show_bug.cgi?id=1246034

manifest/commands: _execute_page_action introduced in: https://bugzilla.mozilla.org/show_bug.cgi?id=1246035

manifest/background: Safari non-persistent background support mentioned in https://developer.apple.com/documentation/safari-release-notes/safari-14_1-release-notes

manifest/content_scripts: match_origin_as_fallback added in: https://chromium.googlesource.com/chromium/src/+/53396b76e9375 https://chromium.googlesource.com/chromium/src/+/53396b76e9375/chrome/VERSION

manifest/content_security_policy: isolated_world never shipped anywhere: https://bugzilla.mozilla.org/show_bug.cgi?id=1594232#c5

#### Related issues

N/A

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
