### PR TITLE
Add data for field-sizing property

### DIFF
--- a/css/properties/field-sizing.json
+++ b/css/properties/field-sizing.json
@@ -1,0 +1,40 @@
+{
+  "css": {
+    "properties": {
+      "field-sizing": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/field-sizing",
+          "spec_url": "https://drafts.csswg.org/css-ui/#field-sizing",
+          "support": {
+            "chrome": {
+              "version_added": "123"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 123 supports the `field-sizing` property, which is used to size textual form elements and textareas by their content, rather than sticking to a fixed size. This PR adds data for the new property.

- ChromeStatus: https://chromestatus.com/feature/5176596826161152
- Spec: https://drafts.csswg.org/css-ui/#field-sizing
- Explainer: https://github.com/tkent-google/explainers/blob/main/form-sizing.md

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
