### PR TITLE
fix(browsers): add release dates/notes for Opera 97/98

### DIFF
--- a/browsers/opera.json
+++ b/browsers/opera.json
@@ -737,11 +737,15 @@
           "engine_version": "110"
         },
         "97": {
+          "release_date": "2023-03-22",
+          "release_notes": "https://blogs.opera.com/desktop/2023/03/opera-ai-tools/",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "111"
         },
         "98": {
+          "release_date": "2023-04-20",
+          "release_notes": "https://blogs.opera.com/desktop/2023/04/opera-98-stable/",
           "status": "retired",
           "engine": "Blink",
           "engine_version": "112"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds missing release dates for Opera 97 and 98.

#### Test results and supporting details

Sources:

- https://blogs.opera.com/desktop/2023/03/opera-ai-tools/
- https://blogs.opera.com/desktop/2023/04/opera-98-stable/

#### Related issues

Similar to https://github.com/mdn/browser-compat-data/pull/22275.
