### PR TITLE
Chrome/FF RTCStatsReport inbound-rtp.nackCount support

### DIFF
--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -3027,7 +3027,7 @@
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcinboundrtpstreamstats-nackcount",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "80"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -3032,8 +3032,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "55",
-                "version_removed": "96"
+                "version_added": "55"
               },
               "firefox_android": {
                 "version_added": false


### PR DESCRIPTION
Partial fix for #22293

Ran a bisect using Browserstack on chrome using https://wpt.live/webrtc-stats/supported-stats.https.html to show that inbound-rtp.nackCount is supported in version 80.

Tried to do same in FF but while web test works locally does not work on browserstack. But testing on FF123 on my computer shows that it does work. So in this case I have just removed "version_removed" for FF. It might not be accurate, but it is more likely to be accurate than the current data. Also did search on the topic in bugzilla and only found a version added PR, not one for removal.

Safari doesnt allow the test to run on browserstack either. However it does work on  i15 pro max, so definitively does work. Can we at least mark this as >=17 on Safari or "true"?