### PR TITLE
Add missing css.properties.contain-intrinsic-size.none feature

### DIFF
--- a/css/properties/contain-intrinsic-size.json
+++ b/css/properties/contain-intrinsic-size.json
@@ -66,6 +66,38 @@
               "deprecated": false
             }
           }
+        },
+        "none": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "98"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "107"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This PR adds the missing `none` member of the `contain-intrinsic-size` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.9.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/contain-intrinsic-size/none