### PR TITLE
Ensure retired/current browser releases have release date

### DIFF
--- a/test/linter/test-browsers-data.test.ts
+++ b/test/linter/test-browsers-data.test.ts
@@ -24,9 +24,11 @@ describe('test-browsers-data', () => {
       accepts_webextensions: false,
       releases: {
         '20.6.0': {
+          release_date: '2023-09-04',
           status: 'current',
         },
         '21.2.0': {
+          release_date: '2023-11-14',
           status: 'current',
         },
       },

--- a/test/linter/test-browsers-data.test.ts
+++ b/test/linter/test-browsers-data.test.ts
@@ -97,4 +97,30 @@ describe('test-browsers-data', () => {
     test.check(logger, { data, path: { browser } });
     assert.equal(logger.messages.length, 1);
   });
+
+  it('should log an error if a retired or current release has no release date', () => {
+    const browser = 'opera';
+    const data: BrowserStatement = {
+      name: 'Opera',
+      type: 'desktop',
+      upstream: 'chrome',
+      pref_url: 'opera://flags',
+      accepts_flags: true,
+      accepts_webextensions: true,
+      releases: {
+        '97': {
+          status: 'retired',
+          engine: 'Blink',
+          engine_version: '111',
+        },
+        '98': {
+          status: 'current',
+          engine: 'Blink',
+          engine_version: '112',
+        },
+      },
+    };
+    test.check(logger, { data, path: { browser } });
+    assert.equal(logger.messages.length, 2);
+  });
 });

--- a/test/linter/test-browsers-data.ts
+++ b/test/linter/test-browsers-data.ts
@@ -49,6 +49,24 @@ const processData = (
       );
     }
   }
+
+  // Ensure every retired/current release has a release date.
+  for (const status of ['retired', 'current']) {
+    const releasesWithoutDate = Object.entries(data.releases)
+      .filter(
+        ([, data]) =>
+          data.status == status && typeof data.release_date === 'undefined',
+      )
+      .map(([version]) => version);
+
+    if (releasesWithoutDate.length > 0) {
+      logger.error(
+        chalk`{red {bold ${browser}} has {bold ${status}} releases without release date (${releasesWithoutDate.join(
+          ', ',
+        )}), which is {bold not} allowed.}`,
+      );
+    }
+  }
 };
 
 export default {

--- a/test/linter/test-browsers-data.ts
+++ b/test/linter/test-browsers-data.ts
@@ -52,6 +52,10 @@ const processData = (
 
   // Ensure every retired/current release has a release date.
   for (const status of ['retired', 'current']) {
+    if (browser === 'oculus') {
+      // Ignore Oculus Browser, because release dates for versions 5.0 to 15.1 are not publicly documented.
+      continue;
+    }
     const releasesWithoutDate = Object.entries(data.releases)
       .filter(
         ([, data]) =>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Ensure every retired/current browser release has a release date.

#### Test results and supporting details

Ran `npm run unittest`.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/22278.

Avoids the issues that https://github.com/mdn/browser-compat-data/pull/22275 and https://github.com/mdn/browser-compat-data/pull/22341 fixed.