### PR TITLE
Add missing features for mask-composite CSS property

### DIFF
--- a/css/properties/mask-composite.json
+++ b/css/properties/mask-composite.json
@@ -11,10 +11,16 @@
               "notes": "See also <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-composite'><code>-webkit-mask-composite</code></a> for a similar non-standard property that uses different keywords."
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "18",
-              "version_removed": "79"
-            },
+            "edge": [
+              {
+                "version_added": "120",
+                "notes": "See also <a href='https://developer.mozilla.org/docs/Web/CSS/-webkit-mask-composite'><code>-webkit-mask-composite</code></a> for a similar non-standard property that uses different keywords."
+              },
+              {
+                "version_added": "18",
+                "version_removed": "79"
+              }
+            ],
             "firefox": [
               {
                 "version_added": "53"
@@ -43,6 +49,134 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "add": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "120"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "exclude": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "120"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "intersect": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "120"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "subtract": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "120"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "53"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }


### PR DESCRIPTION
This PR adds the missing features of the `mask-composite` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.9.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/mask-composite