### PR TITLE
Add missing css.properties.font-feature-settings.normal feature

### DIFF
--- a/css/properties/font-feature-settings.json
+++ b/css/properties/font-feature-settings.json
@@ -15,9 +15,7 @@
                 "version_added": "16"
               }
             ],
-            "chrome_android": {
-              "version_added": "48"
-            },
+            "chrome_android": "mirror",
             "edge": {
               "version_added": "15"
             },
@@ -38,15 +36,7 @@
             },
             "oculus": "mirror",
             "opera": "mirror",
-            "opera_android": [
-              {
-                "version_added": "35"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "14"
-              }
-            ],
+            "opera_android": "mirror",
             "safari": {
               "version_added": "9.1"
             },
@@ -60,6 +50,38 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "normal": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "16"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "15"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "9.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }


### PR DESCRIPTION
This PR adds the missing `normal` member of the `font-feature-settings` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.9.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/font-feature-settings/normal