### PR TITLE
Add missing css.properties.max-height.none feature

### DIFF
--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -245,6 +245,38 @@
             }
           }
         },
+        "none": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "18"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "1.3"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "stretch": {
           "__compat": {
             "description": "<code>stretch</code>",


### PR DESCRIPTION
This PR adds the missing `none` member of the `max-height` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.9.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/max-height/none