### PR TITLE
Add missing css.properties.word-spacing.normal feature

### DIFF
--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -45,16 +45,20 @@
                 "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+              "version_added": "12"
+            },
               "firefox": {
                 "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "6"
               },
               "oculus": "mirror",
-              "opera": "mirror",
+              "opera": {
+              "version_added": "3.5"
+            },
               "opera_android": "mirror",
               "safari": {
                 "version_added": "1"

--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -46,8 +46,8 @@
               },
               "chrome_android": "mirror",
               "edge": {
-              "version_added": "12"
-            },
+                "version_added": "12"
+              },
               "firefox": {
                 "version_added": "1"
               },
@@ -57,8 +57,8 @@
               },
               "oculus": "mirror",
               "opera": {
-              "version_added": "3.5"
-            },
+                "version_added": "3.5"
+              },
               "opera_android": "mirror",
               "safari": {
                 "version_added": "1"

--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -38,6 +38,38 @@
             "deprecated": false
           }
         },
+        "normal": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "percentages": {
           "__compat": {
             "description": "<code>&lt;percentage&gt;</code> values",


### PR DESCRIPTION
This PR adds the missing `normal` member of the `word-spacing` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.9.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/word-spacing/normal