### PR TITLE
RTCStatsReport.type_media-source for video

### DIFF
--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -4576,6 +4576,111 @@
             }
           }
         },
+        "frames": {
+          "__compat": {
+            "description": "<code>frames</code> in 'media-source' stats",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCVideoSourceStats/frames",
+            "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcvideosourcestats-frames",
+            "support": {
+              "chrome": {
+                "version_added": "90"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "116"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "framesPerSecond": {
+          "__compat": {
+            "description": "<code>framesPerSecond</code> in 'media-source' stats",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCVideoSourceStats/framesPerSecond",
+            "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcvideosourcestats-framespersecond",
+            "support": {
+              "chrome": {
+                "version_added": "80"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "116"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "height": {
+          "__compat": {
+            "description": "<code>height</code> in 'media-source' stats",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCVideoSourceStats/height",
+            "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcvideosourcestats-height",
+            "support": {
+              "chrome": {
+                "version_added": "80"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "116"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "id": {
           "__compat": {
             "description": "<code>id</code> in 'media-source' stats",
@@ -4804,6 +4909,41 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "14.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "width": {
+          "__compat": {
+            "description": "<code>width</code> in 'media-source' stats",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCVideoSourceStats/width",
+            "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcvideosourcestats-width",
+            "support": {
+              "chrome": {
+                "version_added": "80"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "116"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -4578,7 +4578,7 @@
         },
         "frames": {
           "__compat": {
-            "description": "<code>frames</code> in 'media-source' stats",
+            "description": "<code>frames</code> in 'media-source' stats for video",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCVideoSourceStats/frames",
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcvideosourcestats-frames",
             "support": {
@@ -4613,7 +4613,7 @@
         },
         "framesPerSecond": {
           "__compat": {
-            "description": "<code>framesPerSecond</code> in 'media-source' stats",
+            "description": "<code>framesPerSecond</code> in 'media-source' stats for video",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCVideoSourceStats/framesPerSecond",
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcvideosourcestats-framespersecond",
             "support": {
@@ -4648,7 +4648,7 @@
         },
         "height": {
           "__compat": {
-            "description": "<code>height</code> in 'media-source' stats",
+            "description": "<code>height</code> in 'media-source' stats for video",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCVideoSourceStats/height",
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcvideosourcestats-height",
             "support": {
@@ -4923,7 +4923,7 @@
         },
         "width": {
           "__compat": {
-            "description": "<code>width</code> in 'media-source' stats",
+            "description": "<code>width</code> in 'media-source' stats for video",
             "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCVideoSourceStats/width",
             "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtcvideosourcestats-width",
             "support": {


### PR DESCRIPTION
This adds subfeatures for the fields defined in the spec [RTCVideoSourceStatus](https://w3c.github.io/webrtc-stats/#dom-rtcvideosourcestats): frames, framesPerSecond, Width, Height.

1. Used browserstack and https://wpt.live/webrtc-stats/supported-stats.https.html tests to bisect for support on Chrome.
2. FF116 added these in https://bugzilla.mozilla.org/show_bug.cgi?id=1836879
3. No idea for Safari - doesn't run in Browserstack.
