### PR TITLE
Add missing css.properties.z-index.auto feature

### DIFF
--- a/css/properties/z-index.json
+++ b/css/properties/z-index.json
@@ -47,7 +47,9 @@
                 "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
                 "version_added": "1"
               },

--- a/css/properties/z-index.json
+++ b/css/properties/z-index.json
@@ -53,7 +53,7 @@
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "4"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/css/properties/z-index.json
+++ b/css/properties/z-index.json
@@ -30,9 +30,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -102,9 +100,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/z-index.json
+++ b/css/properties/z-index.json
@@ -40,6 +40,38 @@
             "deprecated": false
           }
         },
+        "auto": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "negative_values": {
           "__compat": {
             "description": "Negative values",


### PR DESCRIPTION
This PR adds the missing `auto` member of the `z-index` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.9.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/z-index/auto