### PR TITLE
Update Edge data for disabled CSS selector

### DIFF
--- a/css/selectors/disabled.json
+++ b/css/selectors/disabled.json
@@ -16,7 +16,7 @@
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12",
-              "notes": "Edge does not recognize <code>:disabled</code> on the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/fieldset'><code>&lt;fieldset&gt;</code></a> element."
+              "notes": "Before Edge 79, Edge did not recognize <code>:disabled</code> on the <a href='https://developer.mozilla.org/docs/Web/HTML/Element/fieldset'><code>&lt;fieldset&gt;</code></a> element."
             },
             "firefox": {
               "version_added": "1"


### PR DESCRIPTION
This PR updates and corrects version values for Microsoft Edge for the `disabled` CSS selector. This fixes #22324, which contains the supporting evidence for this change.