### PR TITLE
Remove css.properties.hyphens.language_portuguese_brazilian from BCD

### DIFF
--- a/css/properties/hyphens.json
+++ b/css/properties/hyphens.json
@@ -1782,40 +1782,6 @@
             }
           }
         },
-        "language_portuguese_brazilian": {
-          "__compat": {
-            "description": "Hyphenation dictionary for Brazilian Portuguese (pt-BR)",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "8",
-                "notes": "For Brazilian Portuguese, Firefox uses a Portuguese dictionary."
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "language_punjabi": {
           "__compat": {
             "description": "Hyphenation dictionary for Punjabi/Panjabi (pa, pa-*)",


### PR DESCRIPTION
This PR removes the `language_portuguese_brazilian` member of the `hyphens` CSS property from BCD. The only browser with support marked is Firefox, but the note says that it just uses the regular Portuguese dictionary, so it's basically not supported.

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/hyphens/language_portuguese_brazilian

Additional Notes: Fixes #22281.