### PR TITLE
Update Safari data for api.Window.devicePixelRatio

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -1184,11 +1184,11 @@
               "version_added": "11.1"
             },
             "safari": {
-              "version_added": "3"
+              "version_added": "3",
+              "partial_implementation": true,
+              "notes": "In Safari, the <code>devicePixelRatio</code> does not change when the page is zoomed. See <a href='https://webkit.org/b/124862'>bug 124862</a>."
             },
-            "safari_ios": {
-              "version_added": "1"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
This PR updates and corrects version values for Safari (Desktop and iOS/iPadOS) for the `devicePixelRatio` member of the `Window` API. This fixes #22277, which contains the supporting evidence for this change.