### PR TITLE
Update Opera data for api.Element.beforematch_event

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2902,9 +2902,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `beforematch_event` member of the `Element` API. This fixes #22253, which contains the supporting evidence for this change.