### PR TITLE
Update Opera data for FileSystemFileEntry API

### DIFF
--- a/api/FileSystemFileEntry.json
+++ b/api/FileSystemFileEntry.json
@@ -18,9 +18,7 @@
             "version_added": false
           },
           "oculus": "mirror",
-          "opera": {
-            "version_added": false
-          },
+          "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
             "version_added": "11.1"
@@ -56,9 +54,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false
@@ -94,9 +90,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": "11.1"


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `FileSystemFileEntry` API. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.9.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/api/FileSystemFileEntry