### PR TITLE
Update Opera data for FileSystemFileEntry API

### DIFF
--- a/api/FileSystemFileEntry.json
+++ b/api/FileSystemFileEntry.json
@@ -18,9 +18,7 @@
             "version_added": false
           },
           "oculus": "mirror",
-          "opera": {
-            "version_added": false
-          },
+          "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
             "version_added": "11.1"
@@ -56,9 +54,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": false
@@ -94,9 +90,7 @@
               "version_added": false
             },
             "oculus": "mirror",
-            "opera": {
-              "version_added": false
-            },
+            "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
               "version_added": "11.1"


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `FileSystemFileEntry` API. This fixes #22237, which contains the supporting evidence for this change.