### PR TITLE
Update Firefox data for border-color CSS property

### DIFF
--- a/css/properties/border-bottom-color.json
+++ b/css/properties/border-bottom-color.json
@@ -14,8 +14,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1",
-              "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-bottom-colors'><code>-moz-border-bottom-colors</code></a> CSS property that sets the bottom border to multiple colors."
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/border-color.json
+++ b/css/properties/border-color.json
@@ -17,8 +17,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1",
-              "notes": "Firefox also supports the following non-standard CSS properties to set the border sides to multiple colors: <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-top-colors'><code>-moz-border-top-colors</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-right-colors'><code>-moz-border-right-colors</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-bottom-colors'><code>-moz-border-bottom-colors</code></a>, <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-left-colors'><code>-moz-border-left-colors</code></a>"
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/border-left-color.json
+++ b/css/properties/border-left-color.json
@@ -14,8 +14,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1",
-              "notes": "Firefox also supports the non-standard <code>-moz-border-left-colors</code> CSS property that sets the bottom border to multiple colors."
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/border-right-color.json
+++ b/css/properties/border-right-color.json
@@ -14,8 +14,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1",
-              "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-right-colors'><code>-moz-border-right-colors</code></a> CSS property that sets the right border to multiple colors."
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {

--- a/css/properties/border-top-color.json
+++ b/css/properties/border-top-color.json
@@ -14,8 +14,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1",
-              "notes": "Firefox also supports the non-standard <a href='https://developer.mozilla.org/docs/Web/CSS/-moz-border-top-colors'><code>-moz-border-top-colors</code></a> CSS property that sets the top border to multiple colors."
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `border-color` CSS property. This fixes #22202, which contains the supporting evidence for this change.