### PR TITLE
Safari 17.4 adds support for web app shortcuts. 

### DIFF
--- a/html/manifest/shortcuts.json
+++ b/html/manifest/shortcuts.json
@@ -42,7 +42,7 @@
             "webview_android": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/html/manifest/shortcuts.json
+++ b/html/manifest/shortcuts.json
@@ -33,10 +33,9 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
-              "impl_url": "https://webkit.org/b/201964"
+              "version_added": "17.4"
             },
-            "safari_ios": "mirror",
+            "safari_ios": false,
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },

--- a/html/manifest/shortcuts.json
+++ b/html/manifest/shortcuts.json
@@ -35,7 +35,9 @@
             "safari": {
               "version_added": "17.4"
             },
-            "safari_ios": false,
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
Safari 17.4 adds support for web app shortcuts. 
https://developer.apple.com/documentation/safari-release-notes/safari-17_4-release-notes