### PR TITLE
Update all browsers data for border-style CSS property

### DIFF
--- a/css/properties/border-style.json
+++ b/css/properties/border-style.json
@@ -29,13 +29,9 @@
             "safari": {
               "version_added": "1"
             },
-            "safari_ios": {
-              "version_added": "3"
-            },
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "3"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -45,24 +41,27 @@
         },
         "dashed": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds/#valdef-line-style-dashed",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -77,24 +76,27 @@
         },
         "dotted": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds/#valdef-line-style-dotted",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -109,24 +111,27 @@
         },
         "double": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds/#valdef-line-style-double",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -141,24 +146,27 @@
         },
         "groove": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds/#valdef-line-style-groove",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -173,24 +181,27 @@
         },
         "hidden": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds/#valdef-line-style-hidden",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -205,24 +216,27 @@
         },
         "inset": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds/#valdef-line-style-inset",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -237,24 +251,27 @@
         },
         "none": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds/#valdef-line-style-none",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -269,24 +286,27 @@
         },
         "outset": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds/#valdef-line-style-outset",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -301,24 +321,27 @@
         },
         "ridge": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds/#valdef-line-style-ridge",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -333,24 +356,27 @@
         },
         "solid": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds/#valdef-line-style-solid",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `border-style` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.9.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/border-style

Additional Notes: This is a follow-up to #21617.