### PR TITLE
Update all browsers data for outline-style CSS property

### DIFF
--- a/css/properties/outline-style.json
+++ b/css/properties/outline-style.json
@@ -52,19 +52,21 @@
         },
         "auto": {
           "__compat": {
-            "description": "<code>auto</code>",
+            "spec_url": "https://drafts.csswg.org/css-ui/#outline-style",
             "support": {
               "chrome": {
                 "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
                 "version_added": "1.5"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -87,24 +89,27 @@
         },
         "dashed": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-dashed",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -119,24 +124,27 @@
         },
         "dotted": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-dotted",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -151,24 +159,27 @@
         },
         "double": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-double",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -183,24 +194,27 @@
         },
         "groove": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-groove",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -215,24 +229,27 @@
         },
         "inset": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-inset",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -247,24 +264,27 @@
         },
         "none": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-none",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -279,24 +299,27 @@
         },
         "outset": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-outset",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -311,24 +334,27 @@
         },
         "ridge": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-ridge",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -343,24 +369,27 @@
         },
         "solid": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds-3/#valdef-line-style-solid",
             "support": {
               "chrome": {
-                "version_added": "≤80"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
-              "edge": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
               "firefox": {
-                "version_added": "≤72"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
-                "version_added": false
+                "version_added": "≤11"
               },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤13.1"
+                "version_added": "1.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `outline-style` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.9.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/outline-style

Additional Notes: This is a follow-up to https://github.com/mdn/browser-compat-data/pull/21616.