### PR TITLE
Remove css.properties.text-justify.distribute from BCD

### DIFF
--- a/css/properties/text-justify.json
+++ b/css/properties/text-justify.json
@@ -93,49 +93,24 @@
             }
           }
         },
-        "distribute": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "55"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
         "inter-character": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text/#valdef-text-justify-inter-character",
             "support": {
               "chrome": {
                 "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "55"
-              },
+              "firefox": [
+                {
+                  "version_added": "55"
+                },
+                {
+                  "alternative_name": "distribute",
+                  "version_added": "55"
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false


### PR DESCRIPTION
This PR removes the `distribute` member of the `text-justify` CSS property from BCD. The spec (https://drafts.csswg.org/css-text/#valdef-text-justify-distribute) defines this keyword as a legacy value alias of `inter-character`.