### PR TITLE
Remove css.properties.text-orientation.sideways-right from BCD

### DIFF
--- a/css/properties/text-orientation.json
+++ b/css/properties/text-orientation.json
@@ -88,17 +88,28 @@
         },
         "sideways": {
           "__compat": {
-            "description": "<code>sideways</code>",
+            "spec_url": "https://drafts.csswg.org/css-writing-modes/#valdef-text-orientation-sideways",
             "support": {
-              "chrome": {
-                "version_added": "25"
-              },
+              "chrome": [
+                {
+                  "version_added": "25"
+                },
+                {
+                  "alternative_name": "sideways-right",
+                  "version_added": "≤83"
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "44",
-                "notes": "<code>sideways-right</code> has become an alias of <code>sideways</code>."
-              },
+              "firefox": [
+                {
+                  "version_added": "44"
+                },
+                {
+                  "alternative_name": "sideways-right",
+                  "version_added": "≤72"
+                }
+              ],
               "firefox_android": "mirror",
               "ie": {
                 "version_added": false
@@ -108,38 +119,6 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "7"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "sideways-right": {
-          "__compat": {
-            "support": {
-              "chrome": {
-                "version_added": "≤83"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "≤72"
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": false
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
This PR removes the `sideways-right` member of the `text-orientation` CSS property from BCD. The spec (https://drafts.csswg.org/css-writing-modes/#valdef-text-orientation-sideways-right) defines this feature as an alias of `sideways`.