### PR TITLE
Set occurrences of WebView ≤37 to mirror in CSS properties category

### DIFF
--- a/css/properties/-webkit-line-clamp.json
+++ b/css/properties/-webkit-line-clamp.json
@@ -31,9 +31,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/-webkit-tap-highlight-color.json
+++ b/css/properties/-webkit-tap-highlight-color.json
@@ -29,9 +29,7 @@
               "version_added": "4"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/-webkit-text-security.json
+++ b/css/properties/-webkit-text-security.json
@@ -27,9 +27,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -55,15 +55,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "4.4"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/animation-delay.json
+++ b/css/properties/animation-delay.json
@@ -103,15 +103,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/animation-direction.json
+++ b/css/properties/animation-direction.json
@@ -90,15 +90,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/animation-fill-mode.json
+++ b/css/properties/animation-fill-mode.json
@@ -98,15 +98,7 @@
               }
             ],
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/animation-iteration-count.json
+++ b/css/properties/animation-iteration-count.json
@@ -90,15 +90,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/animation-name.json
+++ b/css/properties/animation-name.json
@@ -90,15 +90,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/animation-play-state.json
+++ b/css/properties/animation-play-state.json
@@ -98,15 +98,7 @@
               }
             ],
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/animation-timing-function.json
+++ b/css/properties/animation-timing-function.json
@@ -90,15 +90,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "43"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/background-attachment.json
+++ b/css/properties/background-attachment.json
@@ -34,9 +34,7 @@
               "version_added": "3.2"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -203,9 +201,7 @@
                 "version_added": "3.2"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -175,9 +175,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "4"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -98,16 +98,7 @@
               }
             ],
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "4"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37",
-                "notes": "WebView accepts alternate synonyms to its values: <code>padding</code>, <code>border</code>, and <code>content</code>."
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/background-color.json
+++ b/css/properties/background-color.json
@@ -31,9 +31,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -31,9 +31,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -114,10 +112,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37",
-                "notes": "Some versions support only experimental gradients prefixed with <code>-webkit</code>."
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -246,9 +241,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -323,9 +316,7 @@
                 "notes": "Support of SVG in CSS background is incomplete."
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/background-position-x.json
+++ b/css/properties/background-position-x.json
@@ -28,9 +28,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/background-position-y.json
+++ b/css/properties/background-position-y.json
@@ -28,9 +28,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/background-position.json
+++ b/css/properties/background-position.json
@@ -30,9 +30,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -164,9 +162,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -333,9 +333,7 @@
                 "version_added": "4"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/background.json
+++ b/css/properties/background.json
@@ -74,9 +74,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/border-bottom-left-radius.json
+++ b/css/properties/border-bottom-left-radius.json
@@ -82,15 +82,7 @@
               }
             ],
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "≤37"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -128,9 +120,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -175,9 +165,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/border-bottom-right-radius.json
+++ b/css/properties/border-bottom-right-radius.json
@@ -82,15 +82,7 @@
               }
             ],
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "≤37"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -128,9 +120,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -175,9 +165,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/border-bottom-style.json
+++ b/css/properties/border-bottom-style.json
@@ -31,9 +31,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/border-image-repeat.json
+++ b/css/properties/border-image-repeat.json
@@ -104,9 +104,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/border-image.json
+++ b/css/properties/border-image.json
@@ -137,9 +137,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -177,9 +175,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -217,9 +213,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/border-radius.json
+++ b/css/properties/border-radius.json
@@ -87,7 +87,7 @@
             "samsunginternet_android": "mirror",
             "webview_android": [
               {
-                "version_added": "≤37"
+                "version_added": "≤4.4"
               },
               {
                 "prefix": "-webkit-",
@@ -137,9 +137,7 @@
                 "version_added": "4.2"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -182,9 +180,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -223,9 +219,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/border-right-style.json
+++ b/css/properties/border-right-style.json
@@ -34,9 +34,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/border-right.json
+++ b/css/properties/border-right.json
@@ -32,9 +32,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/border-spacing.json
+++ b/css/properties/border-spacing.json
@@ -30,9 +30,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/border-top-left-radius.json
+++ b/css/properties/border-top-left-radius.json
@@ -82,15 +82,7 @@
               }
             ],
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "≤37"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -128,9 +120,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -175,9 +165,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/border-top-right-radius.json
+++ b/css/properties/border-top-right-radius.json
@@ -82,15 +82,7 @@
               }
             ],
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "≤37"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -128,9 +120,7 @@
                 "version_added": "1"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -175,9 +165,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/border-top-style.json
+++ b/css/properties/border-top-style.json
@@ -31,9 +31,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/border.json
+++ b/css/properties/border.json
@@ -30,9 +30,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/bottom.json
+++ b/css/properties/bottom.json
@@ -31,9 +31,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/box-align.json
+++ b/css/properties/box-align.json
@@ -47,10 +47,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -11,11 +11,7 @@
               "version_added": "22",
               "notes": "This property is only supported for inline elements."
             },
-            "chrome_android": {
-              "prefix": "-webkit-",
-              "version_added": "18",
-              "notes": "This property is only supported for inline elements."
-            },
+            "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": [
               {
@@ -59,11 +55,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "≤37",
-              "notes": "This property is only supported for inline elements."
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/box-direction.json
+++ b/css/properties/box-direction.json
@@ -47,10 +47,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/box-flex-group.json
+++ b/css/properties/box-flex-group.json
@@ -38,11 +38,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "≤37",
-              "version_removed": "67"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/box-flex.json
+++ b/css/properties/box-flex.json
@@ -47,10 +47,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/box-lines.json
+++ b/css/properties/box-lines.json
@@ -38,11 +38,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "≤37",
-              "version_removed": "67"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/box-ordinal-group.json
+++ b/css/properties/box-ordinal-group.json
@@ -47,10 +47,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/box-orient.json
+++ b/css/properties/box-orient.json
@@ -47,10 +47,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/box-pack.json
+++ b/css/properties/box-pack.json
@@ -47,10 +47,7 @@
               "version_added": "1"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "prefix": "-webkit-",
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/box-shadow.json
+++ b/css/properties/box-shadow.json
@@ -70,16 +70,7 @@
               }
             ],
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "≤37",
-                "notes": "Shadows affect layout in this browser. For example, if you cast an outer shadow to a box with a <code>width</code> of <code>100%</code>, then you'll see a scrollbar."
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -139,15 +130,7 @@
               ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": [
-                {
-                  "version_added": "≤37"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "≤37"
-                }
-              ]
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -212,15 +195,7 @@
                 }
               ],
               "samsunginternet_android": "mirror",
-              "webview_android": [
-                {
-                  "version_added": "≤37"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "≤37"
-                }
-              ]
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -277,15 +252,7 @@
               ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": [
-                {
-                  "version_added": "≤37"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "≤37"
-                }
-              ]
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/caption-side.json
+++ b/css/properties/caption-side.json
@@ -33,9 +33,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -87,15 +87,7 @@
               }
             ],
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "50"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/column-gap.json
+++ b/css/properties/column-gap.json
@@ -257,15 +257,7 @@
                 }
               ],
               "samsunginternet_android": "mirror",
-              "webview_android": [
-                {
-                  "version_added": "50"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "≤37"
-                }
-              ]
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/column-rule-color.json
+++ b/css/properties/column-rule-color.json
@@ -85,15 +85,7 @@
               }
             ],
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "50"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/column-rule-style.json
+++ b/css/properties/column-rule-style.json
@@ -85,15 +85,7 @@
               }
             ],
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "50"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/column-rule-width.json
+++ b/css/properties/column-rule-width.json
@@ -85,15 +85,7 @@
               }
             ],
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "50"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/column-rule.json
+++ b/css/properties/column-rule.json
@@ -86,15 +86,7 @@
               }
             ],
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "50"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/column-span.json
+++ b/css/properties/column-span.json
@@ -62,15 +62,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "50"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/column-width.json
+++ b/css/properties/column-width.json
@@ -90,15 +90,7 @@
               }
             ],
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "50"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -32,9 +32,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -223,15 +221,7 @@
               ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": [
-                {
-                  "version_added": "4.4"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "≤37"
-                }
-              ]
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -355,9 +345,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -413,15 +401,7 @@
               ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": [
-                {
-                  "version_added": "4.4"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "≤37"
-                }
-              ]
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -506,9 +486,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -614,9 +592,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -758,10 +734,7 @@
                 "version_added": "1.0",
                 "notes": "Chrome 65 stopped creating layout objects for elements inside an <code>&lt;iframe&gt;</code> with <code>display:none</code> applied."
               },
-              "webview_android": {
-                "version_added": "≤37",
-                "notes": "WebView 65 stopped creating layout objects for elements inside an <code>&lt;iframe&gt;</code> with <code>display:none</code> applied."
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -972,9 +945,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -1010,9 +981,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -1048,9 +1017,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -1086,9 +1053,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -1124,9 +1089,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -1162,9 +1125,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -1200,9 +1161,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -1238,9 +1197,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -73,15 +73,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "4.4"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/flex-direction.json
+++ b/css/properties/flex-direction.json
@@ -85,15 +85,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "4.4"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/flex-flow.json
+++ b/css/properties/flex-flow.json
@@ -65,15 +65,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "4.4"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/flex-grow.json
+++ b/css/properties/flex-grow.json
@@ -72,15 +72,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "4.4"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/flex-shrink.json
+++ b/css/properties/flex-shrink.json
@@ -76,15 +76,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "4.4"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/flex-wrap.json
+++ b/css/properties/flex-wrap.json
@@ -47,15 +47,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "4.4"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -91,15 +91,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "4.4"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/font-size.json
+++ b/css/properties/font-size.json
@@ -32,9 +32,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/font-size.json
+++ b/css/properties/font-size.json
@@ -64,9 +64,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "4"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -113,9 +111,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "4"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/font-smooth.json
+++ b/css/properties/font-smooth.json
@@ -31,10 +31,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "alternative_name": "-webkit-font-smoothing",
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/font.json
+++ b/css/properties/font.json
@@ -30,9 +30,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/image-rendering.json
+++ b/css/properties/image-rendering.json
@@ -104,10 +104,7 @@
               ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "alternative_name": "-webkit-optimize-contrast",
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/letter-spacing.json
+++ b/css/properties/letter-spacing.json
@@ -32,9 +32,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -104,9 +102,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/line-break.json
+++ b/css/properties/line-break.json
@@ -59,15 +59,7 @@
               }
             ],
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "58"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/list-style-position.json
+++ b/css/properties/list-style-position.json
@@ -31,9 +31,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -35,7 +35,9 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror"
+            "webview_android": {
+              "version_added": "≤4.4"
+            }
           },
           "status": {
             "experimental": false,

--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -35,9 +35,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -96,9 +96,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -133,9 +131,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -37,9 +37,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -97,15 +97,7 @@
               ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": [
-                {
-                  "version_added": "46"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "≤37"
-                }
-              ]
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -72,9 +72,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -136,15 +134,7 @@
               ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": [
-                {
-                  "version_added": "46"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "≤37"
-                }
-              ]
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -83,10 +83,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "37",
-                "notes": "Chrome uses <code>auto</code> as the initial value for <code>min-width</code>."
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -143,15 +140,7 @@
                 "alternative_name": "-webkit-fill-available",
                 "version_added": "5.0"
               },
-              "webview_android": [
-                {
-                  "version_added": "46"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "≤37"
-                }
-              ]
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -243,15 +232,7 @@
               ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": [
-                {
-                  "version_added": "46"
-                },
-                {
-                  "prefix": "-webkit-",
-                  "version_added": "≤37"
-                }
-              ]
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/order.json
+++ b/css/properties/order.json
@@ -66,15 +66,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "4.4"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/outline-style.json
+++ b/css/properties/outline-style.json
@@ -74,9 +74,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/overflow-wrap.json
+++ b/css/properties/overflow-wrap.json
@@ -148,9 +148,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/padding-bottom.json
+++ b/css/properties/padding-bottom.json
@@ -30,9 +30,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/padding-left.json
+++ b/css/properties/padding-left.json
@@ -30,9 +30,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/padding-right.json
+++ b/css/properties/padding-right.json
@@ -30,9 +30,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/padding-top.json
+++ b/css/properties/padding-top.json
@@ -30,9 +30,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/padding.json
+++ b/css/properties/padding.json
@@ -30,9 +30,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -34,9 +34,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -141,9 +139,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/text-align.json
+++ b/css/properties/text-align.json
@@ -35,9 +35,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/text-combine-upright.json
+++ b/css/properties/text-combine-upright.json
@@ -53,17 +53,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "48"
-              },
-              {
-                "alternative_name": "-webkit-text-combine",
-                "version_added": "≤37",
-                "partial_implementation": true,
-                "notes": "This property was initially named <code>-webkit-text-combine</code> according to a <a href='https://www.w3.org/TR/2011/WD-css3-writing-modes-20110531/#text-combine'>2011 version of the CSS3 Writing Modes specification</a>, supporting the values <code>none</code> and <code>horizontal</code> without <code>digits</code>."
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -32,9 +32,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/text-indent.json
+++ b/css/properties/text-indent.json
@@ -33,9 +33,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/text-orientation.json
+++ b/css/properties/text-orientation.json
@@ -38,15 +38,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "48"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/text-overflow.json
+++ b/css/properties/text-overflow.json
@@ -53,9 +53,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/text-rendering.json
+++ b/css/properties/text-rendering.json
@@ -84,10 +84,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37",
-                "notes": "WebView treats <code>auto</code> as <code>optimizeSpeed</code>."
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -125,10 +122,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "37",
-                "notes": "Supports true geometric precision without rounding up or down to the nearest supported font size in the operating system."
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/top.json
+++ b/css/properties/top.json
@@ -31,9 +31,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/transform-origin.json
+++ b/css/properties/transform-origin.json
@@ -97,15 +97,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "4.4"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -306,9 +298,7 @@
                 "version_added": "3.2"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/transition-property.json
+++ b/css/properties/transition-property.json
@@ -89,15 +89,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "4.4"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -133,9 +125,7 @@
                 "version_added": "3"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/transition-timing-function.json
+++ b/css/properties/transition-timing-function.json
@@ -89,15 +89,7 @@
             ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "4.4"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,

--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -67,15 +67,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": [
-              {
-                "version_added": "54"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "≤37"
-              }
-            ]
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -142,9 +134,7 @@
                 "version_added": "3"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -224,9 +214,7 @@
                 "version_added": "3"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,
@@ -262,9 +250,7 @@
                 "version_added": "3"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/visibility.json
+++ b/css/properties/visibility.json
@@ -95,13 +95,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37",
-                "notes": [
-                  "WebView treats <code>visibility: collapse</code> like <code>hidden</code>, leaving a white gap.",
-                  "WebView supports the <code>collapse</code> value only on <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tr'><code>&lt;tr&gt;</code></a>, <a href='https://developer.mozilla.org/docs/Web/HTML/Element/thead' ><code>&lt;thead&gt;</code></a>, <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tbody'><code>&lt;tbody&gt;</code></a>, and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/tfoot'><code>&lt;tfoot&gt;</code></a>, but not on <a href='https://developer.mozilla.org/docs/Web/HTML/Element/col'><code>&lt;col&gt;</code></a> and <a href='https://developer.mozilla.org/docs/Web/HTML/Element/colgroup'><code>&lt;colgroup&gt;</code></a> elements."
-                ]
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -36,9 +36,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -136,9 +134,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -135,9 +135,7 @@
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,

--- a/css/properties/zoom.json
+++ b/css/properties/zoom.json
@@ -37,9 +37,7 @@
               "version_added": "3"
             },
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": "≤37"
-            }
+            "webview_android": "mirror"
           },
           "status": {
             "experimental": false,
@@ -75,10 +73,7 @@
                 "version_added": "3"
               },
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": "≤37",
-                "version_removed": "59"
-              }
+              "webview_android": "mirror"
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
This PR sets occurrences of WebView "≤37" to mirror.  Almost all of these statements were created by the mirroring script before it became a build-time mirroring system.
