### PR TITLE
Update Firefox ≤15 + ≤16 with version numbers

### DIFF
--- a/css/properties/animation-direction.json
+++ b/css/properties/animation-direction.json
@@ -117,7 +117,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤16"
+                "version_added": "5"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -190,7 +190,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤16"
+                "version_added": "5"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/animation-fill-mode.json
+++ b/css/properties/animation-fill-mode.json
@@ -125,7 +125,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤16"
+                "version_added": "4"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -159,7 +159,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤16"
+                "version_added": "4"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -193,7 +193,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤16"
+                "version_added": "4"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -227,7 +227,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤16"
+                "version_added": "4"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/animation-fill-mode.json
+++ b/css/properties/animation-fill-mode.json
@@ -125,7 +125,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "4"
+                "version_added": "5"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -159,7 +159,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "4"
+                "version_added": "5"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -193,7 +193,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "4"
+                "version_added": "5"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -227,7 +227,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "4"
+                "version_added": "5"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/animation-iteration-count.json
+++ b/css/properties/animation-iteration-count.json
@@ -117,7 +117,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤16"
+                "version_added": "5"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/animation-name.json
+++ b/css/properties/animation-name.json
@@ -117,7 +117,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤16"
+                "version_added": "5"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/animation-play-state.json
+++ b/css/properties/animation-play-state.json
@@ -125,7 +125,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤16"
+                "version_added": "5"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -159,7 +159,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤16"
+                "version_added": "5"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -126,7 +126,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤16"
+                "version_added": "4"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -206,7 +206,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤16"
+                "version_added": "4"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -120,9 +120,7 @@
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": {
-                "version_added": "14"
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": "9"
               },
@@ -200,9 +198,7 @@
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": {
-                "version_added": "14"
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": "9"
               },

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -128,7 +128,9 @@
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "14"
+              },
               "ie": {
                 "version_added": "9"
               },
@@ -208,7 +210,9 @@
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "14"
+              },
               "ie": {
                 "version_added": "9"
               },

--- a/css/properties/background-image.json
+++ b/css/properties/background-image.json
@@ -268,7 +268,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤16"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -120,9 +120,7 @@
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": {
-                "version_added": "14"
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": "9"
               },
@@ -200,9 +198,7 @@
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": {
-                "version_added": "14"
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": "9"
               },

--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -128,7 +128,9 @@
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "14"
+              },
               "ie": {
                 "version_added": "9"
               },
@@ -208,7 +210,9 @@
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "14"
+              },
               "ie": {
                 "version_added": "9"
               },

--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -126,7 +126,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤15"
+                "version_added": "4"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -206,7 +206,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤15"
+                "version_added": "4"
               },
               "firefox_android": "mirror",
               "ie": {

--- a/css/properties/background-repeat.json
+++ b/css/properties/background-repeat.json
@@ -90,7 +90,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -124,7 +124,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -158,7 +158,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {
@@ -192,7 +192,7 @@
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤15"
+                "version_added": "1"
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates instances where Firefox was set to ≤15 or ≤16 in recent PRs, correcting them to use the version number that the property was introduced.
