### PR TITLE
Update Firefox data for css.properties.position.absolute

### DIFF
--- a/css/properties/position.json
+++ b/css/properties/position.json
@@ -14,11 +14,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "1",
-              "notes": [
-                "Before Firefox 57, absolute positioning did not work correctly when applied to elements inside tables that have <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> applied to them (<a href='https://bugzil.la/1379306'>bug 1379306</a>).",
-                "Before Firefox 30, absolute positioning of table rows and row groups was not supported (<a href='https://bugzil.la/63895'>bug 63895</a>)."
-              ]
+              "version_added": "1"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -53,7 +49,11 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "1"
+                "version_added": "1",
+                "notes": [
+                  "Before Firefox 57, absolute positioning did not work correctly when applied to elements inside tables that have <a href='https://developer.mozilla.org/docs/Web/CSS/border-collapse'><code>border-collapse</code></a> applied to them (<a href='https://bugzil.la/1379306'>bug 1379306</a>).",
+                  "Before Firefox 30, absolute positioning of table rows and row groups was not supported (<a href='https://bugzil.la/63895'>bug 63895</a>)."
+                ]
               },
               "firefox_android": "mirror",
               "ie": {


### PR DESCRIPTION
This PR updates and corrects version values for Firefox and Firefox Android for the `absolute` member of the `position` CSS property. This moves the notes specific to absolute positioning from the parent to this specific feature.

Additional Notes: Addresses https://github.com/mdn/browser-compat-data/pull/22488#discussion_r1512509699.
