### PR TITLE
Update Firefox Android data for background-clip CSS property

### DIFF
--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -43,15 +43,7 @@
                 "notes": "Used the <code>-moz-background-clip: padding | border</code> syntax."
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "14"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "49"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "9",
               "notes": "In IE 7 and IE 8 of Internet Explorer, this property always behaved like <code>background-clip: padding</code> when <code>overflow</code> was <code>hidden</code>, <code>auto</code>, or <code>scroll</code>."
@@ -163,9 +155,7 @@
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": {
-                "version_added": "14"
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": "9",
                 "notes": "In IE 7 and IE 9 of Internet Explorer, it always behaved like <code>background-clip: padding</code> if <code>overflow: hidden | auto | scroll</code>"


### PR DESCRIPTION
This PR updates and corrects version values for Firefox Android for the `background-clip` CSS property. This data came from the wiki migration, so it's likely incorrect.
