### PR TITLE
Unbreak installing from Git

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,8 @@
     "yargs": "~17.7.0"
   },
   "scripts": {
-    "postinstall": "node --loader=ts-node/esm --no-warnings=ExperimentalWarning scripts/save-git-history.ts",
+    "postinstall": "(git rev-parse --is-inside-work-tree && npm run save-git-history) || echo 'not in Git worktree; skipping save-git-history'",
+    "save-git-history": "node --loader=ts-node/esm --no-warnings=ExperimentalWarning scripts/save-git-history.ts",
     "prepare": "(husky || true) && npm run gentypes && npm run build",
     "diff": "node --loader=ts-node/esm --no-warnings=ExperimentalWarning scripts/diff.ts",
     "unittest": "NODE_ENV=test c8 mocha index.test.ts --recursive \"{,!(node_modules)/**}/*.test.ts\"",

--- a/scripts/save-git-history.ts
+++ b/scripts/save-git-history.ts
@@ -10,6 +10,10 @@ import { getBranchName, getHashOfHEAD } from './lib/git.js';
 const HUSKY_ROOT = '.husky/_/';
 const HISTORY_FILE = HUSKY_ROOT + 'history';
 
-if ('main' === getBranchName() && fs.existsSync(HUSKY_ROOT)) {
+if (
+  'main' === getBranchName() &&
+  fs.existsSync(HUSKY_ROOT) &&
+  process.env['HUSKY'] !== '0'
+) {
   fs.writeFileSync(HISTORY_FILE, getHashOfHEAD());
 }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

`save-git-history.ts` (introduced in https://github.com/mdn/browser-compat-data/pull/22308) breaks installing BCD from Git (in a fit of irony, there won't be a `.git` if you use `npm install github:mdn/browser-compat-data` and the dev dependencies won't be installed). This PR stops the script from running if you're not in a Git repo.

While I'm here, I've stopped the script from running if you are like me and have `HUSKY=0` set.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

https://github.com/mdn/browser-compat-data/pull/22308
https://github.com/mdn/browser-compat-data/pull/21656

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
