### PR TITLE
Update Firefox Android data for background-origin CSS property

### DIFF
--- a/css/properties/background-origin.json
+++ b/css/properties/background-origin.json
@@ -43,15 +43,7 @@
                 "notes": "Used the <code>-moz-background-clip: padding | border</code> syntax."
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "14"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "49"
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "9",
               "notes": "In IE 7 and before, Internet explorer was behaving as if <code>background-origin: border-box</code> was set. In Internet Explorer 8, as if <code>background-origin: padding-box</code>, the regular default value, was set."
@@ -163,9 +155,7 @@
               "firefox": {
                 "version_added": "4"
               },
-              "firefox_android": {
-                "version_added": "14"
-              },
+              "firefox_android": "mirror",
               "ie": {
                 "version_added": "9",
                 "notes": "In IE 7 and IE 9 of Internet Explorer, it always behaved like <code>background-clip: padding</code> if <code>overflow: hidden | auto | scroll</code>."


### PR DESCRIPTION
This PR updates and corrects version values for Firefox Android for the `background-origin` CSS property. This data came from the wiki migration, so it's likely incorrect.
