### PR TITLE
Update Edge 13-18 release note URLs

### DIFF
--- a/browsers/edge.json
+++ b/browsers/edge.json
@@ -17,42 +17,42 @@
         },
         "13": {
           "release_date": "2015-11-12",
-          "release_notes": "https://learn.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-13",
+          "release_notes": "https://learn.microsoft.com/en-us/archive/microsoft-edge/legacy/developer/dev-guide/whats-new/edgehtml-13",
           "status": "retired",
           "engine": "EdgeHTML",
           "engine_version": "13"
         },
         "14": {
           "release_date": "2016-08-02",
-          "release_notes": "https://learn.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-14",
+          "release_notes": "https://learn.microsoft.com/en-us/archive/microsoft-edge/legacy/developer/dev-guide/whats-new/edgehtml-14",
           "status": "retired",
           "engine": "EdgeHTML",
           "engine_version": "14"
         },
         "15": {
           "release_date": "2017-04-05",
-          "release_notes": "https://learn.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-15",
+          "release_notes": "https://learn.microsoft.com/en-us/archive/microsoft-edge/legacy/developer/dev-guide/whats-new/edgehtml-15",
           "status": "retired",
           "engine": "EdgeHTML",
           "engine_version": "15"
         },
         "16": {
           "release_date": "2017-10-17",
-          "release_notes": "https://learn.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-16",
+          "release_notes": "https://learn.microsoft.com/en-us/archive/microsoft-edge/legacy/developer/dev-guide/whats-new/edgehtml-16",
           "status": "retired",
           "engine": "EdgeHTML",
           "engine_version": "16"
         },
         "17": {
           "release_date": "2018-04-30",
-          "release_notes": "https://learn.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new/edgehtml-17",
+          "release_notes": "https://learn.microsoft.com/en-us/archive/microsoft-edge/legacy/developer/dev-guide/whats-new/edgehtml-17",
           "status": "retired",
           "engine": "EdgeHTML",
           "engine_version": "17"
         },
         "18": {
           "release_date": "2018-10-02",
-          "release_notes": "https://learn.microsoft.com/en-us/microsoft-edge/dev-guide/whats-new",
+          "release_notes": "https://learn.microsoft.com/en-us/archive/microsoft-edge/legacy/developer/dev-guide/whats-new",
           "status": "retired",
           "engine": "EdgeHTML",
           "engine_version": "18"


### PR DESCRIPTION
Following the edit in https://github.com/mdn/browser-compat-data/pull/22286. The URLs have been manually tested to confirm they work.