### PR TITLE
Mirror Chrome Android data for *-content keywords

### DIFF
--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -56,9 +56,7 @@
                   "version_added": "25"
                 }
               ],
-              "chrome_android": {
-                "version_added": "46"
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": [
                 {
@@ -158,9 +156,7 @@
                   "version_added": "22"
                 }
               ],
-              "chrome_android": {
-                "version_added": "46"
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": [
                 {
@@ -227,9 +223,7 @@
                   "version_added": "25"
                 }
               ],
-              "chrome_android": {
-                "version_added": "46"
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": [
                 {

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -94,9 +94,7 @@
                   "version_added": "25"
                 }
               ],
-              "chrome_android": {
-                "version_added": "46"
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": [
                 {

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -105,9 +105,7 @@
                   "version_added": "25"
                 }
               ],
-              "chrome_android": {
-                "version_added": "46"
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": [
                 {
@@ -201,9 +199,7 @@
                   "version_added": "25"
                 }
               ],
-              "chrome_android": {
-                "version_added": "46"
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": [
                 {

--- a/css/properties/width.json
+++ b/css/properties/width.json
@@ -224,9 +224,7 @@
                   "version_added": "22"
                 }
               ],
-              "chrome_android": {
-                "version_added": "46"
-              },
+              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": [
                 {


### PR DESCRIPTION
These are the min-content, max-content, and fit-content property values.
The only difference when mirroring is the prefixed variants, and the
previous data can be assumed to be wrong, because this extremely rarely
depends on the platform.