### PR TITLE
Add missing features for appearance CSS property

### DIFF
--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -5,6 +5,9 @@
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/appearance",
           "spec_url": "https://drafts.csswg.org/css-ui/#appearance-switching",
+          "tags": [
+            "web-features:appearance"
+          ],
           "support": {
             "chrome": [
               {
@@ -75,6 +78,9 @@
         "auto": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-auto",
+            "tags": [
+              "web-features:appearance"
+            ],
             "support": {
               "chrome": {
                 "version_added": "83"
@@ -108,6 +114,9 @@
         "button": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-button",
+            "tags": [
+              "web-features:appearance"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -143,6 +152,9 @@
         "checkbox": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-checkbox",
+            "tags": [
+              "web-features:appearance"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -178,6 +190,9 @@
         "listbox": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-listbox",
+            "tags": [
+              "web-features:appearance"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -213,6 +228,9 @@
         "menulist": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-menulist",
+            "tags": [
+              "web-features:appearance"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -248,6 +266,9 @@
         "menulist-button": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-menulist-button",
+            "tags": [
+              "web-features:appearance"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -292,6 +313,9 @@
         "meter": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-meter",
+            "tags": [
+              "web-features:appearance"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -327,6 +351,9 @@
         "none": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-none",
+            "tags": [
+              "web-features:appearance"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -371,6 +398,9 @@
         "progress-bar": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-progress-bar",
+            "tags": [
+              "web-features:appearance"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -406,6 +436,9 @@
         "radio": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-radio",
+            "tags": [
+              "web-features:appearance"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -441,6 +474,9 @@
         "searchfield": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-searchfield",
+            "tags": [
+              "web-features:appearance"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -476,6 +512,9 @@
         "textarea": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-textarea",
+            "tags": [
+              "web-features:appearance"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -511,6 +550,9 @@
         "textfield": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-textfield",
+            "tags": [
+              "web-features:appearance"
+            ],
             "support": {
               "chrome": {
                 "version_added": "1"

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -74,6 +74,7 @@
         },
         "auto": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-auto",
             "support": {
               "chrome": {
                 "version_added": "83"
@@ -104,9 +105,9 @@
             }
           }
         },
-        "compat-auto": {
+        "button": {
           "__compat": {
-            "description": "<code>&lt;compat-auto&gt;</code> (compatibility values <code>searchfield</code>, <code>textarea</code>, <code>checkbox</code>, <code>radio</code>, <code>menulist</code>, <code>listbox</code>, <code>meter</code>, <code>progress-bar</code>, <code>button</code>)",
+            "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-button",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -128,9 +129,112 @@
               "safari": {
                 "version_added": "3"
               },
-              "safari_ios": {
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "checkbox": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-checkbox",
+            "support": {
+              "chrome": {
                 "version_added": "1"
               },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "3"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "listbox": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-listbox",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "3"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "menulist": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-menulist",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "3"
+              },
+              "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror"
             },
@@ -143,7 +247,7 @@
         },
         "menulist-button": {
           "__compat": {
-            "description": "<code>menulist-button</code>",
+            "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-menulist-button",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -185,8 +289,44 @@
             }
           }
         },
+        "meter": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-meter",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "3"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "none": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-none",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -228,8 +368,149 @@
             }
           }
         },
+        "progress-bar": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-progress-bar",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "3"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "radio": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-radio",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "3"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "searchfield": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-searchfield",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "3"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "textarea": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-textarea",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "3"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "textfield": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-appearance-textfield",
             "support": {
               "chrome": {
                 "version_added": "1"


### PR DESCRIPTION
This PR adds the missing features of the `appearance` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.9.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/appearance