### PR TITLE
Add missing features for box-decoration-break CSS property

### DIFF
--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -13,16 +13,9 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": [
-              {
-                "version_added": "32"
-              },
-              {
-                "alternative_name": "-moz-background-inline-policy",
-                "version_added": "1",
-                "version_removed": "32"
-              }
-            ],
+            "firefox": {
+              "version_added": "32"
+            },
             "firefox_android": "mirror",
             "ie": {
               "version_added": false
@@ -61,6 +54,70 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "clone": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "22"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "32"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "slice": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "22"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "32"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "7"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       }

--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -58,6 +58,7 @@
         },
         "clone": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-break/#valdef-box-decoration-break-clone",
             "support": {
               "chrome": {
                 "version_added": "22"
@@ -90,6 +91,7 @@
         },
         "slice": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-break/#valdef-box-decoration-break-slice",
             "support": {
               "chrome": {
                 "version_added": "22"


### PR DESCRIPTION
This PR adds the missing features of the `box-decoration-break` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.9.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/box-decoration-break

Additional Notes: The alternative name does not support any of the known values and isn't documented on MDN, so I have removed it.