### PR TITLE
Add missing css.properties.column-count.auto feature

### DIFF
--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -94,6 +94,38 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "auto": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "1.5"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "3"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -97,6 +97,7 @@
         },
         "auto": {
           "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-multicol/#valdef-column-count-auto",
             "support": {
               "chrome": {
                 "version_added": "1"


### PR DESCRIPTION
This PR adds the missing `auto` member of the `column-count` CSS property. The data comes from the [mdn-bcd-collector](https://mdn-bcd-collector.gooborg.com) project (v10.9.0).

_Check out the [collector's guide on how to review this PR](https://github.com/openwebdocs/mdn-bcd-collector#reviewing-bcd-changes)._

Tests Used: https://mdn-bcd-collector.gooborg.com/tests/css/properties/column-count/auto