### PR TITLE
Update all browsers data for column-count CSS property

### DIFF
--- a/css/properties/column-count.json
+++ b/css/properties/column-count.json
@@ -36,38 +36,13 @@
                 "notes": "Before version 37, multiple columns didn't work with <code>display: table-caption</code> elements."
               }
             ],
-            "firefox_android": [
-              {
-                "version_added": "52"
-              },
-              {
-                "prefix": "-moz-",
-                "version_added": "4",
-                "notes": "Before version 37, multiple columns didn't work with <code>display: table-caption</code> elements."
-              }
-            ],
+            "firefox_android": "mirror",
             "ie": {
               "version_added": "10"
             },
             "oculus": "mirror",
-            "opera": [
-              {
-                "version_added": "11.1"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "15"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "11.1"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "14"
-              }
-            ],
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": [
               {
                 "version_added": "9"
@@ -77,15 +52,7 @@
                 "version_added": "3"
               }
             ],
-            "safari_ios": [
-              {
-                "version_added": "9"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "1"
-              }
-            ],
+            "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror"
           },


### PR DESCRIPTION
This PR updates and corrects version values for all browsers for the `column-count` CSS property. This sets derivative browsers to mirror as their data had gotten desynchronized.