### PR TITLE
Update Opera data for column-span CSS property

### DIFF
--- a/css/properties/column-span.json
+++ b/css/properties/column-span.json
@@ -33,24 +33,8 @@
               "version_added": "10"
             },
             "oculus": "mirror",
-            "opera": [
-              {
-                "version_added": "11.1"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "15"
-              }
-            ],
-            "opera_android": [
-              {
-                "version_added": "11.1"
-              },
-              {
-                "prefix": "-webkit-",
-                "version_added": "14"
-              }
-            ],
+            "opera": "mirror",
+            "opera_android": "mirror",
             "safari": [
               {
                 "version_added": "9"


### PR DESCRIPTION
This PR updates and corrects version values for Opera and Opera Android for the `column-span` CSS property. This sets Opera to mirror to synchronize it with Chrome results.