### PR TITLE
More minor fixes for vertical slider support

### DIFF
--- a/css/properties/direction.json
+++ b/css/properties/direction.json
@@ -132,7 +132,9 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "16.5",
+                "partial_implementation": true,
+                "notes": "Only supported for vertical range sliders."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -408,7 +408,7 @@
                   "version_added": "17.4"
                 },
                 {
-                  "version_added": "14",
+                  "version_added": "16.5",
                   "partial_implementation": true,
                   "notes": "Support for range sliders, textual inputs, and textareas only"
                 }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

A couple more fixes coming out of conversations and testing around my vertical form control content (see https://github.com/mdn/content/pull/32142).

Specifically:

- It looks like writing-mode for vertical sliders are not supported as far as Safari 14. It seemed more like 16.5, as it worked in that on mine, but not in 16.1 on @wbamberg's mac.
- I also added in Safari support for direction, in the same version.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
