### PR TITLE
Update color.json- STP 189 added support for light-dark(), update Safari to "preview"

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -785,8 +785,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "impl_url": "https://webkit.org/b/262914"
+                "version_added": "preview",
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
STP 189 added support for light-dark() function for color values. Update Safari to `"preview"`.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->
Attached is a test case using MDN's playground: 
<img width="1826" alt="light-dark-stp-mdn" src="https://github.com/mdn/browser-compat-data/assets/113309999/20884911-2515-49ce-9314-e287281d574e">

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
[Webkit's STP release notes](https://webkit.org/blog/15050/release-notes-for-safari-technology-preview-189/)
[Apple's STP release notes](https://developer.apple.com/documentation/safari-technology-preview-release-notes/stp-release-189)

[enabled](https://github.com/WebKit/WebKit/commit/42f9569ae95a1bbef0a26f460bdaa7efdb637fff)
[implementation](https://github.com/WebKit/WebKit/pull/22242/files)

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
