### PR TITLE
fix: add es module support version for Edge

### DIFF
--- a/api/ServiceWorker.json
+++ b/api/ServiceWorker.json
@@ -43,9 +43,7 @@
               "version_added": "91"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
#### Summary

add es module support version for Edge

#### Test results and supporting details

Test on BrowserStack (feature test page: https://asset.dvlp4.fun/bcd-test/service-worker-es-module/index.html)

![image](https://github.com/mdn/browser-compat-data/assets/15844309/f45172ed-94b2-4946-8ed5-69fbdcbacf57)
